### PR TITLE
change admin server port to 9097

### DIFF
--- a/projects/gateway2/admin/server.go
+++ b/projects/gateway2/admin/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	AdminPort = 9091
+	AdminPort = 9092
 )
 
 func RunAdminServer(ctx context.Context, setupOpts *controller.SetupOpts) error {

--- a/projects/gateway2/admin/server.go
+++ b/projects/gateway2/admin/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	AdminPort = 9092
+	AdminPort = 9095
 )
 
 func RunAdminServer(ctx context.Context, setupOpts *controller.SetupOpts) error {

--- a/projects/gateway2/admin/server.go
+++ b/projects/gateway2/admin/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	AdminPort = 9095
+	AdminPort = 9097
 )
 
 func RunAdminServer(ctx context.Context, setupOpts *controller.SetupOpts) error {

--- a/test/ginkgo/parallel/ports.go
+++ b/test/ginkgo/parallel/ports.go
@@ -102,7 +102,7 @@ func portInUseListen(proposedPort uint32) error {
 var denyListPorts = map[uint32]struct{}{
 	// See projects/gateway2/admin/server.go
 	// This port is reserved for the admin server
-	9091: {},
+	9092: {},
 }
 
 func portInDenyList(proposedPort uint32) error {

--- a/test/ginkgo/parallel/ports.go
+++ b/test/ginkgo/parallel/ports.go
@@ -102,7 +102,7 @@ func portInUseListen(proposedPort uint32) error {
 var denyListPorts = map[uint32]struct{}{
 	// See projects/gateway2/admin/server.go
 	// This port is reserved for the admin server
-	9092: {},
+	9095: {},
 }
 
 func portInDenyList(proposedPort uint32) error {

--- a/test/ginkgo/parallel/ports.go
+++ b/test/ginkgo/parallel/ports.go
@@ -102,7 +102,7 @@ func portInUseListen(proposedPort uint32) error {
 var denyListPorts = map[uint32]struct{}{
 	// See projects/gateway2/admin/server.go
 	// This port is reserved for the admin server
-	9095: {},
+	9097: {},
 }
 
 func portInDenyList(proposedPort uint32) error {


### PR DESCRIPTION
Change to 9097 for now, so it won't conflict with existing ports used by the legacy admin server, until https://github.com/kgateway-dev/kgateway/issues/10501 is implemented