### PR TITLE
set use remote address to true, and minor cleanup in httpListenerPolicy

### DIFF
--- a/internal/kgateway/setup/testdata/accesslog-filtercel-httplisteneropt-out.yaml
+++ b/internal/kgateway/setup/testdata/accesslog-filtercel-httplisteneropt-out.yaml
@@ -218,6 +218,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 - address:
@@ -273,6 +274,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: other
         statPrefix: http
+        useRemoteAddress: true
     name: other
   name: other
 routes:

--- a/internal/kgateway/setup/testdata/accesslog-filterhttp-httplisteneropt-out.yaml
+++ b/internal/kgateway/setup/testdata/accesslog-filterhttp-httplisteneropt-out.yaml
@@ -221,6 +221,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 - address:
@@ -276,6 +277,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: other
         statPrefix: http
+        useRemoteAddress: true
     name: other
   name: other
 routes:

--- a/internal/kgateway/setup/testdata/accesslog-httplisteneropt-out.yaml
+++ b/internal/kgateway/setup/testdata/accesslog-httplisteneropt-out.yaml
@@ -190,6 +190,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 - address:
@@ -273,6 +274,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: other
         statPrefix: http
+        useRemoteAddress: true
     name: other
   name: other
 routes:

--- a/internal/kgateway/setup/testdata/failover-default-diffns-out.yaml
+++ b/internal/kgateway/setup/testdata/failover-default-diffns-out.yaml
@@ -182,6 +182,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 routes:

--- a/internal/kgateway/setup/testdata/failover-default-out.yaml
+++ b/internal/kgateway/setup/testdata/failover-default-out.yaml
@@ -182,6 +182,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 routes:

--- a/internal/kgateway/setup/testdata/failover-out.yaml
+++ b/internal/kgateway/setup/testdata/failover-out.yaml
@@ -181,6 +181,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 routes:

--- a/internal/kgateway/setup/testdata/happypath-out.yaml
+++ b/internal/kgateway/setup/testdata/happypath-out.yaml
@@ -131,6 +131,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 routes:

--- a/internal/kgateway/setup/testdata/listeneropts-out.yaml
+++ b/internal/kgateway/setup/testdata/listeneropts-out.yaml
@@ -131,6 +131,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
   perConnectionBufferLimitBytes: 42000
@@ -156,6 +157,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: other
         statPrefix: http
+        useRemoteAddress: true
     name: other
   name: other
   perConnectionBufferLimitBytes: 42000

--- a/internal/kgateway/setup/testdata/routeoptions-out.yaml
+++ b/internal/kgateway/setup/testdata/routeoptions-out.yaml
@@ -131,6 +131,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 routes:

--- a/internal/kgateway/setup/testdata/upstream-out.yaml
+++ b/internal/kgateway/setup/testdata/upstream-out.yaml
@@ -127,6 +127,7 @@ listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        useRemoteAddress: true
     name: http
   name: http
 routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-plugin-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-plugin-proxy.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/bug-10379.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/bug-10379.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/bug-6621.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/bug-6621.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-lambda-destination-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-lambda-destination-proxy.yaml
@@ -24,6 +24,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: https
         statPrefix: http
+        use_remote_address: true
     name: https
     transportSocket:
       name: envoy.transport_sockets.tls
@@ -52,6 +53,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: https-with-hostname
         statPrefix: http
+        use_remote_address: true
     name: https-with-hostname
     transportSocket:
       name: envoy.transport_sockets.tls

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http-httpbin
         statPrefix: http
+        use_remote_address: true
     name: http-httpbin
   name: http-httpbin~http-bookinfo
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
@@ -21,6 +21,7 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: http
         statPrefix: http
+        use_remote_address: true
     name: http
   name: http
 Routes:

--- a/internal/kgateway/translator/irtranslator/fc.go
+++ b/internal/kgateway/translator/irtranslator/fc.go
@@ -244,10 +244,11 @@ func (h *hcmNetworkFilterTranslator) initializeHCM() *envoyhttp.HttpConnectionMa
 	}
 
 	return &envoyhttp.HttpConnectionManager{
-		CodecType:     envoyhttp.HttpConnectionManager_AUTO,
-		StatPrefix:    statPrefix,
-		NormalizePath: wrapperspb.Bool(true),
-		MergeSlashes:  true,
+		CodecType:        envoyhttp.HttpConnectionManager_AUTO,
+		StatPrefix:       statPrefix,
+		NormalizePath:    wrapperspb.Bool(true),
+		MergeSlashes:     true,
+		UseRemoteAddress: wrapperspb.Bool(true),
 		RouteSpecifier: &envoyhttp.HttpConnectionManager_Rds{
 			Rds: &envoyhttp.Rds{
 				ConfigSource: &envoy_config_core_v3.ConfigSource{


### PR DESCRIPTION
default use_remote_address to true - that's a reasonable default for ingress. otherwise envoy will use the address from the XFF header. In the future we can add options to customize this.

also: minor cleanup for the httplistenerpolicy - remove the spec from the IR.