### PR TITLE
minor test fixes + equals on policy ir

### DIFF
--- a/internal/kgateway/controller/start.go
+++ b/internal/kgateway/controller/start.go
@@ -52,9 +52,9 @@ type SetupOpts struct {
 	// static set of global Settings
 	GlobalSettings *settings.Settings
 
-	// If running from env tests, set to true. so we won't bind to any ports
-	// and tests can run in parallel.
-	Test bool
+	PprofBindAddress       string
+	HealthProbeBindAddress string
+	MetricsBindAddress     string
 }
 
 var setupLog = ctrl.Log.WithName("setup")
@@ -104,24 +104,14 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		return nil, err
 	}
 
-	pprofBindAddress := "127.0.0.1:9099"
-	healthProbeBindAddress := ":9093"
-	metricsBindAddress := ":9092"
-
-	if cfg.SetupOpts.Test {
-		pprofBindAddress = ""
-		healthProbeBindAddress = ""
-		metricsBindAddress = ""
-	}
-
 	mgrOpts := ctrl.Options{
 		BaseContext:      func() context.Context { return ctx },
 		Scheme:           scheme,
-		PprofBindAddress: pprofBindAddress,
+		PprofBindAddress: cfg.SetupOpts.PprofBindAddress,
 		// if you change the port here, also change the port "health" in the helmchart.
-		HealthProbeBindAddress: healthProbeBindAddress,
+		HealthProbeBindAddress: cfg.SetupOpts.HealthProbeBindAddress,
 		Metrics: metricsserver.Options{
-			BindAddress: metricsBindAddress,
+			BindAddress: cfg.SetupOpts.MetricsBindAddress,
 		},
 		Controller: config.Controller{
 			// see https://github.com/kubernetes-sigs/controller-runtime/issues/2937

--- a/internal/kgateway/controller/start.go
+++ b/internal/kgateway/controller/start.go
@@ -51,6 +51,10 @@ type SetupOpts struct {
 
 	// static set of global Settings
 	GlobalSettings *settings.Settings
+
+	// If running from env tests, set to true. so we won't bind to any ports
+	// and tests can run in parallel.
+	Test bool
 }
 
 var setupLog = ctrl.Log.WithName("setup")
@@ -100,14 +104,24 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		return nil, err
 	}
 
+	pprofBindAddress := "127.0.0.1:9099"
+	healthProbeBindAddress := ":9093"
+	metricsBindAddress := ":9092"
+
+	if cfg.SetupOpts.Test {
+		pprofBindAddress = ""
+		healthProbeBindAddress = ""
+		metricsBindAddress = ""
+	}
+
 	mgrOpts := ctrl.Options{
 		BaseContext:      func() context.Context { return ctx },
 		Scheme:           scheme,
-		PprofBindAddress: "127.0.0.1:9099",
+		PprofBindAddress: pprofBindAddress,
 		// if you change the port here, also change the port "health" in the helmchart.
-		HealthProbeBindAddress: ":9093",
+		HealthProbeBindAddress: healthProbeBindAddress,
 		Metrics: metricsserver.Options{
-			BindAddress: ":9092",
+			BindAddress: metricsBindAddress,
 		},
 		Controller: config.Controller{
 			// see https://github.com/kubernetes-sigs/controller-runtime/issues/2937

--- a/internal/kgateway/ir/iface.go
+++ b/internal/kgateway/ir/iface.go
@@ -131,7 +131,7 @@ func (c PolicyWrapper) Equals(in PolicyWrapper) bool {
 		return false
 	}
 
-	return versionEquals(c.Policy, in.Policy)
+	return versionEquals(c.Policy, in.Policy) && c.PolicyIR.Equals(in.PolicyIR)
 }
 
 var (

--- a/internal/kgateway/krtcollections/uniqueclients_test.go
+++ b/internal/kgateway/krtcollections/uniqueclients_test.go
@@ -76,6 +76,84 @@ func TestUniqueClients(t *testing.T) {
 			),
 		},
 		{
+			name: "two UCCs",
+			inputs: []any{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "podname",
+						Namespace: "ns",
+						Labels:    map[string]string{"a": "b"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node",
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node",
+						Labels: map[string]string{
+							corev1.LabelTopologyRegion: "region",
+							corev1.LabelTopologyZone:   "zone",
+						},
+					},
+				},
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "podname2",
+						Namespace: "ns",
+						Labels:    map[string]string{"a": "b"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node2",
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+						Labels: map[string]string{
+							corev1.LabelTopologyRegion: "region2",
+							corev1.LabelTopologyZone:   "zone2",
+						},
+					},
+				},
+			},
+			requests: []*envoy_service_discovery_v3.DiscoveryRequest{
+				{
+					Node: &corev3.Node{
+						Id: "podname.ns",
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								xds.RoleKey: structpb.NewStringValue(wellknown.GatewayApiProxyValue + "~best-proxy-role"),
+							},
+						},
+					},
+				},
+				{
+					Node: &corev3.Node{
+						Id: "podname2.ns",
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								xds.RoleKey: structpb.NewStringValue(wellknown.GatewayApiProxyValue + "~best-proxy-role"),
+							},
+						},
+					},
+				},
+			},
+			result: sets.New(
+				fmt.Sprintf("kgateway-kube-gateway-api~best-proxy-role~%d~ns", utils.HashLabels(map[string]string{
+					corev1.LabelTopologyRegion: "region",
+					corev1.LabelTopologyZone:   "zone",
+					"a":                        "b",
+				})), fmt.Sprintf("kgateway-kube-gateway-api~best-proxy-role~%d~ns", utils.HashLabels(map[string]string{
+					corev1.LabelTopologyRegion: "region2",
+					corev1.LabelTopologyZone:   "zone2",
+					"a":                        "b",
+				})),
+			),
+		},
+		{
 			name:   "no-pods",
 			inputs: nil,
 			requests: []*envoy_service_discovery_v3.DiscoveryRequest{
@@ -140,16 +218,18 @@ func TestUniqueClients(t *testing.T) {
 			g.Expect(names).To(Equal(tc.result))
 
 			for i := range tc.requests {
-				for j := 0; j < 10; j++ {
-					g.Expect(ucc.List()).To(HaveLen(len(allUcc) - i))
+				for j := 0; j < 9; j++ {
 					cb.OnStreamClosed(int64(i*10+j), nil)
 				}
-				// FIXME: this assertion will be reworked; the goal here is to test jitter
-				// that as clients disconnect we don't impact other UCCs etc.
-				// g.Eventually(func() []ir.UniqlyConnectedClient {
-				// 	allUcc = ucc.List()
-				// 	return allUcc
-				// }, "1s").Should(HaveLen(len(tc.result)))
+			}
+
+			g.Expect(ucc.List()).Should(HaveLen(len(tc.result)))
+
+			for i := range tc.requests {
+				j := 9
+				g.Eventually(ucc.List).Should(HaveLen(len(allUcc) - i))
+				cb.OnStreamClosed(int64(i*10+j), nil)
+
 			}
 
 			// as events happens async, eventually after all clients disconnect all UCCs should be removed

--- a/internal/kgateway/krtcollections/uniqueclients_test.go
+++ b/internal/kgateway/krtcollections/uniqueclients_test.go
@@ -229,7 +229,6 @@ func TestUniqueClients(t *testing.T) {
 				j := 9
 				g.Eventually(ucc.List).Should(HaveLen(len(allUcc) - i))
 				cb.OnStreamClosed(int64(i*10+j), nil)
-
 			}
 
 			// as events happens async, eventually after all clients disconnect all UCCs should be removed

--- a/internal/kgateway/setup/ggv2setup.go
+++ b/internal/kgateway/setup/ggv2setup.go
@@ -73,10 +73,13 @@ func StartGGv2(
 	}
 
 	setupOpts := &controller.SetupOpts{
-		Cache:               cache,
-		KrtDebugger:         new(krt.DebugHandler),
-		ExtraGatewayClasses: extraGwClasses,
-		GlobalSettings:      st,
+		Cache:                  cache,
+		KrtDebugger:            new(krt.DebugHandler),
+		ExtraGatewayClasses:    extraGwClasses,
+		GlobalSettings:         st,
+		PprofBindAddress:       "127.0.0.1:9099",
+		HealthProbeBindAddress: ":9093",
+		MetricsBindAddress:     ":9092",
 	}
 
 	restConfig := ctrl.GetConfigOrDie()

--- a/internal/kgateway/setup/ggv2setup_test.go
+++ b/internal/kgateway/setup/ggv2setup_test.go
@@ -189,7 +189,6 @@ func TestScenarios(t *testing.T) {
 		Cache:          snapCache,
 		KrtDebugger:    new(krt.DebugHandler),
 		GlobalSettings: st,
-		Test:           true,
 	}
 
 	// start ggv2

--- a/internal/kgateway/setup/ggv2setup_test.go
+++ b/internal/kgateway/setup/ggv2setup_test.go
@@ -178,10 +178,8 @@ func TestScenarios(t *testing.T) {
 		t.Fatalf("can't listen %v", err)
 	}
 	xdsPort := lis.Addr().(*net.TCPAddr).Port
-	snapCache, err := ggv2setup.NewControlPlaneWithListener(ctx, lis, uniqueClientCallbacks)
-	if err != nil {
-		t.Fatalf("can't listen %v", err)
-	}
+	snapCache, grpcServer := ggv2setup.NewControlPlaneWithListener(ctx, lis, uniqueClientCallbacks)
+	t.Cleanup(func() { grpcServer.Stop() })
 
 	st, err := settings.BuildSettings()
 	if err != nil {
@@ -191,6 +189,7 @@ func TestScenarios(t *testing.T) {
 		Cache:          snapCache,
 		KrtDebugger:    new(krt.DebugHandler),
 		GlobalSettings: st,
+		Test:           true,
 	}
 
 	// start ggv2

--- a/internal/kgateway/setup/testdata/setupyaml/setup.yaml
+++ b/internal/kgateway/setup/testdata/setupyaml/setup.yaml
@@ -15,4 +15,29 @@ apiVersion: gateway.kgateway.dev/v1alpha1
 metadata:
   name: kgateway
 spec:
-  kube: {}
+  kube:
+    deployment:
+      replicas: 1
+    envoyContainer:
+      image:
+        registry: ghcr.io/kgateway-dev
+        repository: envoy-wrapper
+        tag: v0.0.1
+        pullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - NET_BIND_SERVICE
+          drop:
+          - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10101
+    service:
+      type: LoadBalancer
+    stats:
+      enableStatsRoute: true
+      enabled: true
+      routePrefixRewrite: /stats/prometheus
+      statsRoutePrefixRewrite: /stats


### PR DESCRIPTION
- add a test to cover 2 UCCs
- fix a rare flake in env test, where grpc server logs after test env is shutdown
- don't bind controll runtime ports in envtest - so they can be run in parallel
- fill in GW Params in envtest so that deployer doesnt log errors
- check policy ir in equals