### PR TITLE
*: Add the -local goimports flag to the fmt Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,15 +134,9 @@ include Makefile.ci
 init:
 	git config core.hooksPath .githooks
 
-# Runs [`goimports`](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) which updates imports and formats code
-# TODO: deprecate in favor of using fmt-v2
+# Formats code and imports
 .PHONY: fmt
 fmt:
-	go run golang.org/x/tools/cmd/goimports -w $(shell ls -d */ | grep -v vendor)
-
-# Formats code and imports
-.PHONY: fmt-v2
-fmt-v2:
 	go run golang.org/x/tools/cmd/goimports -local "github.com/kgateway-dev/kgateway/"  -w $(shell ls -d */ | grep -v vendor)
 
 .PHONY: fmt-changed

--- a/docs/cmd/generate_docs.go
+++ b/docs/cmd/generate_docs.go
@@ -19,12 +19,13 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-github/v32/github"
-	. "github.com/kgateway-dev/kgateway/docs/cmd/securityscanutils"
 	"github.com/rotisserie/eris"
 	changelogdocutils "github.com/solo-io/go-utils/changeloggenutils"
 	"github.com/solo-io/go-utils/githubutils"
 	"github.com/solo-io/go-utils/versionutils"
 	"github.com/spf13/cobra"
+
+	. "github.com/kgateway-dev/kgateway/docs/cmd/securityscanutils"
 )
 
 func main() {

--- a/docs/cmd/test/securityscanutils/generate_securityscan_doc_test.go
+++ b/docs/cmd/test/securityscanutils/generate_securityscan_doc_test.go
@@ -1,9 +1,10 @@
 package securityscanutils_test
 
 import (
-	. "github.com/kgateway-dev/kgateway/docs/cmd/securityscanutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kgateway-dev/kgateway/docs/cmd/securityscanutils"
 )
 
 var _ = Describe("generate security scan docgen", func() {

--- a/docs/content/crds/generate.go
+++ b/docs/content/crds/generate.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/kgateway-dev/kgateway/pkg/utils/cmdutils"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/rotisserie/eris"
 	"github.com/stoewer/go-strcase"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/cmdutils"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 func main() {

--- a/docs/content/guides/dev/example-proxy-controller.go
+++ b/docs/content/guides/dev/example-proxy-controller.go
@@ -12,13 +12,14 @@ import (
 	"os"
 	"time"
 
-	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	matchers "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
 	"github.com/solo-io/k8s-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
 	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	matchers "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
 
 	// import for GKE
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/docs/content/guides/dev/plugin.go
+++ b/docs/content/guides/dev/plugin.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/discovery"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/plugins"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	// add these imports to use Envoy's API
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"

--- a/install/test/5-gateway-validation-webhook-configuration_test.go
+++ b/install/test/5-gateway-validation-webhook-configuration_test.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/onsi/gomega/types"
 	v1 "k8s.io/api/admissionregistration/v1"
 
-	gloostringutils "github.com/kgateway-dev/kgateway/pkg/utils/stringutils"
+	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/go-utils/stringutils"
@@ -23,6 +23,8 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
+
+	gloostringutils "github.com/kgateway-dev/kgateway/pkg/utils/stringutils"
 )
 
 const (

--- a/install/test/grpc_json_transcoder_test.go
+++ b/install/test/grpc_json_transcoder_test.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
-	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	. "github.com/solo-io/k8s-utils/manifesttestutils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
+	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 )
 
 var _ = Describe("GrpcJsonTranscoder helm test", func() {

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -11,11 +11,6 @@ import (
 	"text/template"
 
 	"github.com/ghodss/yaml"
-	"github.com/kgateway-dev/kgateway/pkg/cliutil/helm"
-	"github.com/kgateway-dev/kgateway/projects/gloo/cli/pkg/cmd/install"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
-	"github.com/kgateway-dev/kgateway/test/makefile"
-	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -30,6 +25,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kgateway-dev/kgateway/pkg/cliutil/helm"
+	"github.com/kgateway-dev/kgateway/projects/gloo/cli/pkg/cmd/install"
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
+	"github.com/kgateway-dev/kgateway/test/makefile"
+	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 )
 
 const (

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -14,12 +14,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/proto"
-	values "github.com/kgateway-dev/kgateway/install/helm/gloo/generate"
-	"github.com/kgateway-dev/kgateway/install/test/securitycontext"
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
-	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -38,6 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
+
+	values "github.com/kgateway-dev/kgateway/install/helm/gloo/generate"
+	"github.com/kgateway-dev/kgateway/install/test/securitycontext"
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 )
 
 func GetPodNamespaceStats() corev1.EnvVar {

--- a/install/test/k8sgateway_test.go
+++ b/install/test/k8sgateway_test.go
@@ -5,12 +5,6 @@ package test
 import (
 	"fmt"
 
-	"github.com/kgateway-dev/kgateway/install/utils/kuberesource"
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/solo-io/k8s-utils/manifesttestutils"
@@ -18,6 +12,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+
+	"github.com/kgateway-dev/kgateway/install/utils/kuberesource"
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 )
 
 var _ = Describe("Kubernetes Gateway API integration", func() {

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -5,8 +5,9 @@ package test
 import (
 	"fmt"
 
-	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/install/test/svc_accnt_test.go
+++ b/install/test/svc_accnt_test.go
@@ -3,8 +3,9 @@
 package test
 
 import (
-	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 	. "github.com/onsi/ginkgo/v2"
+
+	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
 
 	. "github.com/onsi/gomega"
 	. "github.com/solo-io/k8s-utils/manifesttestutils"

--- a/pkg/bootstrap/leaderelector/identity_test.go
+++ b/pkg/bootstrap/leaderelector/identity_test.go
@@ -1,9 +1,10 @@
 package leaderelector_test
 
 import (
-	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
 )
 
 var _ = Describe("Identity", func() {

--- a/pkg/bootstrap/leaderelector/kube/factory.go
+++ b/pkg/bootstrap/leaderelector/kube/factory.go
@@ -6,12 +6,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
-	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
 	"github.com/solo-io/go-utils/contextutils"
 	"k8s.io/client-go/rest"
 	k8sleaderelection "k8s.io/client-go/tools/leaderelection"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
+
+	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
+	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
 )
 
 var _ leaderelector.ElectionFactory = new(kubeElectionFactory)

--- a/pkg/bootstrap/leaderelector/leader_test.go
+++ b/pkg/bootstrap/leaderelector/leader_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"sync/atomic"
 
-	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
 )
 
 var _ = Describe("Leader Startup Action", func() {

--- a/pkg/bootstrap/leaderelector/singlereplica/factory.go
+++ b/pkg/bootstrap/leaderelector/singlereplica/factory.go
@@ -3,8 +3,9 @@ package singlereplica
 import (
 	"context"
 
-	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
 	"github.com/solo-io/go-utils/contextutils"
+
+	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
 )
 
 var _ leaderelector.ElectionFactory = new(singleReplicaElectionFactory)

--- a/pkg/cliutil/input_test.go
+++ b/pkg/cliutil/input_test.go
@@ -1,10 +1,11 @@
 package cliutil_test
 
 import (
-	. "github.com/kgateway-dev/kgateway/pkg/cliutil"
-	"github.com/kgateway-dev/kgateway/pkg/cliutil/testutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kgateway-dev/kgateway/pkg/cliutil"
+	"github.com/kgateway-dev/kgateway/pkg/cliutil/testutil"
 )
 
 var _ = Describe("GetBoolInput", func() {

--- a/pkg/cliutil/testutil/testutil.go
+++ b/pkg/cliutil/testutil/testutil.go
@@ -7,10 +7,11 @@ import (
 
 	expect "github.com/Netflix/go-expect"
 	"github.com/hinshun/vt10x"
-	"github.com/kgateway-dev/kgateway/pkg/cliutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/AlecAivazis/survey.v1/terminal"
+
+	"github.com/kgateway-dev/kgateway/pkg/cliutil"
 )
 
 func Stdio(c *expect.Console) terminal.Stdio {

--- a/pkg/cliutil/uri.go
+++ b/pkg/cliutil/uri.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 
 	"github.com/avast/retry-go/v4"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/portforward"
 
 	"github.com/hashicorp/go-multierror"

--- a/pkg/github-action-utils/version.go
+++ b/pkg/github-action-utils/version.go
@@ -5,11 +5,12 @@ import (
 	"math"
 	"os"
 
-	"github.com/kgateway-dev/kgateway/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/solo-io/go-utils/changelogutils"
 	"github.com/solo-io/go-utils/versionutils"
 	"github.com/solo-io/go-utils/vfsutils"
+
+	"github.com/kgateway-dev/kgateway/pkg/version"
 )
 
 // GetLatestEnterpriseVersion computes the latest Gloo Enterprise version.

--- a/pkg/schemes/extended_scheme.go
+++ b/pkg/schemes/extended_scheme.go
@@ -3,12 +3,13 @@ package schemes
 import (
 	"fmt"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )

--- a/pkg/utils/envoyutils/admincli/client.go
+++ b/pkg/utils/envoyutils/admincli/client.go
@@ -10,10 +10,11 @@ import (
 	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/solo-io/go-utils/threadsafe"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/cmdutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/protoutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
-	"github.com/solo-io/go-utils/threadsafe"
 
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/portforward"

--- a/pkg/utils/envoyutils/admincli/client_test.go
+++ b/pkg/utils/envoyutils/admincli/client_test.go
@@ -3,11 +3,12 @@ package admincli_test
 import (
 	"context"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/envoyutils/admincli"
-	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/go-utils/threadsafe"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/envoyutils/admincli"
+	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 )
 
 var _ = Describe("Client", func() {

--- a/pkg/utils/envoyutils/bootstrap/bootstrap.go
+++ b/pkg/utils/envoyutils/bootstrap/bootstrap.go
@@ -13,11 +13,12 @@ import (
 	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	"github.com/rotisserie/eris"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 )
 
 var (

--- a/pkg/utils/envoyutils/bootstrap/bootstrap_test.go
+++ b/pkg/utils/envoyutils/bootstrap/bootstrap_test.go
@@ -3,8 +3,9 @@ package bootstrap
 import (
 	"context"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	envoytransformation "github.com/solo-io/envoy-gloo/go/config/filter/http/transformation/v2"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"

--- a/pkg/utils/envoyutils/validation/validation.go
+++ b/pkg/utils/envoyutils/validation/validation.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/contextutils"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/envoyutils/bootstrap"
 	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/projects/envoyinit/pkg/runner"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
-	"github.com/rotisserie/eris"
-	"github.com/solo-io/go-utils/contextutils"
 )
 
 const (

--- a/pkg/utils/glooadminutils/admincli/client.go
+++ b/pkg/utils/glooadminutils/admincli/client.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/threadsafe"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/cmdutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
-	"github.com/rotisserie/eris"
-	"github.com/solo-io/go-utils/threadsafe"
 )
 
 const (

--- a/pkg/utils/glooadminutils/admincli/client_test.go
+++ b/pkg/utils/glooadminutils/admincli/client_test.go
@@ -3,11 +3,12 @@ package admincli_test
 import (
 	"context"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/glooadminutils/admincli"
-	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/go-utils/threadsafe"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/glooadminutils/admincli"
+	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 )
 
 var _ = Describe("Client", func() {

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 
 	"github.com/avast/retry-go/v4"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/portforward"
 )
 

--- a/pkg/utils/probes/probes_test.go
+++ b/pkg/utils/probes/probes_test.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 	"time"
 
-	. "github.com/kgateway-dev/kgateway/pkg/utils/probes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kgateway-dev/kgateway/pkg/utils/probes"
 )
 
 var _ = Describe("Probes", func() {

--- a/pkg/utils/regexutils/regex_test.go
+++ b/pkg/utils/regexutils/regex_test.go
@@ -1,9 +1,10 @@
 package regexutils_test
 
 import (
-	. "github.com/kgateway-dev/kgateway/pkg/utils/regexutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kgateway-dev/kgateway/pkg/utils/regexutils"
 )
 
 var _ = Describe("Regex", func() {

--- a/pkg/utils/requestutils/curl/request_test.go
+++ b/pkg/utils/requestutils/curl/request_test.go
@@ -1,9 +1,10 @@
 package curl_test
 
 import (
-	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 
 	. "github.com/onsi/ginkgo/v2"
 )

--- a/pkg/utils/setuputils/main_setup.go
+++ b/pkg/utils/setuputils/main_setup.go
@@ -7,16 +7,17 @@ import (
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 
 	"github.com/go-logr/zapr"
-	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
-	kube2 "github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector/kube"
-	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector/singlereplica"
-	"github.com/kgateway-dev/kgateway/pkg/version"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	zaputil "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector"
+	kube2 "github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector/kube"
+	"github.com/kgateway-dev/kgateway/pkg/bootstrap/leaderelector/singlereplica"
+	"github.com/kgateway-dev/kgateway/pkg/version"
 )
 
 func startLeaderElection(ctx context.Context, settingsDir string, electionConfig *leaderelector.ElectionConfig) (leaderelector.Identity, error) {

--- a/pkg/version/enterprise_version_test.go
+++ b/pkg/version/enterprise_version_test.go
@@ -1,10 +1,11 @@
 package version_test
 
 import (
-	"github.com/kgateway-dev/kgateway/pkg/version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
+
+	"github.com/kgateway-dev/kgateway/pkg/version"
 )
 
 var _ = Describe("LatestVersionFromRepo", func() {

--- a/projects/envoyinit/pkg/runner/run.go
+++ b/projects/envoyinit/pkg/runner/run.go
@@ -8,10 +8,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/cmdutils"
-	"github.com/kgateway-dev/kgateway/projects/envoyinit/pkg/downward"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/contextutils"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/cmdutils"
+	"github.com/kgateway-dev/kgateway/projects/envoyinit/pkg/downward"
 )
 
 const (

--- a/projects/gateway2/admin/resources.go
+++ b/projects/gateway2/admin/resources.go
@@ -3,9 +3,10 @@ package admin
 import (
 	"slices"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // TODO: these need to be updated

--- a/projects/gateway2/admin/response_test.go
+++ b/projects/gateway2/admin/response_test.go
@@ -1,12 +1,13 @@
 package admin_test
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rotisserie/eris"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
 )
 
 var _ = Describe("SnapshotResponseData", func() {

--- a/projects/gateway2/admin/server.go
+++ b/projects/gateway2/admin/server.go
@@ -10,9 +10,10 @@ import (
 	"sort"
 
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
 	"github.com/solo-io/go-utils/contextutils"
 	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
 )
 
 const (

--- a/projects/gateway2/api/applyconfiguration/api/v1alpha1/directresponse.go
+++ b/projects/gateway2/api/applyconfiguration/api/v1alpha1/directresponse.go
@@ -3,12 +3,13 @@
 package v1alpha1
 
 import (
-	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+
+	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // DirectResponseApplyConfiguration represents a declarative configuration of the DirectResponse type for use

--- a/projects/gateway2/api/applyconfiguration/api/v1alpha1/gatewayparameters.go
+++ b/projects/gateway2/api/applyconfiguration/api/v1alpha1/gatewayparameters.go
@@ -3,12 +3,13 @@
 package v1alpha1
 
 import (
-	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+
+	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // GatewayParametersApplyConfiguration represents a declarative configuration of the GatewayParameters type for use

--- a/projects/gateway2/api/applyconfiguration/api/v1alpha1/httplistenerpolicy.go
+++ b/projects/gateway2/api/applyconfiguration/api/v1alpha1/httplistenerpolicy.go
@@ -3,12 +3,13 @@
 package v1alpha1
 
 import (
-	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+
+	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // HttpListenerPolicyApplyConfiguration represents a declarative configuration of the HttpListenerPolicy type for use

--- a/projects/gateway2/api/applyconfiguration/api/v1alpha1/listenerpolicy.go
+++ b/projects/gateway2/api/applyconfiguration/api/v1alpha1/listenerpolicy.go
@@ -3,12 +3,13 @@
 package v1alpha1
 
 import (
-	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+
+	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // ListenerPolicyApplyConfiguration represents a declarative configuration of the ListenerPolicy type for use

--- a/projects/gateway2/api/applyconfiguration/api/v1alpha1/routepolicy.go
+++ b/projects/gateway2/api/applyconfiguration/api/v1alpha1/routepolicy.go
@@ -3,12 +3,13 @@
 package v1alpha1
 
 import (
-	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+
+	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // RoutePolicyApplyConfiguration represents a declarative configuration of the RoutePolicy type for use

--- a/projects/gateway2/api/applyconfiguration/api/v1alpha1/upstream.go
+++ b/projects/gateway2/api/applyconfiguration/api/v1alpha1/upstream.go
@@ -3,12 +3,13 @@
 package v1alpha1
 
 import (
-	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+
+	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // UpstreamApplyConfiguration represents a declarative configuration of the Upstream type for use

--- a/projects/gateway2/api/applyconfiguration/utils.go
+++ b/projects/gateway2/api/applyconfiguration/utils.go
@@ -3,12 +3,13 @@
 package applyconfiguration
 
 import (
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	testing "k8s.io/client-go/testing"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	internal "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/internal"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no

--- a/projects/gateway2/cmd/main.go
+++ b/projects/gateway2/cmd/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 
+	"github.com/solo-io/go-utils/log"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/probes"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/setup"
-	"github.com/solo-io/go-utils/log"
 )
 
 func main() {

--- a/projects/gateway2/controller/controller_suite_test.go
+++ b/projects/gateway2/controller/controller_suite_test.go
@@ -13,9 +13,6 @@ import (
 
 	"github.com/kgateway-dev/kgateway/pkg/schemes"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	api "sigs.k8s.io/gateway-api/apis/v1"
 	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 )
 
 var (

--- a/projects/gateway2/controller/gw_controller.go
+++ b/projects/gateway2/controller/gw_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"slices"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/deployer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,6 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	api "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/deployer"
 )
 
 const (

--- a/projects/gateway2/controller/start.go
+++ b/projects/gateway2/controller/start.go
@@ -7,8 +7,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 
-	glooschemes "github.com/kgateway-dev/kgateway/pkg/schemes"
 	"github.com/solo-io/go-utils/contextutils"
+
+	glooschemes "github.com/kgateway-dev/kgateway/pkg/schemes"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,6 +19,12 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	uzap "go.uber.org/zap"
+	istiokube "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/krt"
+	istiolog "istio.io/istio/pkg/log"
+	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/deployer"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
@@ -30,11 +37,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/proxy_syncer"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	uzap "go.uber.org/zap"
-	istiokube "istio.io/istio/pkg/kube"
-	"istio.io/istio/pkg/kube/krt"
-	istiolog "istio.io/istio/pkg/log"
-	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (

--- a/projects/gateway2/deployer/deployer.go
+++ b/projects/gateway2/deployer/deployer.go
@@ -9,10 +9,6 @@ import (
 	"io/fs"
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/pkg/version"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/helm"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 	"helm.sh/helm/v3/pkg/action"
@@ -30,6 +26,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	api "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/pkg/version"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/helm"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 )
 
 var (

--- a/projects/gateway2/deployer/deployer_test.go
+++ b/projects/gateway2/deployer/deployer_test.go
@@ -8,12 +8,6 @@ import (
 	envoy_config_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	_ "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/ghodss/yaml"
-	"github.com/kgateway-dev/kgateway/pkg/schemes"
-	"github.com/kgateway-dev/kgateway/pkg/version"
-	gw2_v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/deployer"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -28,6 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	api "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/pkg/schemes"
+	"github.com/kgateway-dev/kgateway/pkg/version"
+	gw2_v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/deployer"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 
 	// TODO BML tests in this suite fail if this no-op import is not imported first.
 	//

--- a/projects/gateway2/deployer/merge.go
+++ b/projects/gateway2/deployer/merge.go
@@ -1,9 +1,10 @@
 package deployer
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // mergePointers will decide whether to use dst or src without dereferencing or recursing

--- a/projects/gateway2/deployer/merge_test.go
+++ b/projects/gateway2/deployer/merge_test.go
@@ -1,10 +1,11 @@
 package deployer
 
 import (
-	gw2_v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+
+	gw2_v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 var _ = Describe("deepMergeGatewayParameters", func() {

--- a/projects/gateway2/deployer/values.go
+++ b/projects/gateway2/deployer/values.go
@@ -1,8 +1,9 @@
 package deployer
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // The top-level helm values used by the deployer.

--- a/projects/gateway2/deployer/values_helpers.go
+++ b/projects/gateway2/deployer/values_helpers.go
@@ -6,12 +6,13 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ports"
 	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 	"k8s.io/utils/ptr"
 	api "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ports"
 )
 
 // This file contains helper functions that generate helm values in the format needed

--- a/projects/gateway2/deployer/values_helpers_test.go
+++ b/projects/gateway2/deployer/values_helpers_test.go
@@ -1,9 +1,10 @@
 package deployer_test
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/deployer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/deployer"
 )
 
 var _ = Describe("Values Helpers", func() {

--- a/projects/gateway2/endpoints/prioritize.go
+++ b/projects/gateway2/endpoints/prioritize.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"go.uber.org/zap"
 	"istio.io/api/networking/v1alpha3"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"

--- a/projects/gateway2/extensions2/common/krt.go
+++ b/projects/gateway2/extensions2/common/krt.go
@@ -4,11 +4,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/settings"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"istio.io/istio/pkg/kube"
 	istiokube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
@@ -16,6 +11,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/settings"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 type CommonCollections struct {

--- a/projects/gateway2/extensions2/plugin/plugin.go
+++ b/projects/gateway2/extensions2/plugin/plugin.go
@@ -5,12 +5,14 @@ import (
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
 )
 
 type AttachmentPoints uint

--- a/projects/gateway2/extensions2/plugins/destrule/destrule.go
+++ b/projects/gateway2/extensions2/plugins/destrule/destrule.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"google.golang.org/protobuf/proto"
 	"istio.io/api/networking/v1alpha3"
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
@@ -13,6 +12,8 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/kubetypes"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 type NsWithHostname struct {

--- a/projects/gateway2/extensions2/plugins/destrule/destrule_plugin.go
+++ b/projects/gateway2/extensions2/plugins/destrule/destrule_plugin.go
@@ -11,14 +11,15 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/endpoints"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
-	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/solo-io/go-utils/contextutils"
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/endpoints"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
+	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 )
 
 const (

--- a/projects/gateway2/extensions2/plugins/directresponse/direct_response_plugin.go
+++ b/projects/gateway2/extensions2/plugins/directresponse/direct_response_plugin.go
@@ -11,18 +11,19 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
-	extensionplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 	skubeclient "istio.io/istio/pkg/config/schema/kubeclient"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
+	extensionplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 )
 
 type directResponse struct {

--- a/projects/gateway2/extensions2/plugins/istio/plugin.go
+++ b/projects/gateway2/extensions2/plugins/istio/plugin.go
@@ -16,13 +16,14 @@ import (
 	sockets_raw_buffer "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/raw_buffer/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/solo-io/go-utils/contextutils"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	ourwellknown "github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	"github.com/solo-io/go-utils/contextutils"
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (

--- a/projects/gateway2/extensions2/plugins/kubernetes/k8s.go
+++ b/projects/gateway2/extensions2/plugins/kubernetes/k8s.go
@@ -9,16 +9,17 @@ import (
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/settings"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	"istio.io/istio/pkg/kube/kclient"
-	"istio.io/istio/pkg/kube/krt"
-	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensionsplug.Plugin {

--- a/projects/gateway2/extensions2/plugins/listenerpolicy/listener_policy_plugin.go
+++ b/projects/gateway2/extensions2/plugins/listenerpolicy/listener_policy_plugin.go
@@ -8,6 +8,9 @@ import (
 
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+	"istio.io/istio/pkg/kube/krt"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
@@ -15,8 +18,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
-	"istio.io/istio/pkg/kube/krt"
 )
 
 type listenerOptsPlugin struct {

--- a/projects/gateway2/extensions2/plugins/routepolicy/route_policy_plugin.go
+++ b/projects/gateway2/extensions2/plugins/routepolicy/route_policy_plugin.go
@@ -9,6 +9,8 @@ import (
 
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"istio.io/istio/pkg/kube/krt"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
@@ -16,7 +18,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	"istio.io/istio/pkg/kube/krt"
 )
 
 type routeOptsPlugin struct {

--- a/projects/gateway2/extensions2/plugins/upstream/aws.go
+++ b/projects/gateway2/extensions2/plugins/upstream/aws.go
@@ -11,11 +11,12 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	awspb "github.com/solo-io/envoy-gloo/go/config/filter/http/aws_lambda/v2"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/pluginutils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	awspb "github.com/solo-io/envoy-gloo/go/config/filter/http/aws_lambda/v2"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const (

--- a/projects/gateway2/extensions2/plugins/upstream/plugin.go
+++ b/projects/gateway2/extensions2/plugins/upstream/plugin.go
@@ -13,6 +13,13 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	awspb "github.com/solo-io/envoy-gloo/go/config/filter/http/aws_lambda/v2"
+	skubeclient "istio.io/istio/pkg/config/schema/kubeclient"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
@@ -20,12 +27,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
-	awspb "github.com/solo-io/envoy-gloo/go/config/filter/http/aws_lambda/v2"
-	skubeclient "istio.io/istio/pkg/config/schema/kubeclient"
-	"istio.io/istio/pkg/kube/kclient"
-	"istio.io/istio/pkg/kube/krt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (

--- a/projects/gateway2/extensions2/plugins/upstream/static.go
+++ b/projects/gateway2/extensions2/plugins/upstream/static.go
@@ -7,6 +7,7 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 )

--- a/projects/gateway2/extensions2/pluginutils/pluginutils.go
+++ b/projects/gateway2/extensions2/pluginutils/pluginutils.go
@@ -4,10 +4,11 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 )
 
 func EnvoySingleEndpointLoadAssignment(out *envoy_config_cluster_v3.Cluster, address string, port uint32) {

--- a/projects/gateway2/extensions2/registry/registry.go
+++ b/projects/gateway2/extensions2/registry/registry.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"maps"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugins/destrule"
@@ -13,8 +16,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugins/listenerpolicy"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugins/routepolicy"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugins/upstream"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func mergedGw(funcs []extensionsplug.GwTranslatorFactory) extensionsplug.GwTranslatorFactory {

--- a/projects/gateway2/ir/gw2.go
+++ b/projects/gateway2/ir/gw2.go
@@ -1,9 +1,10 @@
 package ir
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 	"google.golang.org/protobuf/types/known/anypb"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 )
 
 // This is the IR that is used in the translation to XDS. it is self contained and no IO/krt is

--- a/projects/gateway2/ir/iface.go
+++ b/projects/gateway2/ir/iface.go
@@ -8,9 +8,10 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
 )
 
 type ListenerContext struct {

--- a/projects/gateway2/ir/model.go
+++ b/projects/gateway2/ir/model.go
@@ -8,8 +8,9 @@ import (
 	"maps"
 
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 )
 
 const KeyDelimiter = "~"

--- a/projects/gateway2/krtcollections/builtin.go
+++ b/projects/gateway2/krtcollections/builtin.go
@@ -15,11 +15,12 @@ import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoytype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	extensionplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var (

--- a/projects/gateway2/krtcollections/endpoints.go
+++ b/projects/gateway2/krtcollections/endpoints.go
@@ -9,15 +9,16 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/settings"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	"github.com/solo-io/go-utils/contextutils"
 	"istio.io/istio/pkg/kube/krt"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/settings"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 )
 
 type EndpointsSettings struct {

--- a/projects/gateway2/krtcollections/endpoints_test.go
+++ b/projects/gateway2/krtcollections/endpoints_test.go
@@ -7,8 +7,6 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/fgrosse/zaptest"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/go-utils/contextutils"
@@ -21,6 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 func TestEndpointsForUpstreamOrderDoesntMatter(t *testing.T) {

--- a/projects/gateway2/krtcollections/ns.go
+++ b/projects/gateway2/krtcollections/ns.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"maps"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 type NamespaceMetadata struct {

--- a/projects/gateway2/krtcollections/pods.go
+++ b/projects/gateway2/krtcollections/pods.go
@@ -3,8 +3,6 @@ package krtcollections
 import (
 	"maps"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"istio.io/api/label"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/kclient"
@@ -12,6 +10,9 @@ import (
 	"istio.io/istio/pkg/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 type NodeMetadata struct {

--- a/projects/gateway2/krtcollections/pods_test.go
+++ b/projects/gateway2/krtcollections/pods_test.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
-	. "github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
+	. "github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 func TestPods(t *testing.T) {

--- a/projects/gateway2/krtcollections/policy.go
+++ b/projects/gateway2/krtcollections/policy.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 	"slices"
 
-	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/backendref"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"istio.io/istio/pkg/kube/krt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,6 +12,11 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/backendref"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 var (

--- a/projects/gateway2/krtcollections/policy_test.go
+++ b/projects/gateway2/krtcollections/policy_test.go
@@ -12,12 +12,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 var (

--- a/projects/gateway2/krtcollections/secrets.go
+++ b/projects/gateway2/krtcollections/secrets.go
@@ -1,10 +1,11 @@
 package krtcollections
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 )
 
 type From struct {

--- a/projects/gateway2/krtcollections/setup.go
+++ b/projects/gateway2/krtcollections/setup.go
@@ -9,15 +9,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 
-	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/gvr"
 	skubeclient "istio.io/istio/pkg/config/schema/kubeclient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 func registerTypes() {

--- a/projects/gateway2/krtcollections/uniqueclients.go
+++ b/projects/gateway2/krtcollections/uniqueclients.go
@@ -11,14 +11,15 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	xdsserver "github.com/envoyproxy/go-control-plane/pkg/server/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 )
 
 type ConnectedClient struct {

--- a/projects/gateway2/krtcollections/uniqueclients_test.go
+++ b/projects/gateway2/krtcollections/uniqueclients_test.go
@@ -7,11 +7,6 @@ import (
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	. "github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -20,6 +15,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	. "github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 )
 
 func TestUniqueClients(t *testing.T) {

--- a/projects/gateway2/pkg/client/clientset/versioned/clientset.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/clientset.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"net/http"
 
-	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+
+	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1"
 )
 
 type Interface interface {

--- a/projects/gateway2/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -3,15 +3,16 @@
 package fake
 
 import (
-	applyconfiguration "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration"
-	clientset "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned"
-	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1"
-	fakegatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+
+	applyconfiguration "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration"
+	clientset "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned"
+	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1"
+	fakegatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/projects/gateway2/pkg/client/clientset/versioned/fake/register.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/fake/register.go
@@ -3,12 +3,13 @@
 package fake
 
 import (
-	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/projects/gateway2/pkg/client/clientset/versioned/scheme/register.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/scheme/register.go
@@ -3,12 +3,13 @@
 package scheme
 
 import (
-	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	gatewayv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/api_client.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/api_client.go
@@ -5,9 +5,10 @@ package v1alpha1
 import (
 	"net/http"
 
+	rest "k8s.io/client-go/rest"
+
 	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
-	rest "k8s.io/client-go/rest"
 )
 
 type GatewayV1alpha1Interface interface {

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/directresponse.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/directresponse.go
@@ -5,13 +5,14 @@ package v1alpha1
 import (
 	"context"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 )
 
 // DirectResponsesGetter has a method to return a DirectResponseInterface.

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_api_client.go
@@ -3,9 +3,10 @@
 package fake
 
 import (
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
+
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1"
 )
 
 type FakeGatewayV1alpha1 struct {

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_directresponse.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_directresponse.go
@@ -7,13 +7,14 @@ import (
 	json "encoding/json"
 	"fmt"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // FakeDirectResponses implements DirectResponseInterface

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_gatewayparameters.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_gatewayparameters.go
@@ -7,13 +7,14 @@ import (
 	json "encoding/json"
 	"fmt"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // FakeGatewayParameterses implements GatewayParametersInterface

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_httplistenerpolicy.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_httplistenerpolicy.go
@@ -7,13 +7,14 @@ import (
 	json "encoding/json"
 	"fmt"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // FakeHttpListenerPolicies implements HttpListenerPolicyInterface

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_listenerpolicy.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_listenerpolicy.go
@@ -7,13 +7,14 @@ import (
 	json "encoding/json"
 	"fmt"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // FakeListenerPolicies implements ListenerPolicyInterface

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_routepolicy.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_routepolicy.go
@@ -7,13 +7,14 @@ import (
 	json "encoding/json"
 	"fmt"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // FakeRoutePolicies implements RoutePolicyInterface

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_upstream.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/fake/fake_upstream.go
@@ -7,13 +7,14 @@ import (
 	json "encoding/json"
 	"fmt"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 )
 
 // FakeUpstreams implements UpstreamInterface

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/gatewayparameters.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/gatewayparameters.go
@@ -5,13 +5,14 @@ package v1alpha1
 import (
 	"context"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 )
 
 // GatewayParametersesGetter has a method to return a GatewayParametersInterface.

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/httplistenerpolicy.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/httplistenerpolicy.go
@@ -5,13 +5,14 @@ package v1alpha1
 import (
 	"context"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 )
 
 // HttpListenerPoliciesGetter has a method to return a HttpListenerPolicyInterface.

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/listenerpolicy.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/listenerpolicy.go
@@ -5,13 +5,14 @@ package v1alpha1
 import (
 	"context"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 )
 
 // ListenerPoliciesGetter has a method to return a ListenerPolicyInterface.

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/routepolicy.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/routepolicy.go
@@ -5,13 +5,14 @@ package v1alpha1
 import (
 	"context"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 )
 
 // RoutePoliciesGetter has a method to return a RoutePolicyInterface.

--- a/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/upstream.go
+++ b/projects/gateway2/pkg/client/clientset/versioned/typed/api/v1alpha1/upstream.go
@@ -5,13 +5,14 @@ package v1alpha1
 import (
 	"context"
 
-	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
-	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
-	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	gentype "k8s.io/client-go/gentype"
+
+	apiv1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/applyconfiguration/api/v1alpha1"
+	v1alpha1 "github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
+	scheme "github.com/kgateway-dev/kgateway/projects/gateway2/pkg/client/clientset/versioned/scheme"
 )
 
 // UpstreamsGetter has a method to return a UpstreamInterface.

--- a/projects/gateway2/plugins/stages.go
+++ b/projects/gateway2/plugins/stages.go
@@ -8,10 +8,11 @@ import (
 
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/filters"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/filters"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 )
 
 var (

--- a/projects/gateway2/proxy_syncer/cla.go
+++ b/projects/gateway2/proxy_syncer/cla.go
@@ -5,10 +5,11 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"go.uber.org/zap"
 	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 func prioritize(ep ir.EndpointsForUpstream) *envoy_config_endpoint_v3.ClusterLoadAssignment {

--- a/projects/gateway2/proxy_syncer/cla_test.go
+++ b/projects/gateway2/proxy_syncer/cla_test.go
@@ -5,10 +5,11 @@ import (
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/endpoints"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/endpoints"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 )
 
 func TestTranslatesDestrulesFailoverPriority(t *testing.T) {

--- a/projects/gateway2/proxy_syncer/perclient.go
+++ b/projects/gateway2/proxy_syncer/perclient.go
@@ -5,10 +5,11 @@ import (
 
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"go.uber.org/zap"
 	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 func snapshotPerClient(

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -19,6 +19,14 @@ import (
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/solo-io/go-utils/contextutils"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
 	extensions "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
@@ -32,13 +40,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
-	"github.com/solo-io/go-utils/contextutils"
-	"google.golang.org/protobuf/proto"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 const gatewayV1A2Version = "v1alpha2"

--- a/projects/gateway2/proxy_syncer/upstreams.go
+++ b/projects/gateway2/proxy_syncer/upstreams.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/solo-io/go-utils/contextutils"
+	"go.uber.org/zap"
+	"istio.io/istio/pkg/kube/krt"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/irtranslator"
 	ggv2utils "github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	"github.com/solo-io/go-utils/contextutils"
-	"go.uber.org/zap"
-	"istio.io/istio/pkg/kube/krt"
 )
 
 type uccWithCluster struct {

--- a/projects/gateway2/proxy_syncer/xdswrapper.go
+++ b/projects/gateway2/proxy_syncer/xdswrapper.go
@@ -7,6 +7,7 @@ import (
 	udpaannontations "github.com/cncf/xds/go/udpa/annotations"
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 

--- a/projects/gateway2/proxy_syncer/xdswrapper_test.go
+++ b/projects/gateway2/proxy_syncer/xdswrapper_test.go
@@ -8,10 +8,11 @@ import (
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	. "github.com/kgateway-dev/kgateway/projects/gateway2/proxy_syncer"
 	"github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	. "github.com/kgateway-dev/kgateway/projects/gateway2/proxy_syncer"
 )
 
 func mustAny(src proto.Message) *anypb.Any {

--- a/projects/gateway2/query/mocks/mock_queries.go
+++ b/projects/gateway2/query/mocks/mock_queries.go
@@ -9,11 +9,12 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	ir "github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	query "github.com/kgateway-dev/kgateway/projects/gateway2/query"
 	krt "istio.io/istio/pkg/kube/krt"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	ir "github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	query "github.com/kgateway-dev/kgateway/projects/gateway2/query"
 )
 
 // MockGatewayQueries is a mock of GatewayQueries interface.

--- a/projects/gateway2/query/query_test.go
+++ b/projects/gateway2/query/query_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/pkg/schemes"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
+
+	"github.com/kgateway-dev/kgateway/pkg/schemes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +24,9 @@ import (
 	apiv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	apiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 
 	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/query"

--- a/projects/gateway2/query/utils.go
+++ b/projects/gateway2/query/utils.go
@@ -3,11 +3,12 @@ package query
 import (
 	"errors"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
 )
 
 func ProcessBackendError(err error, reporter reports.ParentRefReporter) {

--- a/projects/gateway2/setup/controlplane.go
+++ b/projects/gateway2/setup/controlplane.go
@@ -13,11 +13,12 @@ import (
 	xdsserver "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/xds"
 )
 
 func NewControlPlane(

--- a/projects/gateway2/setup/ggv2setup.go
+++ b/projects/gateway2/setup/ggv2setup.go
@@ -8,15 +8,6 @@ import (
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	xdsserver "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/go-logr/zapr"
-	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
-	"github.com/kgateway-dev/kgateway/pkg/utils/namespaces"
-	"github.com/kgateway-dev/kgateway/pkg/version"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
-	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -27,6 +18,16 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	zaputil "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/pkg/utils/namespaces"
+	"github.com/kgateway-dev/kgateway/pkg/version"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
+	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 const (

--- a/projects/gateway2/setup/ggv2setup_test.go
+++ b/projects/gateway2/setup/ggv2setup_test.go
@@ -30,10 +30,6 @@ import (
 
 	discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/go-logr/zapr"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/proxy_syncer"
-	ggv2setup "github.com/kgateway-dev/kgateway/projects/gateway2/setup"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -48,6 +44,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/controller"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/proxy_syncer"
+	ggv2setup "github.com/kgateway-dev/kgateway/projects/gateway2/setup"
 )
 
 func getAssetsDir(t *testing.T) string {

--- a/projects/gateway2/translator/backendref/types.go
+++ b/projects/gateway2/translator/backendref/types.go
@@ -3,8 +3,9 @@ package backendref
 import (
 	"fmt"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 )
 
 // RefIsHTTPRoute checks if the BackendObjectReference is an HTTPRoute

--- a/projects/gateway2/translator/gateway/gateway_translator.go
+++ b/projects/gateway2/translator/gateway/gateway_translator.go
@@ -3,17 +3,19 @@ package gateway
 import (
 	"context"
 
+	"github.com/solo-io/go-utils/contextutils"
+	"istio.io/istio/pkg/kube/krt"
+
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
-	"github.com/solo-io/go-utils/contextutils"
-	"istio.io/istio/pkg/kube/krt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/projects/gateway2/query"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/listener"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func NewTranslator(queries query.GatewayQueries) extensionsplug.KGwTranslator {

--- a/projects/gateway2/translator/gateway/testtest_test.go
+++ b/projects/gateway2/translator/gateway/testtest_test.go
@@ -17,8 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 	"istio.io/istio/pkg/kube/kclient/clienttest"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
 )
 
 func xTestRun(t *testing.T) {

--- a/projects/gateway2/translator/gateway/testutils/test_file_loader.go
+++ b/projects/gateway2/translator/gateway/testutils/test_file_loader.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/kgateway-dev/kgateway/pkg/schemes"
 
+	"github.com/rotisserie/eris"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/protoutils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/irtranslator"
-	"github.com/rotisserie/eris"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"

--- a/projects/gateway2/translator/gateway/translator_case_test.go
+++ b/projects/gateway2/translator/gateway/translator_case_test.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	"istio.io/istio/pkg/kube/krt"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
@@ -33,8 +36,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/gateway/testutils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/irtranslator"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils/krtutil"
-	"istio.io/istio/pkg/kube/kclient/clienttest"
-	"istio.io/istio/pkg/kube/krt"
 )
 
 type TestCase struct {

--- a/projects/gateway2/translator/httproute/delegation.go
+++ b/projects/gateway2/translator/httproute/delegation.go
@@ -12,12 +12,13 @@ import (
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/contextutils"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/query"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	"github.com/rotisserie/eris"
-	"github.com/solo-io/go-utils/contextutils"
 )
 
 type DelegationCtx struct {

--- a/projects/gateway2/translator/httproute/delegation_helpers.go
+++ b/projects/gateway2/translator/httproute/delegation_helpers.go
@@ -6,12 +6,13 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/query"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/query"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 )
 
 // inheritMatcherAnnotation is the annotation used on an child HTTPRoute that

--- a/projects/gateway2/translator/httproute/delegation_test.go
+++ b/projects/gateway2/translator/httproute/delegation_test.go
@@ -3,11 +3,12 @@ package httproute
 import (
 	"testing"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 )
 
 func TestIsDelegatedRouteMatch(t *testing.T) {

--- a/projects/gateway2/translator/httproute/gateway_http_route_translator.go
+++ b/projects/gateway2/translator/httproute/gateway_http_route_translator.go
@@ -4,13 +4,14 @@ import (
 	"container/list"
 	"context"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 
 	"github.com/kgateway-dev/kgateway/projects/gateway2/query"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"

--- a/projects/gateway2/translator/irtranslator/fc.go
+++ b/projects/gateway2/translator/irtranslator/fc.go
@@ -17,15 +17,16 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	envoy_tls_inspector "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	"github.com/solo-io/go-utils/contextutils"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/plugins"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 )
 
 const (

--- a/projects/gateway2/translator/irtranslator/gateway.go
+++ b/projects/gateway2/translator/irtranslator/gateway.go
@@ -4,11 +4,12 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
-	"golang.org/x/net/context"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type Translator struct {

--- a/projects/gateway2/translator/irtranslator/route.go
+++ b/projects/gateway2/translator/irtranslator/route.go
@@ -9,16 +9,17 @@ import (
 
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	"github.com/kgateway-dev/kgateway/pkg/utils/regexutils"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/routeutils"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/regexutils"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/routeutils"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 )
 
 type httpRouteConfigurationTranslator struct {

--- a/projects/gateway2/translator/irtranslator/upstream.go
+++ b/projects/gateway2/translator/irtranslator/upstream.go
@@ -10,9 +10,10 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"istio.io/istio/pkg/kube/krt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (

--- a/projects/gateway2/translator/listener/gateway_listener_translator.go
+++ b/projects/gateway2/translator/listener/gateway_listener_translator.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/krtcollections"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ports"
@@ -25,7 +27,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/routeutils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/sslutils"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // TranslateListeners translates the set of gloo listeners required to produce a full output proxy (either form one Gateway or multiple merged Gateways)

--- a/projects/gateway2/translator/listener/validation.go
+++ b/projects/gateway2/translator/listener/validation.go
@@ -3,11 +3,12 @@ package listener
 import (
 	"slices"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/reports"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const NormalizedHTTPSTLSType = "HTTPS/TLS"

--- a/projects/gateway2/translator/routeutils/sortable_route.go
+++ b/projects/gateway2/translator/routeutils/sortable_route.go
@@ -1,11 +1,12 @@
 package routeutils
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 )
 
 type SortableRoute struct {

--- a/projects/gateway2/translator/routeutils/sortable_route_test.go
+++ b/projects/gateway2/translator/routeutils/sortable_route_test.go
@@ -1,12 +1,13 @@
 package routeutils
 
 import (
-	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/ir"
 )
 
 func defaultMatcher() gwv1.HTTPRouteMatch {

--- a/projects/gateway2/translator/translator.go
+++ b/projects/gateway2/translator/translator.go
@@ -10,6 +10,10 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/solo-io/go-utils/contextutils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway2/endpoints"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/common"
 	extensionsplug "github.com/kgateway-dev/kgateway/projects/gateway2/extensions2/plugin"
@@ -20,9 +24,6 @@ import (
 	gwtranslator "github.com/kgateway-dev/kgateway/projects/gateway2/translator/gateway"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/translator/irtranslator"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/utils"
-	"github.com/solo-io/go-utils/contextutils"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // Combines all the translators needed for xDS translation.

--- a/projects/gateway2/utils/queue_test.go
+++ b/projects/gateway2/utils/queue_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kgateway-dev/kgateway/projects/gateway2/utils"
 )
 
 type testType struct {

--- a/projects/gateway2/xds/utils.go
+++ b/projects/gateway2/xds/utils.go
@@ -6,8 +6,9 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/wellknown"
 )
 
 var _ cache.NodeHash = new(nodeRoleHasher)

--- a/projects/sds/pkg/run/run.go
+++ b/projects/sds/pkg/run/run.go
@@ -10,8 +10,9 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/zap"
 
-	"github.com/kgateway-dev/kgateway/projects/sds/pkg/server"
 	"github.com/solo-io/go-utils/contextutils"
+
+	"github.com/kgateway-dev/kgateway/projects/sds/pkg/server"
 )
 
 func Run(ctx context.Context, secrets []server.Secret, sdsClient, sdsServerAddress string) error {

--- a/projects/sds/pkg/run/run_e2e_test.go
+++ b/projects/sds/pkg/run/run_e2e_test.go
@@ -8,11 +8,12 @@ import (
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_service_secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	"github.com/spf13/afero"
+	"google.golang.org/grpc"
+
 	"github.com/kgateway-dev/kgateway/projects/sds/pkg/run"
 	"github.com/kgateway-dev/kgateway/projects/sds/pkg/server"
 	"github.com/kgateway-dev/kgateway/projects/sds/pkg/testutils"
-	"github.com/spf13/afero"
-	"google.golang.org/grpc"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/projects/sds/pkg/run/run_main.go
+++ b/projects/sds/pkg/run/run_main.go
@@ -10,10 +10,11 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/kgateway-dev/kgateway/pkg/version"
-	"github.com/kgateway-dev/kgateway/projects/sds/pkg/server"
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/go-utils/stats"
+
+	"github.com/kgateway-dev/kgateway/pkg/version"
+	"github.com/kgateway-dev/kgateway/projects/sds/pkg/server"
 )
 
 var (

--- a/projects/sds/pkg/server/server_test.go
+++ b/projects/sds/pkg/server/server_test.go
@@ -8,12 +8,13 @@ import (
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_service_secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
-	"github.com/kgateway-dev/kgateway/projects/sds/pkg/server"
-	"github.com/kgateway-dev/kgateway/projects/sds/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 	"google.golang.org/grpc"
+
+	"github.com/kgateway-dev/kgateway/projects/sds/pkg/server"
+	"github.com/kgateway-dev/kgateway/projects/sds/pkg/testutils"
 )
 
 var _ = Describe("SDS Server", func() {

--- a/test/aws_credentials/ec2_test.go
+++ b/test/aws_credentials/ec2_test.go
@@ -5,19 +5,22 @@ package aws_credentials
 import (
 	"context"
 
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 
+	"github.com/kgateway-dev/kgateway/test/testutils"
+
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/plugins/aws/ec2"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/plugins/aws/ec2"
+
 	ec2api "github.com/aws/aws-sdk-go/service/ec2"
 
-	glooec2 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/aws/ec2"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	glooec2 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/aws/ec2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/debugprint/debug_print_resource.go
+++ b/test/debugprint/debug_print_resource.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/kgateway-dev/kgateway/pkg/utils/protoutils"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"sigs.k8s.io/yaml"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/protoutils"
 )
 
 func PrintYaml(ress ...proto.Message) {

--- a/test/e2e/aggregate_listener_test.go
+++ b/test/e2e/aggregate_listener_test.go
@@ -11,17 +11,19 @@ import (
 	"github.com/kgateway-dev/kgateway/test/e2e"
 
 	"github.com/golang/protobuf/ptypes/duration"
+
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/selectors"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 var _ = Describe("Aggregate Listener", func() {

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -14,18 +14,20 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/testutils"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 
+	"github.com/kgateway-dev/kgateway/test/helpers"
+
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	glooec2 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/aws/ec2"
-	"github.com/kgateway-dev/kgateway/test/services"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	glooec2 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/aws/ec2"
+	"github.com/kgateway-dev/kgateway/test/services"
 )
 
 /*

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -23,24 +23,27 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/form3tech-oss/jwt-go"
-	aws2 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/extensions/aws"
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	aws2 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/extensions/aws"
+	"github.com/kgateway-dev/kgateway/test/helpers"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 
 	"github.com/kgateway-dev/kgateway/test/services"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gw1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gwdefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
 	aws_plugin "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/aws"

--- a/test/e2e/buffer_test.go
+++ b/test/e2e/buffer_test.go
@@ -11,15 +11,17 @@ import (
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	"github.com/kgateway-dev/kgateway/test/helpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	buffer "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/extensions/filters/http/buffer/v3"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("buffer", func() {

--- a/test/e2e/connection_limit_test.go
+++ b/test/e2e/connection_limit_test.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/solo-io/solo-kit/pkg/utils/prototime"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
@@ -15,8 +18,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	"github.com/solo-io/solo-kit/pkg/utils/prototime"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kgateway-dev/kgateway/test/ginkgo/decorators"
 
 	"github.com/golang/protobuf/ptypes/duration"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
@@ -18,13 +19,15 @@ import (
 
 	consulplugin "github.com/kgateway-dev/kgateway/projects/gloo/pkg/plugins/consul"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/hashicorp/consul/api"
+
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	consulapi "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/consul"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/upstreams/consul"

--- a/test/e2e/cors_test.go
+++ b/test/e2e/cors_test.go
@@ -10,13 +10,15 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
-	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
-	"github.com/kgateway-dev/kgateway/test/e2e"
-	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/test/e2e"
+	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
+
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/cors"
 )

--- a/test/e2e/csrf_test.go
+++ b/test/e2e/csrf_test.go
@@ -13,11 +13,14 @@ import (
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	"github.com/kgateway-dev/kgateway/test/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/types"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
@@ -27,7 +30,6 @@ import (
 	glootype "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/type/v3"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
-	"github.com/onsi/gomega/types"
 )
 
 const (

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -10,12 +10,20 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/services/envoy"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"github.com/gogo/googleapis/google/rpc"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
+
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
 	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
@@ -23,12 +31,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc"
 )
 
 var _ = Describe("CustomAuth", func() {

--- a/test/e2e/dns_test.go
+++ b/test/e2e/dns_test.go
@@ -8,10 +8,11 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	"github.com/kgateway-dev/kgateway/test/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/test/e2e"
 )
 
 var _ = Describe("DNS E2E Test", func() {

--- a/test/e2e/dynamic_forward_proxy_test.go
+++ b/test/e2e/dynamic_forward_proxy_test.go
@@ -18,10 +18,11 @@ import (
 
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/transformation"
 
-	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 )
 
 var _ = Describe("dynamic forward proxy", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -15,9 +15,10 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/solo-kit/test/helpers"
+
+	"github.com/kgateway-dev/kgateway/test/services"
 
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 )

--- a/test/e2e/example_test.go
+++ b/test/e2e/example_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Example E2E Test For Developers", Label(), func() {

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -12,12 +12,13 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/e2e"
 
-	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	fault "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/faultinjection"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/utils/prototime"
+
+	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	fault "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/faultinjection"
 )
 
 var _ = Describe("Fault Injection", func() {

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -14,6 +14,16 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/common/kubernetes"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"github.com/solo-io/solo-kit/pkg/errors"
+	"github.com/solo-io/solo-kit/pkg/utils/kubeutils"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/statsutils/metrics"
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
@@ -27,15 +37,6 @@ import (
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/common/kubernetes"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"github.com/solo-io/solo-kit/pkg/errors"
-	"github.com/solo-io/solo-kit/pkg/utils/kubeutils"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/test/e2e/grpc_discovery_test.go
+++ b/test/e2e/grpc_discovery_test.go
@@ -17,11 +17,12 @@ import (
 	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/kgateway-dev/kgateway/test/services"
-	"github.com/kgateway-dev/kgateway/test/v1helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/kgateway-dev/kgateway/test/services"
+	"github.com/kgateway-dev/kgateway/test/v1helpers"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"

--- a/test/e2e/grpc_json_test.go
+++ b/test/e2e/grpc_json_test.go
@@ -12,12 +12,19 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/services/envoy"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 
 	"github.com/onsi/gomega/format"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gwdefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
@@ -25,11 +32,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/grpc_json"
 	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"

--- a/test/e2e/grpc_plugin_test.go
+++ b/test/e2e/grpc_plugin_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gwdefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
@@ -28,8 +31,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/e2e/gzip_test.go
+++ b/test/e2e/gzip_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/kgateway-dev/kgateway/test/e2e"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	gloogzip "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/config/filter/http/gzip/v2"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	gloogzip "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/config/filter/http/gzip/v2"
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 )
 
 var _ = Describe("gzip", func() {

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -17,6 +17,12 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	errors "github.com/rotisserie/eris"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
@@ -29,11 +35,6 @@ import (
 	testhelpers "github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	errors "github.com/rotisserie/eris"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 var _ = Describe("Happy path", func() {

--- a/test/e2e/header_validation_test.go
+++ b/test/e2e/header_validation_test.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	header_validation "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/header_validation"
 	"github.com/kgateway-dev/kgateway/test/e2e"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Header Validation", Label(), func() {

--- a/test/e2e/headers_test.go
+++ b/test/e2e/headers_test.go
@@ -16,6 +16,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	envoycore_sk "github.com/solo-io/solo-kit/pkg/api/external/envoy/api/v2/core"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	coreV1 "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/api_conversion"
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
@@ -31,11 +37,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/services/envoy"
 	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	envoycore_sk "github.com/solo-io/solo-kit/pkg/api/external/envoy/api/v2/core"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	coreV1 "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 var _ = Describe("HeaderManipulation", func() {

--- a/test/e2e/health_checks_test.go
+++ b/test/e2e/health_checks_test.go
@@ -13,21 +13,28 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/services/envoy"
 
-	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 
 	"github.com/kgateway-dev/kgateway/test/testutils"
 
 	v3 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/config/core/v3"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/golang/protobuf/ptypes/duration"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/api_conversion"
 	gwdefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
@@ -36,10 +43,6 @@ import (
 	. "github.com/kgateway-dev/kgateway/test/gomega"
 	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 )
 
 var _ = Describe("Health Checks", func() {

--- a/test/e2e/http_tunneling_test.go
+++ b/test/e2e/http_tunneling_test.go
@@ -29,20 +29,22 @@ import (
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
 	static_plugin_gloo "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
 	testhelpers "github.com/kgateway-dev/kgateway/test/helpers"
 
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	"github.com/kgateway-dev/kgateway/test/services"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/test/services"
 )
 
 var _ = Describe("tunneling", func() {

--- a/test/e2e/hybrid_test.go
+++ b/test/e2e/hybrid_test.go
@@ -12,13 +12,17 @@ import (
 
 	"math/rand"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
+	"github.com/kgateway-dev/kgateway/test/testutils"
+
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	v3 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/config/core/v3"
@@ -27,8 +31,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/proxy_protocol"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
 	"github.com/kgateway-dev/kgateway/test/e2e"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 type ClientConnectionProperties struct {

--- a/test/e2e/loadbalancer_plugin_test.go
+++ b/test/e2e/loadbalancer_plugin_test.go
@@ -8,12 +8,13 @@ import (
 
 	envoy_admin_v3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	glooV1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	"github.com/kgateway-dev/kgateway/test/helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 // setupLBPluginTest sets up a test context with a virtual service that uses the provided load balancer config

--- a/test/e2e/local_ratelimit_test.go
+++ b/test/e2e/local_ratelimit_test.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
@@ -16,8 +19,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/e2e/proxy_protocol_test.go
+++ b/test/e2e/proxy_protocol_test.go
@@ -10,15 +10,16 @@ import (
 	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 var (

--- a/test/e2e/ratelimit_test.go
+++ b/test/e2e/ratelimit_test.go
@@ -20,13 +20,6 @@ import (
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
-	gloov1static "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
-	"github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/kgateway-dev/kgateway/test/services"
-	"github.com/kgateway-dev/kgateway/test/v1helpers"
 	"github.com/solo-io/go-utils/contextutils"
 	rltypes "github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -34,6 +27,14 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
+	gloov1static "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
+	"github.com/kgateway-dev/kgateway/test/helpers"
+	"github.com/kgateway-dev/kgateway/test/services"
+	"github.com/kgateway-dev/kgateway/test/v1helpers"
 )
 
 type acceptOrDenyRateLimitServer struct {

--- a/test/e2e/route_transformation_test.go
+++ b/test/e2e/route_transformation_test.go
@@ -6,17 +6,19 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/kgateway-dev/kgateway/test/testutils"
+
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/onsi/gomega/gstruct"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/test/gomega/transforms"
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	"github.com/onsi/gomega/gstruct"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/e2e/staged_transformation_test.go
+++ b/test/e2e/staged_transformation_test.go
@@ -6,26 +6,29 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/kgateway-dev/kgateway/test/testutils"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	extauthv1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 	gloov1static "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
 	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	"net/http"
 
-	"github.com/kgateway-dev/kgateway/test/e2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/e2e"
 
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"

--- a/test/e2e/tcp_stats_test.go
+++ b/test/e2e/tcp_stats_test.go
@@ -8,15 +8,16 @@ import (
 	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 var _ = Describe("TCP Stats transport_socket", func() {

--- a/test/e2e/test_context.go
+++ b/test/e2e/test_context.go
@@ -14,6 +14,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
@@ -22,9 +26,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/services"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 )
 
 const (

--- a/test/e2e/tls_ocsp_test.go
+++ b/test/e2e/tls_ocsp_test.go
@@ -6,6 +6,11 @@ import (
 	"net/http"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"golang.org/x/crypto/ocsp"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
@@ -14,10 +19,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"golang.org/x/crypto/ocsp"
 )
 
 var _ = Describe("TLS OCSP e2e", func() {

--- a/test/e2e/vault_aws_test.go
+++ b/test/e2e/vault_aws_test.go
@@ -6,6 +6,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"go.opencensus.io/stats/view"
+
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 	bootstrap "github.com/kgateway-dev/kgateway/projects/gloo/pkg/bootstrap/clients"
@@ -14,11 +20,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/ginkgo/decorators"
 	"github.com/kgateway-dev/kgateway/test/gomega/assertions"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"go.opencensus.io/stats/view"
 )
 
 const (

--- a/test/e2e/vault_test.go
+++ b/test/e2e/vault_test.go
@@ -3,6 +3,9 @@
 package e2e_test
 
 import (
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 	bootstrap "github.com/kgateway-dev/kgateway/projects/gloo/pkg/bootstrap/clients"
@@ -10,8 +13,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/e2e"
 	"github.com/kgateway-dev/kgateway/test/ginkgo/decorators"
 	"github.com/kgateway-dev/kgateway/test/services"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/e2e/zipkin_test.go
+++ b/test/e2e/zipkin_test.go
@@ -15,10 +15,14 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/testutils"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/hcm"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/translator"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
@@ -28,12 +32,11 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/tracing"
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/v1helpers"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
-	. "github.com/kgateway-dev/kgateway/test/gomega"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kgateway-dev/kgateway/test/gomega"
 
 	"github.com/kgateway-dev/kgateway/test/services"
 )

--- a/test/ginkgo/parallel/ports_test.go
+++ b/test/ginkgo/parallel/ports_test.go
@@ -6,10 +6,11 @@ import (
 	"net"
 
 	"github.com/avast/retry-go"
-	"github.com/kgateway-dev/kgateway/test/ginkgo/parallel"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rotisserie/eris"
+
+	"github.com/kgateway-dev/kgateway/test/ginkgo/parallel"
 )
 
 var _ = Describe("Ports", func() {

--- a/test/gomega/assertions/goroutines.go
+++ b/test/gomega/assertions/goroutines.go
@@ -5,10 +5,11 @@ package assertions
 import (
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gleak"
 	"github.com/onsi/gomega/types"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 )
 
 // GoRoutineMonitor is a helper for monitoring goroutine leaks in tests

--- a/test/gomega/assertions/goroutines_test.go
+++ b/test/gomega/assertions/goroutines_test.go
@@ -5,11 +5,12 @@ package assertions_test
 import (
 	"context"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/assertions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gleak"
 	"github.com/onsi/gomega/types"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/assertions"
 )
 
 var _ = Describe("GoRoutineMonitor", func() {

--- a/test/gomega/assertions/logging.go
+++ b/test/gomega/assertions/logging.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/testutils"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/solo-io/go-utils/stats"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 // LogLevelAssertion returns an Assertion to verify that the dynamic log level matches the provided value

--- a/test/gomega/assertions/stats.go
+++ b/test/gomega/assertions/stats.go
@@ -18,11 +18,12 @@ import (
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/test/gomega/transforms"
 
-	"github.com/kgateway-dev/kgateway/pkg/cliutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/solo-io/go-utils/stats"
+
+	"github.com/kgateway-dev/kgateway/pkg/cliutil"
 )
 
 // Gloo Edge exports statistics to provide details about how the system is behaving

--- a/test/gomega/matchers/benchmark_test.go
+++ b/test/gomega/matchers/benchmark_test.go
@@ -6,9 +6,10 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var _ = Describe("Benchmark", func() {

--- a/test/gomega/matchers/contain_headers.go
+++ b/test/gomega/matchers/contain_headers.go
@@ -6,10 +6,11 @@ import (
 	"net/http"
 	"net/textproto"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/transforms"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/transforms"
 )
 
 // ContainHeaders produces a matcher that will only match if all provided headers

--- a/test/gomega/matchers/contain_headers_test.go
+++ b/test/gomega/matchers/contain_headers_test.go
@@ -5,9 +5,10 @@ package matchers_test
 import (
 	"net/http"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var _ = Describe("ContainHeaders", func() {

--- a/test/gomega/matchers/contain_map_elements_test.go
+++ b/test/gomega/matchers/contain_map_elements_test.go
@@ -3,9 +3,10 @@
 package matchers_test
 
 import (
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var _ = Describe("ContainMapElements", func() {

--- a/test/gomega/matchers/contain_substrings_test.go
+++ b/test/gomega/matchers/contain_substrings_test.go
@@ -3,9 +3,10 @@
 package matchers_test
 
 import (
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var _ = Describe("ContainSubstrings", func() {

--- a/test/gomega/matchers/custom_resource_test.go
+++ b/test/gomega/matchers/custom_resource_test.go
@@ -3,9 +3,6 @@
 package matchers_test
 
 import (
-	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -13,6 +10,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+
+	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var _ = Describe("CustomResource", func() {

--- a/test/gomega/matchers/json_contains_test.go
+++ b/test/gomega/matchers/json_contains_test.go
@@ -3,9 +3,10 @@
 package matchers_test
 
 import (
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var _ = Describe("JSON", func() {

--- a/test/gomega/transforms/curl_test.go
+++ b/test/gomega/transforms/curl_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 	"github.com/kgateway-dev/kgateway/test/gomega/transforms"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/onsi/gomega/gstruct"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/helpers/certs.go
+++ b/test/helpers/certs.go
@@ -21,9 +21,10 @@ import (
 	"sync"
 	"time"
 
-	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	corev1 "k8s.io/api/core/v1"
+
+	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 
 	"golang.org/x/crypto/ocsp"
 

--- a/test/helpers/default_gateways.go
+++ b/test/helpers/default_gateways.go
@@ -3,9 +3,10 @@
 package helpers
 
 import (
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 )
 
 func WriteDefaultGateways(writeNamespace string, gatewayClient v1.GatewayClient) error {

--- a/test/helpers/glooctl_debug_dump.go
+++ b/test/helpers/glooctl_debug_dump.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kgateway-dev/kgateway/pkg/cliutil"
 	"github.com/solo-io/go-utils/testutils"
+
+	"github.com/kgateway-dev/kgateway/pkg/cliutil"
 )
 
 func RegisterGlooDebugLogPrintHandlerAndClearLogs() {

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/onsi/ginkgo/v2"
 
+	"github.com/solo-io/go-utils/threadsafe"
+
 	"github.com/kgateway-dev/kgateway/pkg/cliutil/install"
 	"github.com/kgateway-dev/kgateway/pkg/utils/envoyutils/admincli"
 	glooAdminCli "github.com/kgateway-dev/kgateway/pkg/utils/glooadminutils/admincli"
@@ -23,7 +25,6 @@ import (
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/portforward"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
-	"github.com/solo-io/go-utils/threadsafe"
 )
 
 // StandardGlooDumpOnFail creates adump of the kubernetes state and certain envoy data from

--- a/test/helpers/resources.go
+++ b/test/helpers/resources.go
@@ -5,8 +5,9 @@ package helpers
 import (
 	"time"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/statusutils"
 	"github.com/onsi/gomega/types"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/statusutils"
 
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 

--- a/test/helpers/route_tables.go
+++ b/test/helpers/route_tables.go
@@ -4,8 +4,9 @@ package helpers
 
 import (
 	"github.com/golang/protobuf/proto"
-	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 )
 
 // RouteTableBuilder simplifies the process of generating RouteTables in tests

--- a/test/helpers/routes.go
+++ b/test/helpers/routes.go
@@ -4,10 +4,11 @@ package helpers
 
 import (
 	"github.com/golang/protobuf/proto"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 const (

--- a/test/helpers/scaled_snapshots.go
+++ b/test/helpers/scaled_snapshots.go
@@ -12,12 +12,13 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	v3 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/external/envoy/config/core/v3"
 	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
 	v1static "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 // ScaledSnapshotBuilder enumerates the number of each type of resource that should be included in a snapshot and

--- a/test/helpers/scaled_snapshots_test.go
+++ b/test/helpers/scaled_snapshots_test.go
@@ -3,12 +3,13 @@
 package helpers_test
 
 import (
-	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
+	"github.com/kgateway-dev/kgateway/test/helpers"
 )
 
 var _ = Describe("ScaledSnapshotBuilder", func() {

--- a/test/helpers/snapshot_writer.go
+++ b/test/helpers/snapshot_writer.go
@@ -5,13 +5,15 @@ package helpers
 import (
 	"time"
 
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 	"github.com/onsi/ginkgo/v2"
 
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
+
 	"github.com/avast/retry-go"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/errors"
+
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
 )
 
 var _ SnapshotWriter = new(SnapshotWriterImpl)

--- a/test/helpers/upstreams_test.go
+++ b/test/helpers/upstreams_test.go
@@ -3,9 +3,10 @@
 package helpers_test
 
 import (
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 )
 
 var _ = Describe("UpstreamBuilder", func() {

--- a/test/helpers/util.go
+++ b/test/helpers/util.go
@@ -8,12 +8,13 @@ import (
 	"math"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	skerrors "github.com/solo-io/solo-kit/pkg/errors"
+
+	"github.com/kgateway-dev/kgateway/test/gomega"
 )
 
 // PatchResource mutates an existing persisted resource, retrying if a resourceVersionError is encountered

--- a/test/helpers/util_test.go
+++ b/test/helpers/util_test.go
@@ -5,10 +5,11 @@ package helpers_test
 import (
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/gomega"
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/gomega"
+	"github.com/kgateway-dev/kgateway/test/helpers"
 )
 
 var _ = Describe("PercentileIndex", func() {

--- a/test/helpers/virtual_services.go
+++ b/test/helpers/virtual_services.go
@@ -6,12 +6,13 @@ import (
 	"errors"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 // VirtualServiceBuilder simplifies the process of generating VirtualServices in tests

--- a/test/helpers/virtual_services_test.go
+++ b/test/helpers/virtual_services_test.go
@@ -5,15 +5,16 @@ package helpers_test
 import (
 	"hash"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/test/matchers"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/cors"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
 	"github.com/kgateway-dev/kgateway/test/gomega/assertions"
 	"github.com/kgateway-dev/kgateway/test/helpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/test/matchers"
 )
 
 var _ = Describe("VirtualServiceBuilder", func() {

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/cluster"
 	"github.com/solo-io/skv2/codegen/util"
+
+	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/cluster"
 
 	kubetestclients "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/clients"
 
@@ -22,11 +23,12 @@ import (
 
 	gloodefaults "github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 
+	skhelpers "github.com/solo-io/solo-kit/test/helpers"
+
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/kube2e"
 	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	testruntime "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/runtime"
-	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -22,14 +22,28 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/utils"
 
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/grpc/debug"
 	"google.golang.org/grpc"
+
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/grpc/debug"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/wrappers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"sigs.k8s.io/yaml"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
@@ -47,18 +61,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/kube2e"
 	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/rotisserie/eris"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("Kube2e: gateway", func() {

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
 
@@ -29,14 +30,13 @@ import (
 
 	testutils "github.com/solo-io/k8s-utils/testutils/kube"
 
-	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
+	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
+
 	"k8s.io/apimachinery/pkg/labels"
 
-	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,6 +44,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 )
 
 var _ = Describe("Robustness tests", func() {

--- a/test/kube2e/gloo/bootstrap_clients_test.go
+++ b/test/kube2e/gloo/bootstrap_clients_test.go
@@ -22,24 +22,27 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/hashicorp/consul/api"
-	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
-	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	vault_client "github.com/kgateway-dev/kgateway/projects/gloo/pkg/bootstrap/clients/vault"
-	"github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/kgateway-dev/kgateway/test/services"
 	skclients "github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	corecache "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 
-	. "github.com/kgateway-dev/kgateway/test/gomega"
+	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
+	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	vault_client "github.com/kgateway-dev/kgateway/projects/gloo/pkg/bootstrap/clients/vault"
+	"github.com/kgateway-dev/kgateway/test/helpers"
+	"github.com/kgateway-dev/kgateway/test/services"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	. "github.com/kgateway-dev/kgateway/test/gomega"
+
 	vaultapi "github.com/hashicorp/vault/api"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/bootstrap/clients"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/bootstrap/clients"
 )
 
 // Kubernetes tests for clients generated from projects/gloo/pkg/bootstrap/clients

--- a/test/kube2e/gloo/eds_test.go
+++ b/test/kube2e/gloo/eds_test.go
@@ -6,15 +6,16 @@ import (
 	"os/exec"
 
 	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/kube2e"
 	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 )

--- a/test/kube2e/gloo/generated_kube_types_test.go
+++ b/test/kube2e/gloo/generated_kube_types_test.go
@@ -3,12 +3,13 @@
 package gloo_test
 
 import (
-	kubetestclients "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/clients"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubetestclients "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/clients"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gatewayv1kubetypes "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"

--- a/test/kube2e/gloo/gloo_suite_test.go
+++ b/test/kube2e/gloo/gloo_suite_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/cluster"
 	"github.com/solo-io/skv2/codegen/util"
+
+	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/cluster"
 
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 
@@ -21,13 +22,14 @@ import (
 
 	"github.com/kgateway-dev/kgateway/test/services"
 
+	"github.com/solo-io/go-utils/testutils"
+
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/kube2e"
 	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	testruntime "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/runtime"
 	glootestutils "github.com/kgateway-dev/kgateway/test/testutils"
-	"github.com/solo-io/go-utils/testutils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/kube2e/gloo/happypath_test.go
+++ b/test/kube2e/gloo/happypath_test.go
@@ -9,15 +9,11 @@ import (
 
 	kubetestclients "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/clients"
 
-	"github.com/kgateway-dev/kgateway/test/services/envoy"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/kgateway-dev/kgateway/test/services/envoy"
+
 	"github.com/golang/protobuf/ptypes/wrappers"
-	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	testhelpers "github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/kgateway-dev/kgateway/test/services"
-	"github.com/kgateway-dev/kgateway/test/v1helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -27,6 +23,12 @@ import (
 	"github.com/solo-io/solo-kit/test/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	gatewaydefaults "github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	testhelpers "github.com/kgateway-dev/kgateway/test/helpers"
+	"github.com/kgateway-dev/kgateway/test/services"
+	"github.com/kgateway-dev/kgateway/test/v1helpers"
 )
 
 var _ = Describe("Happy path", func() {

--- a/test/kube2e/gloo/kubernetes_test.go
+++ b/test/kube2e/gloo/kubernetes_test.go
@@ -11,16 +11,17 @@ import (
 
 	"github.com/solo-io/solo-kit/test/helpers"
 
-	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	kubepluginapi "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/kubernetes"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/discovery"
-	kubeplugin "github.com/kgateway-dev/kgateway/projects/gloo/pkg/plugins/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	kubecache "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	kubepluginapi "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/kubernetes"
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/discovery"
+	kubeplugin "github.com/kgateway-dev/kgateway/projects/gloo/pkg/plugins/kubernetes"
 
 	"k8s.io/client-go/kubernetes"
 )

--- a/test/kube2e/gloo/setup_syncer_test.go
+++ b/test/kube2e/gloo/setup_syncer_test.go
@@ -20,19 +20,21 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/syncer/setup"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/xds"
 
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
+
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/grpc/validation"
-	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	"github.com/kgateway-dev/kgateway/test/kube2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 	"github.com/solo-io/solo-kit/pkg/utils/prototime"
 	"google.golang.org/grpc"
+
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/grpc/validation"
+	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/test/kube2e"
 )
 
 var _ = Describe("Setup Syncer", func() {

--- a/test/kube2e/gloo/snapshot_writer_test.go
+++ b/test/kube2e/gloo/snapshot_writer_test.go
@@ -4,18 +4,20 @@ package gloo_test
 
 import (
 	"github.com/google/uuid"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
-	"github.com/kgateway-dev/kgateway/test/kube2e"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/gloosnapshot"
+	"github.com/kgateway-dev/kgateway/test/kube2e"
 
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/test/helpers"
 
-	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+
+	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 )
 
 // This tests the gloo/test/helpers/snapshot_writer.go functionality in a Kubernetes cluster

--- a/test/kube2e/helper/curl.go
+++ b/test/kube2e/helper/curl.go
@@ -18,12 +18,13 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/types"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	"github.com/kgateway-dev/kgateway/test/gomega/transforms"
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/solo-io/go-utils/log"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	"github.com/kgateway-dev/kgateway/test/gomega/transforms"
+	"github.com/kgateway-dev/kgateway/test/helpers"
 )
 
 const (

--- a/test/kube2e/helper/install.go
+++ b/test/kube2e/helper/install.go
@@ -16,11 +16,12 @@ import (
 	"github.com/spf13/afero"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/testutils/exec"
 	"github.com/solo-io/k8s-utils/testutils/kube"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 )
 
 const (

--- a/test/kube2e/upgrade/upgrade_suite_test.go
+++ b/test/kube2e/upgrade/upgrade_suite_test.go
@@ -10,15 +10,17 @@ import (
 
 	"github.com/kgateway-dev/kgateway/pkg/utils/helmutils"
 
-	"github.com/kgateway-dev/kgateway/test/kube2e"
-	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/helper"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/go-utils/versionutils"
 	"github.com/solo-io/skv2/codegen/util"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
+	"github.com/kgateway-dev/kgateway/test/kube2e"
+	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/helper"
+
 	. "github.com/onsi/ginkgo/v2"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 )
 
 func TestUpgrade(t *testing.T) {

--- a/test/kube2e/upgrade/upgrade_test.go
+++ b/test/kube2e/upgrade/upgrade_test.go
@@ -13,24 +13,27 @@ import (
 	"strings"
 	"time"
 
+	"github.com/solo-io/skv2/codegen/util"
+
 	"github.com/kgateway-dev/kgateway/pkg/cliutil"
 	"github.com/kgateway-dev/kgateway/pkg/utils/helmutils"
-	"github.com/solo-io/skv2/codegen/util"
 
 	kubetestclients "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/clients"
 
-	"github.com/kgateway-dev/kgateway/projects/gloo/cli/pkg/helpers"
 	exec_utils "github.com/solo-io/go-utils/testutils/exec"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/kgateway-dev/kgateway/projects/gloo/cli/pkg/helpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/kgateway-dev/kgateway/projects/gloo/cli/pkg/cmd/version"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/test/kube2e"
 	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -10,6 +10,14 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	errors "github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/stats"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/fsutils"
 	"github.com/kgateway-dev/kgateway/projects/gloo/cli/pkg/cmd/check"
 	"github.com/kgateway-dev/kgateway/projects/gloo/cli/pkg/cmd/options"
@@ -20,13 +28,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	newhelper "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/helper"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	errors "github.com/rotisserie/eris"
-	"github.com/solo-io/go-utils/stats"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"go.uber.org/zap/zapcore"
 )
 
 const (

--- a/test/kubernetes/e2e/defaults/defaults.go
+++ b/test/kubernetes/e2e/defaults/defaults.go
@@ -8,8 +8,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 	"github.com/solo-io/skv2/codegen/util"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 )
 
 var (

--- a/test/kubernetes/e2e/features/admin_server/suite.go
+++ b/test/kubernetes/e2e/features/admin_server/suite.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/client_tls/suite.go
+++ b/test/kubernetes/e2e/features/client_tls/suite.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
-	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"

--- a/test/kubernetes/e2e/features/client_tls/types.go
+++ b/test/kubernetes/e2e/features/client_tls/types.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/onsi/gomega"
 	"github.com/solo-io/skv2/codegen/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var (

--- a/test/kubernetes/e2e/features/crd_categories/suite.go
+++ b/test/kubernetes/e2e/features/crd_categories/suite.go
@@ -8,9 +8,10 @@ import (
 	"io"
 	"strings"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/features/helm"
-	"github.com/stretchr/testify/suite"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/deployer/istio_integration_suite.go
+++ b/test/kubernetes/e2e/features/deployer/istio_integration_suite.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"time"
 
-	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"

--- a/test/kubernetes/e2e/features/deployer/minimal_default_gatewayparameters_suite.go
+++ b/test/kubernetes/e2e/features/deployer/minimal_default_gatewayparameters_suite.go
@@ -5,8 +5,9 @@ package deployer
 import (
 	"context"
 
-	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/kubernetes/e2e/features/discovery_watchlabels/discovery_watchlabels_suite.go
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/discovery_watchlabels_suite.go
@@ -7,15 +7,17 @@ import (
 
 	"github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/plugins/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 )
 
 var _ e2e.NewSuiteFunc = NewDiscoveryWatchlabelsSuite

--- a/test/kubernetes/e2e/features/headless_svc/generate/generate.go
+++ b/test/kubernetes/e2e/features/headless_svc/generate/generate.go
@@ -6,11 +6,12 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/solo-io/skv2/codegen/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/features/headless_svc"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/resources"
-	"github.com/solo-io/skv2/codegen/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Dev tool to generate the manifest files for the test suite for demo and docs purposes

--- a/test/kubernetes/e2e/features/helm/suite.go
+++ b/test/kubernetes/e2e/features/helm/suite.go
@@ -16,12 +16,13 @@ import (
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
+	"github.com/solo-io/skv2/codegen/util"
+	"github.com/solo-io/solo-kit/pkg/code-generator/schemagen"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/envoyutils/admincli"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/helper"
-	"github.com/solo-io/skv2/codegen/util"
-	"github.com/solo-io/solo-kit/pkg/code-generator/schemagen"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/helm/types.go
+++ b/test/kubernetes/e2e/features/helm/types.go
@@ -5,8 +5,9 @@ package helm
 import (
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
 	"github.com/solo-io/skv2/codegen/util"
+
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
 )
 
 var (

--- a/test/kubernetes/e2e/features/helm_settings/suite.go
+++ b/test/kubernetes/e2e/features/helm_settings/suite.go
@@ -14,9 +14,10 @@ import (
 
 	"text/template"
 
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	"github.com/solo-io/skv2/codegen/util"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/http_listener_options/http_lis_opt_suite.go
+++ b/test/kubernetes/e2e/features/http_listener_options/http_lis_opt_suite.go
@@ -9,12 +9,13 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/istio/k8s_gateway_no_auto_mtls_suite.go
+++ b/test/kubernetes/e2e/features/istio/k8s_gateway_no_auto_mtls_suite.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
-	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/istio/resources.go
+++ b/test/kubernetes/e2e/features/istio/resources.go
@@ -6,18 +6,20 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/kgateway-dev/kgateway/projects/gloo/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/projects/gloo/constants"
+
 	v1 "github.com/solo-io/solo-apis/pkg/api/gateway.solo.io/v1"
 	soloapis_gloov1 "github.com/solo-io/solo-apis/pkg/api/gloo.solo.io/v1"
 	"github.com/solo-io/solo-apis/pkg/api/gloo.solo.io/v1/core/matchers"
 	soloapis_kubernetes "github.com/solo-io/solo-apis/pkg/api/gloo.solo.io/v1/options/kubernetes"
 	"github.com/solo-io/solo-apis/pkg/api/gloo.solo.io/v1/ssl"
 	gloocore "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 )
 
 type UpstreamConfigOpts struct {

--- a/test/kubernetes/e2e/features/istio/types.go
+++ b/test/kubernetes/e2e/features/istio/types.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"path/filepath"
 
-	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/onsi/gomega"
 	"github.com/solo-io/skv2/codegen/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testmatchers "github.com/kgateway-dev/kgateway/test/gomega/matchers"
 
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 )

--- a/test/kubernetes/e2e/features/listener_options/lis_opt_suite.go
+++ b/test/kubernetes/e2e/features/listener_options/lis_opt_suite.go
@@ -9,12 +9,13 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/envoyutils/admincli"
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/listener_options/lis_opt_types.go
+++ b/test/kubernetes/e2e/features/listener_options/lis_opt_types.go
@@ -6,13 +6,14 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	e2edefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 	"github.com/onsi/gomega"
 	"github.com/solo-io/skv2/codegen/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	e2edefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 )
 
 var (

--- a/test/kubernetes/e2e/features/metrics/suite.go
+++ b/test/kubernetes/e2e/features/metrics/suite.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/envoyutils/admincli"
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
@@ -20,8 +23,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
-	"github.com/onsi/gomega"
-	"github.com/stretchr/testify/suite"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/metrics/types.go
+++ b/test/kubernetes/e2e/features/metrics/types.go
@@ -5,10 +5,6 @@ package metrics
 import (
 	"path/filepath"
 
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/kubernetes"
-	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
 	"github.com/solo-io/skv2/codegen/util"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,6 +12,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/kubernetes"
+	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
 )
 
 var (

--- a/test/kubernetes/e2e/features/port_routing/k8s_gateway_suite.go
+++ b/test/kubernetes/e2e/features/port_routing/k8s_gateway_suite.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
-	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ e2e.NewSuiteFunc = NewK8sGatewayTestingSuite

--- a/test/kubernetes/e2e/features/port_routing/types.go
+++ b/test/kubernetes/e2e/features/port_routing/types.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
 
 	"github.com/solo-io/skv2/codegen/util"
 

--- a/test/kubernetes/e2e/features/route_options/types.go
+++ b/test/kubernetes/e2e/features/route_options/types.go
@@ -6,13 +6,14 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	"github.com/solo-io/skv2/codegen/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var (

--- a/test/kubernetes/e2e/features/server_tls/suite.go
+++ b/test/kubernetes/e2e/features/server_tls/suite.go
@@ -6,14 +6,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
-	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"

--- a/test/kubernetes/e2e/features/server_tls/types.go
+++ b/test/kubernetes/e2e/features/server_tls/types.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 	"github.com/onsi/gomega"
 	"github.com/solo-io/skv2/codegen/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
 )
 
 var (

--- a/test/kubernetes/e2e/features/services/httproute/types.go
+++ b/test/kubernetes/e2e/features/services/httproute/types.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/solo-io/skv2/codegen/util"
 
-	"github.com/kgateway-dev/kgateway/projects/gateway2/crds"
 	"github.com/onsi/gomega/gstruct"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/projects/gateway2/crds"
 )
 
 var (

--- a/test/kubernetes/e2e/features/tracing/suite.go
+++ b/test/kubernetes/e2e/features/tracing/suite.go
@@ -7,18 +7,19 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
-	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
-	gloo_defaults "github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
-	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
+	gloo_defaults "github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
+	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/upgrade/suite.go
+++ b/test/kubernetes/e2e/features/upgrade/suite.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/solo-io/skv2/codegen/util"
+
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/helper"
-	"github.com/solo-io/skv2/codegen/util"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/virtualhost_options/types.go
+++ b/test/kubernetes/e2e/features/virtualhost_options/types.go
@@ -6,14 +6,15 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	e2edefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	"github.com/solo-io/skv2/codegen/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	e2edefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 )
 
 var (

--- a/test/kubernetes/e2e/features/virtualhost_options/vhost_opt_suite.go
+++ b/test/kubernetes/e2e/features/virtualhost_options/vhost_opt_suite.go
@@ -10,6 +10,11 @@ import (
 	"github.com/onsi/gomega/gstruct"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
@@ -17,10 +22,6 @@ import (
 	"github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	testdefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/watch_namespace_selector/types.go
+++ b/test/kubernetes/e2e/features/watch_namespace_selector/types.go
@@ -5,14 +5,16 @@ package watch_namespace_selector
 import (
 	"path/filepath"
 
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
 	"github.com/solo-io/skv2/codegen/util"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
 	e2edefaults "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/types.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/types.go
@@ -5,9 +5,10 @@ package zero_downtime_rollout
 import (
 	"path/filepath"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests/base"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/solo-io/skv2/codegen/util"
 

--- a/test/kubernetes/e2e/tests/base/base_suite.go
+++ b/test/kubernetes/e2e/tests/base/base_suite.go
@@ -8,13 +8,14 @@ import (
 	"slices"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
-	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/helper"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
+	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/helper"
 )
 
 // This defines a test case used by the BaseTestingSuite

--- a/test/kubernetes/e2e/tests/discovery_watchlabels_test.go
+++ b/test/kubernetes/e2e/tests/discovery_watchlabels_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/solo-io/skv2/codegen/util"
+
 	"github.com/kgateway-dev/kgateway/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/e2e"
 	. "github.com/kgateway-dev/kgateway/test/kubernetes/e2e/tests"
 	"github.com/kgateway-dev/kgateway/test/kubernetes/testutils/gloogateway"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	"github.com/solo-io/skv2/codegen/util"
 )
 
 // TestDiscoveryWatchlabels is the function which executes a series of tests against a given installation where

--- a/test/kubernetes/testutils/assertions/gloo.go
+++ b/test/kubernetes/testutils/assertions/gloo.go
@@ -8,15 +8,16 @@ import (
 	"net"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/glooadminutils/admincli"
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/portforward"
-	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
-	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/glooadminutils/admincli"
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/portforward"
+	"github.com/kgateway-dev/kgateway/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/projects/gateway2/admin"
 )
 
 func (p *Provider) AssertGlooAdminApi(

--- a/test/kubernetes/testutils/assertions/objects.go
+++ b/test/kubernetes/testutils/assertions/objects.go
@@ -10,11 +10,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
 )
 
 func (p *Provider) EventuallyObjectsExist(ctx context.Context, objects ...client.Object) {

--- a/test/kubernetes/testutils/assertions/pods.go
+++ b/test/kubernetes/testutils/assertions/pods.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 )
 
 // EventuallyPodsRunning asserts that the pod(s) are in the ready state

--- a/test/kubernetes/testutils/assertions/resources.go
+++ b/test/kubernetes/testutils/assertions/resources.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/test/helpers"
+	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 )
 
 func (p *Provider) EventuallyResourceExists(getter helpers.ResourceGetter, timeout ...time.Duration) {

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
-	"github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -19,6 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kgateway-dev/kgateway/test/gomega/matchers"
+	"github.com/kgateway-dev/kgateway/test/helpers"
+	"github.com/kgateway-dev/kgateway/test/kube2e/helper"
 )
 
 // Checks GetNamespacedStatuses status for gloo installation namespace

--- a/test/kubernetes/testutils/clients/clients.go
+++ b/test/kubernetes/testutils/clients/clients.go
@@ -3,8 +3,9 @@
 package clients
 
 import (
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils"
 )
 
 // MustClientset returns the Kubernetes Clientset, or panics

--- a/test/kubernetes/testutils/cluster/istio.go
+++ b/test/kubernetes/testutils/cluster/istio.go
@@ -11,10 +11,11 @@ import (
 	"path/filepath"
 	"runtime"
 
-	glooruntime "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/runtime"
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/contextutils"
+
+	glooruntime "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/runtime"
+	"github.com/kgateway-dev/kgateway/test/testutils"
 )
 
 const (

--- a/test/kubernetes/testutils/gloogateway/context.go
+++ b/test/kubernetes/testutils/gloogateway/context.go
@@ -3,8 +3,9 @@
 package gloogateway
 
 import (
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/rotisserie/eris"
+
+	"github.com/kgateway-dev/kgateway/test/testutils"
 )
 
 // Context contains the set of properties for a given installation of Gloo Gateway

--- a/test/kubernetes/testutils/helper/install.go
+++ b/test/kubernetes/testutils/helper/install.go
@@ -17,12 +17,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 
-	"github.com/kgateway-dev/kgateway/pkg/utils/fsutils"
-	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
-	test_runtime "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/runtime"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/testutils/exec"
+
+	"github.com/kgateway-dev/kgateway/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/pkg/utils/kubeutils/kubectl"
+	test_runtime "github.com/kgateway-dev/kgateway/test/kubernetes/testutils/runtime"
 )
 
 // Default test configuration

--- a/test/kubernetes/testutils/helper/util.go
+++ b/test/kubernetes/testutils/helper/util.go
@@ -12,14 +12,15 @@ import (
 	"time"
 
 	"github.com/google/go-github/v32/github"
-	"github.com/kgateway-dev/kgateway/test/testutils"
-	"github.com/kgateway-dev/kgateway/test/testutils/version"
 	. "github.com/onsi/gomega"
 	errors "github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/changelogutils"
 	"github.com/solo-io/go-utils/githubutils"
 	"github.com/solo-io/go-utils/versionutils"
 	"github.com/solo-io/skv2/codegen/util"
+
+	"github.com/kgateway-dev/kgateway/test/testutils"
+	"github.com/kgateway-dev/kgateway/test/testutils/version"
 )
 
 // Deprecated; if this is needed create a resource yaml for it.

--- a/test/mocks/gloo/validation_client.go
+++ b/test/mocks/gloo/validation_client.go
@@ -11,8 +11,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	validation "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/grpc/validation"
 	grpc "google.golang.org/grpc"
+
+	validation "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/grpc/validation"
 )
 
 // MockGlooValidationServiceClient is a mock of GlooValidationServiceClient interface.

--- a/test/samples/route_tables.go
+++ b/test/samples/route_tables.go
@@ -5,11 +5,12 @@ package samples
 import (
 	"fmt"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	v1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/core/matchers"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 func LinkedRouteTablesWithVirtualService(vsName, namespace string) (*v1.VirtualService, v1.RouteTableList) {

--- a/test/samples/sample_gloo_api_snapshot.go
+++ b/test/samples/sample_gloo_api_snapshot.go
@@ -4,6 +4,8 @@ package samples
 
 import (
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	gwv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gateway/pkg/defaults"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
@@ -14,7 +16,6 @@ import (
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/ssl"
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 func SimpleUpstream() *v1.Upstream {

--- a/test/services/envoy/factory.go
+++ b/test/services/envoy/factory.go
@@ -13,17 +13,19 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/kgateway-dev/kgateway/test/services"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/kgateway-dev/kgateway/test/services"
+
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
+
+	"github.com/onsi/ginkgo/v2"
+	errors "github.com/rotisserie/eris"
+	"github.com/solo-io/skv2/codegen/util"
 
 	"github.com/kgateway-dev/kgateway/test/services/utils"
 	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/kgateway-dev/kgateway/test/testutils/version"
-	"github.com/onsi/ginkgo/v2"
-	errors "github.com/rotisserie/eris"
-	"github.com/solo-io/skv2/codegen/util"
 )
 
 var _ Factory = new(factoryImpl)

--- a/test/services/gloo.go
+++ b/test/services/gloo.go
@@ -56,10 +56,11 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 
+	"google.golang.org/grpc"
+
 	gatewayv1 "github.com/kgateway-dev/kgateway/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/bootstrap"
-	"google.golang.org/grpc"
 
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"go.uber.org/zap"
@@ -67,12 +68,13 @@ import (
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 
-	fds_syncer "github.com/kgateway-dev/kgateway/projects/discovery/pkg/fds/syncer"
-	uds_syncer "github.com/kgateway-dev/kgateway/projects/discovery/pkg/uds/syncer"
-	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
+
+	fds_syncer "github.com/kgateway-dev/kgateway/projects/discovery/pkg/fds/syncer"
+	uds_syncer "github.com/kgateway-dev/kgateway/projects/discovery/pkg/uds/syncer"
+	"github.com/kgateway-dev/kgateway/projects/gloo/pkg/defaults"
 )
 
 var glooPortBase = uint32(30400)

--- a/test/services/logging.go
+++ b/test/services/logging.go
@@ -10,11 +10,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/onsi/gomega"
 	errors "github.com/rotisserie/eris"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/kgateway-dev/kgateway/test/testutils"
 )
 
 const (

--- a/test/services/logging_test.go
+++ b/test/services/logging_test.go
@@ -3,10 +3,11 @@
 package services_test
 
 import (
-	"github.com/kgateway-dev/kgateway/test/services"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/kgateway-dev/kgateway/test/services"
 )
 
 var _ = Describe("Logging", func() {

--- a/test/services/utils/download_test.go
+++ b/test/services/utils/download_test.go
@@ -11,9 +11,10 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kgateway-dev/kgateway/test/services/utils"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetBinaryFromEnv(t *testing.T) {

--- a/test/services/vault.go
+++ b/test/services/vault.go
@@ -15,10 +15,11 @@ import (
 
 	errors "github.com/rotisserie/eris"
 
-	"github.com/kgateway-dev/kgateway/test/services/utils"
-	"github.com/kgateway-dev/kgateway/test/testutils"
 	"github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/utils/protoutils"
+
+	"github.com/kgateway-dev/kgateway/test/services/utils"
+	"github.com/kgateway-dev/kgateway/test/testutils"
 
 	v1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
 

--- a/test/testutils/helm_values.go
+++ b/test/testutils/helm_values.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"path"
 
-	"github.com/kgateway-dev/kgateway/install/helm/gloo/generate"
-	"github.com/kgateway-dev/kgateway/pkg/utils/helmutils"
 	"helm.sh/helm/v3/pkg/strvals"
 	"knative.dev/pkg/test/helpers"
 	k8syamlutil "sigs.k8s.io/yaml"
+
+	"github.com/kgateway-dev/kgateway/install/helm/gloo/generate"
+	"github.com/kgateway-dev/kgateway/pkg/utils/helmutils"
 )
 
 // HelmValues is a struct that holds the values that will be passed to a Helm chart

--- a/test/testutils/http_client_test.go
+++ b/test/testutils/http_client_test.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/kgateway-dev/kgateway/test/gomega/assertions"
 	gloohelpers "github.com/kgateway-dev/kgateway/test/helpers"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("HttpClientBuilder", func() {

--- a/test/testutils/http_request_test.go
+++ b/test/testutils/http_request_test.go
@@ -3,9 +3,10 @@
 package testutils_test
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+
 	"github.com/kgateway-dev/kgateway/test/gomega/assertions"
 	"github.com/kgateway-dev/kgateway/test/testutils"
-	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("HttpRequestBuilder", func() {

--- a/test/testutils/version/changelog_test.go
+++ b/test/testutils/version/changelog_test.go
@@ -5,10 +5,11 @@ package version_test
 import (
 	"fmt"
 
-	"github.com/kgateway-dev/kgateway/test/testutils/version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"github.com/kgateway-dev/kgateway/test/testutils/version"
 )
 
 type mockDirEntry struct {

--- a/test/v1helpers/test_grpc_service/testgrpcservice.go
+++ b/test/v1helpers/test_grpc_service/testgrpcservice.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
-	glootest "github.com/kgateway-dev/kgateway/test/v1helpers/test_grpc_service/glootest/protos"
 	"github.com/solo-io/go-utils/healthchecker"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
+
+	glootest "github.com/kgateway-dev/kgateway/test/v1helpers/test_grpc_service/glootest/protos"
 )
 
 // For reflection to work, this uses the golang/proto plugin. To install it, run this command:

--- a/test/v1helpers/test_upstream.go
+++ b/test/v1helpers/test_upstream.go
@@ -21,10 +21,6 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"github.com/golang/protobuf/proto"
-	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
-	static_plugin_gloo "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
-	"github.com/kgateway-dev/kgateway/test/helpers"
-	testgrpcservice "github.com/kgateway-dev/kgateway/test/v1helpers/test_grpc_service"
 	"github.com/mccutchen/go-httpbin/v2/httpbin"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,6 +28,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	gloov1 "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1"
+	static_plugin_gloo "github.com/kgateway-dev/kgateway/projects/gloo/pkg/api/v1/options/static"
+	"github.com/kgateway-dev/kgateway/test/helpers"
+	testgrpcservice "github.com/kgateway-dev/kgateway/test/v1helpers/test_grpc_service"
 )
 
 // TestUpstream is a testing utility (used in in-memory e2e tests) to compose the following concepts:


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Update the "fmt" Makefile target and enable the -local goimports CLI flag. Previously, there was a TODO comment in the fmt-v2 target the mentioned the want/need to do this in the long term. This commit purges the fmt-v2 target & update the fmt target to provide the desired goimports flag. This provides a consistent module structure throughout the repository:

- Standard library dependencies
- Third party dependencies (note: over time, this will include github.com/solo-io dependencies that aren't ported over)
- Local code in the root module path

Partially related to https://github.com/kgateway-dev/kgateway/issues/10444 which is tracking the root Go module name change. We'll need to also change that in the Makefile once we're closer with that stream of work.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
