### PR TITLE
test: Force delete helper Pods

### DIFF
--- a/test/kubernetes/e2e/defaults/testdata/curl_pod.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/curl_pod.yaml
@@ -14,6 +14,7 @@ metadata:
     version: v1
     app.kubernetes.io/name: curl
 spec:
+  terminationGracePeriodSeconds: 0
   containers:
     - name: curl
       image: curlimages/curl:7.83.1

--- a/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
@@ -25,6 +25,7 @@ metadata:
   labels:
     app.kubernetes.io/name: http-echo
 spec:
+  terminationGracePeriodSeconds: 0
   containers:
   - name: http-echo
     # we avoid using checksums so that we automatically select amd64 or arm64

--- a/test/kubernetes/e2e/defaults/testdata/nginx_pod.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/nginx_pod.yaml
@@ -108,6 +108,7 @@ metadata:
   labels:
     app.kubernetes.io/name: nginx
 spec:
+  terminationGracePeriodSeconds: 0
   containers:
   - name: nginx
     image: nginx:stable

--- a/test/kubernetes/e2e/defaults/testdata/tcp_echo.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/tcp_echo.yaml
@@ -24,6 +24,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tcp-echo
 spec:
+  terminationGracePeriodSeconds: 0
   containers:
   - name: tcp-echo
     image: soloio/tcp-echo:latest


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Add the `spec.terminationGracePeriodSeconds: 0` field to the test helper Pods that are used by various e2e suites. This helps reduce the time waiting for Pods to be deleted in CI.

Pulled out from #10720 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
