### PR TITLE
make: golangci-lint should use the current go mod version rather than negotiating down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,12 +148,14 @@ check-spelling:
 #----------------------------------------------------------------------------
 
 LINTER_VERSION := $(shell cat .github/workflows/static-analysis.yaml | yq '.jobs.static-analysis.steps.[] | select( .uses == "*golangci/golangci-lint-action*") | .with.version ')
+GO_VERSION := $(shell cat go.mod | grep -E '^go' | awk '{print $$2}')
+GOTOOLCHAIN ?= go$(GO_VERSION)
 
 GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINTER_VERSION)
 ANALYZE_ARGS ?= --fast --verbose
 .PHONY: analyze
 analyze:  ## Run golangci-lint. Override options with ANALYZE_ARGS.
-	$(GOLANGCI_LINT) run $(ANALYZE_ARGS) ./...
+	GOTOOLCHAIN=$(GOTOOLCHAIN) $(GOLANGCI_LINT) run $(ANALYZE_ARGS) ./...
 
 #----------------------------------------------------------------------------------
 # Ginkgo Tests


### PR DESCRIPTION
Make target for golangci-lint was painful locally.

Since we didnt set a toolchain it would negotiate to the highest 1.23 setup
Therefore lets try to pass default GOTOOLCHAIN.


This ist the error you would see:
`go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 run --fast --verbose ./...
go: github.com/golangci/golangci-lint@v1.64.5 requires go >= 1.23.0; switching to go1.23.7
INFO golangci-lint has version v1.64.5 built with go1.23.7 from (unknown, modified: ?, mod sum: "h1:5omC86XFBKXZgCrVdUWU+WNHKd+CWCxNx717KXnzKZY=") on (unknown)
INFO [config_reader] Config search paths: [./ /Users/nfudenberg/go/src/github.com/nfuden/k8sgateway /Users/nfudenberg/go/src/github.com/nfuden /Users/nfudenberg/go/src/github.com /Users/nfudenberg/go/src /Users/nfudenberg/go /Users/nfudenberg /Users /]
INFO [config_reader] Used config file .golangci.yaml
Error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
Failed executing command with error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
exit status 3`


Now we just add a toolchain by inspecting the go mod. 
This reuses awk and grep which we already had started using in the makefile.