### PR TITLE
internal/kgateway: Rename component logger from gloo -> kgateway

### DIFF
--- a/internal/kgateway/setup/ggv2setup.go
+++ b/internal/kgateway/setup/ggv2setup.go
@@ -31,11 +31,11 @@ import (
 )
 
 const (
-	glooComponentName = "gloo"
+	componentName = "kgateway"
 )
 
 func Main(customCtx context.Context) error {
-	SetupLogging(customCtx, glooComponentName)
+	SetupLogging(customCtx, componentName)
 	return startSetupLoop(customCtx)
 }
 
@@ -56,7 +56,6 @@ func createKubeClient(restConfig *rest.Config) (istiokube.Client, error) {
 func StartGGv2(ctx context.Context,
 	extraPlugins []extensionsplug.Plugin,
 	extraGwClasses []string, // TODO: we can remove this and replace with something that watches all GW classes with our controller name
-
 ) error {
 	restConfig := ctrl.GetConfigOrDie()
 


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Quick PR that renames the component logger name from "gloo" -> "kgateway".

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
