### PR TITLE
feat: support h2c app protocol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -691,7 +691,7 @@ $(TEST_ASSET_DIR)/conformance/conformance_test.go:
 	cat $(shell go list -json -m sigs.k8s.io/gateway-api | jq -r '.Dir')/conformance/conformance_test.go >> $@
 	go fmt $@
 
-CONFORMANCE_SUPPORTED_FEATURES ?= -supported-features=Gateway,ReferenceGrant,HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRouteResponseHeaderModification,HTTPRoutePortRedirect,HTTPRouteHostRewrite,HTTPRouteSchemeRedirect,HTTPRoutePathRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,HTTPRouteRequestMirror,TLSRoute
+CONFORMANCE_SUPPORTED_FEATURES ?= -supported-features=Gateway,ReferenceGrant,HTTPRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPRouteResponseHeaderModification,HTTPRoutePortRedirect,HTTPRouteHostRewrite,HTTPRouteSchemeRedirect,HTTPRoutePathRedirect,HTTPRouteHostRewrite,HTTPRoutePathRewrite,HTTPRouteRequestMirror,TLSRoute,HTTPRouteBackendProtocolH2C
 CONFORMANCE_SUPPORTED_PROFILES ?= -conformance-profiles=GATEWAY-HTTP
 CONFORMANCE_GATEWAY_CLASS ?= kgateway
 CONFORMANCE_REPORT_ARGS ?= -report-output=$(TEST_ASSET_DIR)/conformance/$(VERSION)-report.yaml -organization=kgateway-dev -project=kgateway -version=$(VERSION) -url=github.com/kgateway-dev/kgateway -contact=github.com/kgateway-dev/kgateway/issues/new/choose

--- a/internal/kgateway/extensions2/plugins/kubernetes/k8s.go
+++ b/internal/kgateway/extensions2/plugins/kubernetes/k8s.go
@@ -56,6 +56,7 @@ func NewPluginFromCollections(
 				},
 				Obj:               svc,
 				Port:              port.Port,
+				AppProtocol:       translateAppProtocol(port.AppProtocol),
 				GvPrefix:          "kube",
 				CanonicalHostname: fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, clusterDomain),
 			})
@@ -76,6 +77,18 @@ func NewPluginFromCollections(
 				Backends:  k8sServiceUpstreams,
 			},
 		},
+	}
+}
+
+func translateAppProtocol(appProtocol *string) ir.AppProtocol {
+	if appProtocol == nil {
+		return ir.DefaultAppProtocol
+	}
+	switch *appProtocol {
+	case "kubernetes.io/h2c":
+		return ir.HTTP2AppProtocol
+	default:
+		return ir.DefaultAppProtocol
 	}
 }
 

--- a/internal/kgateway/ir/backend.go
+++ b/internal/kgateway/ir/backend.go
@@ -59,7 +59,8 @@ type BackendObjectIR struct {
 	// set them explicitly here, and pass this around as the reference.
 	ObjectSource `json:",inline"`
 	// optional port for if ObjectSource is a service that can have multiple ports.
-	Port        int32
+	Port int32
+	// optional application protocol for the backend. Can be used to enable http2.
 	AppProtocol AppProtocol
 
 	// prefix the cluster name with this string to distringuish it from other GVKs.

--- a/internal/kgateway/ir/backend.go
+++ b/internal/kgateway/ir/backend.go
@@ -47,12 +47,20 @@ func (c ObjectSource) Equals(in ObjectSource) bool {
 	return c.Namespace == in.Namespace && c.Name == in.Name && c.Group == in.Group && c.Kind == in.Kind
 }
 
+type AppProtocol string
+
+const (
+	DefaultAppProtocol AppProtocol = ""
+	HTTP2AppProtocol   AppProtocol = "http2"
+)
+
 type BackendObjectIR struct {
 	// Ref to source object. sometimes the group and kind are not populated from api-server, so
 	// set them explicitly here, and pass this around as the reference.
 	ObjectSource `json:",inline"`
 	// optional port for if ObjectSource is a service that can have multiple ports.
-	Port int32
+	Port        int32
+	AppProtocol AppProtocol
 
 	// prefix the cluster name with this string to distringuish it from other GVKs.
 	// here explicitly as it shows up in stats. each (group, kind) pair should have a unique prefix.

--- a/internal/kgateway/setup/testdata/accesslog-filterhttp-httplisteneropt-out.yaml
+++ b/internal/kgateway/setup/testdata/accesslog-filterhttp-httplisteneropt-out.yaml
@@ -97,6 +97,11 @@ clusters:
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
   type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
 - connectTimeout: 5s
   edsClusterConfig:
     edsConfig:

--- a/internal/kgateway/setup/testdata/accesslog-filterhttp-httplisteneropt.yaml
+++ b/internal/kgateway/setup/testdata/accesslog-filterhttp-httplisteneropt.yaml
@@ -87,6 +87,7 @@ spec:
   ports:
     - name: grpc
       port: 50051
+      appProtocol: kubernetes.io/h2c
       targetPort: 50051
   selector:
     app: log-test

--- a/internal/kgateway/translator/irtranslator/backend_test.go
+++ b/internal/kgateway/translator/irtranslator/backend_test.go
@@ -1,0 +1,57 @@
+package irtranslator_test
+
+import (
+	"context"
+	"testing"
+
+	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_upstreams_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func testBInitBackend(ctx context.Context, in ir.BackendObjectIR, out *envoy_config_cluster_v3.Cluster) {
+}
+
+func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
+	var bt irtranslator.BackendTranslator
+	var ucc ir.UniqlyConnectedClient
+	var kctx krt.TestingDummyContext
+	backend := ir.BackendObjectIR{
+		ObjectSource: ir.ObjectSource{
+			Group:     "group",
+			Kind:      "kind",
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		AppProtocol: ir.HTTP2AppProtocol,
+	}
+	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
+		{Group: "group", Kind: "kind"}: {
+			InitBackend: testBInitBackend,
+		},
+	}
+
+	c, err := bt.TranslateBackend(kctx, ucc, backend)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	opts := c.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+	if opts == nil {
+		t.Errorf("Expected HttpProtocolOptions, got nil")
+	}
+
+	p, err := opts.UnmarshalNew()
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	httpOpts, ok := p.(*envoy_upstreams_v3.HttpProtocolOptions)
+	if !ok {
+		t.Errorf("Expected HttpProtocolOptions, got %T", p)
+	}
+	if httpOpts.GetExplicitHttpConfig().GetHttp2ProtocolOptions() == nil {
+		t.Errorf("Expected Http2ProtocolOptions, got nil")
+	}
+}

--- a/internal/kgateway/translator/irtranslator/backend_test.go
+++ b/internal/kgateway/translator/irtranslator/backend_test.go
@@ -6,10 +6,11 @@ import (
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_upstreams_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
 )
 
 func testBInitBackend(ctx context.Context, in ir.BackendObjectIR, out *envoy_config_cluster_v3.Cluster) {

--- a/internal/kgateway/translator/irtranslator/backend_test.go
+++ b/internal/kgateway/translator/irtranslator/backend_test.go
@@ -9,6 +9,8 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
 )
@@ -17,6 +19,7 @@ func testBInitBackend(ctx context.Context, in ir.BackendObjectIR, out *envoy_con
 }
 
 func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
+	g := NewWithT(t)
 	var bt irtranslator.BackendTranslator
 	var ucc ir.UniqlyConnectedClient
 	var kctx krt.TestingDummyContext
@@ -36,23 +39,14 @@ func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 	}
 
 	c, err := bt.TranslateBackend(kctx, ucc, backend)
-	if err != nil {
-		t.Errorf("Error: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 	opts := c.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-	if opts == nil {
-		t.Errorf("Expected HttpProtocolOptions, got nil")
-	}
+	g.Expect(opts).NotTo(BeNil())
 
 	p, err := opts.UnmarshalNew()
-	if err != nil {
-		t.Errorf("Error: %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
+
 	httpOpts, ok := p.(*envoy_upstreams_v3.HttpProtocolOptions)
-	if !ok {
-		t.Errorf("Expected HttpProtocolOptions, got %T", p)
-	}
-	if httpOpts.GetExplicitHttpConfig().GetHttp2ProtocolOptions() == nil {
-		t.Errorf("Expected Http2ProtocolOptions, got nil")
-	}
+	g.Expect(ok).To(BeTrue())
+	g.Expect(httpOpts.GetExplicitHttpConfig().GetHttp2ProtocolOptions()).NotTo(BeNil())
 }


### PR DESCRIPTION
i noticed we didn't have http2 set for grpc access log. so added support for app protocol for k8s service.