### PR TITLE
Add the ineffassign linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
     - forbidigo
     - ginkgolinter
     - goimports
+    - ineffassign
     - misspell
     - nakedret
     - predeclared

--- a/internal/sds/pkg/server/server_test.go
+++ b/internal/sds/pkg/server/server_test.go
@@ -137,6 +137,7 @@ var _ = Describe("SDS Server", func() {
 			// Before any snapshot is set, expect an error when fetching secrets
 			resp, err := client.FetchSecrets(ctx, &envoy_service_discovery_v3.DiscoveryRequest{})
 			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
 
 			// After snapshot is set, expect to see the secrets
 			srv.UpdateSDSConfig(ctx)


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Add the https://golangci-lint.run/usage/linters/#ineffassign linter which is enabled by default
in golangci-lint.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
