### PR TITLE
gateway/status: preserve external conditions

### DIFF
--- a/internal/kgateway/reports/status.go
+++ b/internal/kgateway/reports/status.go
@@ -58,6 +58,13 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 		}
 		meta.SetStatusCondition(&finalConditions, gwCondition)
 	}
+	// If there are conditions on the Gateway that are not owned by our reporter, include
+	// them in the final list of conditions to preseve conditions we do not own
+	for _, condition := range gw.Status.Conditions {
+		if meta.FindStatusCondition(finalConditions, condition.Type) == nil {
+			finalConditions = append(finalConditions, condition)
+		}
+	}
 
 	finalGwStatus := gwv1.GatewayStatus{}
 	finalGwStatus.Conditions = finalConditions
@@ -131,6 +138,13 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 				finalConditions = append(finalConditions, *cond)
 			}
 			meta.SetStatusCondition(&finalConditions, pCondition)
+		}
+		// If there are conditions on the route that are not owned by our reporter, include
+		// them in the final list of conditions to preseve conditions we do not own
+		for _, condition := range currentParentRefConditions {
+			if meta.FindStatusCondition(finalConditions, condition.Type) == nil {
+				finalConditions = append(finalConditions, condition)
+			}
 		}
 
 		routeParentStatus := gwv1.RouteParentStatus{


### PR DESCRIPTION
Crossport of https://github.com/solo-io/gloo/pull/10663
---
There is a requirement to allow external controllers to update the statuses on Gateway objects by writing Conditions that do not conflict with the Types owned by the Gateway. Currently, only condition.Types that are a part of the status reporter are set as the final list of conditions. This change allows external controllers to write Condition.Types that do not conflict.
