### PR TITLE
DFP proposal

### DIFF
--- a/api/v1alpha1/upstream_policy_types.go
+++ b/api/v1alpha1/upstream_policy_types.go
@@ -29,11 +29,16 @@ type UpstreamList struct {
 	Items           []Upstream `json:"items"`
 }
 
-// +kubebuilder:validation:XValidation:message="There must one and only one upstream type set",rule="1 == (self.aws != null?1:0) + (self.static != null?1:0)"
+// +kubebuilder:validation:XValidation:message="There must one and only one upstream type set",rule="1 == (self.aws != null?1:0) + (self.static != null?1:0) + (self.dynamicForwardProxy != null?1:0)"
 type UpstreamSpec struct {
-	Aws    *AwsUpstream    `json:"aws,omitempty"`
-	Static *StaticUpstream `json:"static,omitempty"`
+	Aws                 *AwsUpstream         `json:"aws,omitempty"`
+	Static              *StaticUpstream      `json:"static,omitempty"`
+	DynamicForwardProxy *DynamicForwardProxy `json:"dynamicForwardProxy,omitempty"`
 }
+
+type DynamicForwardProxy struct {
+}
+
 type AwsUpstream struct {
 	Region    string                      `json:"region,omitempty"`
 	SecretRef corev1.LocalObjectReference `json:"secretRef,omitempty"`

--- a/internal/gateway2/extensions2/plugins/upstream/aws.go
+++ b/internal/gateway2/extensions2/plugins/upstream/aws.go
@@ -110,10 +110,10 @@ func (p *plugin2) processBackendAws(
 ) error {
 
 	functionName := dest.FunctionName
-	if p.needFilter == nil {
-		p.needFilter = make(map[string]bool)
+	if p.needAwsFilter == nil {
+		p.needAwsFilter = make(map[string]bool)
 	}
-	p.needFilter[pCtx.FilterChainName] = true
+	p.needAwsFilter[pCtx.FilterChainName] = true
 
 	lambdaRouteFunc := &awspb.AWSLambdaPerRoute{
 		Async: false,

--- a/internal/gateway2/extensions2/plugins/upstream/dfp.go
+++ b/internal/gateway2/extensions2/plugins/upstream/dfp.go
@@ -1,0 +1,58 @@
+package upstream
+
+import (
+	"context"
+
+	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoyclusters "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/kgateway-dev/kgateway/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/internal/gateway2/ir"
+)
+
+func (p *plugin2) processDFPRoute(ctx context.Context, pCtx *ir.RouteContext, outputRoute *envoy_config_route_v3.Route) {
+	for _, b := range pCtx.In.Backends {
+		if u := b.Backend.Upstream; u != nil {
+			if ir, ok := u.ObjIr.(*UpstreamIr); ok {
+				if ir.dfpFilterConfig != nil {
+					filters := p.neededDfpFilter[pCtx.FilterChainName]
+					if _, ok := filters[u.ClusterName()]; !ok {
+						filters[u.ClusterName()] = ir.dfpFilterConfig
+						p.neededDfpFilter[pCtx.FilterChainName] = filters
+					}
+				}
+			}
+		}
+	}
+}
+
+func processDFPCluster(ctx context.Context, in *v1alpha1.DynamicForwardProxy, out *envoy_config_cluster_v3.Cluster) {
+	out.LbPolicy = envoy_config_cluster_v3.Cluster_CLUSTER_PROVIDED
+	c := &envoyclusters.ClusterConfig{
+		ClusterImplementationSpecifier: &envoyclusters.ClusterConfig_SubClustersConfig{
+			SubClustersConfig: &envoyclusters.SubClustersConfig{
+				LbPolicy: envoy_config_cluster_v3.Cluster_LEAST_REQUEST,
+			},
+		},
+	}
+	var anyCluster anypb.Any
+	err := anypb.MarshalFrom(&anyCluster, c, proto.MarshalOptions{Deterministic: true})
+	// error should never happen here. panic?
+	if err != nil {
+		panic(err)
+	}
+
+	// the upstream has a DNS name. We need Envoy to resolve the DNS name
+	// set the type to strict dns
+	out.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_ClusterType{
+		ClusterType: &envoy_config_cluster_v3.Cluster_CustomClusterType{
+			Name:        "envoy.clusters.dynamic_forward_proxy",
+			TypedConfig: &anyCluster,
+		},
+	}
+
+}

--- a/internal/gateway2/ir/iface.go
+++ b/internal/gateway2/ir/iface.go
@@ -35,8 +35,9 @@ func (r *RouteBackendContext) AddTypedConfig(key string, v *anypb.Any) {
 }
 
 type RouteContext struct {
-	Policy PolicyIR
-	In     HttpRouteRuleMatchIR
+	FilterChainName string
+	Policy          PolicyIR
+	In              HttpRouteRuleMatchIR
 }
 
 type ProxyTranslationPass interface {

--- a/internal/gateway2/translator/irtranslator/route.go
+++ b/internal/gateway2/translator/irtranslator/route.go
@@ -215,8 +215,9 @@ func (h *httpRouteConfigurationTranslator) runRoutePlugins(ctx context.Context, 
 			}
 			for _, pol := range pols {
 				pctx := &ir.RouteContext{
-					Policy: pol.PolicyIr,
-					In:     in,
+					FilterChainName: h.fc.FilterChainName,
+					Policy:          pol.PolicyIr,
+					In:              in,
 				}
 				err := pass.ApplyForRoute(ctx, pctx, out)
 				if err != nil {


### PR DESCRIPTION
very rough draft - mainly to get early feedback.

Adding dynamic forward proxy support. 

Notes:
- This uses envoy's new sub cluster config that seems more ergonomic to use, and has more features. The old dns cache would make envoy NACK if the config on the listener is different than the config on the cluster.
- Not exposing any settings. we use the defaults, until we get feedback otherwise to simplify the API.

Unlike the previous impl that represents DFP as a route action, this one represents it as an upstream type. This makes more sense for the k8s-GW-API, as we cannot add custom route actions.

For every DFP upstream we add a DFP cluster and a filter on the relevant filter chain.
