### PR TITLE
Bumps gomod to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kgateway-dev/kgateway
 
-go 1.23.3
+go 1.23.6
 
 require (
 	fybrik.io/crdoc v0.6.3


### PR DESCRIPTION
Bumps go mod to the latest Go 1.23.x patch release.