### PR TITLE
Fix basicrouting flake

### DIFF
--- a/test/kubernetes/e2e/features/basicrouting/suite.go
+++ b/test/kubernetes/e2e/features/basicrouting/suite.go
@@ -80,7 +80,7 @@ func (s *testingSuite) AfterTest(suiteName, testName string) {
 }
 
 func (s *testingSuite) TestGatewayWithRoute() {
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 
 	// Should have a successful response
 	s.testInstallation.Assertions.AssertEventualCurlResponse(

--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -115,11 +115,11 @@ func (s *testingSuite) AfterTest(suiteName, testName string) {
 }
 
 func (s *testingSuite) TestProvisionDeploymentAndService() {
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 }
 
 func (s *testingSuite) TestConfigureProxiesFromGatewayParameters() {
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 
 	// check that the labels and annotations got passed through from GatewayParameters to the ServiceAccount
 	sa := &corev1.ServiceAccount{}
@@ -152,7 +152,7 @@ func (s *testingSuite) TestConfigureProxiesFromGatewayParameters() {
 	})
 
 	// Assert that the expected custom configuration exists.
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(2))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(2))
 
 	s.testInstallation.Assertions.AssertEnvoyAdminApi(
 		s.ctx,
@@ -163,7 +163,7 @@ func (s *testingSuite) TestConfigureProxiesFromGatewayParameters() {
 }
 
 func (s *testingSuite) TestConfigureAwsLambda() {
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 
 	s.testInstallation.Assertions.AssertEnvoyAdminApi(
 		s.ctx,
@@ -173,7 +173,7 @@ func (s *testingSuite) TestConfigureAwsLambda() {
 }
 
 func (s *testingSuite) TestProvisionResourcesUpdatedWithValidParameters() {
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 
 	// modify the number of replicas in the GatewayParameters
 	s.patchGatewayParameters(gwParamsDefault.ObjectMeta, func(parameters *v1alpha1.GatewayParameters) {
@@ -182,11 +182,11 @@ func (s *testingSuite) TestProvisionResourcesUpdatedWithValidParameters() {
 
 	// the GatewayParameters modification should cause the deployer to re-run and update the
 	// deployment to have 2 replicas
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(2))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(2))
 }
 
 func (s *testingSuite) TestProvisionResourcesNotUpdatedWithInvalidParameters() {
-	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.testInstallation.Assertions.EventuallyReadyReplicas(s.ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 
 	var (
 		// initially, allowPrivilegeEscalation should be true and privileged should not be set

--- a/test/kubernetes/e2e/features/metrics/suite.go
+++ b/test/kubernetes/e2e/features/metrics/suite.go
@@ -40,7 +40,7 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 // TestKubeServiceSuccessStats sends a number of requests to a kube Service and checks that the cluster metrics
 // show the expected number of successful requests
 func (s *testingSuite) TestKubeServiceSuccessStats() {
-	s.TestInstallation.Assertions.EventuallyRunningReplicas(s.Ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.TestInstallation.Assertions.EventuallyReadyReplicas(s.Ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 
 	kubeSvcUpstream := kubernetes.ServiceToUpstream(s.Ctx, exampleSvc, exampleSvc.Spec.Ports[0])
 	s.sendAndAssertNumSuccessfulRequests(3, kubeSvcUpstream)
@@ -49,7 +49,7 @@ func (s *testingSuite) TestKubeServiceSuccessStats() {
 // TestKubeUpstreamSuccessStats sends a number of requests to a kube Upstream and checks that the cluster metrics
 // show the expected number of successful requests
 func (s *testingSuite) TestKubeUpstreamSuccessStats() {
-	s.TestInstallation.Assertions.EventuallyRunningReplicas(s.Ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
+	s.TestInstallation.Assertions.EventuallyReadyReplicas(s.Ctx, proxyDeployment.ObjectMeta, gomega.Equal(1))
 
 	s.sendAndAssertNumSuccessfulRequests(2, kubeUpstream)
 }

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
@@ -30,7 +30,7 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 
 func (s *testingSuite) TestZeroDowntimeRollout() {
 	// Ensure the gloo gateway pod is up and running
-	s.TestInstallation.Assertions.EventuallyRunningReplicas(s.Ctx, glooProxyObjectMeta, Equal(1))
+	s.TestInstallation.Assertions.EventuallyReadyReplicas(s.Ctx, glooProxyObjectMeta, Equal(1))
 	s.TestInstallation.Assertions.AssertEventualCurlResponse(
 		s.Ctx,
 		defaults.CurlPodExecOpt,

--- a/test/kubernetes/testutils/assertions/deployments.go
+++ b/test/kubernetes/testutils/assertions/deployments.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
-// EventuallyReadyReplicas asserts that eventually the number of pods matching the replicaMatcher
+// EventuallyReadyReplicas asserts that given a Deployment, eventually the number of pods matching the replicaMatcher
 // are in the ready state and able to receive traffic.
 func (p *Provider) EventuallyReadyReplicas(ctx context.Context, deploymentMeta metav1.ObjectMeta, replicaMatcher types.GomegaMatcher) {
 	p.Gomega.Eventually(func(innerG Gomega) {

--- a/test/kubernetes/testutils/assertions/deployments.go
+++ b/test/kubernetes/testutils/assertions/deployments.go
@@ -11,7 +11,9 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
-func (p *Provider) EventuallyRunningReplicas(ctx context.Context, deploymentMeta metav1.ObjectMeta, replicaMatcher types.GomegaMatcher) {
+// EventuallyReadyReplicas asserts that eventually the number of pods matching the replicaMatcher
+// are in the ready state and able to receive traffic.
+func (p *Provider) EventuallyReadyReplicas(ctx context.Context, deploymentMeta metav1.ObjectMeta, replicaMatcher types.GomegaMatcher) {
 	p.Gomega.Eventually(func(innerG Gomega) {
 		// We intentionally rely only on Pods that have marked themselves as ready as a way of defining more explicit assertions
 		pods, err := kubeutils.GetReadyPodsForDeployment(ctx, p.clusterContext.Clientset, deploymentMeta)

--- a/test/kubernetes/testutils/assertions/envoy.go
+++ b/test/kubernetes/testutils/assertions/envoy.go
@@ -23,7 +23,7 @@ func (p *Provider) AssertEnvoyAdminApi(
 	adminAssertions ...func(ctx context.Context, adminClient *admincli.Client),
 ) {
 	// Before opening a port-forward, we assert that there is at least one Pod that is ready
-	p.EventuallyRunningReplicas(ctx, envoyDeployment, BeNumerically(">=", 1))
+	p.EventuallyReadyReplicas(ctx, envoyDeployment, BeNumerically(">=", 1))
 
 	portForwarder, err := p.clusterContext.Cli.StartPortForward(ctx,
 		portforward.WithDeployment(envoyDeployment.GetName(), envoyDeployment.GetNamespace()),

--- a/test/kubernetes/testutils/assertions/gloo.go
+++ b/test/kubernetes/testutils/assertions/gloo.go
@@ -26,7 +26,7 @@ func (p *Provider) AssertGlooAdminApi(
 	adminAssertions ...func(ctx context.Context, adminClient *admincli.Client),
 ) {
 	// Before opening a port-forward, we assert that there is at least one Pod that is ready
-	p.EventuallyRunningReplicas(ctx, glooDeployment, BeNumerically(">=", 1))
+	p.EventuallyReadyReplicas(ctx, glooDeployment, BeNumerically(">=", 1))
 
 	portForwarder, err := p.clusterContext.Cli.StartPortForward(ctx,
 		portforward.WithDeployment(glooDeployment.GetName(), glooDeployment.GetNamespace()),

--- a/test/kubernetes/testutils/assertions/kgateway.go
+++ b/test/kubernetes/testutils/assertions/kgateway.go
@@ -3,19 +3,16 @@ package assertions
 import (
 	"context"
 
-	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
 func (p *Provider) EventuallyKgatewayInstallSucceeded(ctx context.Context) {
 	p.expectInstallContextDefined()
 
-	p.EventuallyReadyReplicas(ctx, metav1.ObjectMeta{
-		Name:      kubeutils.GlooDeploymentName,
-		Namespace: p.installContext.InstallNamespace,
-	}, gomega.Equal(1))
+	p.EventuallyPodsRunning(ctx, p.installContext.InstallNamespace,
+		metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=kgateway",
+		})
 }
 
 func (p *Provider) EventuallyKgatewayUninstallSucceeded(ctx context.Context) {
@@ -30,8 +27,8 @@ func (p *Provider) EventuallyKgatewayUninstallSucceeded(ctx context.Context) {
 func (p *Provider) EventuallyKgatewayUpgradeSucceeded(ctx context.Context, version string) {
 	p.expectInstallContextDefined()
 
-	p.EventuallyReadyReplicas(ctx, metav1.ObjectMeta{
-		Name:      kubeutils.GlooDeploymentName,
-		Namespace: p.installContext.InstallNamespace,
-	}, gomega.Equal(1))
+	p.EventuallyPodsRunning(ctx, p.installContext.InstallNamespace,
+		metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=kgateway",
+		})
 }

--- a/test/kubernetes/testutils/assertions/kgateway.go
+++ b/test/kubernetes/testutils/assertions/kgateway.go
@@ -3,16 +3,19 @@ package assertions
 import (
 	"context"
 
+	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
 func (p *Provider) EventuallyKgatewayInstallSucceeded(ctx context.Context) {
 	p.expectInstallContextDefined()
 
-	p.EventuallyPodsRunning(ctx, p.installContext.InstallNamespace,
-		metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/name=kgateway",
-		})
+	p.EventuallyReadyReplicas(ctx, metav1.ObjectMeta{
+		Name:      kubeutils.GlooDeploymentName,
+		Namespace: p.installContext.InstallNamespace,
+	}, gomega.Equal(1))
 }
 
 func (p *Provider) EventuallyKgatewayUninstallSucceeded(ctx context.Context) {
@@ -27,5 +30,8 @@ func (p *Provider) EventuallyKgatewayUninstallSucceeded(ctx context.Context) {
 func (p *Provider) EventuallyKgatewayUpgradeSucceeded(ctx context.Context, version string) {
 	p.expectInstallContextDefined()
 
-	// TODO check other things here, e.g. expected pods are up
+	p.EventuallyReadyReplicas(ctx, metav1.ObjectMeta{
+		Name:      kubeutils.GlooDeploymentName,
+		Namespace: p.installContext.InstallNamespace,
+	}, gomega.Equal(1))
 }

--- a/test/kubernetes/testutils/assertions/pods.go
+++ b/test/kubernetes/testutils/assertions/pods.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/helpers"
 )
 
-// EventuallyPodsRunning asserts that the pod(s) are in the PodRunning state
+// EventuallyPodsRunning asserts that eventually all pods matching the given ListOptions are in the PodRunning state
 func (p *Provider) EventuallyPodsRunning(
 	ctx context.Context,
 	podNamespace string,

--- a/test/kubernetes/testutils/assertions/pods.go
+++ b/test/kubernetes/testutils/assertions/pods.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/helpers"
 )
 
-// EventuallyPodsRunning asserts that the pod(s) are in the ready state
+// EventuallyPodsRunning asserts that the pod(s) are in the PodRunning state
 func (p *Provider) EventuallyPodsRunning(
 	ctx context.Context,
 	podNamespace string,


### PR DESCRIPTION
Fix basic routing test flake: wait for nginx, curl, proxy pods to be running before trying to curl

Also renamed `EventuallyRunningReplicas` to `EventuallyReadyReplicas` to accurately reflect that it waits for pods to have the `PodReady` condition

Fixes https://github.com/kgateway-dev/kgateway/issues/10661