### PR TITLE
krtcollections: Show one way we can have debug logs on by default. No…

### DIFF
--- a/internal/kgateway/krtcollections/endpoints_test.go
+++ b/internal/kgateway/krtcollections/endpoints_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/go-utils/contextutils"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
@@ -277,6 +278,7 @@ func TestEndpointsForUpstreamWithDifferentNameButSameEndpoints(t *testing.T) {
 }
 
 func TestEndpoints(t *testing.T) {
+	contextutils.SetLogLevel(zapcore.DebugLevel)
 	logger := zaptest.Logger(t)
 	contextutils.SetFallbackLogger(logger.Sugar())
 

--- a/internal/kgateway/krtcollections/pods_test.go
+++ b/internal/kgateway/krtcollections/pods_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/contextutils"
+	"go.uber.org/zap/zapcore"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +20,7 @@ import (
 )
 
 func TestPods(t *testing.T) {
+	contextutils.SetLogLevel(zapcore.DebugLevel)
 	testCases := []struct {
 		name   string
 		inputs []any

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/zapcore"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +20,7 @@ import (
 	extensionsplug "github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
+	"github.com/solo-io/go-utils/contextutils"
 )
 
 var (
@@ -35,6 +37,7 @@ func backends(refN, refNs string) []any {
 }
 
 func TestGetBackendSameNamespace(t *testing.T) {
+	contextutils.SetLogLevel(zapcore.DebugLevel)
 	inputs := []any{
 		svc(""),
 	}

--- a/internal/kgateway/krtcollections/uniqueclients_test.go
+++ b/internal/kgateway/krtcollections/uniqueclients_test.go
@@ -8,6 +8,8 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/go-utils/contextutils"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"istio.io/istio/pkg/kube/krt"
@@ -25,6 +27,8 @@ import (
 )
 
 func TestUniqueClients(t *testing.T) {
+	// TODO(nfuden): try to get off the contextutils dependency ideally this is on a context and not a global
+	contextutils.SetLogLevel(zapcore.DebugLevel)
 	testCases := []struct {
 		name     string
 		inputs   []any


### PR DESCRIPTION
I dont think this is the right way to set debug level logging for each of the tests but it is how a non-helm based install would set debug at least today with contextutills.

Putting this up mainly to show what the current form factor would be and to potentially near term fix the krtcollections flake. 


Would love opinions on this and if we think this is what we want to do in the near term we can slap this line into other unit tests that have contexts.