### PR TITLE
Hardcode kgateway service name

### DIFF
--- a/install/helm/kgateway/templates/_helpers.tpl
+++ b/install/helm/kgateway/templates/_helpers.tpl
@@ -9,6 +9,8 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
+
+TODO: consider whether this name should be applied to the service / deployment / HPA (https://github.com/kgateway-dev/kgateway/issues/10658)
 */}}
 {{- define "kgateway.fullname" -}}
 {{- if .Values.fullnameOverride }}

--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kgateway.fullname" . }}
+  name: kgateway
   labels:
     {{- include "kgateway.labels" . | nindent 4 }}
 spec:

--- a/install/helm/kgateway/templates/hpa.yaml
+++ b/install/helm/kgateway/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "kgateway.fullname" . }}
+  name: kgateway
   labels:
     {{- include "kgateway.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "kgateway.fullname" . }}
+    name: kgateway
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/install/helm/kgateway/templates/service.yaml
+++ b/install/helm/kgateway/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kgateway.fullname" . }}
+  name: kgateway
   labels:
     {{- include "kgateway.labels" . | nindent 4 }}
 spec:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -5036,7 +5036,7 @@ metadata:
 						})
 
 						// make sure the resource requests and limits are set in the pod template
-						deploy := getStructuredDeployment(testManifest, kubeutils.GlooDeploymentName)
+						deploy := getStructuredDeployment(testManifest, kubeutils.KgatewayDeploymentName)
 						glooContainer := deploy.Spec.Template.Spec.Containers[0]
 						Expect(glooContainer.Resources).To(Equal(corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
@@ -5077,7 +5077,7 @@ metadata:
 						})
 
 						// make sure the resource requests are set in the pod template
-						deploy := getStructuredDeployment(testManifest, kubeutils.GlooDeploymentName)
+						deploy := getStructuredDeployment(testManifest, kubeutils.KgatewayDeploymentName)
 						glooContainer := deploy.Spec.Template.Spec.Containers[0]
 						Expect(glooContainer.Resources).To(Equal(corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/install/test/k8sgateway_test.go
+++ b/install/test/k8sgateway_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 			})
 
 			It("relevant resources are rendered", func() {
-				deployment := getDeployment(testManifest, namespace, kubeutils.GlooDeploymentName)
+				deployment := getDeployment(testManifest, namespace, kubeutils.KgatewayDeploymentName)
 				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1), "should have exactly 1 container")
 
 				// make sure the GatewayClass and RBAC resources exist (note, since they are all cluster-scoped, they do not have a namespace)
@@ -487,7 +487,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 			})
 
 			It("relevant resources are not rendered", func() {
-				deployment := getDeployment(testManifest, namespace, kubeutils.GlooDeploymentName)
+				deployment := getDeployment(testManifest, namespace, kubeutils.KgatewayDeploymentName)
 				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1), "should have exactly 1 container")
 
 				// the RBAC resources should not be rendered

--- a/internal/kgateway/setup/ggv2setup.go
+++ b/internal/kgateway/setup/ggv2setup.go
@@ -79,7 +79,7 @@ func StartGGv2(ctx context.Context,
 // GetControlPlaneXdsHost gets the xDS address from the gloo Service.
 func GetControlPlaneXdsHost() string {
 	return kubeutils.ServiceFQDN(metav1.ObjectMeta{
-		Name:      kubeutils.GlooServiceName,
+		Name:      kubeutils.KgatewayServiceName,
 		Namespace: namespaces.GetPodNamespace(),
 	})
 }

--- a/pkg/utils/kubeutils/names.go
+++ b/pkg/utils/kubeutils/names.go
@@ -1,13 +1,13 @@
 package kubeutils
 
 const (
-	GlooDeploymentName    = "kgateway"
-	GlooServiceName       = "kgateway"
-	KgatewayContainerName = "kgateway"
+	// control plane resource names
+	// TODO if we make the names configurable we should stop using these constants (https://github.com/kgateway-dev/kgateway/issues/10658)
+	KgatewayDeploymentName = "kgateway"
+	KgatewayServiceName    = "kgateway"
+	KgatewayContainerName  = "kgateway"
 
-	// GlooXdsPortName is the name of the port in the Gloo Gateway control plane Kubernetes Service that serves xDS config.
-	// See: install/helm/gloo/templates/2-gloo-service.yaml
-	GlooXdsPortName = "grpc-xds"
-
-	DiscoveryDeploymentName = "discovery"
+	// XdsPortName is the name of the port in the kgateway control plane Kubernetes Service that serves xDS config.
+	// See: install/helm/kgateway/templates/service.yaml
+	XdsPortName = "grpc-xds"
 )

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -686,7 +686,7 @@ var _ = Describe("Kube2e: gateway", func() {
 
 			It("Returns proxies", func() {
 				portForwarder, err := kubeCli.StartPortForward(ctx,
-					portforward.WithDeployment(kubeutils.GlooDeploymentName, testHelper.InstallNamespace),
+					portforward.WithDeployment(kubeutils.KgatewayDeploymentName, testHelper.InstallNamespace),
 					portforward.WithRemotePort(defaults2.GlooProxyDebugPort),
 				)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/kube2e/gloo/setup_syncer_test.go
+++ b/test/kube2e/gloo/setup_syncer_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Setup Syncer", func() {
 
 		It("restarts validation grpc server when settings change", func() {
 			portForwarder, err := testHelper.StartPortForward(ctx,
-				portforward.WithDeployment(kubeutils.GlooDeploymentName, testHelper.InstallNamespace),
+				portforward.WithDeployment(kubeutils.KgatewayDeploymentName, testHelper.InstallNamespace),
 				portforward.WithRemotePort(defaults.GlooValidationPort),
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/kubernetes/e2e/features/admin_server/suite.go
+++ b/test/kubernetes/e2e/features/admin_server/suite.go
@@ -44,7 +44,7 @@ func (s *testingSuite) TestGetInputSnapshotIncludesSettings() {
 	s.testInstallation.Assertions.AssertGlooAdminApi(
 		s.ctx,
 		metav1.ObjectMeta{
-			Name:      kubeutils.GlooDeploymentName,
+			Name:      kubeutils.KgatewayDeploymentName,
 			Namespace: s.testInstallation.Metadata.InstallNamespace,
 		},
 		s.testInstallation.Assertions.InputSnapshotContainsElement(v1.SettingsGVK, metav1.ObjectMeta{
@@ -68,7 +68,7 @@ func (s *testingSuite) TestGetInputSnapshotIncludesEdgeApiResources() {
 	s.testInstallation.Assertions.AssertGlooAdminApi(
 		s.ctx,
 		metav1.ObjectMeta{
-			Name:      kubeutils.GlooDeploymentName,
+			Name:      kubeutils.KgatewayDeploymentName,
 			Namespace: s.testInstallation.Metadata.InstallNamespace,
 		},
 		s.testInstallation.Assertions.InputSnapshotContainsElement(v1.UpstreamGVK, upstreamMeta),
@@ -89,7 +89,7 @@ func (s *testingSuite) TestGetInputSnapshotIncludesK8sGatewayApiResources() {
 	s.testInstallation.Assertions.AssertGlooAdminApi(
 		s.ctx,
 		metav1.ObjectMeta{
-			Name:      kubeutils.GlooDeploymentName,
+			Name:      kubeutils.KgatewayDeploymentName,
 			Namespace: s.testInstallation.Metadata.InstallNamespace,
 		},
 		s.testInstallation.Assertions.InputSnapshotContainsElement(v1alpha1.GatewayParametersGVK, gatewayParametersMeta),

--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -316,7 +316,7 @@ func xdsClusterAssertion(testInstallation *e2e.TestInstallation) func(ctx contex
 			g.Expect(xdsSocketAddress).NotTo(gomega.BeNil())
 
 			g.Expect(xdsSocketAddress.GetAddress()).To(gomega.Equal(kubeutils.ServiceFQDN(metav1.ObjectMeta{
-				Name:      kubeutils.GlooServiceName,
+				Name:      kubeutils.KgatewayServiceName,
 				Namespace: testInstallation.Metadata.InstallNamespace,
 			})), "xds socket address points to gloo service, in installation namespace")
 

--- a/test/kubernetes/e2e/features/server_tls/suite.go
+++ b/test/kubernetes/e2e/features/server_tls/suite.go
@@ -327,7 +327,7 @@ func (s *serverTlsTestingSuite) eventuallyInSnapshot(gvk schema.GroupVersionKind
 	s.testInstallation.Assertions.AssertGlooAdminApi(
 		s.ctx,
 		metav1.ObjectMeta{
-			Name:      kubeutils.GlooDeploymentName,
+			Name:      kubeutils.KgatewayDeploymentName,
 			Namespace: s.testInstallation.Metadata.InstallNamespace,
 		},
 		s.testInstallation.Assertions.InputSnapshotContainsElement(gvk, meta),
@@ -337,7 +337,7 @@ func (s *serverTlsTestingSuite) eventuallyNotInSnapshot(gvk schema.GroupVersionK
 	s.testInstallation.Assertions.AssertGlooAdminApi(
 		s.ctx,
 		metav1.ObjectMeta{
-			Name:      kubeutils.GlooDeploymentName,
+			Name:      kubeutils.KgatewayDeploymentName,
 			Namespace: s.testInstallation.Metadata.InstallNamespace,
 		},
 		s.testInstallation.Assertions.InputSnapshotDoesNotContainElement(gvk, meta),


### PR DESCRIPTION
Since our controller makes an assumption about the control plane service being named `kgateway` we should hardcode this in the helm chart for now.

Also removed "gloo" references from some constants.

Fixes https://github.com/kgateway-dev/kgateway/issues/10659