### PR TITLE
*: Migrate container registry from quay.io to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,7 @@ on:
       - main
 
 env:
-  # IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  IMAGE_REGISTRY: quay.io/solo-io
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 permissions:
   contents: write

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -279,7 +279,7 @@ ingressProxy:
   tracing:
 global:
   image:
-    registry: quay.io/solo-io
+    registry: ghcr.io/kgateway
     pullPolicy: IfNotPresent
   glooRbac:
     create: true

--- a/test/makefile/make_test.go
+++ b/test/makefile/make_test.go
@@ -15,8 +15,7 @@ const (
 
 // Makefile vars
 const (
-	HelmBucket          = "HELM_BUCKET"
-	QuayExpirationLabel = "QUAY_EXPIRATION_LABEL"
+	HelmBucket = "HELM_BUCKET"
 )
 
 // NOTE: These tests are mostly to check that the makefile ifeq directive logic is working as expected.
@@ -31,7 +30,6 @@ var _ = Describe("Make", func() {
 				{TaggedVersion, ""},
 			}, []*MakeVar{
 				{HelmBucket, "gs://solo-public-tagged-helm"},
-				{QuayExpirationLabel, "--label quay.expires-after=3w"},
 			})
 		})
 
@@ -42,7 +40,6 @@ var _ = Describe("Make", func() {
 				{TaggedVersion, ""},
 			}, []*MakeVar{
 				{HelmBucket, "gs://solo-public-helm"},
-				{QuayExpirationLabel, ""},
 			})
 		})
 
@@ -53,7 +50,6 @@ var _ = Describe("Make", func() {
 				{TaggedVersion, ""},
 			}, []*MakeVar{
 				{HelmBucket, "gs://solo-public-tagged-helm"},
-				{QuayExpirationLabel, "--label quay.expires-after=3w"},
 			})
 		})
 	})


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

This commit is a follow-up to #10443 and #10470 and migrates away from the quay.io/solo-io container image registry in favor of the ghcr.io repository in the project.

Additional work around renaming the gloo component, binaries, etc. will be handled once we're closing the finish line with the https://github.com/kgateway-dev/kgateway/issues/10444 cleanup work.

Introducing automation to replace the quay container image expiration label is being tracked in the https://github.com/kgateway-dev/kgateway/issues/10441 epic.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
