### PR TITLE
internal change: policies can reference upstreams

### DIFF
--- a/internal/kgateway/extensions2/common/krt.go
+++ b/internal/kgateway/extensions2/common/krt.go
@@ -24,6 +24,8 @@ type CommonCollections struct {
 	Client    kube.Client
 	KrtOpts   krtutil.KrtOptions
 	Secrets   *krtcollections.SecretIndex
+	Upstreams *krtcollections.UpstreamIndex
+
 	Pods      krt.Collection[krtcollections.LocalityPod]
 	RefGrants *krtcollections.RefGrantIndex
 

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -335,9 +335,9 @@ func preRouteIndex(t *testing.T, inputs []any) *RoutesIndex {
 	services := krttest.GetMockCollection[*corev1.Service](mock)
 
 	policies := NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{})
-	upstreams := NewUpstreamIndex(krtutil.KrtOptions{}, nil, policies)
-	upstreams.AddUpstreams(SvcGk, k8sUpstreams(services))
 	refgrants := NewRefGrantIndex(krttest.GetMockCollection[*gwv1beta1.ReferenceGrant](mock))
+	upstreams := NewUpstreamIndex(krtutil.KrtOptions{}, nil, policies, refgrants)
+	upstreams.AddUpstreams(SvcGk, k8sUpstreams(services))
 
 	httproutes := krttest.GetMockCollection[*gwv1.HTTPRoute](mock)
 	tcpproutes := krttest.GetMockCollection[*gwv1a2.TCPRoute](mock)

--- a/internal/kgateway/query/query_test.go
+++ b/internal/kgateway/query/query_test.go
@@ -754,11 +754,11 @@ func newQueries(initObjs ...client.Object) query.GatewayQueries {
 	}
 	mock := krttest.NewMock(GinkgoT(), anys)
 	services := krttest.GetMockCollection[*corev1.Service](mock)
+	refgrants := krtcollections.NewRefGrantIndex(krttest.GetMockCollection[*apiv1beta1.ReferenceGrant](mock))
 
 	policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{})
-	upstreams := krtcollections.NewUpstreamIndex(krtutil.KrtOptions{}, nil, policies)
+	upstreams := krtcollections.NewUpstreamIndex(krtutil.KrtOptions{}, nil, policies, refgrants)
 	upstreams.AddUpstreams(SvcGk, k8sUpstreams(services))
-	refgrants := krtcollections.NewRefGrantIndex(krttest.GetMockCollection[*apiv1beta1.ReferenceGrant](mock))
 
 	httproutes := krttest.GetMockCollection[*gwv1.HTTPRoute](mock)
 	tcpproutes := krttest.GetMockCollection[*gwv1a2.TCPRoute](mock)

--- a/internal/kgateway/translator/gateway/translator_case_test.go
+++ b/internal/kgateway/translator/gateway/translator_case_test.go
@@ -195,17 +195,18 @@ func (tc TestCase) Run(t test.Failer, ctx context.Context) (map[types.Namespaced
 		return true
 	}
 
-	translator := translator.NewCombinedTranslator(ctx, extensions, commoncol)
-	translator.Init(ctx, isOurGw)
-
 	gi, ri, ui, ei := krtcollections.InitCollections(ctx, extensions, cli, isOurGw, commoncol.RefGrants, krtOpts)
+
+	translator := translator.NewCombinedTranslator(ctx, extensions, commoncol)
+	translator.Init(ctx, ri)
+
 	cli.RunAndWait(ctx.Done())
 	gi.Gateways.Synced().WaitUntilSynced(ctx.Done())
 	kubeclient.WaitForCacheSync("routes", ctx.Done(), ri.HasSynced)
 	kubeclient.WaitForCacheSync("extensions", ctx.Done(), extensions.HasSynced)
 	kubeclient.WaitForCacheSync("commoncol", ctx.Done(), commoncol.HasSynced)
 	kubeclient.WaitForCacheSync("translator", ctx.Done(), translator.HasSynced)
-	kubeclient.WaitForCacheSync("upstreams", ctx.Done(), ui.Synced().HasSynced)
+	kubeclient.WaitForCacheSync("upstreams", ctx.Done(), ui.HasSynced)
 	kubeclient.WaitForCacheSync("endpoints", ctx.Done(), ei.Synced().HasSynced)
 
 	results := make(map[types.NamespacedName]ActualTestResult)


### PR DESCRIPTION
Allow policies to get upstreams by placing the upstream index in the common collections.
these changes:
- Add the UpstreamIndex to the CommonCollections in proxy_syncer Init (before k8s client is started)
- Expose the `GetUpstreamFromRef` that return an upstream while doing reference grant checks.
