### PR TITLE
always dump option for krt dbg info

### DIFF
--- a/internal/kgateway/setup/ggv2setup_test.go
+++ b/internal/kgateway/setup/ggv2setup_test.go
@@ -287,12 +287,9 @@ func testScenario(
 
 	t.Cleanup(func() {
 		if t.Failed() {
-			j, err := kdbg.MarshalJSON()
-			if err != nil {
-				t.Logf("failed to marshal krt state: %v", err)
-			} else {
-				t.Logf("krt state for failed test: %s %s", t.Name(), string(j))
-			}
+			logKrtState(t, fmt.Sprintf("krt state for failed test: %s", t.Name()), kdbg)
+		} else if os.Getenv("KGW_DUMP_KRT_ON_SUCCESS") == "true" {
+			logKrtState(t, fmt.Sprintf("krt state for successful test: %s", t.Name()), kdbg)
 		}
 	})
 
@@ -314,6 +311,17 @@ func testScenario(
 	}
 	dump.Compare(t, expectedXdsDump)
 	fmt.Println("test done")
+}
+
+// logKrtState logs the krt state with a message
+func logKrtState(t *testing.T, msg string, kdbg *krt.DebugHandler) {
+	t.Helper()
+	j, err := kdbg.MarshalJSON()
+	if err != nil {
+		t.Logf("failed to marshal krt state: %v", err)
+	} else {
+		t.Logf("%s: %s", msg, string(j))
+	}
 }
 
 type xdsDumper struct {


### PR DESCRIPTION

# Description

add ability to alway dump krt debug, even on successful tests by setting KGW_DUMP_KRT_ON_SUCCESS=true

we can bike shed the var name, just wanted to get something out quick

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

add a helper for printing krt dbg stuff, add reading an env var during testing to dump

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

krt dbg is handy do make [these](https://mermaid.live/edit#pako:eNqNlVtr2zAUx79K8eNISiQ7jZOHwUi7bvRCSVo2lpSh2WosKkueJKeE0u8-ybMutlO2N-l3js75n0uc1yjjOY4W0RPlL1mBhDq5Xm3ZyQnTGKbj8UdzAHOLwMQi4LzOWgRnziuxXlOL4rhFceLQtEWOABvJAWgDTSyymrykuX3lfKAL5CIl_VxWtRMNrQv0om21sasW2HdgNkRegK0WgiDWaRsMDlkS9Ol9FIeNaRk4guJAmmVp0K8B0w2z7OwIS4ONaBmcB2O0LB2yOD7CJn7gFvk5tcQNAc422-gWlVhWKMNyGz26iIm2fCYM0YdKKoFRGVrBVFvzA_u5B4hWBQKn10QqzLC445Rkh9A11a6VoaSTAE40v6p_4Uuk8As6dGzxRhsFrxWW40KpatyeX4gqxpVN4cVC7b7klOJMEc42H_bg9BxLpeWb-6qmeJTru9CHvuGbQFWFxWOQPjHZHxj5XeMlZ0wHxfmSEsyUDLOaHqyVDpRtCFMxDEPM-_1ZmQIGzYEmxv3yrrGG_GzTGcwNVihHCoXpITA-_9EdaMQgSo-7-d-LCXeHxd9KL9ieHy5YXnHSKzuOh45LWuvxi67ftOP3PZdrhipZ8F644ehuNR49C5U5LBtmuxA2GgAzBSz2pLu_oBniYCu9fTbI207K7vuICHfuZJybyDu_tb7RqbHccPl-sUat7erXVWfnTbN4HqImXHdxvApojJeU86tUHp3TrGlMJrDq9KXZrKDwoMp-xf5RHMhe016roZH-5f5-uMVJ8DNW2b_2tNnnT_Wu1NuiOxGaGtHSFeOfNEtrviKCYR26XYTwk6V9o1FUYlEikus_41fzdhupApda60IfcySet9GWvWk_VCu-PrAsWuiPBR4Z8bsiWjwhKvWtrvT64XOCdgKVjlaI_eDc3t_-ABCLrKk) so it's nice to make dumping that easy. Probably other uses too

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

KGW_DUMP_KRT_ON_SUCCESS="true" go test -v ./internal/kgateway/setup/...

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
