### PR TITLE
.github: Re-create the rolling main release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,6 +110,19 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
+      # We publish a rolling main release for every commit to main. Deleting the release
+      # ensures that the tagged commit is not stale. Goreleaser will create a new tag
+      # and release for the tagged commit.
+      - name: Delete v2.0.0-main release if it exists
+        if: ${{ github.ref == 'refs/heads/main' }}
+        continue-on-error: true
+        run: |
+          set -x
+          echo "Deleting the v2.0.0-main release"
+          gh release delete v2.0.0-main --repo ${{ github.repository }} --yes --cleanup-tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Log into ghcr.io
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3


### PR DESCRIPTION
# Description

Ensures the v2.0.0-main release always points to the latest main branch commit by deleting the existing release and tag before goreleaser creates a new one. This prevents stale releases from persisting in the repository.

Closes https://github.com/kgateway-dev/kgateway/issues/10641

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
