### PR TITLE
Replace quickstart instructions in release template with doc site

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -170,28 +170,4 @@ release:
 
     ## Quickstart
 
-    First, create a [kind cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation).
-
-    ```bash
-    kind create cluster
-    ```
-
-    Then, deploy the Kubernetes Gateway API CRDs.
-
-    ```bash
-    kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.2.1"
-    ```
-
-    Install the `kgateway` controller.
-
-    ```bash
-    helm install --create-namespace --namespace kgateway-system --version {{ .Env.VERSION }} kgateway oci://{{ .Env.IMAGE_REGISTRY }}/charts/kgateway
-    ```
-
-    Verify the release was successful.
-
-    ```bash
-    kubectl get pods -n kgateway-system
-    ```
-
-    If the release was successful, you should see a `kgateway` pod running.
+    For detailed installation instructions and next steps, please visit our [quickstart guide](https://kgateway.dev/docs/quickstart/).


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Avoid maintaining two sets of quickstart instructions and link out to the doc site instead.

Closes https://github.com/kgateway-dev/kgateway/issues/10695

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
