### PR TITLE
*: Enable the whitespace linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - unused
     - usestdlibvars
     - importas
+    - whitespace
 
 # Settings dedicated to specific linters.
 linters-settings:

--- a/internal/kgateway/admin/server.go
+++ b/internal/kgateway/admin/server.go
@@ -21,16 +21,15 @@ const (
 )
 
 func RunAdminServer(ctx context.Context, setupOpts *controller.SetupOpts) error {
-	// serverHandlers defines the custom handlers that the Admin Server will support
-	serverHandlers := getServerHandlers(ctx, setupOpts.KrtDebugger, setupOpts.Cache)
-
 	// initialize the atomic log level
 	if envLogLevel := os.Getenv(contextutils.LogLevelEnvName); envLogLevel != "" {
 		contextutils.SetLogLevelFromString(envLogLevel)
 	}
-
-	startHandlers(ctx, serverHandlers)
-
+	// serverHandlers defines the custom handlers that the Admin Server will support
+	serverHandlers := getServerHandlers(ctx, setupOpts.KrtDebugger, setupOpts.Cache)
+	if err := startHandlers(ctx, serverHandlers); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -115,7 +114,6 @@ func startHandlers(ctx context.Context, addHandlers ...func(mux *http.ServeMux, 
 
 func index(profileDescriptions map[string]dynamicProfileDescription) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		type profile struct {
 			Name string
 			Href string
@@ -139,7 +137,6 @@ func index(profileDescriptions map[string]dynamicProfileDescription) func(w http
 		fmt.Fprintf(&buf, "<h1>Admin Server</h1>\n")
 		for _, p := range profiles {
 			fmt.Fprintf(&buf, "<h2><a href=\"%s\"}>%s</a></h2><p>%s</p>\n", p.Name, p.Name, p.Desc)
-
 		}
 		w.Write(buf.Bytes())
 	}

--- a/internal/kgateway/controller/typed_client.go
+++ b/internal/kgateway/controller/typed_client.go
@@ -31,7 +31,6 @@ var _ runtime.Unstructured = &ObjList[corev1.Namespace, *corev1.Namespace]{}
 
 func (t *ObjList[T, PT]) GetObjectKind() schema.ObjectKind {
 	return t
-
 }
 func (t *ObjList[T, PT]) NewEmptyInstance() runtime.Unstructured {
 	return &ObjList[T, PT]{}

--- a/internal/kgateway/deployer/deployer.go
+++ b/internal/kgateway/deployer/deployer.go
@@ -565,5 +565,4 @@ func applyFloatingUserId(dstKube *v1alpha1.KubernetesProxyConfig) {
 			securityContext.RunAsUser = nil
 		}
 	}
-
 }

--- a/internal/kgateway/extensions2/plugins/destrule/destrule_plugin.go
+++ b/internal/kgateway/extensions2/plugins/destrule/destrule_plugin.go
@@ -77,11 +77,9 @@ func (d *destrulePlugin) processEndpoints(kctx krt.HandlerContext, ctx context.C
 
 func (d *destrulePlugin) processUpstream(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniqlyConnectedClient, in ir.Upstream, outCluster *envoy_config_cluster_v3.Cluster) {
 	destrule := d.destinationRulesIndex.FetchDestRulesFor(kctx, ucc.Namespace, in.CanonicalHostname, ucc.Labels)
-
 	if destrule != nil {
 		trafficPolicy := getTrafficPolicy(destrule, uint32(in.Port))
 		if outlier := trafficPolicy.GetOutlierDetection(); outlier != nil {
-
 			if getLocalityLbSetting(trafficPolicy) != nil {
 				if outCluster.GetCommonLbConfig() == nil {
 					outCluster.CommonLbConfig = &envoy_config_cluster_v3.Cluster_CommonLbConfig{}
@@ -124,10 +122,8 @@ func (d *destrulePlugin) processUpstream(kctx krt.HandlerContext, ctx context.Co
 			}
 
 			outCluster.OutlierDetection = out
-
 		}
 	}
-
 }
 
 func getPriorityInfoFromDestrule(localityLb *v1alpha3.LocalityLoadBalancerSetting) *endpoints.PriorityInfo {

--- a/internal/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
+++ b/internal/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
@@ -67,7 +67,6 @@ func registerTypes(ourCli versioned.Interface) {
 }
 
 func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensionplug.Plugin {
-
 	registerTypes(commoncol.OurClient)
 
 	col := krt.WrapClient(kclient.New[*v1alpha1.DirectResponse](commoncol.Client), commoncol.KrtOpts.ToOptions("DirectResponse")...)

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_converter.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_converter.go
@@ -439,7 +439,6 @@ func getFormatterExtensions() ([]*envoycore.TypedExtensionConfig, error) {
 			TypedConfig: mdFormatterTc,
 		},
 	}, nil
-
 }
 
 func newAccessLogWithConfig(name string, config proto.Message) (*envoyaccesslog.AccessLog, error) {

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_listener_plugin_test.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_listener_plugin_test.go
@@ -663,7 +663,6 @@ func TestConvertJsonFormat_EdgeCases(t *testing.T) {
 			})
 		}
 	})
-
 }
 
 // Helper function to handle MessageToAny error in test cases

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
@@ -63,7 +63,6 @@ func (p *httpListenerPolicyPluginGwPass) ApplyListenerPlugin(ctx context.Context
 }
 
 func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensionplug.Plugin {
-
 	// need upstreams for backend refs
 	col := krtutil.SetupCollectionDynamic[v1alpha1.HTTPListenerPolicy](
 		ctx,

--- a/internal/kgateway/extensions2/plugins/istio/plugin.go
+++ b/internal/kgateway/extensions2/plugins/istio/plugin.go
@@ -232,7 +232,6 @@ func createDefaultIstioMatch() *envoy_config_cluster_v3.Cluster_TransportSocketM
 }
 
 func buildSni(upstream ir.Upstream) string {
-
 	switch us := upstream.Obj.(type) {
 	case *corev1.Service:
 		return buildDNSSrvSubsetKey(

--- a/internal/kgateway/extensions2/plugins/listenerpolicy/listener_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/listenerpolicy/listener_policy_plugin.go
@@ -42,7 +42,6 @@ type listenerPolicyPluginGwPass struct {
 }
 
 func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensionplug.Plugin {
-
 	col := krtutil.SetupCollectionDynamic[v1alpha1.ListenerPolicy](
 		ctx,
 		commoncol.Client,

--- a/internal/kgateway/extensions2/plugins/upstream/aws.go
+++ b/internal/kgateway/extensions2/plugins/upstream/aws.go
@@ -26,7 +26,6 @@ const (
 )
 
 func processAws(ctx context.Context, in *v1alpha1.AwsUpstream, ir *UpstreamIr, out *envoy_config_cluster_v3.Cluster) {
-
 	lambdaHostname := getLambdaHostname(in)
 
 	// configure Envoy cluster routing info
@@ -108,7 +107,6 @@ func (p *upstreamPlugin) processBackendAws(
 	pCtx *ir.RouteBackendContext,
 	dest *upstreamDestination,
 ) error {
-
 	functionName := dest.FunctionName
 	if p.needFilter == nil {
 		p.needFilter = make(map[string]bool)

--- a/internal/kgateway/extensions2/plugins/upstream/plugin.go
+++ b/internal/kgateway/extensions2/plugins/upstream/plugin.go
@@ -101,7 +101,6 @@ func registerTypes(ourCli versioned.Interface) {
 }
 
 func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensionsplug.Plugin {
-
 	registerTypes(commoncol.OurClient)
 
 	col := krt.WrapClient(kclient.New[*v1alpha1.Upstream](commoncol.Client), commoncol.KrtOpts.ToOptions("Upstreams")...)
@@ -109,9 +108,7 @@ func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensi
 	gk := v1alpha1.UpstreamGVK.GroupKind()
 	translate := buildTranslateFunc(commoncol.Secrets)
 	ucol := krt.NewCollection(col, func(krtctx krt.HandlerContext, i *v1alpha1.Upstream) *ir.Upstream {
-
 		// resolve secrets
-
 		return &ir.Upstream{
 			ObjectSource: ir.ObjectSource{
 				Kind:      gk.Kind,
@@ -209,9 +206,7 @@ func hostname(in *v1alpha1.Upstream) string {
 }
 
 func processEndpoints(up *v1alpha1.Upstream) *ir.EndpointsForUpstream {
-
 	spec := up.Spec
-
 	switch {
 	case spec.Static != nil:
 		return processEndpointsStatic(spec.Static)
@@ -244,7 +239,6 @@ func (p *upstreamPlugin) ApplyVhostPlugin(ctx context.Context, pCtx *ir.VirtualH
 
 // called 0 or more times
 func (p *upstreamPlugin) ApplyForRoute(ctx context.Context, pCtx *ir.RouteContext, outputRoute *envoy_config_route_v3.Route) error {
-
 	return nil
 }
 

--- a/internal/kgateway/extensions2/plugins/upstream/static.go
+++ b/internal/kgateway/extensions2/plugins/upstream/static.go
@@ -13,7 +13,6 @@ import (
 )
 
 func processStatic(ctx context.Context, in *v1alpha1.StaticUpstream, out *envoy_config_cluster_v3.Cluster) {
-
 	var hostname string
 	out.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_STATIC,
@@ -82,7 +81,6 @@ func processStatic(ctx context.Context, in *v1alpha1.StaticUpstream, out *envoy_
 		//		// fix issue where ipv6 addr cannot bind
 		//		out.DnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
 	}
-
 }
 
 func processEndpointsStatic(in *v1alpha1.StaticUpstream) *ir.EndpointsForUpstream {

--- a/internal/kgateway/extensions2/pluginutils/pluginutils.go
+++ b/internal/kgateway/extensions2/pluginutils/pluginutils.go
@@ -54,5 +54,4 @@ func SetExtensionProtocolOptions(out *envoy_config_cluster_v3.Cluster, filterNam
 
 	out.GetTypedExtensionProtocolOptions()[filterName] = protoextAny
 	return nil
-
 }

--- a/internal/kgateway/extensions2/registry/registry.go
+++ b/internal/kgateway/extensions2/registry/registry.go
@@ -29,8 +29,8 @@ func mergedGw(funcs []extensionsplug.GwTranslatorFactory) extensionsplug.GwTrans
 		}
 		return nil
 	}
-
 }
+
 func mergeSynced(funcs []func() bool) func() bool {
 	return func() bool {
 		for _, f := range funcs {

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -71,7 +71,6 @@ func NewBuiltInIr(kctx krt.HandlerContext, f gwv1.HTTPRouteFilter, fromgk schema
 }
 
 func NewBuiltinPlugin(ctx context.Context) extensionplug.Plugin {
-
 	return extensionplug.Plugin{
 		ContributesPolicies: map[schema.GroupKind]extensionsplug.PolicyPlugin{
 			VirtualBuiltInGK: {
@@ -171,7 +170,6 @@ func convertURLRewrite(kctx krt.HandlerContext, config *gwv1.HTTPURLRewriteFilte
 		}
 		return nil
 	}
-
 }
 
 func convertRequestRedirect(kctx krt.HandlerContext, config *gwv1.HTTPRequestRedirectFilter) func(in ir.HttpRouteRuleMatchIR, outputRoute *envoy_config_route_v3.Route) error {
@@ -347,7 +345,6 @@ func convertMirror(kctx krt.HandlerContext, f *gwv1.HTTPRequestMirrorFilter, fro
 		RuntimeFraction: fraction,
 	}
 	return func(in ir.HttpRouteRuleMatchIR, outputRoute *envoy_config_route_v3.Route) error {
-
 		route := outputRoute.GetRoute()
 		if route == nil {
 			// TODO: report error
@@ -405,7 +402,6 @@ func (p *builtinPluginGwPass) ApplyVhostPlugin(ctx context.Context, pCtx *ir.Vir
 
 // called 0 or more times
 func (p *builtinPluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteContext, outputRoute *envoy_config_route_v3.Route) error {
-
 	policy, ok := pCtx.Policy.(*builtinPlugin)
 	if !ok {
 		return nil

--- a/internal/kgateway/krtcollections/endpoints_test.go
+++ b/internal/kgateway/krtcollections/endpoints_test.go
@@ -277,7 +277,6 @@ func TestEndpointsForUpstreamWithDifferentNameButSameEndpoints(t *testing.T) {
 }
 
 func TestEndpoints(t *testing.T) {
-
 	logger := zaptest.Logger(t)
 	contextutils.SetFallbackLogger(logger.Sugar())
 

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -366,7 +366,6 @@ func NewRefGrantIndex(refgrants krt.Collection[*gwv1beta1.ReferenceGrant]) *RefG
 		ret := make([]refGrantIndexKey, 0, len(p.Spec.To)*len(p.Spec.From))
 		for _, from := range p.Spec.From {
 			for _, to := range p.Spec.To {
-
 				ret = append(ret, refGrantIndexKey{
 					RefGrantNs: p.Namespace,
 					ToGK:       schema.GroupKind{Group: emptyIfCore(string(to.Group)), Kind: string(to.Kind)},
@@ -468,7 +467,6 @@ func NewRoutesIndex(
 	upstreams *UpstreamIndex,
 	refgrants *RefGrantIndex,
 ) *RoutesIndex {
-
 	h := &RoutesIndex{policies: policies, refgrants: refgrants, upstreams: upstreams}
 	h.hasSyncedFuncs = append(h.hasSyncedFuncs, httproutes.Synced().HasSynced, tcproutes.Synced().HasSynced)
 	h.httpRoutes = krt.NewCollection(httproutes, h.transformHttpRoute, krtopts.ToOptions("http-routes-with-policy")...)
@@ -574,7 +572,6 @@ func (h *RoutesIndex) transformHttpRoute(kctx krt.HandlerContext, i *gwv1.HTTPRo
 func (h *RoutesIndex) transformRules(kctx krt.HandlerContext, src ir.ObjectSource, i []gwv1.HTTPRouteRule) []ir.HttpRouteRuleIR {
 	rules := make([]ir.HttpRouteRuleIR, 0, len(i))
 	for _, r := range i {
-
 		extensionRefs := h.getExtensionRefs(kctx, src.Namespace, r.Filters)
 		var policies ir.AttachedPolicies
 		if r.Name != nil {
@@ -590,7 +587,6 @@ func (h *RoutesIndex) transformRules(kctx krt.HandlerContext, src ir.ObjectSourc
 		})
 	}
 	return rules
-
 }
 
 func (h *RoutesIndex) getExtensionRefs(kctx krt.HandlerContext, ns string, r []gwv1.HTTPRouteFilter) ir.AttachedPolicies {
@@ -603,7 +599,6 @@ func (h *RoutesIndex) getExtensionRefs(kctx krt.HandlerContext, ns string, r []g
 		if policy != nil {
 			ret.Policies[gk] = append(ret.Policies[gk], ir.PolicyAtt{PolicyIr: policy /*direct attachment - no target ref*/})
 		}
-
 	}
 	return ret
 }

--- a/internal/kgateway/krtcollections/setup.go
+++ b/internal/kgateway/krtcollections/setup.go
@@ -82,9 +82,7 @@ func initCollectionsWithGateways(
 	extensions extensionsplug.Plugin,
 	krtopts krtutil.KrtOptions,
 ) (*GatewayIndex, *RoutesIndex, *UpstreamIndex, krt.Collection[ir.EndpointsForUpstream]) {
-
 	policies := NewPolicyIndex(krtopts, extensions.ContributesPolicies)
-
 	var backendRefPlugins []extensionsplug.GetBackendForRefPlugin
 	for _, ext := range extensions.ContributesPolicies {
 		if ext.GetBackendForRef != nil {
@@ -106,7 +104,6 @@ func initUpstreams(
 	upstreamIndex *UpstreamIndex,
 	krtopts krtutil.KrtOptions,
 ) krt.Collection[ir.EndpointsForUpstream] {
-
 	allEndpoints := []krt.Collection[ir.EndpointsForUpstream]{}
 	for k, col := range extensions.ContributesUpstreams {
 		if col.Upstreams != nil {

--- a/internal/kgateway/krtcollections/uniqueclients.go
+++ b/internal/kgateway/krtcollections/uniqueclients.go
@@ -136,7 +136,6 @@ func roleFromRequest(r *envoy_service_discovery_v3.DiscoveryRequest) string {
 }
 
 func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.DiscoveryRequest) (string, bool, error) {
-
 	var pod *LocalityPod
 	// see if user wants to use pod locality info
 	usePod := x.augmentedPods != nil
@@ -177,7 +176,6 @@ func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.Disco
 		}
 	}
 	return c.uniqueClientName, addedNew, nil
-
 }
 
 // OnStreamRequest is called once a request is received on a stream.
@@ -236,7 +234,6 @@ func (x *callbacksCollection) getClients() []ir.UniqlyConnectedClient {
 // OnFetchRequest is called for each Fetch request. Returning an error will end processing of the
 // request and respond with an error.
 func (x *callbacks) OnFetchRequest(ctx context.Context, r *envoy_service_discovery_v3.DiscoveryRequest) error {
-
 	role := r.GetNode().GetMetadata().GetFields()[xds.RoleKey].GetStringValue()
 	// as gloo-edge and ggv2 share a control plane, check that this collection only handles ggv2 clients
 	if !xds.IsKubeGatewayCacheKey(role) {

--- a/internal/kgateway/krtcollections/uniqueclients_test.go
+++ b/internal/kgateway/krtcollections/uniqueclients_test.go
@@ -107,7 +107,6 @@ func TestUniqueClients(t *testing.T) {
 			fetchNames := sets.New[string]()
 
 			for i, r := range tc.requests {
-
 				fetchDR := proto.Clone(r).(*envoy_service_discovery_v3.DiscoveryRequest)
 				err := cb.OnFetchRequest(context.Background(), fetchDR)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -134,8 +133,6 @@ func TestUniqueClients(t *testing.T) {
 				// make sure client removed only when all similar clients are removed.
 				g.Expect(ucc.List()).To(HaveLen(len(allUcc) - 1 - i))
 			}
-
 		})
 	}
-
 }

--- a/internal/kgateway/plugins/stages.go
+++ b/internal/kgateway/plugins/stages.go
@@ -154,7 +154,6 @@ func MustNewStagedFilter(name string, config proto.Message, stage FilterStage[We
 // Errors if the config is nil or we cannot determine the type of the config.
 // Config type determination may fail if the config is both  unknown and has no fields.
 func NewStagedFilter(name string, config proto.Message, stage FilterStage[WellKnownFilterStage]) (StagedHttpFilter, error) {
-
 	s := StagedHttpFilter{
 		Filter: &envoyhttp.HttpFilter{
 			Name: name,

--- a/internal/kgateway/proxy_syncer/kube_gw_translator_syncer.go
+++ b/internal/kgateway/proxy_syncer/kube_gw_translator_syncer.go
@@ -34,5 +34,4 @@ func (s *ProxyTranslator) syncXds(
 	// a default initial fetch timeout
 	// snap.MakeConsistent()
 	s.xdsCache.SetSnapshot(ctx, proxyKey, snap)
-
 }

--- a/internal/kgateway/proxy_syncer/perclient.go
+++ b/internal/kgateway/proxy_syncer/perclient.go
@@ -20,7 +20,6 @@ func snapshotPerClient(
 	endpoints PerClientEnvoyEndpoints,
 	clusters PerClientEnvoyClusters,
 ) krt.Collection[XdsSnapWrapper] {
-
 	xdsSnapshotsForUcc := krt.NewCollection(uccCol, func(kctx krt.HandlerContext, ucc ir.UniqlyConnectedClient) *XdsSnapWrapper {
 		maybeMostlySnap := krt.FetchOne(kctx, mostXdsSnapshots, krt.FilterKey(ucc.Role))
 		if maybeMostlySnap == nil {

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -102,7 +102,6 @@ func sliceToResourcesHash[T proto.Message](slice []T) ([]envoycachetypes.Resourc
 func sliceToResources[T proto.Message](slice []T) envoycache.Resources {
 	r, h := sliceToResourcesHash(slice)
 	return envoycache.NewResourcesWithTTL(fmt.Sprintf("%d", h), r)
-
 }
 
 func toResources(gw ir.Gateway, xdsSnap irtranslator.TranslationResult, r reports.ReportMap) *GatewayXdsResources {

--- a/internal/kgateway/proxy_syncer/xdswrapper.go
+++ b/internal/kgateway/proxy_syncer/xdswrapper.go
@@ -91,7 +91,6 @@ func (p XdsSnapWrapper) MarshalJSON() (out []byte, err error) {
 }
 
 func addToSnap(snapJson map[string]map[string]any, k string, resources map[string]envoycachetypes.ResourceWithTTL) {
-
 	for rname, r := range resources {
 		rJson, _ := protojson.Marshal(r.Resource)
 		var rAny any
@@ -179,7 +178,6 @@ func visitMessage(msg protoreflect.Message, fd protoreflect.FieldDescriptor, v p
 	if anymsg, ok := m.(*anypb.Any); ok {
 		anyMsg, _ = anypb.UnmarshalNew(anymsg, proto.UnmarshalOptions{})
 		visitMsg = anyMsg.ProtoReflect()
-
 	}
 	visitFields(visitMsg, sensitive)
 	if anyMsg != nil {

--- a/internal/kgateway/query/httproute.go
+++ b/internal/kgateway/query/httproute.go
@@ -255,7 +255,6 @@ func (r *gatewayQueries) fetchChildRoutes(
 	kctx krt.HandlerContext,
 	backend ir.HttpBackendOrDelegate,
 ) ([]ir.HttpRouteIR, error) {
-
 	if backend.Delegate == nil {
 		return nil, nil
 	}

--- a/internal/kgateway/query/query_test.go
+++ b/internal/kgateway/query/query_test.go
@@ -725,7 +725,6 @@ func newQueries(initObjs ...client.Object) query.GatewayQueries {
 		time.Sleep(time.Second / 10)
 	}
 	return query.NewData(rtidx, secrets, nsCol)
-
 }
 
 func k8sUpstreams(services krt.Collection[*corev1.Service]) krt.Collection[ir.Upstream] {

--- a/internal/kgateway/setup/ggv2setup.go
+++ b/internal/kgateway/setup/ggv2setup.go
@@ -53,7 +53,8 @@ func createKubeClient(restConfig *rest.Config) (istiokube.Client, error) {
 	return client, nil
 }
 
-func StartGGv2(ctx context.Context,
+func StartGGv2(
+	ctx context.Context,
 	extraPlugins []extensionsplug.Plugin,
 	extraGwClasses []string, // TODO: we can remove this and replace with something that watches all GW classes with our controller name
 ) error {
@@ -84,9 +85,10 @@ func GetControlPlaneXdsHost() string {
 	})
 }
 
-func startControlPlane(ctx context.Context,
-	callbacks xdsserver.Callbacks) (envoycache.SnapshotCache, error) {
-
+func startControlPlane(
+	ctx context.Context,
+	callbacks xdsserver.Callbacks,
+) (envoycache.SnapshotCache, error) {
 	return NewControlPlane(ctx, &net.TCPAddr{IP: net.IPv4zero, Port: 9977}, callbacks)
 }
 

--- a/internal/kgateway/setup/ggv2setup_test.go
+++ b/internal/kgateway/setup/ggv2setup_test.go
@@ -216,7 +216,6 @@ func TestScenarios(t *testing.T) {
 				// once we change it to only include the ones in the proxy, we can re-enable this
 				//				t.Parallel()
 				testScenario(t, ctx, setupOpts.KrtDebugger, client, xdsPort, fullpath)
-
 			})
 		}
 	}
@@ -374,7 +373,6 @@ func newXdsDumper(t *testing.T, ctx context.Context, xdsPort int, gwname string)
 }
 
 func (x xdsDumper) Dump(t *testing.T, ctx context.Context) xdsDump {
-
 	dr := proto.Clone(x.dr).(*discovery_v3.DiscoveryRequest)
 	dr.TypeUrl = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
 	x.adsClient.Send(dr)
@@ -398,7 +396,6 @@ func (x xdsDumper) Dump(t *testing.T, ctx context.Context) xdsDump {
 			t.Logf("got response: %s len: %d", dresp.GetTypeUrl(), len(dresp.GetResources()))
 			if dresp.GetTypeUrl() == "type.googleapis.com/envoy.config.cluster.v3.Cluster" {
 				for _, anyCluster := range dresp.GetResources() {
-
 					var cluster envoycluster.Cluster
 					if err := anyCluster.UnmarshalTo(&cluster); err != nil {
 						t.Errorf("failed to unmarshal cluster: %v", err)
@@ -616,7 +613,6 @@ func (x *xdsDump) Compare(t *testing.T, other xdsDump) {
 		}
 		c.Endpoints = ce
 		otherc.Endpoints = ocd
-
 	}
 }
 

--- a/internal/kgateway/translator/gateway/testutils/test_file_loader.go
+++ b/internal/kgateway/translator/gateway/testutils/test_file_loader.go
@@ -34,7 +34,6 @@ var (
 )
 
 func LoadFromFiles(ctx context.Context, filename string) ([]client.Object, error) {
-
 	fileOrDir, err := os.Stat(filename)
 	if err != nil {
 		return nil, err
@@ -80,7 +79,6 @@ func LoadFromFiles(ctx context.Context, filename string) ([]client.Object, error
 			}
 			resources = append(resources, clientObj)
 		}
-
 	}
 
 	return resources, nil
@@ -107,7 +105,6 @@ func parseFile(ctx context.Context, filename string) ([]runtime.Object, error) {
 	// Create resources from YAML documents
 	var genericResources []runtime.Object
 	for _, objYaml := range resourceYamlStrings {
-
 		// Skip empty documents
 		if len(bytes.TrimSpace(objYaml)) == 0 {
 			continue

--- a/internal/kgateway/translator/gateway/translator_case_test.go
+++ b/internal/kgateway/translator/gateway/translator_case_test.go
@@ -64,15 +64,12 @@ func CompareProxy(expectedFile string, actualProxy *irtranslator.TranslationResu
 }
 
 func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) error {
-
 	for nns, routeReport := range reportsMap.HTTPRoutes {
 		for ref, parentRefReport := range routeReport.Parents {
-
 			for _, c := range parentRefReport.Conditions {
 				// most route conditions true is good, except RouteConditionPartiallyInvalid
 				if c.Type == string(gwv1.RouteConditionPartiallyInvalid) && c.Status != metav1.ConditionFalse {
 					return fmt.Errorf("condition error for httproute: %v ref: %v condition: %v", nns, ref, c)
-
 				} else if c.Status != metav1.ConditionTrue {
 					return fmt.Errorf("condition error for httproute: %v ref: %v condition: %v", nns, ref, c)
 				}
@@ -81,12 +78,10 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 	}
 	for nns, routeReport := range reportsMap.TCPRoutes {
 		for ref, parentRefReport := range routeReport.Parents {
-
 			for _, c := range parentRefReport.Conditions {
 				// most route conditions true is good, except RouteConditionPartiallyInvalid
 				if c.Type == string(gwv1.RouteConditionPartiallyInvalid) && c.Status != metav1.ConditionFalse {
 					return fmt.Errorf("condition error for tcproute: %v ref: %v condition: %v", nns, ref, c)
-
 				} else if c.Status != metav1.ConditionTrue {
 					return fmt.Errorf("condition error for tcproute: %v ref: %v condition: %v", nns, ref, c)
 				}
@@ -113,7 +108,6 @@ type testBackendPlugin struct{}
 
 // GetBackendForRef implements query.BackendRefResolver.
 func (tp testBackendPlugin) GetBackendForRefPlugin(kctx krt.HandlerContext, key ir.ObjectSource, port int32) *ir.Upstream {
-
 	if key.Kind != "test-backend-plugin" {
 		return nil
 	}

--- a/internal/kgateway/translator/irtranslator/fc.go
+++ b/internal/kgateway/translator/irtranslator/fc.go
@@ -128,6 +128,7 @@ func (n *filterChainTranslator) computeNetworkFiltersForHttp(ctx context.Context
 	networkFilters = append(networkFilters, networkFilter)
 	return networkFilters, nil
 }
+
 func (n *filterChainTranslator) computePreHCMFilters(ctx context.Context, l ir.HttpFilterChainIR, reporter reports.ListenerReporter) []plugins.StagedNetworkFilter {
 	var networkFilters []plugins.StagedNetworkFilter
 	// Process the network filters.
@@ -155,7 +156,6 @@ func (n *filterChainTranslator) computePreHCMFilters(ctx context.Context, l ir.H
 }
 
 func convertCustomNetworkFilters(customNetworkFilters []ir.CustomEnvoyFilter) []plugins.StagedNetworkFilter {
-
 	var out []plugins.StagedNetworkFilter
 	for _, customFilter := range customNetworkFilters {
 		out = append(out, plugins.StagedNetworkFilter{
@@ -170,6 +170,7 @@ func convertCustomNetworkFilters(customNetworkFilters []ir.CustomEnvoyFilter) []
 	}
 	return out
 }
+
 func sortNetworkFilters(filters plugins.StagedNetworkFilterList) []*envoy_config_listener_v3.Filter {
 	sort.Sort(filters)
 	var sortedFilters []*envoy_config_listener_v3.Filter
@@ -553,5 +554,4 @@ func bytesDataSource(s []byte) *envoy_config_core_v3.DataSource {
 			InlineBytes: s,
 		},
 	}
-
 }

--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -52,10 +52,8 @@ func (h *httpRouteConfigurationTranslator) ComputeRouteConfiguration(ctx context
 }
 
 func (h *httpRouteConfigurationTranslator) computeVirtualHosts(ctx context.Context, virtualHosts []*ir.VirtualHost) []*envoy_config_route_v3.VirtualHost {
-
 	var envoyVirtualHosts []*envoy_config_route_v3.VirtualHost
 	for _, virtualHost := range virtualHosts {
-
 		envoyVirtualHosts = append(envoyVirtualHosts, h.computeVirtualHost(ctx, virtualHost))
 	}
 	return envoyVirtualHosts
@@ -119,19 +117,16 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(ctx context.Context,
 	in ir.HttpRouteRuleMatchIR,
 	generatedName string,
 ) *envoy_config_route_v3.Route {
-
 	out := h.initRoutes(in, generatedName)
-
 	if len(in.Backends) > 0 {
 		out.Action = h.translateRouteAction(in, out)
 	}
+
 	// run plugins here that may set actoin
 	err := h.runRoutePlugins(ctx, routeReport, in, out)
-
 	if err == nil {
 		err = validateEnvoyRoute(out)
 	}
-
 	if err == nil && out.GetAction() == nil {
 		if in.HasChildren {
 			return nil
@@ -139,7 +134,6 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(ctx context.Context,
 			err = errors.New("no action specified")
 		}
 	}
-
 	if err != nil {
 		contextutils.LoggerFrom(ctx).Desugar().Debug("invalid route", zap.Error(err))
 		// TODO: we may want to aggregate all these errors per http route object and report one message?
@@ -159,7 +153,6 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(ctx context.Context,
 		// 	},
 		// }
 		out = nil
-
 	}
 
 	return out
@@ -189,7 +182,6 @@ func (h *httpRouteConfigurationTranslator) runVhostPlugins(ctx context.Context, 
 }
 
 func (h *httpRouteConfigurationTranslator) runRoutePlugins(ctx context.Context, routeReport reports.ParentRefReporter, in ir.HttpRouteRuleMatchIR, out *envoy_config_route_v3.Route) error {
-
 	// all policies up to listener have been applied as vhost polices; we need to apply the httproute policies and below
 	var policiesFromDelegateParent ir.AttachedPolicies
 	if in.DelegateParent != nil {
@@ -248,7 +240,6 @@ func (h *httpRouteConfigurationTranslator) runBackendPolicies(ctx context.Contex
 			continue
 		}
 		for _, pol := range pols {
-
 			err := pass.ApplyForRouteBackend(ctx, pol.PolicyIr, pCtx)
 			if err != nil {
 				errs = append(errs, err)
@@ -345,7 +336,6 @@ func (h *httpRouteConfigurationTranslator) initRoutes(
 	in ir.HttpRouteRuleMatchIR,
 	generatedName string,
 ) *envoy_config_route_v3.Route {
-
 	//	if len(in.Matches) == 0 {
 	//		return []*envoy_config_route_v3.Route{
 	//			{
@@ -422,7 +412,6 @@ func setEnvoyPathMatcher(match gwv1.HTTPRouteMatch, out *envoy_config_route_v3.R
 func envoyHeaderMatcher(in []gwv1.HTTPHeaderMatch) []*envoy_config_route_v3.HeaderMatcher {
 	var out []*envoy_config_route_v3.HeaderMatcher
 	for _, matcher := range in {
-
 		envoyMatch := &envoy_config_route_v3.HeaderMatcher{
 			Name: string(matcher.Name),
 		}

--- a/internal/kgateway/translator/irtranslator/upstream.go
+++ b/internal/kgateway/translator/irtranslator/upstream.go
@@ -73,7 +73,6 @@ func (t *UpstreamTranslator) runPlugins(kctx krt.HandlerContext, ctx context.Con
 }
 
 func initializeCluster(u ir.Upstream) *envoy_config_cluster_v3.Cluster {
-
 	// circuitBreakers := t.settings.GetGloo().GetCircuitBreakers()
 	out := &envoy_config_cluster_v3.Cluster{
 		Name:     u.ClusterName(),

--- a/internal/kgateway/translator/listener/gateway_listener_translator.go
+++ b/internal/kgateway/translator/listener/gateway_listener_translator.go
@@ -514,7 +514,6 @@ func (httpFilterChain *httpFilterChain) translateHttpFilterChain(
 		virtualHosts     = []*ir.VirtualHost{}
 	)
 	for host, vhostRoutes := range routesByHost {
-
 		// find the parent this host belongs to, and use its policies
 		var attachedPolicies ir.AttachedPolicies
 		maxHostnameLen := -1
@@ -534,7 +533,6 @@ func (httpFilterChain *httpFilterChain) translateHttpFilterChain(
 		sort.Stable(vhostRoutes)
 		vhostName := makeVhostName(ctx, parentName, host)
 		if !virtualHostNames[vhostName] {
-
 			virtualHostNames[vhostName] = true
 			virtualHost := &ir.VirtualHost{
 				Name:             vhostName,

--- a/internal/kgateway/translator/listener/gateway_listener_translator_test.go
+++ b/internal/kgateway/translator/listener/gateway_listener_translator_test.go
@@ -39,7 +39,6 @@ func lisToIr(l gwv1.Listener) ir.Listener {
 }
 
 func tcpToIr(tcpRoute *gwv1a2.TCPRoute) *ir.TcpRouteIR {
-
 	routeir := &ir.TcpRouteIR{
 		ObjectSource: ir.ObjectSource{
 			Namespace: tcpRoute.Namespace,

--- a/internal/kgateway/translator/sslutils/ssl_utils.go
+++ b/internal/kgateway/translator/sslutils/ssl_utils.go
@@ -21,8 +21,8 @@ var (
 func ValidateTlsSecret(sslSecret *corev1.Secret) (cleanedCertChain string, err error) {
 	return ValidateTlsSecretData(sslSecret.Name, sslSecret.Namespace, sslSecret.Data)
 }
-func ValidateTlsSecretData(n, ns string, sslSecretData map[string][]byte) (cleanedCertChain string, err error) {
 
+func ValidateTlsSecretData(n, ns string, sslSecretData map[string][]byte) (cleanedCertChain string, err error) {
 	certChain := string(sslSecretData[corev1.TLSCertKey])
 	privateKey := string(sslSecretData[corev1.TLSPrivateKeyKey])
 	rootCa := string(sslSecretData[corev1.ServiceAccountRootCAKey])
@@ -35,7 +35,6 @@ func ValidateTlsSecretData(n, ns string, sslSecretData map[string][]byte) (clean
 }
 
 func cleanedSslKeyPair(certChain, privateKey, rootCa string) (cleanedChain string, err error) {
-
 	// in the case where we _only_ provide a rootCa, we do not want to validate tls.key+tls.cert
 	if (certChain == "") && (privateKey == "") && (rootCa != "") {
 		return certChain, nil

--- a/internal/kgateway/translator/translator.go
+++ b/internal/kgateway/translator/translator.go
@@ -152,7 +152,6 @@ func (s *CombinedTranslator) TranslateGateway(kctx krt.HandlerContext, ctx conte
 	xdsSnap := s.irtranslator.Translate(*gwir, r)
 
 	return &xdsSnap, rm
-
 }
 
 func (s *CombinedTranslator) TranslateEndpoints(kctx krt.HandlerContext, ucc ir.UniqlyConnectedClient, ep ir.EndpointsForUpstream) (*envoy_config_endpoint_v3.ClusterLoadAssignment, uint64) {
@@ -160,7 +159,6 @@ func (s *CombinedTranslator) TranslateEndpoints(kctx krt.HandlerContext, ucc ir.
 	cla, additionalHash := proccessWithPlugins(s.endpointPlugins, kctx, context.TODO(), ucc, ep)
 	if cla != nil {
 		return cla, additionalHash
-
 	}
 	return endpoints.PrioritizeEndpoints(s.logger, nil, ep, ucc), 0
 }

--- a/internal/kgateway/utils/ip.go
+++ b/internal/kgateway/utils/ip.go
@@ -14,7 +14,6 @@ func IsIpv4Address(bindAddress string) (validIpv4, strictIPv4 bool, err error) {
 	if bindIP == nil {
 		// If bindAddress is not a valid textual representation of an IP address
 		return false, false, errors.Errorf("bindAddress %s is not a valid IP address", bindAddress)
-
 	} else if bindIP.To4() == nil {
 		// If bindIP is not an IPv4 address, To4 returns nil.
 		// so this is not an acceptable ipv4

--- a/internal/kgateway/utils/queue.go
+++ b/internal/kgateway/utils/queue.go
@@ -38,7 +38,6 @@ func (a *asyncQueue[T]) Dequeue(ctx context.Context) (T, error) {
 }
 
 func (a *asyncQueue[T]) Enqueue(t T) {
-
 	select {
 	case <-a.queue: // If an item is already in the queue, drop it
 	default: // If not continue

--- a/pkg/utils/cmdutils/local.go
+++ b/pkg/utils/cmdutils/local.go
@@ -100,7 +100,6 @@ func (cmd *LocalCmd) Run() *RunError {
 // Start starts the command but doesn't block
 // If the returned error is non-nil, it should be of type *RunError
 func (cmd *LocalCmd) Start() *RunError {
-
 	cmd.Stdout = io.MultiWriter(cmd.Stdout, cmd.combinedOutput)
 	cmd.Stderr = io.MultiWriter(cmd.Stderr, cmd.combinedOutput)
 

--- a/pkg/utils/envoyutils/bootstrap/bootstrap.go
+++ b/pkg/utils/envoyutils/bootstrap/bootstrap.go
@@ -53,7 +53,6 @@ func FromEnvoyResources(resources *EnvoyResources) (string, error) {
 // per-filter config matching the arguments, marshals it to json, and returns
 // the stringified json or any error if it occurred.
 func FromFilter(filterName string, msg proto.Message) (string, error) {
-
 	typedFilter, err := anypb.New(msg)
 	if err != nil {
 		return "", err
@@ -119,7 +118,6 @@ func FromSnapshot(
 	ctx context.Context,
 	snap envoycache.ResourceSnapshot,
 ) (string, error) {
-
 	// Get the resources we're going to need as concrete types.
 	resources, err := resourcesFromSnapshot(snap)
 	if err != nil {

--- a/pkg/utils/envoyutils/bootstrap/bootstrap_test.go
+++ b/pkg/utils/envoyutils/bootstrap/bootstrap_test.go
@@ -476,7 +476,6 @@ func (f *fakeSnapshot) GetResources(typ string) map[string]types.Resource {
 		return withoutTTL
 	}
 	panic("unknown resources type" + typ)
-
 }
 
 func (f *fakeSnapshot) GetResourcesAndTTL(typ string) map[string]types.ResourceWithTTL {

--- a/pkg/utils/kubeutils/portforward/api_forwarder.go
+++ b/pkg/utils/kubeutils/portforward/api_forwarder.go
@@ -203,7 +203,6 @@ func (f *apiPortForwarder) getPodName(ctx context.Context) (string, error) {
 // Fetch ClientConfig. If kubeConfigPath is not specified, retrieve the kubeconfig from environment in which this is invoked.
 // Override the API Server URL and current context if specified.
 func GetClientConfigWithContext(kubeConfigPath, kubeContext, apiServerUrl string) (clientcmd.ClientConfig, error) {
-
 	// default loading rules checks for KUBECONFIG env var
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	// also check recommended default kubeconfig file locations

--- a/pkg/utils/regexutils/regex.go
+++ b/pkg/utils/regexutils/regex.go
@@ -31,7 +31,6 @@ func CheckRegexString(candidateRegex string) error {
 // This means its tightly coupled to envoy's implementation of regex.
 // NOTE: Call this after having checked regex with CheckRegexString.
 func NewRegexWithProgramSize(candidateRegex string, programsize *uint32) *envoy_type_matcher_v3.RegexMatcher {
-
 	var maxProgramSize *wrappers.UInt32Value
 	if programsize != nil {
 		maxProgramSize = &wrappers.UInt32Value{

--- a/pkg/utils/stringutils/stringutils.go
+++ b/pkg/utils/stringutils/stringutils.go
@@ -11,7 +11,6 @@ func DeleteOneByValue(slice []string, value string) []string {
 		return slice
 	}
 	return slices.Delete(slice, index, index+1)
-
 }
 
 // AppendIfMissing returns a slice, with the provided value included

--- a/test/gomega/matchers/have_http_response.go
+++ b/test/gomega/matchers/have_http_response.go
@@ -91,7 +91,6 @@ func (r *HttpResponse) String() string {
 
 	return fmt.Sprintf("HttpResponse{StatusCode: %d, Body: %s, Headers: %v, Custom: %v}",
 		r.StatusCode, bodyString, r.Headers, r.Custom)
-
 }
 
 // HaveHttpResponse returns a GomegaMatcher which validates that an http.Response contains

--- a/test/kubernetes/e2e/suite.go
+++ b/test/kubernetes/e2e/suite.go
@@ -66,7 +66,6 @@ func (o *orderedSuites) Register(name string, newSuite NewSuiteFunc) {
 		name:     name,
 		newSuite: newSuite,
 	})
-
 }
 
 func (u *suites) Run(ctx context.Context, t *testing.T, testInstallation *TestInstallation) {

--- a/test/kubernetes/testutils/assertions/curl.go
+++ b/test/kubernetes/testutils/assertions/curl.go
@@ -189,7 +189,6 @@ func (p *Provider) AssertEventualCurlError(
 		} else {
 			fmt.Printf("wanted any curl error, got error: %s\n", err.Error())
 		}
-
 	}).
 		WithTimeout(pollTimeout).
 		WithPolling(pollInterval).


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

This PR introduces the [whitespace](https://golangci-lint.run/usage/linters/#whitespace) linter. Enabling this linter has the following benefits:

- A more consistent codebase over time
- Eliminates PRs that manually remove whitespace that are unrelated to the rest of the PR's changes, enabling a diff better scoped to the issue being addressed
- Reduces back-and-forth review feedback around this type of style

Follow-up to #10650 and #10680. Tracked via #10496.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
