### PR TITLE
release: Publish main branch images and charts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+      - '!v0.0.0-main'
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -30,7 +33,7 @@ jobs:
       - name: Set the release related variables
         id: set_vars
         run: |
-          GIT_TAG=$(git describe --tags --abbrev=0)
+          GIT_TAG=$(git describe --tags --abbrev=0 --always)
           GIT_SHA=$(git rev-parse --short HEAD)
           GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -e "s/\//-/g")
 
@@ -41,6 +44,9 @@ jobs:
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
             echo "goreleaser_args=--clean" >> $GITHUB_OUTPUT
+          elif [[ $GITHUB_REF == refs/heads/main ]]; then
+            VERSION="v0.0.0-main"
+            echo "goreleaser_args=--clean --skip=validate" >> $GITHUB_OUTPUT
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
             PR_NUM=$(echo "${GITHUB_REF}" | sed -E 's|refs/pull/([^/]+)/?.*|\1|')
             VERSION="${GIT_TAG}-pr.${PR_NUM}-${GIT_SHA}"
@@ -108,3 +114,4 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           GORELEASER_ARGS: ${{ needs.setup.outputs.goreleaser_args }}
+          GORELEASER_CURRENT_TAG: ${{ needs.setup.outputs.version }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -137,7 +137,61 @@ docker_manifests:
       - *envoyinit_arm_image
       - *envoyinit_amd_image
 changelog:
-  disable: false
+  disable: true
 release:
   prerelease: "auto"
   mode: "replace"
+  replace_existing_artifacts: true
+  header: |
+    {{ if eq .Env.VERSION "v0.0.0-main" }}
+    🚀 Nightly build of kgateway!
+    ---
+    It includes the latest changes but may be unstable. Use it for testing and providing feedback.
+    {{ else }}
+    🎉 Welcome to the {{ .Env.VERSION }} release of the kgateway project!
+    ---
+    {{ end }}
+  footer: |
+    ## Installation
+
+    The kgateway project is available as a Helm chart and docker images.
+
+    ### Helm Charts
+
+    The Helm chart is available at {{ .Env.IMAGE_REGISTRY }}/charts/kgateway.
+
+    ### Docker Images
+
+    The docker images are available at:
+
+    - {{ .Env.IMAGE_REGISTRY }}:{{ .Env.CONTROLLER_IMAGE_REPO }}:{{ .Env.VERSION }}
+    - {{ .Env.IMAGE_REGISTRY }}:{{ .Env.SDS_IMAGE_REPO }}:{{ .Env.VERSION }}
+    - {{ .Env.IMAGE_REGISTRY }}:{{ .Env.ENVOYINIT_IMAGE_REPO }}:{{ .Env.VERSION }}
+
+    ## Quickstart
+
+    First, create a [kind cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation).
+
+    ```bash
+    kind create cluster
+    ```
+
+    Then, deploy the Kubernetes Gateway API CRDs.
+
+    ```bash
+    kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.2.1"
+    ```
+
+    Install the `kgateway` controller.
+
+    ```bash
+    helm install --create-namespace --namespace kgateway-system --version {{ .Env.VERSION }} kgateway oci://{{ .Env.IMAGE_REGISTRY }}/charts/kgateway
+    ```
+
+    Verify the release was successful.
+
+    ```bash
+    kubectl get pods -n kgateway-system
+    ```
+
+    If the release was successful, you should see a `kgateway` pod running.

--- a/Makefile
+++ b/Makefile
@@ -261,10 +261,11 @@ view-test-coverage:
 	go tool cover -html $(OUTPUT_DIR)/cover.out
 
 .PHONY: package-kgateway-chart
+HELM_PACKAGE_ARGS ?= --version $(VERSION)
 package-kgateway-chart: ## Package the new kgateway helm chart for testing
-	mkdir -p $(TEST_ASSET_DIR)
-	helm package --version $(VERSION) --destination $(TEST_ASSET_DIR) install/helm/kgateway
-	helm repo index $(TEST_ASSET_DIR)
+	mkdir -p $(TEST_ASSET_DIR); \
+	helm package $(HELM_PACKAGE_ARGS) --destination $(TEST_ASSET_DIR) install/helm/kgateway; \
+	helm repo index $(TEST_ASSET_DIR);
 
 #----------------------------------------------------------------------------------
 # Clean
@@ -583,11 +584,12 @@ publish-docker: docker docker-push
 
 endif # Publish Artifact Targets
 
-GORELEASER_ARGS ?= --snapshot --clean
 GORELEASER ?= go run github.com/goreleaser/goreleaser/v2@v2.5.1
+GORELEASER_ARGS ?= --snapshot --clean
+GORELEASER_CURRENT_TAG ?= $(VERSION)
 .PHONY: release
 release:  ## Create a release using goreleaser
-	$(GORELEASER) release $(GORELEASER_ARGS)
+	GORELEASER_CURRENT_TAG=$(GORELEASER_CURRENT_TAG) $(GORELEASER) release $(GORELEASER_ARGS)
 
 #----------------------------------------------------------------------------------
 # Docker


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

This modifies the release.yaml workflow and adds the main branch push trigger to publish main branch images and the latest helm chart to ghcr.io.

Related to #10510.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
