### PR TITLE
update lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,6 +59,13 @@ issues:
   # Set to 0 to disable.
   max-same-issues: 0
 
+  exclude-dirs:
+    # don't lint ruleguard files
+    - test/rules
+
+    # don't lint gomock intermediate files
+    - 'gomock_reflect_\d*'
+
 run:
   # Number of CPUs to use when running golangci-lint.
   # Default: the number of logical CPUs in the machine
@@ -76,24 +83,10 @@ run:
   # If we find that the job is timing out, we can explore ways to make this job run faster, or increase the timeout.
   timeout: 10m
 
-  skip-dirs:
-    # don't lint ruleguard files
-    - test/rules
-
-    # don't lint gomock intermediate files
-    - 'gomock_reflect_\d*'
-
 # output configuration options
 output:
-  # Format: colored-line-number|line-number|json|colored-tab|tab|checkstyle|code-climate|junit-xml|github-actions|teamcity
-  #
-  # Multiple can be specified by separating them by comma, output can be provided
-  # for each of them by separating format name and path by colon symbol.
-  # Output path can be either `stdout`, `stderr` or path to the file to write to.
-  # Example: "checkstyle:report.xml,json:stdout,colored-line-number"
-  #
-  # Default: colored-line-number
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
 
   # Print lines of code with issue.
   print-issued-lines: true


### PR DESCRIPTION
Fixes errors from the static analysis job:
```
level=warning msg="[config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`."
level=warning msg="[config_reader] The configuration option `output.format` is deprecated, please use `output.formats`"
jsonschema: "run" does not validate with "/properties/run/additionalProperties": additionalProperties 'skip-dirs' not allowed
jsonschema: "output" does not validate with "/properties/output/additionalProperties": additionalProperties 'format' not allowed
Error: the configuration contains invalid elements
```
https://github.com/kgateway-dev/kgateway/actions/runs/13360836538/job/37310233413?pr=10632