### PR TITLE
e2e tests: rename TestK8sGateway to TestKgateway

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -38,12 +38,12 @@ jobs:
 #         # Dec 4, 2024: 24 minutes
 #         - cluster-name: 'cluster-three'
 #           go-test-args: '-v -timeout=30m'
-#           go-test-run-regex: '(^TestKgatewayIstioAutoMtls$$|^TestAutomtlsIstioEdgeApisGateway$$|^TestIstioEdgeApiGateway$$|^TestIstioRegression$$)'
+#           go-test-run-regex: '(^TestKgatewayIstioAutoMtls$$|^TestIstioRegression$$)'
 
 #         # Dec 4, 2024: 21 minutes
 #         - cluster-name: 'cluster-four'
 #           go-test-args: '-v -timeout=30m'
-#           go-test-run-regex: '(^TestKgatewayIstio$$|^TestGlooGatewayEdgeGateway$$|^TestGlooctlIstioInjectEdgeApiGateway$$)'
+#           go-test-run-regex: '(^TestKgatewayIstio$$)'
 
 #         # Dec 4, 2024: 24 minutes
 #         - cluster-name: 'cluster-five'
@@ -58,7 +58,7 @@ jobs:
 #         # Dec 4, 2024: 13 minutes
 #         - cluster-name: 'cluster-seven'
 #           go-test-args: '-v -timeout=25m'
-#           go-test-run-regex: '^TestKgateway$$/^CRDCategories$$|^TestKgateway$$/^Metrics$$|^TestGloomtlsGatewayEdgeGateway$$|^TestWatchNamespaceSelector$$'
+#           go-test-run-regex: '^TestKgateway$$/^CRDCategories$$|^TestKgateway$$/^Metrics$$|^TestWatchNamespaceSelector$$'
 
         # In our PR tests, we run the suite of tests using the upper ends of versions that we claim to support
         # The versions should mirror: https://kgateway.dev/docs/reference/versions/

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -28,22 +28,22 @@ jobs:
         # Feb 17, 2025: ? minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGateway$$/^BasicRouting$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$'
 
 #         # Dec 4, 2024: 23 minutes
 #         - cluster-name: 'cluster-two'
 #           go-test-args: '-v -timeout=25m'
-#           go-test-run-regex: '^TestK8sGateway$$/^RouteDelegation$$|^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$|^TestK8sGateway$$/^HttpListenerOptions$$|^TestK8sGateway$$/^ListenerOptions$$|^TestK8sGateway$$/^GlooAdminServer$$'
+#           go-test-run-regex: '^TestKgateway$$/^RouteDelegation$$|^TestKgatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteOptions$$|^TestKgateway$$/^VirtualHostOptions$$|^TestKgateway$$/^Upstreams$$|^TestKgateway$$/^HeadlessSvc$$|^TestKgateway$$/^PortRouting$$|^TestKgatewayMinimalDefaultGatewayParameters$$|^TestKgateway$$/^DirectResponse$$|^TestKgateway$$/^HttpListenerOptions$$|^TestKgateway$$/^ListenerOptions$$|^TestKgateway$$/^GlooAdminServer$$'
 
 #         # Dec 4, 2024: 24 minutes
 #         - cluster-name: 'cluster-three'
 #           go-test-args: '-v -timeout=30m'
-#           go-test-run-regex: '(^TestK8sGatewayIstioAutoMtls$$|^TestAutomtlsIstioEdgeApisGateway$$|^TestIstioEdgeApiGateway$$|^TestIstioRegression$$)'
+#           go-test-run-regex: '(^TestKgatewayIstioAutoMtls$$|^TestAutomtlsIstioEdgeApisGateway$$|^TestIstioEdgeApiGateway$$|^TestIstioRegression$$)'
 
 #         # Dec 4, 2024: 21 minutes
 #         - cluster-name: 'cluster-four'
 #           go-test-args: '-v -timeout=30m'
-#           go-test-run-regex: '(^TestK8sGatewayIstio$$|^TestGlooGatewayEdgeGateway$$|^TestGlooctlIstioInjectEdgeApiGateway$$)'
+#           go-test-run-regex: '(^TestKgatewayIstio$$|^TestGlooGatewayEdgeGateway$$|^TestGlooctlIstioInjectEdgeApiGateway$$)'
 
 #         # Dec 4, 2024: 24 minutes
 #         - cluster-name: 'cluster-five'
@@ -53,12 +53,12 @@ jobs:
 #         # Dec 4, 2024: 26 minutes
 #         - cluster-name: 'cluster-six'
 #           go-test-args: '-v -timeout=30m'
-#           go-test-run-regex: '^TestDiscoveryWatchlabels$$|^TestK8sGatewayNoValidation$$|^TestHelm$$|^TestHelmSettings$$|^TestK8sGatewayAws$$|^TestK8sGateway$$/^HTTPRouteServices$$|^TestK8sGateway$$/^TCPRouteServices$$|^TestZeroDowntimeRollout$$'
+#           go-test-run-regex: '^TestDiscoveryWatchlabels$$|^TestKgatewayNoValidation$$|^TestHelm$$|^TestHelmSettings$$|^TestKgatewayAws$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$|^TestZeroDowntimeRollout$$'
 
 #         # Dec 4, 2024: 13 minutes
 #         - cluster-name: 'cluster-seven'
 #           go-test-args: '-v -timeout=25m'
-#           go-test-run-regex: '^TestK8sGateway$$/^CRDCategories$$|^TestK8sGateway$$/^Metrics$$|^TestGloomtlsGatewayEdgeGateway$$|^TestWatchNamespaceSelector$$'
+#           go-test-run-regex: '^TestKgateway$$/^CRDCategories$$|^TestKgateway$$/^Metrics$$|^TestGloomtlsGatewayEdgeGateway$$|^TestWatchNamespaceSelector$$'
 
         # In our PR tests, we run the suite of tests using the upper ends of versions that we claim to support
         # The versions should mirror: https://kgateway.dev/docs/reference/versions/

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -25,7 +25,7 @@ jobs:
         # NOTE: We use the GitHub action step time (as opposed to the `go test` time), because it is easier to capture
 
         test:
-        # Feb 17, 2025: ? minutes
+        # Feb 18, 2025: 4 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^BasicRouting$$'

--- a/test/kubernetes/e2e/debugging.md
+++ b/test/kubernetes/e2e/debugging.md
@@ -4,7 +4,7 @@ This document describes workflows that may be useful when debugging e2e tests wi
 
 ## Overview
 
-The entry point for an e2e test is a Go test function of the form `func TestXyz(t *testing.T)` which represents a top level suite against an installation mode of Gloo. For example, the `TestK8sGateway` function in [k8s_gw_test.go](/test/kubernetes/e2e/tests/k8s_gw_test.go) is a top-level suite comprising multiple feature specific suites that are invoked as subtests.
+The entry point for an e2e test is a Go test function of the form `func TestXyz(t *testing.T)` which represents a top level suite against an installation mode of Gloo. For example, the `TestKgateway` function in [k8s_gw_test.go](/test/kubernetes/e2e/tests/k8s_gw_test.go) is a top-level suite comprising multiple feature specific suites that are invoked as subtests.
 
 Each feature suite is invoked as a subtest of the top level suite. The subtests use [testify](https://github.com/stretchr/testify) to structure the tests in the feature's test suite and make use of the library's assertions.
 
@@ -41,9 +41,9 @@ _should run `kind-<CLUSTER_NAME>`_
 
 Since each feature suite is a subtest of the top level suite, you can run a single feature suite by running the top level suite with the `-run` flag.
 
-For example, to run the `Deployer` feature suite in `TestK8sGateway`, you can run:
+For example, to run the `Deployer` feature suite in `TestKgateway`, you can run:
 ```bash
-go test -v -timeout 600s ./test/kubernetes/e2e/tests -run ^TestK8sGateway$/^Deployer$
+go test -v -timeout 600s ./test/kubernetes/e2e/tests -run ^TestKgateway$/^Deployer$
 ```
 Note that the `-run` flag takes a sequence of regular expressions, and that each part may match a substring of a suite/test name. See https://pkg.go.dev/cmd/go#hdr-Testing_flags for details. To match only exact suite/test names, use the `^` and `$` characters as shown.
 
@@ -61,7 +61,7 @@ Alternatively, you can use a custom debugger launch config that sets the `test.r
   "program": "${workspaceFolder}/test/kubernetes/e2e/tests/k8s_gw_test.go",
   "args": [
     "-test.run",
-    "^TestK8sGateway$/^Deployer$",
+    "^TestKgateway$/^Deployer$",
     "-test.v",
   ],
   "env": {
@@ -78,9 +78,9 @@ When invoking tests using VSCode's `run test` option, remember to set `"go.testT
 
 Similar to running a specific feature suite, you can run a single test within a feature suite by selecting the test to run using the `-run` flag.
 
-For example, to run `TestProvisionDeploymentAndService` in `Deployer` feature suite that is a part of `TestK8sGateway`, you can run:
+For example, to run `TestProvisionDeploymentAndService` in `Deployer` feature suite that is a part of `TestKgateway`, you can run:
 ```bash
-go test -v -timeout 600s ./test/kubernetes/e2e/tests -run ^TestK8sGateway$/^Deployer$/^TestProvisionDeploymentAndService$
+go test -v -timeout 600s ./test/kubernetes/e2e/tests -run ^TestKgateway$/^Deployer$/^TestProvisionDeploymentAndService$
 ```
 
 Alternatively, with VSCode you can use a custom debugger launch config that sets the `test.run` flag to run a specific test:
@@ -93,7 +93,7 @@ Alternatively, with VSCode you can use a custom debugger launch config that sets
   "program": "${workspaceFolder}/test/kubernetes/e2e/tests/k8s_gw_test.go",
   "args": [
     "-test.run",
-    "^TestK8sGateway$/^Deployer$/^TestProvisionDeploymentAndService$",
+    "^TestKgateway$/^Deployer$/^TestProvisionDeploymentAndService$",
     "-test.v",
   ],
   "env": {
@@ -113,7 +113,7 @@ is also the case for other env variables that are required for the test to run (
 If there are multiple tests in a feature suite, you can run a single test by adding the test name to the `-run` flag in the run configuration:
 
 ```
--test.run="^TestK8sGateway$/^RouteOptions$/^TestConfigureRouteOptionsWithTargetRef$"
+-test.run="^TestKgateway$/^RouteOptions$/^TestConfigureRouteOptionsWithTargetRef$"
 ```
 
 
@@ -121,7 +121,7 @@ If there are multiple tests in a feature suite, you can run a single test by add
 We [load balance tests](./load_balancing_tests.md) across different clusters when executing them in CI. If you would like to replicate the exact set of tests that are run for a given cluster, you should:
 1. Inspect the `go-test-run-regex` defined in the [test matrix](/.github/workflows/pr-kubernetes-tests.yaml)
 ```
-go-test-run-regex: '(^TestK8sGateway$$)'
+go-test-run-regex: '(^TestKgateway$$)'
 ```
 _NOTE: There is `$$` in the GitHub action definition, since a single `$` is expanded_
 2. Inspect the `go-test-args` defined in the [test matrix](/.github/workflows/pr-kubernetes-tests.yaml)
@@ -130,5 +130,5 @@ go-test-args: '-v -timeout=25m'
 ```
 3. Combine these arguments when invoking go test:
 ```bash
-TEST_PKG=./test/kubernetes/e2e/... GO_TEST_USER_ARGS='-v -timeout=25m -run \(^TestK8sGateway$$/\)' make go-test
+TEST_PKG=./test/kubernetes/e2e/... GO_TEST_USER_ARGS='-v -timeout=25m -run \(^TestKgateway$$/\)' make go-test
 ```

--- a/test/kubernetes/e2e/tests/automtls_istio_test.go
+++ b/test/kubernetes/e2e/tests/automtls_istio_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-// TestK8sGatewayIstioAutoMtls is the function which executes a series of tests against a given installation
-func TestK8sGatewayIstioAutoMtls(t *testing.T) {
+// TestKgatewayIstioAutoMtls is the function which executes a series of tests against a given installation
+func TestKgatewayIstioAutoMtls(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "automtls-istio-k8s-gw-test")
 	testInstallation := e2e.CreateTestInstallation(

--- a/test/kubernetes/e2e/tests/k8s_gw_aws_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_aws_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-// TestK8sGatewayAws is the function which executes a series of tests against a given installation
+// TestKgatewayAws is the function which executes a series of tests against a given installation
 // with Kubernetes Gateway integration enabled and AWS lambda options configured
-func TestK8sGatewayAws(t *testing.T) {
+func TestKgatewayAws(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "k8s-gw-aws-test")
 	testInstallation := e2e.CreateTestInstallation(

--- a/test/kubernetes/e2e/tests/k8s_gw_istio_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_istio_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-// TestK8sGatewayIstio is the function which executes a series of tests against a given installation
-func TestK8sGatewayIstio(t *testing.T) {
+// TestKgatewayIstio is the function which executes a series of tests against a given installation
+func TestKgatewayIstio(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "istio-k8s-gw-test")
 	testInstallation := e2e.CreateTestInstallation(

--- a/test/kubernetes/e2e/tests/k8s_gw_minimal_default_gatewayparameters_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_minimal_default_gatewayparameters_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-// TestK8sGatewayMinimalDefaultGatewayParameters is the function which executes a series of tests against a given installation
+// TestKgatewayMinimalDefaultGatewayParameters is the function which executes a series of tests against a given installation
 // which is expected to have all user-facing options set to null in helm values
-func TestK8sGatewayMinimalDefaultGatewayParameters(t *testing.T) {
+func TestKgatewayMinimalDefaultGatewayParameters(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "k8s-gateway-minimal-default-gatewayparameters-test")
 	testInstallation := e2e.CreateTestInstallation(

--- a/test/kubernetes/e2e/tests/k8s_gw_no_validation_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_no_validation_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-// TestK8sGatewayNoValidation executes tests against a K8s Gateway gloo install with validation disabled
-func TestK8sGatewayNoValidation(t *testing.T) {
+// TestKgatewayNoValidation executes tests against a K8s Gateway gloo install with validation disabled
+func TestKgatewayNoValidation(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "k8s-gw-test-no-validation")
 	testInstallation := e2e.CreateTestInstallation(

--- a/test/kubernetes/e2e/tests/k8s_gw_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-// TestK8sGateway is the function which executes a series of tests against a given installation
-func TestK8sGateway(t *testing.T) {
+// TestKgateway is the function which executes a series of tests against a given installation
+func TestKgateway(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "k8s-gw-test")
 	testInstallation := e2e.CreateTestInstallation(

--- a/test/kubernetes/e2e/tests/revision_istio_k8s_gw_test.go
+++ b/test/kubernetes/e2e/tests/revision_istio_k8s_gw_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-// TestK8sGatewayIstioRevision is the function which executes a series of tests against a given installation with
+// TestKgatewayIstioRevision is the function which executes a series of tests against a given installation with
 // k8s gateway enabled and Istio installed with revisions
-func TestK8sGatewayIstioRevision(t *testing.T) {
+func TestKgatewayIstioRevision(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "istio-rev-k8s-gw-test")
 	testInstallation := e2e.CreateTestInstallation(


### PR DESCRIPTION
Addresses a [review comment](https://github.com/kgateway-dev/kgateway/pull/10519#discussion_r1960661809) from last PR

Also remove references to the already-deleted edge tests in the GH workflow file