### PR TITLE
remove upstream  filters on the router filter

### DIFF
--- a/internal/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
+++ b/internal/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
@@ -159,10 +159,6 @@ func (p *directResponsePluginGwPass) HttpFilters(ctx context.Context, fcc ir.Fil
 	return nil, nil
 }
 
-func (p *directResponsePluginGwPass) UpstreamHttpFilters(ctx context.Context) ([]plugins.StagedUpstreamHttpFilter, error) {
-	return nil, nil
-}
-
 func (p *directResponsePluginGwPass) NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error) {
 	return nil, nil
 }

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
@@ -165,10 +165,6 @@ func (p *httpListenerPolicyPluginGwPass) HttpFilters(ctx context.Context, fcc ir
 	return nil, nil
 }
 
-func (p *httpListenerPolicyPluginGwPass) UpstreamHttpFilters(ctx context.Context) ([]plugins.StagedUpstreamHttpFilter, error) {
-	return nil, nil
-}
-
 func (p *httpListenerPolicyPluginGwPass) NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error) {
 	return nil, nil
 }

--- a/internal/kgateway/extensions2/plugins/listenerpolicy/listener_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/listenerpolicy/listener_policy_plugin.go
@@ -137,10 +137,6 @@ func (p *listenerPolicyPluginGwPass) HttpFilters(ctx context.Context, fcc ir.Fil
 	return nil, nil
 }
 
-func (p *listenerPolicyPluginGwPass) UpstreamHttpFilters(ctx context.Context) ([]plugins.StagedUpstreamHttpFilter, error) {
-	return nil, nil
-}
-
 func (p *listenerPolicyPluginGwPass) NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error) {
 	return nil, nil
 }

--- a/internal/kgateway/extensions2/plugins/routepolicy/route_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/route_policy_plugin.go
@@ -132,10 +132,6 @@ func (p *routePolicyPluginGwPass) HttpFilters(ctx context.Context, fcc ir.Filter
 	return nil, nil
 }
 
-func (p *routePolicyPluginGwPass) UpstreamHttpFilters(ctx context.Context) ([]plugins.StagedUpstreamHttpFilter, error) {
-	return nil, nil
-}
-
 func (p *routePolicyPluginGwPass) NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error) {
 	return nil, nil
 }

--- a/internal/kgateway/ir/iface.go
+++ b/internal/kgateway/ir/iface.go
@@ -88,7 +88,6 @@ type ProxyTranslationPass interface {
 	// if a plugin emits new filters, they must be with a plugin unique name.
 	// any filter returned from route config must be disabled, so it doesnt impact other routes.
 	HttpFilters(ctx context.Context, fc FilterChainCommon) ([]plugins.StagedHttpFilter, error)
-	UpstreamHttpFilters(ctx context.Context) ([]plugins.StagedUpstreamHttpFilter, error)
 
 	NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error)
 	// called 1 time (per envoy proxy). replaces GeneratedResources
@@ -116,9 +115,6 @@ func (s UnimplementedProxyTranslationPass) ApplyForRouteBackend(ctx context.Cont
 	return nil
 }
 func (s UnimplementedProxyTranslationPass) HttpFilters(ctx context.Context, fc FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
-	return nil, nil
-}
-func (s UnimplementedProxyTranslationPass) UpstreamHttpFilters(ctx context.Context) ([]plugins.StagedUpstreamHttpFilter, error) {
 	return nil, nil
 }
 func (s UnimplementedProxyTranslationPass) NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error) {

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -420,10 +420,6 @@ func (p *builtinPluginGwPass) HttpFilters(ctx context.Context, fcc ir.FilterChai
 	return nil, nil
 }
 
-func (p *builtinPluginGwPass) UpstreamHttpFilters(ctx context.Context) ([]plugins.StagedUpstreamHttpFilter, error) {
-	return nil, nil
-}
-
 func (p *builtinPluginGwPass) NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Remove the ability to set upstream filters on the router filter. upstream filters should go on clusters instead.

If filters are present on the cluster, envoy will use them instead of the router. so by exposing the ability to set them on the router filter, may lead to inconsistent behaviour with plugins that set them on the cluster (like aws for example). As we have no use case for setting them on the router, lets remove them.
