### PR TITLE
Envconfig settings

### DIFF
--- a/internal/kgateway/extensions2/plugins/istio/plugin.go
+++ b/internal/kgateway/extensions2/plugins/istio/plugin.go
@@ -35,7 +35,7 @@ var (
 
 type IstioSettings struct {
 	EnableIstioIntegration      bool
-	EnableAutoMTLS              bool
+	EnableAutoMtls              bool
 	EnableIstioSidecarOnGateway bool
 }
 
@@ -67,7 +67,7 @@ func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensi
 	// when translating upstreams. if we want we can add the gateway to the context of PerClientProcessUpstream
 	sidecarEnabled := envutils.IsEnvTruthy(ourwellknown.IstioInjectionEnabled)
 	istioSettings := IstioSettings{
-		EnableAutoMTLS:              commoncol.Settings.EnableAutoMTLS,
+		EnableAutoMtls:              commoncol.Settings.EnableAutoMtls,
 		EnableIstioIntegration:      commoncol.Settings.EnableIstioIntegration,
 		EnableIstioSidecarOnGateway: sidecarEnabled,
 	}
@@ -114,7 +114,7 @@ func (p istioPlugin) processUpstream(ctx context.Context, ir ir.PolicyIR, in ir.
 	// 1) automtls is enabled on the settings
 	// 2) the upstream has not disabled auto mtls
 	// 3) the upstream has no sslConfig
-	if st.EnableAutoMTLS && !isDisabledForUpstream(in) && !doesClusterHaveSslConfigPresent(out) {
+	if st.EnableAutoMtls && !isDisabledForUpstream(in) && !doesClusterHaveSslConfigPresent(out) {
 		// Istio automtls config is not applied if istio integration is disabled on the helm chart.
 		// When istio integration is disabled via istioSds.enabled=false, there is no sds or istio-proxy sidecar present
 		if !st.EnableIstioIntegration {

--- a/internal/kgateway/extensions2/settings/settings.go
+++ b/internal/kgateway/extensions2/settings/settings.go
@@ -5,10 +5,10 @@ import (
 )
 
 type Settings struct {
-	EnableIstioIntegration bool
-	EnableAutoMTLS         bool
-	StsClusterName         string
-	StsUri                 string
+	EnableIstioIntegration bool   `split_words:"true"`
+	EnableAutoMtls         bool   `split_words:"true"`
+	StsClusterName         string `split_words:"true"`
+	StsUri                 string `split_words:"true"`
 }
 
 // BuildSettings returns a zero-valued Settings obj if error is encountered when parsing env

--- a/internal/kgateway/extensions2/settings/settings_test.go
+++ b/internal/kgateway/extensions2/settings/settings_test.go
@@ -1,0 +1,97 @@
+package settings_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/settings"
+)
+
+func TestSettings(t *testing.T) {
+	testCases := []struct {
+		// name of the test case
+		name string
+
+		// env vars that are set at the beginning of test (and removed after test)
+		envVars map[string]string
+
+		// if set, then these are the expected populated settings
+		expectedSettings *settings.Settings
+
+		// if set, then an error parsing the settings is expected to occur
+		expectedErrorStr string
+	}{
+		{
+			name:    "defaults to empty values",
+			envVars: map[string]string{},
+			expectedSettings: &settings.Settings{
+				EnableIstioIntegration: false,
+				EnableAutoMtls:         false,
+				StsClusterName:         "",
+				StsUri:                 "",
+			},
+		},
+		{
+			name: "all values set",
+			envVars: map[string]string{
+				"KGW_ENABLE_ISTIO_INTEGRATION": "true",
+				"KGW_ENABLE_AUTO_MTLS":         "true",
+				"KGW_STS_CLUSTER_NAME":         "my-cluster",
+				"KGW_STS_URI":                  "my.sts.uri",
+			},
+			expectedSettings: &settings.Settings{
+				EnableIstioIntegration: true,
+				EnableAutoMtls:         true,
+				StsClusterName:         "my-cluster",
+				StsUri:                 "my.sts.uri",
+			},
+		},
+		{
+			name: "errors on invalid bool",
+			envVars: map[string]string{
+				"KGW_ENABLE_ISTIO_INTEGRATION": "true123",
+			},
+			expectedErrorStr: "invalid syntax",
+		},
+		{
+			name: "ignores other env vars",
+			envVars: map[string]string{
+				"KGW_DOES_NOT_EXIST":   "true",
+				"ANOTHER_VAR":          "abc",
+				"KGW_ENABLE_AUTO_MTLS": "true",
+			},
+			expectedSettings: &settings.Settings{
+				EnableAutoMtls: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			t.Cleanup(func() {
+				for k := range tc.envVars {
+					err := os.Unsetenv(k)
+					g.Expect(err).NotTo(HaveOccurred())
+				}
+			})
+
+			for k, v := range tc.envVars {
+				err := os.Setenv(k, v)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			s, err := settings.BuildSettings()
+			if tc.expectedErrorStr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(gomega.ContainSubstring(tc.expectedErrorStr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(s).To(Equal(tc.expectedSettings))
+			}
+		})
+	}
+}

--- a/internal/kgateway/krtcollections/endpoints.go
+++ b/internal/kgateway/krtcollections/endpoints.go
@@ -57,7 +57,7 @@ func NewGlooK8sEndpointInputs(
 	k8supstreams krt.Collection[ir.Upstream],
 ) EndpointsInputs {
 	endpointSettings := EndpointsSettings{
-		EnableAutoMtls: stngs.EnableAutoMTLS,
+		EnableAutoMtls: stngs.EnableAutoMtls,
 	}
 
 	// Create index on EndpointSlices by service name and endpointslice namespace

--- a/internal/kgateway/setup/ggv2setup_test.go
+++ b/internal/kgateway/setup/ggv2setup_test.go
@@ -115,6 +115,11 @@ func TestScenarios(t *testing.T) {
 	// set global settings env vars; current ggv2setup_tests all assume these are set to true
 	os.Setenv("KGW_ENABLE_ISTIO_INTEGRATION", "true")
 	os.Setenv("KGW_ENABLE_AUTO_MTLS", "true")
+	t.Cleanup(func() {
+		os.Unsetenv("POD_NAMESPACE")
+		os.Unsetenv("KGW_ENABLE_ISTIO_INTEGRATION")
+		os.Unsetenv("KGW_ENABLE_AUTO_MTLS")
+	})
 
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{

--- a/internal/kgateway/setup/ggv2setup_test.go
+++ b/internal/kgateway/setup/ggv2setup_test.go
@@ -113,8 +113,8 @@ func TestScenarios(t *testing.T) {
 
 	os.Setenv("POD_NAMESPACE", "gwtest") // TODO: is this still needed?
 	// set global settings env vars; current ggv2setup_tests all assume these are set to true
-	os.Setenv("KGW_ENABLEISTIOINTEGRATION", "true")
-	os.Setenv("KGW_ENABLEAUTOMTLS", "true")
+	os.Setenv("KGW_ENABLE_ISTIO_INTEGRATION", "true")
+	os.Setenv("KGW_ENABLE_AUTO_MTLS", "true")
 
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{


### PR DESCRIPTION
Small update to our envconfig usage:
- use `split_words` for readability (so the env vars would look like `KGW_ENABLE_ISTIO_INTEGRATION` rather than `KGW_ENABLEISTIOINTEGRATION`
- add unit tests