### PR TITLE
reenable TCPRoute e2e test

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -28,7 +28,7 @@ jobs:
         # Feb 18, 2025: 4 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^TCPRouteServices$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$'
 
 #         # Dec 4, 2024: 23 minutes
 #         - cluster-name: 'cluster-two'

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -25,7 +25,7 @@ jobs:
         # NOTE: We use the GitHub action step time (as opposed to the `go test` time), because it is easier to capture
 
         test:
-        # Feb 18, 2025: 4 minutes
+        # Feb 27, 2025: 13 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$'

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -28,7 +28,7 @@ jobs:
         # Feb 18, 2025: 4 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^TCPRouteServices$$'
 
 #         # Dec 4, 2024: 23 minutes
 #         - cluster-name: 'cluster-two'

--- a/test/gomega/matchers/contain_substrings.go
+++ b/test/gomega/matchers/contain_substrings.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 package matchers
 
 import (

--- a/test/kubernetes/e2e/features/services/httproute/suite.go
+++ b/test/kubernetes/e2e/features/services/httproute/suite.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 package httproute
 
 import (

--- a/test/kubernetes/e2e/features/services/httproute/types.go
+++ b/test/kubernetes/e2e/features/services/httproute/types.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 package httproute
 
 import (

--- a/test/kubernetes/e2e/features/services/tcproute/suite.go
+++ b/test/kubernetes/e2e/features/services/tcproute/suite.go
@@ -149,7 +149,7 @@ func (s *testingSuite) TestConfigureTCPRouteBackingDestinations() {
 			tcpRouteManifest:  crossNsNoRefGrantTCPRouteManifest,
 			proxyService:      crossNsNoRefGrantProxyService,
 			proxyDeployment:   crossNsNoRefGrantProxyDeployment,
-			expectedErrorCode: 7,
+			expectedErrorCode: 56,
 			ports:             []int{8080},
 			listenerNames: []v1.SectionName{
 				v1.SectionName(crossNsNoRefGrantListenerName),

--- a/test/kubernetes/e2e/features/services/tcproute/suite.go
+++ b/test/kubernetes/e2e/features/services/tcproute/suite.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 package tcproute
 
 import (

--- a/test/kubernetes/e2e/features/services/tcproute/types.go
+++ b/test/kubernetes/e2e/features/services/tcproute/types.go
@@ -86,25 +86,12 @@ var (
 	ctxTimeout = 5 * time.Minute
 	timeout    = 60 * time.Second
 
-	// Proxy resources to be translated
-	singleSvcNS = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: singleSvcNsName,
-		},
-	}
-
 	singleGlooProxy = metav1.ObjectMeta{
 		Name:      "single-tcp-gateway",
 		Namespace: singleSvcNsName,
 	}
 	singleSvcProxyDeployment = &appsv1.Deployment{ObjectMeta: singleGlooProxy}
 	singleSvcProxyService    = &corev1.Service{ObjectMeta: singleGlooProxy}
-
-	multiSvcNS = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: multiSvcNsName,
-		},
-	}
 
 	multiGlooProxy = metav1.ObjectMeta{
 		Name:      "multi-tcp-gateway",

--- a/test/kubernetes/e2e/features/services/tcproute/types.go
+++ b/test/kubernetes/e2e/features/services/tcproute/types.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 package tcproute
 
 import (

--- a/test/kubernetes/e2e/tests/kgateway_tests.go
+++ b/test/kubernetes/e2e/tests/kgateway_tests.go
@@ -15,7 +15,7 @@ import (
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/port_routing"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/route_delegation"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/route_options"
-	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/httproute"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/httproute"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/tcproute"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/upstreams"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/virtualhost_options"
@@ -32,7 +32,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	// kubeGatewaySuiteRunner.Register("RouteOptions", route_options.NewTestingSuite)
 	// kubeGatewaySuiteRunner.Register("VirtualHostOptions", virtualhost_options.NewTestingSuite)
 	// kubeGatewaySuiteRunner.Register("Upstreams", upstreams.NewTestingSuite)
-	// kubeGatewaySuiteRunner.Register("HTTPRouteServices", httproute.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("HTTPRouteServices", httproute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TCPRouteServices", tcproute.NewTestingSuite)
 	// kubeGatewaySuiteRunner.Register("HeadlessSvc", headless_svc.NewK8sGatewayHeadlessSvcSuite)
 	// kubeGatewaySuiteRunner.Register("PortRouting", port_routing.NewK8sGatewayTestingSuite)

--- a/test/kubernetes/e2e/tests/kgateway_tests.go
+++ b/test/kubernetes/e2e/tests/kgateway_tests.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/basicrouting"
+
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/admin_server"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/crd_categories"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/deployer"
@@ -15,7 +16,7 @@ import (
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/route_delegation"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/route_options"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/httproute"
-	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/tcproute"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/tcproute"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/upstreams"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/virtualhost_options"
 )
@@ -32,7 +33,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	// kubeGatewaySuiteRunner.Register("VirtualHostOptions", virtualhost_options.NewTestingSuite)
 	// kubeGatewaySuiteRunner.Register("Upstreams", upstreams.NewTestingSuite)
 	// kubeGatewaySuiteRunner.Register("HTTPRouteServices", httproute.NewTestingSuite)
-	// kubeGatewaySuiteRunner.Register("TCPRouteServices", tcproute.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("TCPRouteServices", tcproute.NewTestingSuite)
 	// kubeGatewaySuiteRunner.Register("HeadlessSvc", headless_svc.NewK8sGatewayHeadlessSvcSuite)
 	// kubeGatewaySuiteRunner.Register("PortRouting", port_routing.NewK8sGatewayTestingSuite)
 	// kubeGatewaySuiteRunner.Register("RouteDelegation", route_delegation.NewTestingSuite)

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -1,5 +1,3 @@
-//go:build ignore
-
 package assertions
 
 import (
@@ -10,8 +8,9 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
-	errors "github.com/rotisserie/eris"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	// errors "github.com/rotisserie/eris"
+	// "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -21,92 +20,92 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/helpers"
 )
 
-// Checks GetNamespacedStatuses status for gloo installation namespace
-func (p *Provider) EventuallyResourceStatusMatchesWarningReasons(getter helpers.InputResourceGetter, desiredStatusReasons []string, desiredReporter string, timeout ...time.Duration) {
-	ginkgo.GinkgoHelper()
+// // Checks GetNamespacedStatuses status for gloo installation namespace
+// func (p *Provider) EventuallyResourceStatusMatchesWarningReasons(getter helpers.InputResourceGetter, desiredStatusReasons []string, desiredReporter string, timeout ...time.Duration) {
+// 	ginkgo.GinkgoHelper()
 
-	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
-	gomega.Eventually(func(g gomega.Gomega) {
-		statusWarningsMatcher := matchers.MatchStatusInNamespace(
-			p.installContext.InstallNamespace,
-			gomega.And(matchers.HaveWarningStateWithReasonSubstrings(desiredStatusReasons...), matchers.HaveReportedBy(desiredReporter)),
-		)
+// 	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+// 	gomega.Eventually(func(g gomega.Gomega) {
+// 		statusWarningsMatcher := matchers.MatchStatusInNamespace(
+// 			p.installContext.InstallNamespace,
+// 			gomega.And(matchers.HaveWarningStateWithReasonSubstrings(desiredStatusReasons...), matchers.HaveReportedBy(desiredReporter)),
+// 		)
 
-		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
-		g.Expect(status).ToNot(gomega.BeNil())
-		g.Expect(status).To(gomega.HaveValue(statusWarningsMatcher))
-	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
-}
+// 		status, err := getResourceNamespacedStatus(getter)
+// 		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+// 		g.Expect(status).ToNot(gomega.BeNil())
+// 		g.Expect(status).To(gomega.HaveValue(statusWarningsMatcher))
+// 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
+// }
 
-func (p *Provider) EventuallyResourceStatusMatchesRejectedReasons(getter helpers.InputResourceGetter, desiredStatusReasons []string, desiredReporter string, timeout ...time.Duration) {
-	ginkgo.GinkgoHelper()
+// func (p *Provider) EventuallyResourceStatusMatchesRejectedReasons(getter helpers.InputResourceGetter, desiredStatusReasons []string, desiredReporter string, timeout ...time.Duration) {
+// 	ginkgo.GinkgoHelper()
 
-	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
-	gomega.Eventually(func(g gomega.Gomega) {
-		statusRejectionsMatcher := matchers.MatchStatusInNamespace(
-			p.installContext.InstallNamespace,
-			gomega.And(matchers.HaveRejectedStateWithReasonSubstrings(desiredStatusReasons...), matchers.HaveReportedBy(desiredReporter)),
-		)
+// 	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+// 	gomega.Eventually(func(g gomega.Gomega) {
+// 		statusRejectionsMatcher := matchers.MatchStatusInNamespace(
+// 			p.installContext.InstallNamespace,
+// 			gomega.And(matchers.HaveRejectedStateWithReasonSubstrings(desiredStatusReasons...), matchers.HaveReportedBy(desiredReporter)),
+// 		)
 
-		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
-		g.Expect(status).ToNot(gomega.BeNil())
-		g.Expect(status).To(gomega.HaveValue(statusRejectionsMatcher))
-	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
-}
+// 		status, err := getResourceNamespacedStatus(getter)
+// 		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+// 		g.Expect(status).ToNot(gomega.BeNil())
+// 		g.Expect(status).To(gomega.HaveValue(statusRejectionsMatcher))
+// 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
+// }
 
-func (p *Provider) EventuallyResourceStatusMatchesState(
-	getter helpers.InputResourceGetter,
-	desiredState core.Status_State,
-	desiredReporter string,
-	timeout ...time.Duration,
-) {
-	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
-	p.Gomega.Eventually(func(g gomega.Gomega) {
-		statusStateMatcher := matchers.MatchStatusInNamespace(
-			p.installContext.InstallNamespace,
-			gomega.And(matchers.HaveState(desiredState), matchers.HaveReportedBy(desiredReporter)),
-		)
-		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
-		g.Expect(status).ToNot(gomega.BeNil())
-		g.Expect(status).To(gomega.HaveValue(statusStateMatcher))
-	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
-}
+// func (p *Provider) EventuallyResourceStatusMatchesState(
+// 	getter helpers.InputResourceGetter,
+// 	desiredState core.Status_State,
+// 	desiredReporter string,
+// 	timeout ...time.Duration,
+// ) {
+// 	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+// 	p.Gomega.Eventually(func(g gomega.Gomega) {
+// 		statusStateMatcher := matchers.MatchStatusInNamespace(
+// 			p.installContext.InstallNamespace,
+// 			gomega.And(matchers.HaveState(desiredState), matchers.HaveReportedBy(desiredReporter)),
+// 		)
+// 		status, err := getResourceNamespacedStatus(getter)
+// 		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+// 		g.Expect(status).ToNot(gomega.BeNil())
+// 		g.Expect(status).To(gomega.HaveValue(statusStateMatcher))
+// 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
+// }
 
-func (p *Provider) EventuallyResourceStatusMatchesSubResource(
-	getter helpers.InputResourceGetter,
-	desiredSubresourceName string,
-	desiredSubresource matchers.SoloKitSubresourceStatus,
-	timeout ...time.Duration,
-) {
-	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
-	p.Gomega.Eventually(func(g gomega.Gomega) {
-		subResourceStatusMatcher := matchers.HaveSubResourceStatusState(desiredSubresourceName, desiredSubresource)
-		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
-		g.Expect(status).ToNot(gomega.BeNil())
-		g.Expect(status).To(gomega.HaveValue(subResourceStatusMatcher))
-	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
-}
+// func (p *Provider) EventuallyResourceStatusMatchesSubResource(
+// 	getter helpers.InputResourceGetter,
+// 	desiredSubresourceName string,
+// 	desiredSubresource matchers.SoloKitSubresourceStatus,
+// 	timeout ...time.Duration,
+// ) {
+// 	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+// 	p.Gomega.Eventually(func(g gomega.Gomega) {
+// 		subResourceStatusMatcher := matchers.HaveSubResourceStatusState(desiredSubresourceName, desiredSubresource)
+// 		status, err := getResourceNamespacedStatus(getter)
+// 		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+// 		g.Expect(status).ToNot(gomega.BeNil())
+// 		g.Expect(status).To(gomega.HaveValue(subResourceStatusMatcher))
+// 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
+// }
 
-func getResourceNamespacedStatus(getter helpers.InputResourceGetter) (*core.NamespacedStatuses, error) {
-	resource, err := getter()
-	if err != nil {
-		return &core.NamespacedStatuses{}, errors.Wrapf(err, "failed to get resource")
-	}
+// func getResourceNamespacedStatus(getter helpers.InputResourceGetter) (*core.NamespacedStatuses, error) {
+// 	resource, err := getter()
+// 	if err != nil {
+// 		return &core.NamespacedStatuses{}, errors.Wrapf(err, "failed to get resource")
+// 	}
 
-	namespacedStatuses := resource.GetNamespacedStatuses()
+// 	namespacedStatuses := resource.GetNamespacedStatuses()
 
-	// In newer versions of Gloo Edge we provide a default "empty" status, which allows us to patch it to perform updates
-	// As a result, a nil check isn't enough to determine that that status hasn't been reported
-	if namespacedStatuses == nil || namespacedStatuses.GetStatuses() == nil {
-		return &core.NamespacedStatuses{}, errors.Wrapf(err, "waiting for %v status to be non-empty", resource.GetMetadata().GetName())
-	}
+// 	// In newer versions of Gloo Edge we provide a default "empty" status, which allows us to patch it to perform updates
+// 	// As a result, a nil check isn't enough to determine that that status hasn't been reported
+// 	if namespacedStatuses == nil || namespacedStatuses.GetStatuses() == nil {
+// 		return &core.NamespacedStatuses{}, errors.Wrapf(err, "waiting for %v status to be non-empty", resource.GetMetadata().GetName())
+// 	}
 
-	return namespacedStatuses, nil
-}
+// 	return namespacedStatuses, nil
+// }
 
 // EventuallyHTTPRouteStatusContainsMessage asserts that eventually at least one of the HTTPRoute's route parent statuses contains
 // the given message substring.
@@ -142,7 +141,8 @@ func (p *Provider) EventuallyHTTPRouteStatusContainsReason(
 	routeName string,
 	routeNamespace string,
 	reason string,
-	timeout ...time.Duration) {
+	timeout ...time.Duration,
+) {
 	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
 	p.Gomega.Eventually(func(g gomega.Gomega) {
 		matcher := matchers.HaveKubeGatewayRouteStatus(&matchers.KubeGatewayRouteStatus{


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

reenable TCPRoute and HTTPRoute e2e suite. 

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
