### PR TITLE
api: Add basic Backend printer columns

### DIFF
--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -9,7 +9,7 @@ import (
 // +kubebuilder:rbac:groups=gateway.kgateway.dev,resources=backends,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.kgateway.dev,resources=backends/status,verbs=get;update;patch
 
-// +kubebuilder:printcolumn:name="Backend Type",type=string,JSONPath=".spec.type",description="Which backend type?"
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=".spec.type",description="Which backend type?"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="The age of the backend."
 
 // +genclient

--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -9,6 +9,9 @@ import (
 // +kubebuilder:rbac:groups=gateway.kgateway.dev,resources=backends,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.kgateway.dev,resources=backends/status,verbs=get;update;patch
 
+// +kubebuilder:printcolumn:name="Backend Type",type=string,JSONPath=".spec.type",description="Which backend type?"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="The age of the backend."
+
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
@@ -21,7 +21,16 @@ spec:
     singular: backend
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Which backend type?
+      jsonPath: .spec.type
+      name: Backend Type
+      type: string
+    - description: The age of the backend.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
@@ -24,7 +24,7 @@ spec:
   - additionalPrinterColumns:
     - description: Which backend type?
       jsonPath: .spec.type
-      name: Backend Type
+      name: Type
       type: string
     - description: The age of the backend.
       jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Add basic printer columns to the Backend CRD:

```bash
$ k get backend -A       
NAMESPACE     NAME             BACKEND TYPE   AGE
lambda-test   lambda-backend   aws            4m25s
```

Once #10555 is resolved and the Backend plugin is reporting status,
we can add another printer column that emits whether the CR is
in a good state or not.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
