### PR TITLE
hack,install: Enable CRD description generation

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -38,7 +38,7 @@ API_INPUT_DIRS_SPACE="${API_INPUT_DIRS_SPACE%,}" # drop trailing space
 API_INPUT_DIRS_COMMA="${API_INPUT_DIRS_COMMA%,}" # drop trailing comma
 
 go run k8s.io/code-generator/cmd/register-gen --output-file zz_generated.register.go ${API_INPUT_DIRS_SPACE}
-go run sigs.k8s.io/controller-tools/cmd/controller-gen crd:maxDescLen=0 object rbac:roleName=kgateway paths="${APIS_PKG}/api/${VERSION}" \
+go run sigs.k8s.io/controller-tools/cmd/controller-gen crd:maxDescLen=1000 object rbac:roleName=kgateway paths="${APIS_PKG}/api/${VERSION}" \
     output:crd:artifacts:config=${ROOT_DIR}/${CRD_DIR} output:rbac:artifacts:config=${ROOT_DIR}/${MANIFESTS_DIR}
 
 # throw away

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
@@ -26,26 +26,46 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
+            description: BackendSpec defines the desired state of Backend.
             properties:
               ai:
+                description: AI is the AI backend configuration.
                 maxProperties: 1
                 minProperties: 1
                 properties:
                   llm:
+                    description: The LLM configures the AI gateway to use a single
+                      LLM provider backend.
                     properties:
                       hostOverride:
+                        description: |-
+                          Send requests to a custom host and port, such as to proxy the request,
+                          or to use a different backend that is API-compliant with the Backend version.
                         properties:
                           host:
+                            description: Host is the host name.
                             maxLength: 253
                             minLength: 1
                             type: string
                           port:
+                            description: Port is the port number.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -55,27 +75,54 @@ spec:
                         - port
                         type: object
                       provider:
+                        description: The LLM provider type to configure.
                         maxProperties: 1
                         minProperties: 1
                         properties:
                           anthropic:
+                            description: AnthropicConfig settings for the [Anthropic](https://docs.anthropic.com/en/release-notes/api)
+                              LLM provider.
                             properties:
                               apiVersion:
+                                description: |-
+                                  Optional: A version header to pass to the Anthropic API.
+                                  For more information, see the [Anthropic API versioning docs](https://docs.anthropic.com/en/api/versioning).
                                 type: string
                               authToken:
+                                description: |-
+                                  The authorization token that the AI gateway uses to access the Anthropic API.
+                                  This token is automatically sent in the `x-api-key` header of the request.
                                 properties:
                                   inline:
+                                    description: |-
+                                      Provide the token directly in the configuration for the Backend.
+                                      This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                     type: string
                                   kind:
+                                    description: |-
+                                      Kind specifies which type of authorization token is being used.
+                                      Must be one of: "Inline", "SecretRef", "Passthrough".
                                     enum:
                                     - Inline
                                     - SecretRef
                                     - Passthrough
                                     type: string
                                   secretRef:
+                                    description: |-
+                                      Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                      Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                      because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                      You might use this option in proofs of concept, controlled development and staging environments,
+                                      or well-controlled prod environments that use secrets.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -83,29 +130,60 @@ spec:
                                 - kind
                                 type: object
                               model:
+                                description: |-
+                                  Optional: Override the model name.
+                                  If unset, the model name is taken from the request.
+                                  This setting can be useful when testing model failover scenarios.
                                 type: string
                             required:
                             - authToken
                             type: object
                           azureopenai:
+                            description: AzureOpenAIConfig settings for the [Azure
+                              OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/)
+                              LLM provider.
                             properties:
                               apiVersion:
+                                description: |-
+                                  The version of the Azure OpenAI API to use.
+                                  For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs).
                                 minLength: 1
                                 type: string
                               authToken:
+                                description: |-
+                                  The authorization token that the AI gateway uses to access the Azure OpenAI API.
+                                  This token is automatically sent in the `api-key` header of the request.
                                 properties:
                                   inline:
+                                    description: |-
+                                      Provide the token directly in the configuration for the Backend.
+                                      This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                     type: string
                                   kind:
+                                    description: |-
+                                      Kind specifies which type of authorization token is being used.
+                                      Must be one of: "Inline", "SecretRef", "Passthrough".
                                     enum:
                                     - Inline
                                     - SecretRef
                                     - Passthrough
                                     type: string
                                   secretRef:
+                                    description: |-
+                                      Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                      Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                      because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                      You might use this option in proofs of concept, controlled development and staging environments,
+                                      or well-controlled prod environments that use secrets.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -113,9 +191,15 @@ spec:
                                 - kind
                                 type: object
                               deploymentName:
+                                description: |-
+                                  The name of the Azure OpenAI model deployment to use.
+                                  For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models).
                                 minLength: 1
                                 type: string
                               endpoint:
+                                description: |-
+                                  The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`.
+                                  If the scheme is included, it is stripped.
                                 minLength: 1
                                 type: string
                             required:
@@ -125,23 +209,49 @@ spec:
                             - endpoint
                             type: object
                           gemini:
+                            description: GeminiConfig settings for the [Gemini](https://ai.google.dev/gemini-api/docs)
+                              LLM provider.
                             properties:
                               apiVersion:
+                                description: |-
+                                  The version of the Gemini API to use.
+                                  For more information, see the [Gemini API version docs](https://ai.google.dev/gemini-api/docs/api-versions).
                                 type: string
                               authToken:
+                                description: |-
+                                  The authorization token that the AI gateway uses to access the Gemini API.
+                                  This token is automatically sent in the `key` query parameter of the request.
                                 properties:
                                   inline:
+                                    description: |-
+                                      Provide the token directly in the configuration for the Backend.
+                                      This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                     type: string
                                   kind:
+                                    description: |-
+                                      Kind specifies which type of authorization token is being used.
+                                      Must be one of: "Inline", "SecretRef", "Passthrough".
                                     enum:
                                     - Inline
                                     - SecretRef
                                     - Passthrough
                                     type: string
                                   secretRef:
+                                    description: |-
+                                      Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                      Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                      because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                      You might use this option in proofs of concept, controlled development and staging environments,
+                                      or well-controlled prod environments that use secrets.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -149,6 +259,9 @@ spec:
                                 - kind
                                 type: object
                               model:
+                                description: |-
+                                  The Gemini model to use.
+                                  For more information, see the [Gemini models docs](https://ai.google.dev/gemini-api/docs/models/gemini).
                                 type: string
                             required:
                             - apiVersion
@@ -156,21 +269,45 @@ spec:
                             - model
                             type: object
                           openai:
+                            description: OpenAIConfig settings for the [OpenAI](https://platform.openai.com/docs/api-reference/streaming)
+                              LLM provider.
                             properties:
                               authToken:
+                                description: |-
+                                  The authorization token that the AI gateway uses to access the OpenAI API.
+                                  This token is automatically sent in the `Authorization` header of the
+                                  request and prefixed with `Bearer`.
                                 properties:
                                   inline:
+                                    description: |-
+                                      Provide the token directly in the configuration for the Backend.
+                                      This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                     type: string
                                   kind:
+                                    description: |-
+                                      Kind specifies which type of authorization token is being used.
+                                      Must be one of: "Inline", "SecretRef", "Passthrough".
                                     enum:
                                     - Inline
                                     - SecretRef
                                     - Passthrough
                                     type: string
                                   secretRef:
+                                    description: |-
+                                      Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                      Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                      because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                      You might use this option in proofs of concept, controlled development and staging environments,
+                                      or well-controlled prod environments that use secrets.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -178,29 +315,61 @@ spec:
                                 - kind
                                 type: object
                               model:
+                                description: |-
+                                  Optional: Override the model name, such as `gpt-4o-mini`.
+                                  If unset, the model name is taken from the request.
+                                  This setting can be useful when setting up model failover within the same LLM provider.
                                 type: string
                             required:
                             - authToken
                             type: object
                           vertexai:
+                            description: |-
+                              VertexAIConfig settings for the [Vertex AI](https://cloud.google.com/vertex-ai/docs) LLM provider.
+                              To find the values for the project ID, project location, and publisher, you can check the fields of an API request, such as
+                              `https://{LOCATION}-aiplatform.googleapis.com/{VERSION}/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/{PROVIDER}/<model-path>`.
                             properties:
                               apiVersion:
+                                description: |-
+                                  The version of the Vertex AI API to use.
+                                  For more information, see the [Vertex AI API reference](https://cloud.google.com/vertex-ai/docs/reference#versions).
                                 minLength: 1
                                 type: string
                               authToken:
+                                description: |-
+                                  The authorization token that the AI gateway uses to access the Vertex AI API.
+                                  This token is automatically sent in the `key` header of the request.
                                 properties:
                                   inline:
+                                    description: |-
+                                      Provide the token directly in the configuration for the Backend.
+                                      This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                     type: string
                                   kind:
+                                    description: |-
+                                      Kind specifies which type of authorization token is being used.
+                                      Must be one of: "Inline", "SecretRef", "Passthrough".
                                     enum:
                                     - Inline
                                     - SecretRef
                                     - Passthrough
                                     type: string
                                   secretRef:
+                                    description: |-
+                                      Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                      Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                      because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                      You might use this option in proofs of concept, controlled development and staging environments,
+                                      or well-controlled prod environments that use secrets.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -208,17 +377,28 @@ spec:
                                 - kind
                                 type: object
                               location:
+                                description: The location of the Google Cloud Project
+                                  that you use for the Vertex AI.
                                 minLength: 1
                                 type: string
                               model:
+                                description: |-
+                                  The Vertex AI model to use.
+                                  For more information, see the [Vertex AI model docs](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models).
                                 minLength: 1
                                 type: string
                               modelPath:
+                                description: 'Optional: The model path to route to.
+                                  Defaults to the Gemini model path, `generateContent`.'
                                 type: string
                               projectId:
+                                description: The ID of the Google Cloud Project that
+                                  you use for the Vertex AI.
                                 minLength: 1
                                 type: string
                               publisher:
+                                description: The type of publisher model to use. Currently,
+                                  only Google is supported.
                                 enum:
                                 - GOOGLE
                                 type: string
@@ -235,20 +415,34 @@ spec:
                     - provider
                     type: object
                   multipool:
+                    description: The MultiPool configures the backends for multiple
+                      hosts or models from the same provider in one Backend resource.
                     properties:
                       priorities:
+                        description: |-
+                          The priority list of backend pools. Each entry represents a set of LLM provider backends.
+                          The order defines the priority of the backend endpoints.
                         items:
+                          description: Priority configures the priority of the backend
+                            endpoints.
                           properties:
                             pool:
+                              description: A list of LLM provider backends within
+                                a single endpoint pool entry.
                               items:
                                 properties:
                                   hostOverride:
+                                    description: |-
+                                      Send requests to a custom host and port, such as to proxy the request,
+                                      or to use a different backend that is API-compliant with the Backend version.
                                     properties:
                                       host:
+                                        description: Host is the host name.
                                         maxLength: 253
                                         minLength: 1
                                         type: string
                                       port:
+                                        description: Port is the port number.
                                         format: int32
                                         maximum: 65535
                                         minimum: 1
@@ -258,27 +452,55 @@ spec:
                                     - port
                                     type: object
                                   provider:
+                                    description: The LLM provider type to configure.
                                     maxProperties: 1
                                     minProperties: 1
                                     properties:
                                       anthropic:
+                                        description: AnthropicConfig settings for
+                                          the [Anthropic](https://docs.anthropic.com/en/release-notes/api)
+                                          LLM provider.
                                         properties:
                                           apiVersion:
+                                            description: |-
+                                              Optional: A version header to pass to the Anthropic API.
+                                              For more information, see the [Anthropic API versioning docs](https://docs.anthropic.com/en/api/versioning).
                                             type: string
                                           authToken:
+                                            description: |-
+                                              The authorization token that the AI gateway uses to access the Anthropic API.
+                                              This token is automatically sent in the `x-api-key` header of the request.
                                             properties:
                                               inline:
+                                                description: |-
+                                                  Provide the token directly in the configuration for the Backend.
+                                                  This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                                 type: string
                                               kind:
+                                                description: |-
+                                                  Kind specifies which type of authorization token is being used.
+                                                  Must be one of: "Inline", "SecretRef", "Passthrough".
                                                 enum:
                                                 - Inline
                                                 - SecretRef
                                                 - Passthrough
                                                 type: string
                                               secretRef:
+                                                description: |-
+                                                  Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                                  Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                                  because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                                  You might use this option in proofs of concept, controlled development and staging environments,
+                                                  or well-controlled prod environments that use secrets.
                                                 properties:
                                                   name:
                                                     default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -286,29 +508,60 @@ spec:
                                             - kind
                                             type: object
                                           model:
+                                            description: |-
+                                              Optional: Override the model name.
+                                              If unset, the model name is taken from the request.
+                                              This setting can be useful when testing model failover scenarios.
                                             type: string
                                         required:
                                         - authToken
                                         type: object
                                       azureopenai:
+                                        description: AzureOpenAIConfig settings for
+                                          the [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/)
+                                          LLM provider.
                                         properties:
                                           apiVersion:
+                                            description: |-
+                                              The version of the Azure OpenAI API to use.
+                                              For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs).
                                             minLength: 1
                                             type: string
                                           authToken:
+                                            description: |-
+                                              The authorization token that the AI gateway uses to access the Azure OpenAI API.
+                                              This token is automatically sent in the `api-key` header of the request.
                                             properties:
                                               inline:
+                                                description: |-
+                                                  Provide the token directly in the configuration for the Backend.
+                                                  This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                                 type: string
                                               kind:
+                                                description: |-
+                                                  Kind specifies which type of authorization token is being used.
+                                                  Must be one of: "Inline", "SecretRef", "Passthrough".
                                                 enum:
                                                 - Inline
                                                 - SecretRef
                                                 - Passthrough
                                                 type: string
                                               secretRef:
+                                                description: |-
+                                                  Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                                  Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                                  because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                                  You might use this option in proofs of concept, controlled development and staging environments,
+                                                  or well-controlled prod environments that use secrets.
                                                 properties:
                                                   name:
                                                     default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -316,9 +569,15 @@ spec:
                                             - kind
                                             type: object
                                           deploymentName:
+                                            description: |-
+                                              The name of the Azure OpenAI model deployment to use.
+                                              For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models).
                                             minLength: 1
                                             type: string
                                           endpoint:
+                                            description: |-
+                                              The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`.
+                                              If the scheme is included, it is stripped.
                                             minLength: 1
                                             type: string
                                         required:
@@ -328,23 +587,50 @@ spec:
                                         - endpoint
                                         type: object
                                       gemini:
+                                        description: GeminiConfig settings for the
+                                          [Gemini](https://ai.google.dev/gemini-api/docs)
+                                          LLM provider.
                                         properties:
                                           apiVersion:
+                                            description: |-
+                                              The version of the Gemini API to use.
+                                              For more information, see the [Gemini API version docs](https://ai.google.dev/gemini-api/docs/api-versions).
                                             type: string
                                           authToken:
+                                            description: |-
+                                              The authorization token that the AI gateway uses to access the Gemini API.
+                                              This token is automatically sent in the `key` query parameter of the request.
                                             properties:
                                               inline:
+                                                description: |-
+                                                  Provide the token directly in the configuration for the Backend.
+                                                  This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                                 type: string
                                               kind:
+                                                description: |-
+                                                  Kind specifies which type of authorization token is being used.
+                                                  Must be one of: "Inline", "SecretRef", "Passthrough".
                                                 enum:
                                                 - Inline
                                                 - SecretRef
                                                 - Passthrough
                                                 type: string
                                               secretRef:
+                                                description: |-
+                                                  Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                                  Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                                  because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                                  You might use this option in proofs of concept, controlled development and staging environments,
+                                                  or well-controlled prod environments that use secrets.
                                                 properties:
                                                   name:
                                                     default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -352,6 +638,9 @@ spec:
                                             - kind
                                             type: object
                                           model:
+                                            description: |-
+                                              The Gemini model to use.
+                                              For more information, see the [Gemini models docs](https://ai.google.dev/gemini-api/docs/models/gemini).
                                             type: string
                                         required:
                                         - apiVersion
@@ -359,21 +648,46 @@ spec:
                                         - model
                                         type: object
                                       openai:
+                                        description: OpenAIConfig settings for the
+                                          [OpenAI](https://platform.openai.com/docs/api-reference/streaming)
+                                          LLM provider.
                                         properties:
                                           authToken:
+                                            description: |-
+                                              The authorization token that the AI gateway uses to access the OpenAI API.
+                                              This token is automatically sent in the `Authorization` header of the
+                                              request and prefixed with `Bearer`.
                                             properties:
                                               inline:
+                                                description: |-
+                                                  Provide the token directly in the configuration for the Backend.
+                                                  This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                                 type: string
                                               kind:
+                                                description: |-
+                                                  Kind specifies which type of authorization token is being used.
+                                                  Must be one of: "Inline", "SecretRef", "Passthrough".
                                                 enum:
                                                 - Inline
                                                 - SecretRef
                                                 - Passthrough
                                                 type: string
                                               secretRef:
+                                                description: |-
+                                                  Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                                  Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                                  because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                                  You might use this option in proofs of concept, controlled development and staging environments,
+                                                  or well-controlled prod environments that use secrets.
                                                 properties:
                                                   name:
                                                     default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -381,29 +695,61 @@ spec:
                                             - kind
                                             type: object
                                           model:
+                                            description: |-
+                                              Optional: Override the model name, such as `gpt-4o-mini`.
+                                              If unset, the model name is taken from the request.
+                                              This setting can be useful when setting up model failover within the same LLM provider.
                                             type: string
                                         required:
                                         - authToken
                                         type: object
                                       vertexai:
+                                        description: |-
+                                          VertexAIConfig settings for the [Vertex AI](https://cloud.google.com/vertex-ai/docs) LLM provider.
+                                          To find the values for the project ID, project location, and publisher, you can check the fields of an API request, such as
+                                          `https://{LOCATION}-aiplatform.googleapis.com/{VERSION}/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/{PROVIDER}/<model-path>`.
                                         properties:
                                           apiVersion:
+                                            description: |-
+                                              The version of the Vertex AI API to use.
+                                              For more information, see the [Vertex AI API reference](https://cloud.google.com/vertex-ai/docs/reference#versions).
                                             minLength: 1
                                             type: string
                                           authToken:
+                                            description: |-
+                                              The authorization token that the AI gateway uses to access the Vertex AI API.
+                                              This token is automatically sent in the `key` header of the request.
                                             properties:
                                               inline:
+                                                description: |-
+                                                  Provide the token directly in the configuration for the Backend.
+                                                  This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                                 type: string
                                               kind:
+                                                description: |-
+                                                  Kind specifies which type of authorization token is being used.
+                                                  Must be one of: "Inline", "SecretRef", "Passthrough".
                                                 enum:
                                                 - Inline
                                                 - SecretRef
                                                 - Passthrough
                                                 type: string
                                               secretRef:
+                                                description: |-
+                                                  Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                                  Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                                  because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                                  You might use this option in proofs of concept, controlled development and staging environments,
+                                                  or well-controlled prod environments that use secrets.
                                                 properties:
                                                   name:
                                                     default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -411,17 +757,31 @@ spec:
                                             - kind
                                             type: object
                                           location:
+                                            description: The location of the Google
+                                              Cloud Project that you use for the Vertex
+                                              AI.
                                             minLength: 1
                                             type: string
                                           model:
+                                            description: |-
+                                              The Vertex AI model to use.
+                                              For more information, see the [Vertex AI model docs](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models).
                                             minLength: 1
                                             type: string
                                           modelPath:
+                                            description: 'Optional: The model path
+                                              to route to. Defaults to the Gemini
+                                              model path, `generateContent`.'
                                             type: string
                                           projectId:
+                                            description: The ID of the Google Cloud
+                                              Project that you use for the Vertex
+                                              AI.
                                             minLength: 1
                                             type: string
                                           publisher:
+                                            description: The type of publisher model
+                                              to use. Currently, only Google is supported.
                                             enum:
                                             - GOOGLE
                                             type: string
@@ -453,27 +813,41 @@ spec:
                   rule: (has(self.llm) && !has(self.multipool)) || (!has(self.llm)
                     && has(self.multipool))
               aws:
+                description: Aws is the AWS backend configuration.
                 properties:
                   region:
+                    description: Region is the AWS region.
                     type: string
                   secretRef:
+                    description: SecretRef is the secret reference for the AWS credentials.
                     properties:
                       name:
                         default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               static:
+                description: Static is the static backend configuration.
                 properties:
                   hosts:
+                    description: Hosts is the list of hosts.
                     items:
+                      description: Host is a host and port pair.
                       properties:
                         host:
+                          description: Host is the host name.
                           maxLength: 253
                           minLength: 1
                           type: string
                         port:
+                          description: Port is the port number.
                           format: int32
                           maximum: 65535
                           minimum: 1
@@ -486,6 +860,7 @@ spec:
                     type: array
                 type: object
               type:
+                description: Type indicates the type of the backend to be used.
                 enum:
                 - ai
                 - aws
@@ -508,32 +883,54 @@ spec:
             - message: static backend must be specified when type is 'static'
               rule: '!(!has(self.static) && self.type == ''static'')'
           status:
+            description: BackendStatus defines the observed state of Backend.
             properties:
               conditions:
+                description: Conditions is the list of conditions for the backend.
                 items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_directresponses.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_directresponses.yaml
@@ -24,19 +24,38 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: DirectResponse contains configuration for defining direct response
+          routes.
         properties:
           apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
+            description: DirectResponseSpec describes the desired state of a DirectResponse.
             properties:
               body:
+                description: |-
+                  Body defines the content to be returned in the HTTP response body.
+                  The maximum length of the body is restricted to prevent excessively large responses.
                 maxLength: 4096
                 type: string
               status:
+                description: StatusCode defines the HTTP status code to return for
+                  this route.
                 format: int32
                 maximum: 599
                 minimum: 200
@@ -45,6 +64,7 @@ spec:
             - status
             type: object
           status:
+            description: DirectResponseStatus defines the observed state of a DirectResponse.
             type: object
         type: object
     served: true

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_gatewayparameters.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_gatewayparameters.yaml
@@ -24,77 +24,152 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: |-
+          A GatewayParameters contains configuration that is used to dynamically
+          provision kgateway's data plane (Envoy proxy instance), based on a
+          Kubernetes Gateway.
         properties:
           apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
+            description: |-
+              A GatewayParametersSpec describes the type of environment/platform in which
+              the proxy will be provisioned.
             properties:
               kube:
+                description: The proxy will be deployed on Kubernetes.
                 properties:
                   aiExtension:
+                    description: Configuration for the AI extension.
                     properties:
                       enabled:
+                        description: Whether to enable the extension.
                         type: boolean
                       env:
+                        description: The extension's container environment variables.
                         items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
                           properties:
                             name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
                               type: string
                             value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
+                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
+                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
                                   properties:
                                     key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -106,46 +181,99 @@ spec:
                           type: object
                         type: array
                       image:
+                        description: |-
+                          The extension's container image. See
+                          https://kubernetes.io/docs/concepts/containers/images
+                          for details.
                         properties:
                           digest:
+                            description: The hash digest of the image, e.g. `sha256:12345...`
                             type: string
                           pullPolicy:
+                            description: |-
+                              The image pull policy for the container. See
+                              https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                              for details.
                             type: string
                           registry:
+                            description: The image registry.
                             type: string
                           repository:
+                            description: The image repository (name).
                             type: string
                           tag:
+                            description: The image tag.
                             type: string
                         type: object
                       ports:
+                        description: The extension's container ports.
                         items:
+                          description: ContainerPort represents a network port in
+                            a single container.
                           properties:
                             containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
                               format: int32
                               type: integer
                             hostIP:
+                              description: What host IP to bind the external port
+                                to.
                               type: string
                             hostPort:
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
                               format: int32
                               type: integer
                             name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
                               type: string
                             protocol:
                               default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
                               type: string
                           required:
                           - containerPort
                           type: object
                         type: array
                       resources:
+                        description: |-
+                          The compute resources required by this container. See
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          for details.
                         properties:
                           claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
                             items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
                                   type: string
                                 request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -161,6 +289,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -169,96 +300,258 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       securityContext:
+                        description: |-
+                          The security context for this container. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core
+                          for details.
                         properties:
                           allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                              overrides the pod's appArmorProfile.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
                                 type: string
                             required:
                             - type
                             type: object
                           capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
+                                description: Added capabilities
                                 items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               drop:
+                                description: Removed capabilities
                                 items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
                           privileged:
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default value is Default which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
                                 type: string
                               role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
                                 type: string
                               type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
                                 type: string
                               user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
                                 type: string
                             type: object
                           seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
                                 type: string
                               hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       stats:
+                        description: |-
+                          Additional stats config for AI Extension.
+                          This config can be useful for adding custom labels to the request metrics.
+
+                          Example:
+                          ```yaml
+                          stats:
+                            customLabels:
+                              - name: "subject"
+                                metadataNamespace: "envoy.filters.http.jwt_authn"
+                                metadataKey: "principal:sub"
+                              - name: "issuer"
+                                metadataNamespace: "envoy.filters.http.jwt_authn"
+                                metadataKey: "principal:iss"
+                          ```
                         properties:
                           customLabels:
+                            description: |-
+                              Set of custom labels to be added to the request metrics.
+                              These will be added on each request which goes through the AI Extension.
                             items:
                               properties:
                                 keyDelimiter:
+                                  description: |-
+                                    The key delimiter to use, by default this is set to `:`.
+                                    This allows for keys with `.` in them to be used.
+                                    For example, if you have keys in your path with `:` in them, (e.g. `key1:key2:value`)
+                                    you can instead set this to `~` to be able to split those keys properly.
                                   type: string
                                 metadataKey:
+                                  description: |-
+                                    The key to use to get the data from the metadata namespace.
+                                    If using a JWT data please see the following envoy docs: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#envoy-v3-api-field-extensions-filters-http-jwt-authn-v3-jwtprovider-payload-in-metadata
+                                    This key follows the same format as the envoy access logging for dynamic metadata.
+                                    Examples can be found here: https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage
                                   minLength: 1
                                   type: string
                                 metadataNamespace:
+                                  description: |-
+                                    The dynamic metadata namespace to get the data from. If not specified, the default namespace will be
+                                    the envoy JWT filter namespace.
+                                    This can also be used in combination with early_transformations to insert custom data.
                                   enum:
                                   - envoy.filters.http.jwt_authn
                                   - io.solo.transformation
                                   type: string
                                 name:
+                                  description: Name of the label to use in the prometheus
+                                    metrics
                                   minLength: 1
                                   type: string
                               required:
@@ -269,43 +562,97 @@ spec:
                         type: object
                     type: object
                   deployment:
+                    description: |-
+                      Use a Kubernetes deployment as the proxy workload type. Currently, this is the only
+                      supported workload type.
                     properties:
                       replicas:
+                        description: The number of desired pods. Defaults to 1.
                         format: int32
                         type: integer
                     type: object
                   envoyContainer:
+                    description: Configuration for the container running Envoy.
                     properties:
                       bootstrap:
+                        description: Initial envoy configuration.
                         properties:
                           componentLogLevels:
                             additionalProperties:
                               type: string
+                            description: "Envoy log levels for specific components.
+                              The keys are component names and\nthe values are one
+                              of \"trace\", \"debug\", \"info\", \"warn\", \"error\",\n\"critical\",
+                              or \"off\", e.g.\n\n\t```yaml\n\tcomponentLogLevels:\n\t
+                              \ upstream: debug\n\t  connection: trace\n\t```\n\nThese
+                              will be converted to the `--component-log-level` Envoy
+                              argument\nvalue. See\nhttps://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy#debugging-envoy\nfor
+                              more information.\n\nNote: the keys and values cannot
+                              be empty, but they are not otherwise validated."
                             type: object
                           logLevel:
+                            description: |-
+                              Envoy log level. Options include "trace", "debug", "info", "warn", "error",
+                              "critical" and "off". Defaults to "info". See
+                              https://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy#debugging-envoy
+                              for more information.
                             type: string
                         type: object
                       image:
+                        description: "The envoy container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor
+                          details.\n\nDefault values, which may be overridden individually:\n\n\tregistry:
+                          quay.io/solo-io\n\trepository: gloo-envoy-wrapper (OSS)
+                          / gloo-ee-envoy-wrapper (EE)\n\ttag: <gloo version> (OSS)
+                          / <gloo-ee version> (EE)\n\tpullPolicy: IfNotPresent"
                         properties:
                           digest:
+                            description: The hash digest of the image, e.g. `sha256:12345...`
                             type: string
                           pullPolicy:
+                            description: |-
+                              The image pull policy for the container. See
+                              https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                              for details.
                             type: string
                           registry:
+                            description: The image registry.
                             type: string
                           repository:
+                            description: The image repository (name).
                             type: string
                           tag:
+                            description: The image tag.
                             type: string
                         type: object
                       resources:
+                        description: |-
+                          The compute resources required by this container. See
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          for details.
                         properties:
                           claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
                             items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
                                   type: string
                                 request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -321,6 +668,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -329,154 +679,367 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       securityContext:
+                        description: |-
+                          The security context for this container. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core
+                          for details.
                         properties:
                           allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                              overrides the pod's appArmorProfile.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
                                 type: string
                             required:
                             - type
                             type: object
                           capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
+                                description: Added capabilities
                                 items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               drop:
+                                description: Removed capabilities
                                 items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
                           privileged:
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default value is Default which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
                                 type: string
                               role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
                                 type: string
                               type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
                                 type: string
                               user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
                                 type: string
                             type: object
                           seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
                                 type: string
                               hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                     type: object
                   floatingUserId:
+                    description: Used to unset the `runAsUser` values in security
+                      contexts.
                     type: boolean
                   istio:
+                    description: Configuration for the Istio integration.
                     properties:
                       customSidecars:
+                        description: |-
+                          do not use slice of pointers: https://github.com/kubernetes/code-generator/issues/166
+                          Override the default Istio sidecar in gateway-proxy with a custom container.
                         items:
+                          description: A single application container that you want
+                            to run within a pod.
                           properties:
                             args:
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             command:
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             env:
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
                               items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
                                 properties:
                                   name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
                                     type: string
                                   value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
                                     type: string
                                   valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
                                     properties:
                                       configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
                                         properties:
                                           key:
+                                            description: The key to select.
                                             type: string
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                         properties:
                                           apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
                                             type: string
                                           fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                         properties:
                                           containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
+                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
                                         properties:
                                           key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
                                             type: string
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
                                             type: boolean
                                         required:
                                         - key
@@ -491,25 +1054,54 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             envFrom:
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is starting. When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
                               items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
                                 properties:
                                   configMapRef:
+                                    description: The ConfigMap to select from
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
+                                    description: The Secret to select from
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
+                                        description: Specify whether the Secret must
+                                          be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -517,31 +1109,71 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             image:
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
                               type: string
                             imagePullPolicy:
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                               type: string
                             lifecycle:
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
                               properties:
                                 postStart:
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
                                       properties:
                                         host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
+                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -550,58 +1182,112 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         path:
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
                                       properties:
                                         seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
                                           format: int64
                                           type: integer
                                       required:
                                       - seconds
                                       type: object
                                     tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
                                       properties:
                                         host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                   properties:
                                     exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
                                       properties:
                                         command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
                                       properties:
                                         host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
+                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -610,33 +1296,56 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         path:
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
                                       properties:
                                         seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
                                           format: int64
                                           type: integer
                                       required:
                                       - seconds
                                       type: object
                                     tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
                                       properties:
                                         host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -644,39 +1353,76 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
                                   properties:
                                     command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
                                   properties:
                                     port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
                                       format: int32
                                       type: integer
                                     service:
                                       default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
                                   properties:
                                     host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
                                       items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
                                         properties:
                                           name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
+                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -685,62 +1431,133 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     path:
+                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
                                   properties:
                                     host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             name:
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
                               type: string
                             ports:
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
                               items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
                                 properties:
                                   containerPort:
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
                                     type: string
                                   hostPort:
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -751,39 +1568,76 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
                                   properties:
                                     command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
                                   properties:
                                     port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
                                       format: int32
                                       type: integer
                                     service:
                                       default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
                                   properties:
                                     host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
                                       items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
                                         properties:
                                           name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
+                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -792,51 +1646,100 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     path:
+                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
                                   properties:
                                     host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             resizePolicy:
+                              description: Resources resize policy for the container.
                               items:
+                                description: ContainerResizePolicy represents resource
+                                  resize policy for the container.
                                 properties:
                                   resourceName:
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
                                     type: string
                                   restartPolicy:
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
                                     type: string
                                 required:
                                 - resourceName
@@ -845,13 +1748,35 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             resources:
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               properties:
                                 claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
                                   items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
                                     properties:
                                       name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
                                         type: string
                                       request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
                                         type: string
                                     required:
                                     - name
@@ -867,6 +1792,9 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -875,116 +1803,298 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   type: object
                               type: object
                             restartPolicy:
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This field may only be set for init containers, and the only allowed value is "Always".
+                                For non-init containers or when this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container.
                               type: string
                             securityContext:
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                               properties:
                                 allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
                                       type: string
                                     type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     add:
+                                      description: Added capabilities
                                       items:
+                                        description: Capability represent POSIX capabilities
+                                          type
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     drop:
+                                      description: Removed capabilities
                                       items:
+                                        description: Capability represent POSIX capabilities
+                                          type
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default value is Default which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: string
                                 readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   type: boolean
                                 runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
                                       type: string
                                     role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
                                       type: string
                                     type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
                                       type: string
                                     user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
                                       type: string
                                   type: object
                                 seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                               properties:
                                 exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
                                   properties:
                                     command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
                                   properties:
                                     port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
                                       format: int32
                                       type: integer
                                     service:
                                       default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
                                   properties:
                                     host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
                                       items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
                                         properties:
                                           name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                             type: string
                                           value:
+                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -993,61 +2103,141 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     path:
+                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                                 periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
                                   properties:
                                     host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                   format: int64
                                   type: integer
                                 timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
                               type: boolean
                             stdinOnce:
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
                               type: boolean
                             terminationMessagePath:
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
                               type: string
                             terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
                               type: string
                             tty:
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
                               type: boolean
                             volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
                               items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
                                 properties:
                                   devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
                                     type: string
                                   name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
                                     type: string
                                 required:
                                 - devicePath
@@ -1058,21 +2248,65 @@ spec:
                               - devicePath
                               x-kubernetes-list-type: map
                             volumeMounts:
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
                               items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
                                 properties:
                                   mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
                                     type: string
                                   mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
                                     type: string
                                   name:
+                                    description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
                                     type: boolean
                                   recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
                                     type: string
                                   subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -1083,42 +2317,94 @@ spec:
                               - mountPath
                               x-kubernetes-list-type: map
                             workingDir:
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
                       istioProxyContainer:
+                        description: |-
+                          Configuration for the container running istio-proxy.
+                          Note that if Istio integration is not enabled, the istio container will not be injected
+                          into the gateway proxy deployment.
                         properties:
                           image:
+                            description: |-
+                              The envoy container image. See
+                              https://kubernetes.io/docs/concepts/containers/images
+                              for details.
                             properties:
                               digest:
+                                description: The hash digest of the image, e.g. `sha256:12345...`
                                 type: string
                               pullPolicy:
+                                description: |-
+                                  The image pull policy for the container. See
+                                  https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                                  for details.
                                 type: string
                               registry:
+                                description: The image registry.
                                 type: string
                               repository:
+                                description: The image repository (name).
                                 type: string
                               tag:
+                                description: The image tag.
                                 type: string
                             type: object
                           istioDiscoveryAddress:
+                            description: The address of the istio discovery service.
+                              Defaults to "istiod.istio-system.svc:15012".
                             type: string
                           istioMetaClusterId:
+                            description: The cluster id of the istio cluster. Defaults
+                              to "Kubernetes".
                             type: string
                           istioMetaMeshId:
+                            description: The mesh id of the istio mesh. Defaults to
+                              "cluster.local".
                             type: string
                           logLevel:
+                            description: |-
+                              Log level for istio-proxy. Options include "info", "debug", "warning", and "error".
+                              Default level is info Default is "warning".
                             type: string
                           resources:
+                            description: |-
+                              The compute resources required by this container. See
+                              https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              for details.
                             properties:
                               claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
                                 items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
                                       type: string
                                     request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
                                       type: string
                                   required:
                                   - name
@@ -1134,6 +2420,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1142,101 +2431,267 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           securityContext:
+                            description: |-
+                              The security context for this container. See
+                              https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core
+                              for details.
                             properties:
                               allowPrivilegeEscalation:
+                                description: |-
+                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                  privileges than its parent process. This bool directly controls if
+                                  the no_new_privs flag will be set on the container process.
+                                  AllowPrivilegeEscalation is true always when the container is:
+                                  1) run as Privileged
+                                  2) has CAP_SYS_ADMIN
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               appArmorProfile:
+                                description: |-
+                                  appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                  overrides the pod's appArmorProfile.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile loaded on the node that should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must match the loaded name of the profile.
+                                      Must be set if and only if type is "Localhost".
                                     type: string
                                   type:
+                                    description: |-
+                                      type indicates which kind of AppArmor profile will be applied.
+                                      Valid options are:
+                                        Localhost - a profile pre-loaded on the node.
+                                        RuntimeDefault - the container runtime's default profile.
+                                        Unconfined - no AppArmor enforcement.
                                     type: string
                                 required:
                                 - type
                                 type: object
                               capabilities:
+                                description: |-
+                                  The capabilities to add/drop when running containers.
+                                  Defaults to the default set of capabilities granted by the container runtime.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   add:
+                                    description: Added capabilities
                                     items:
+                                      description: Capability represent POSIX capabilities
+                                        type
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   drop:
+                                    description: Removed capabilities
                                     items:
+                                      description: Capability represent POSIX capabilities
+                                        type
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
                               privileged:
+                                description: |-
+                                  Run container in privileged mode.
+                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                  Defaults to false.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               procMount:
+                                description: |-
+                                  procMount denotes the type of proc mount to use for the containers.
+                                  The default value is Default which uses the container runtime defaults for
+                                  readonly paths and masked paths.
+                                  This requires the ProcMountType feature flag to be enabled.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               readOnlyRootFilesystem:
+                                description: |-
+                                  Whether this container has a read-only root filesystem.
+                                  Default is false.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: boolean
                               runAsGroup:
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
+                                description: |-
+                                  The SELinux context to be applied to the container.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
                                     type: string
                                   role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
                                     type: string
                                   type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
                                     type: string
                                   user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
                                     type: string
                                 type: object
                               seccompProfile:
+                                description: |-
+                                  The seccomp options to use by this container. If seccomp options are
+                                  provided at both the pod & container level, the container options
+                                  override the pod options.
+                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
                                     type: string
                                   type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
                                     type: string
                                 required:
                                 - type
                                 type: object
                               windowsOptions:
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options from the PodSecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
                                 properties:
                                   gmsaCredentialSpec:
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
                                     type: string
                                   gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
                                     type: string
                                   hostProcess:
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
                                     type: boolean
                                   runAsUserName:
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: string
                                 type: object
                             type: object
                         type: object
                     type: object
                   podTemplate:
+                    description: Configuration for the pods that will be created.
                     properties:
                       affinity:
+                        description: |-
+                          If specified, the pod's scheduling constraints. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#affinity-v1-core
+                          for details.
                         properties:
                           nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
                                       properties:
                                         matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
                                           items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
+                                                description: The label key that the
+                                                  selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1248,13 +2703,29 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
                                           items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
+                                                description: The label key that the
+                                                  selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1268,6 +2739,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -1277,18 +2751,46 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
                                     items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
                                           items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
+                                                description: The label key that the
+                                                  selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1300,13 +2802,29 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
                                           items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
                                             properties:
                                               key:
+                                                description: The label key that the
+                                                  selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1327,22 +2845,60 @@ spec:
                                 x-kubernetes-map-type: atomic
                             type: object
                           podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
                                   properties:
                                     podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
                                       properties:
                                         labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
                                           properties:
                                             matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1356,29 +2912,76 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1392,20 +2995,38 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -1415,18 +3036,52 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1440,29 +3095,75 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1476,15 +3177,30 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
@@ -1493,22 +3209,60 @@ spec:
                                 x-kubernetes-list-type: atomic
                             type: object
                           podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
                                 items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
                                   properties:
                                     podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
                                       properties:
                                         labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
                                           properties:
                                             matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1522,29 +3276,76 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1558,20 +3359,38 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -1581,18 +3400,52 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
                                   properties:
                                     labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1606,29 +3459,75 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1642,15 +3541,30 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
@@ -1662,61 +3576,123 @@ spec:
                       extraAnnotations:
                         additionalProperties:
                           type: string
+                        description: Additional annotations to add to the Pod object
+                          metadata.
                         type: object
                       extraLabels:
                         additionalProperties:
                           type: string
+                        description: Additional labels to add to the Pod object metadata.
                         type: object
                       gracefulShutdown:
+                        description: If specified, the pod's graceful shutdown spec.
                         properties:
                           enabled:
+                            description: Enable grace period before shutdown to finish
+                              current requests while Envoy health checks fail to e.g.
+                              notify external load balancers. *NOTE:* This will not
+                              have any effect if you have not defined health checks
+                              via the health check filter
                             type: boolean
                           sleepTimeSeconds:
+                            description: Time (in seconds) for the preStop hook to
+                              wait before allowing Envoy to terminate
                             type: integer
                         type: object
                       imagePullSecrets:
+                        description: |-
+                          An optional list of references to secrets in the same namespace to use for
+                          pulling any of the images used by this Pod spec. See
+                          https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                          for details.
                         items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
                       livenessProbe:
+                        description: |-
+                          If specified, the pod's liveness probe. Periodic probe of container service readiness.
+                          Container will be restarted if the probe fails. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#probe-v1-core
+                          for details.
                         properties:
                           exec:
+                            description: Exec specifies a command to execute in the
+                              container.
                             properties:
                               command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
                           failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
                                 default: ""
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                             - port
                             type: object
                           httpGet:
+                            description: HTTPGet specifies an HTTP GET request to
+                              perform.
                             properties:
                               host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
                                 items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
                                   properties:
                                     name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
+                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -1725,83 +3701,164 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               path:
+                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
+                            description: |-
+                              How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
+                            description: TCPSocket specifies a connection to a TCP
+                              port.
                             properties:
                               host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
                           terminationGracePeriodSeconds:
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: |-
+                          A selector which must be true for the pod to fit on a node. See
+                          https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ for
+                          details.
                         type: object
                       readinessProbe:
+                        description: |-
+                          If specified, the pod's readiness probe. Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#probe-v1-core
+                          for details.
                         properties:
                           exec:
+                            description: Exec specifies a command to execute in the
+                              container.
                             properties:
                               command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
                           failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
+                            description: GRPC specifies a GRPC HealthCheckRequest.
                             properties:
                               port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
                                 format: int32
                                 type: integer
                               service:
                                 default: ""
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                             - port
                             type: object
                           httpGet:
+                            description: HTTPGet specifies an HTTP GET request to
+                              perform.
                             properties:
                               host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
                                 items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
                                   properties:
                                     name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
+                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -1810,105 +3867,271 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               path:
+                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
+                            description: |-
+                              How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
+                            description: TCPSocket specifies a connection to a TCP
+                              port.
                             properties:
                               host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
                           terminationGracePeriodSeconds:
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       securityContext:
+                        description: |-
+                          The pod security context. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podsecuritycontext-v1-core
+                          for details.
                         properties:
                           appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
                                 type: string
                             required:
                             - type
                             type: object
                           fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod.
+                              Some volume types allow the Kubelet to change the ownership of that volume
+                              to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup
+                              2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                              3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           fsGroupChangePolicy:
+                            description: |-
+                              fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                              before being exposed inside Pod. This field will only apply to
+                              volume types which support fsGroup based ownership(and permissions).
+                              It will have no effect on ephemeral volume types such as: secret, configmaps
+                              and emptydir.
+                              Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxChangePolicy:
+                            description: |-
+                              seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                              It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                              Valid values are "MountOption" and "Recursive".
+
+                              "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                              This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                              "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                              This requires all Pods that share the same volume to use the same SELinux label.
+                              It is not possible to share the same volume among privileged and unprivileged Pods.
+                              Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                              whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                              CSIDriver instance. Other volumes are always re-labelled recursively.
                             type: string
                           seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to all containers.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in SecurityContext.  If set in
+                              both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
                                 type: string
                               role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
                                 type: string
                               type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
                                 type: string
                               user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
                                 type: string
                             type: object
                           seccompProfile:
+                            description: |-
+                              The seccomp options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           supplementalGroups:
+                            description: |-
+                              A list of groups applied to the first process run in each container, in
+                              addition to the container's primary GID and fsGroup (if specified).  If
+                              the SupplementalGroupsPolicy feature is enabled, the
+                              supplementalGroupsPolicy field determines whether these are in addition
+                              to or instead of any group memberships defined in the container image.
+                              If unspecified, no additional groups are added, though group memberships
+                              defined in the container image may still be used, depending on the
+                              supplementalGroupsPolicy field.
+                              Note that this field cannot be set when spec.os.name is windows.
                             items:
                               format: int64
                               type: integer
                             type: array
                             x-kubernetes-list-type: atomic
                           supplementalGroupsPolicy:
+                            description: |-
+                              Defines how supplemental groups of the first container processes are calculated.
+                              Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                              (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                              and the container runtime must implement support for this feature.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           sysctls:
+                            description: |-
+                              Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                              sysctls (by the container runtime) might fail to launch.
+                              Note that this field cannot be set when spec.os.name is windows.
                             items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
                               properties:
                                 name:
+                                  description: Name of a property to set
                                   type: string
                                 value:
+                                  description: Value of a property to set
                                   type: string
                               required:
                               - name
@@ -1917,64 +4140,155 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options within a container's SecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
                                 type: string
                               hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       terminationGracePeriodSeconds:
+                        description: |-
+                          If specified, the pod's termination grace period in seconds. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#pod-v1-core
+                          for details
                         type: integer
                       tolerations:
+                        description: |-
+                          do not use slice of pointers: https://github.com/kubernetes/code-generator/issues/166
+                          If specified, the pod's tolerations. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#toleration-v1-core
+                          for details.
                         items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                     type: object
                   sdsContainer:
+                    description: Configuration for the container running the Secret
+                      Discovery Service (SDS).
                     properties:
                       bootstrap:
+                        description: Initial SDS container configuration.
                         properties:
                           logLevel:
+                            description: |-
+                              Log level for SDS. Options include "info", "debug", "warn", "error", "panic" and "fatal".
+                              Default level is "info".
                             type: string
                         type: object
                       image:
+                        description: |-
+                          The SDS container image. See
+                          https://kubernetes.io/docs/concepts/containers/images
+                          for details.
                         properties:
                           digest:
+                            description: The hash digest of the image, e.g. `sha256:12345...`
                             type: string
                           pullPolicy:
+                            description: |-
+                              The image pull policy for the container. See
+                              https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+                              for details.
                             type: string
                           registry:
+                            description: The image registry.
                             type: string
                           repository:
+                            description: The image repository (name).
                             type: string
                           tag:
+                            description: The image tag.
                             type: string
                         type: object
                       resources:
+                        description: |-
+                          The compute resources required by this container. See
+                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          for details.
                         properties:
                           claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
                             items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
                                   type: string
                                 request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
                                   type: string
                               required:
                               - name
@@ -1990,6 +4304,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1998,120 +4315,279 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       securityContext:
+                        description: |-
+                          The security context for this container. See
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core
+                          for details.
                         properties:
                           allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                              overrides the pod's appArmorProfile.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
                                 type: string
                             required:
                             - type
                             type: object
                           capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
+                                description: Added capabilities
                                 items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               drop:
+                                description: Removed capabilities
                                 items:
+                                  description: Capability represent POSIX capabilities
+                                    type
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
                           privileged:
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default value is Default which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
                                 type: string
                               role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
                                 type: string
                               type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
                                 type: string
                               user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
                                 type: string
                             type: object
                           seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                             - type
                             type: object
                           windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
                                 type: string
                               hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                     type: object
                   service:
+                    description: |-
+                      Configuration for the Kubernetes Service that exposes the Envoy proxy over
+                      the network.
                     properties:
                       clusterIP:
+                        description: |-
+                          The manually specified IP address of the service, if a randomly assigned
+                          IP is not desired. See
+                          https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
+                          and
+                          https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
+                          on the implications of setting `clusterIP`.
                         type: string
                       extraAnnotations:
                         additionalProperties:
                           type: string
+                        description: Additional annotations to add to the Service
+                          object metadata.
                         type: object
                       extraLabels:
                         additionalProperties:
                           type: string
+                        description: Additional labels to add to the Service object
+                          metadata.
                         type: object
                       type:
+                        description: The Kubernetes Service type.
                         type: string
                     type: object
                   serviceAccount:
+                    description: Configuration for the Kubernetes ServiceAccount used
+                      by the Envoy pod.
                     properties:
                       extraAnnotations:
                         additionalProperties:
                           type: string
+                        description: Additional annotations to add to the ServiceAccount
+                          object metadata.
                         type: object
                       extraLabels:
                         additionalProperties:
                           type: string
+                        description: Additional labels to add to the ServiceAccount
+                          object metadata.
                         type: object
                     type: object
                   stats:
+                    description: Configuration for the stats server.
                     properties:
                       enableStatsRoute:
+                        description: Enables an additional route to the stats cluster
+                          defaulting to /stats
                         type: boolean
                       enabled:
+                        description: Whether to expose metrics annotations and ports
+                          for scraping metrics.
                         type: boolean
                       routePrefixRewrite:
+                        description: The Envoy stats endpoint to which the metrics
+                          are written
                         type: string
                       statsRoutePrefixRewrite:
+                        description: The Envoy stats endpoint with general metrics
+                          for the additional stats route
                         type: string
                     type: object
                 type: object
               selfManaged:
+                description: The proxy will be self-managed and not auto-provisioned.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
             type: object
@@ -2120,6 +4596,8 @@ spec:
               rule: (has(self.kube) && !has(self.selfManaged)) || (!has(self.kube)
                 && has(self.selfManaged))
           status:
+            description: The current conditions of the GatewayParameters. This is
+              not currently implemented.
             type: object
         type: object
     served: true

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_httplistenerpolicies.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_httplistenerpolicies.yaml
@@ -27,24 +27,48 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             properties:
               accessLog:
+                description: |-
+                  AccessLoggingConfig contains various settings for Envoy's access logging service.
+                  See here for more information: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto
                 items:
+                  description: AccessLog represents the top-level access log configuration.
                   properties:
                     fileSink:
+                      description: Output access logs to local file
                       properties:
                         jsonFormat:
+                          description: |-
+                            the format object by which to envoy will emit the logs in a structured way.
+                            https://www.envoyproxy.io/docs/envoy/v1.33.0/configuration/observability/access_log/usage#format-dictionaries
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         path:
+                          description: the file path to which the file access logging
+                            service will sink
                           type: string
                         stringFormat:
+                          description: |-
+                            the format string by which envoy will format the log lines
+                            https://www.envoyproxy.io/docs/envoy/v1.33.0/configuration/observability/access_log/usage#format-strings
                           type: string
                       required:
                       - path
@@ -60,28 +84,45 @@ spec:
                         minProperties: 1
                       - maxProperties: 1
                         minProperties: 1
+                      description: Filter access logs configuration
                       properties:
                         andFilter:
+                          description: |-
+                            Performs a logical "and" operation on the result of each individual filter.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-andfilter
                           items:
+                            description: |-
+                              FilterType represents the type of filter to apply (only one of these should be set).
+                              Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter
                             maxProperties: 1
                             minProperties: 1
                             properties:
                               celFilter:
+                                description: CELFilter filters requests based on Common
+                                  Expression Language (CEL).
                                 properties:
                                   match:
+                                    description: |-
+                                      The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.
+                                      see: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto
                                     type: string
                                 required:
                                 - match
                                 type: object
                               durationFilter:
+                                description: |-
+                                  DurationFilter filters based on request duration.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter
                                 properties:
                                   op:
+                                    description: Op represents comparison operators.
                                     enum:
                                     - EQ
                                     - GE
                                     - LE
                                     type: string
                                   value:
+                                    description: Value to compare against.
                                     format: int32
                                     maximum: 4294967295
                                     minimum: 0
@@ -90,11 +131,16 @@ spec:
                                 - op
                                 type: object
                               grpcStatusFilter:
+                                description: |-
+                                  GrpcStatusFilter filters gRPC requests based on their response status.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status
                                 properties:
                                   exclude:
                                     type: boolean
                                   statuses:
                                     items:
+                                      description: GrpcStatus represents possible
+                                        gRPC statuses.
                                       enum:
                                       - OK
                                       - CANCELED
@@ -118,21 +164,55 @@ spec:
                                     type: array
                                 type: object
                               headerFilter:
+                                description: |-
+                                  HeaderFilter filters requests based on headers.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter
                                 properties:
                                   header:
+                                    description: |-
+                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                      headers.
                                     properties:
                                       name:
+                                        description: |-
+                                          Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                          case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                          If multiple entries specify equivalent header names, only the first
+                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST be ignored. Due to the
+                                          case-insensitivity of header names, "foo" and "Foo" are considered
+                                          equivalent.
+
+                                          When a header is repeated in an HTTP request, it is
+                                          implementation-specific behavior as to how this is represented.
+                                          Generally, proxies should follow the guidance from the RFC:
+                                          https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                          processing a repeated header, with special handling for "Set-Cookie".
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
                                       type:
                                         default: Exact
+                                        description: |-
+                                          Type specifies how to match against the value of the header.
+
+                                          Support: Core (Exact)
+
+                                          Support: Implementation-specific (RegularExpression)
+
+                                          Since RegularExpression HeaderMatchType has implementation-specific
+                                          conformance, implementations can support POSIX, PCRE or any other dialects
+                                          of regular expressions. Please read the implementation's documentation to
+                                          determine the supported dialect.
                                         enum:
                                         - Exact
                                         - RegularExpression
                                         type: string
                                       value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
                                         maxLength: 4096
                                         minLength: 1
                                         type: string
@@ -144,8 +224,14 @@ spec:
                                 - header
                                 type: object
                               notHealthCheckFilter:
+                                description: |-
+                                  Filters for requests that are not health check requests.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter
                                 type: boolean
                               responseFlagFilter:
+                                description: |-
+                                  ResponseFlagFilter filters based on response flags.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter
                                 properties:
                                   flags:
                                     items:
@@ -156,14 +242,19 @@ spec:
                                 - flags
                                 type: object
                               statusCodeFilter:
+                                description: |-
+                                  StatusCodeFilter filters based on HTTP status code.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter
                                 properties:
                                   op:
+                                    description: Op represents comparison operators.
                                     enum:
                                     - EQ
                                     - GE
                                     - LE
                                     type: string
                                   value:
+                                    description: Value to compare against.
                                     format: int32
                                     maximum: 4294967295
                                     minimum: 0
@@ -172,26 +263,39 @@ spec:
                                 - op
                                 type: object
                               traceableFilter:
+                                description: |-
+                                  Filters for requests that are traceable.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter
                                 type: boolean
                             type: object
                           minItems: 2
                           type: array
                         celFilter:
+                          description: CELFilter filters requests based on Common
+                            Expression Language (CEL).
                           properties:
                             match:
+                              description: |-
+                                The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.
+                                see: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto
                               type: string
                           required:
                           - match
                           type: object
                         durationFilter:
+                          description: |-
+                            DurationFilter filters based on request duration.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter
                           properties:
                             op:
+                              description: Op represents comparison operators.
                               enum:
                               - EQ
                               - GE
                               - LE
                               type: string
                             value:
+                              description: Value to compare against.
                               format: int32
                               maximum: 4294967295
                               minimum: 0
@@ -200,11 +304,15 @@ spec:
                           - op
                           type: object
                         grpcStatusFilter:
+                          description: |-
+                            GrpcStatusFilter filters gRPC requests based on their response status.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status
                           properties:
                             exclude:
                               type: boolean
                             statuses:
                               items:
+                                description: GrpcStatus represents possible gRPC statuses.
                                 enum:
                                 - OK
                                 - CANCELED
@@ -228,21 +336,55 @@ spec:
                               type: array
                           type: object
                         headerFilter:
+                          description: |-
+                            HeaderFilter filters requests based on headers.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter
                           properties:
                             header:
+                              description: |-
+                                HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                headers.
                               properties:
                                 name:
+                                  description: |-
+                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+
+                                    When a header is repeated in an HTTP request, it is
+                                    implementation-specific behavior as to how this is represented.
+                                    Generally, proxies should follow the guidance from the RFC:
+                                    https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                    processing a repeated header, with special handling for "Set-Cookie".
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 type:
                                   default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the header.
+
+                                    Support: Core (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression HeaderMatchType has implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's documentation to
+                                    determine the supported dialect.
                                   enum:
                                   - Exact
                                   - RegularExpression
                                   type: string
                                 value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -254,28 +396,47 @@ spec:
                           - header
                           type: object
                         notHealthCheckFilter:
+                          description: |-
+                            Filters for requests that are not health check requests.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter
                           type: boolean
                         orFilter:
+                          description: |-
+                            Performs a logical "or" operation on the result of each individual filter.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-orfilter
                           items:
+                            description: |-
+                              FilterType represents the type of filter to apply (only one of these should be set).
+                              Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-accesslogfilter
                             maxProperties: 1
                             minProperties: 1
                             properties:
                               celFilter:
+                                description: CELFilter filters requests based on Common
+                                  Expression Language (CEL).
                                 properties:
                                   match:
+                                    description: |-
+                                      The CEL expressions to evaluate. AccessLogs are only emitted when the CEL expressions evaluates to true.
+                                      see: https://www.envoyproxy.io/docs/envoy/v1.33.0/xds/type/v3/cel.proto.html#common-expression-language-cel-proto
                                     type: string
                                 required:
                                 - match
                                 type: object
                               durationFilter:
+                                description: |-
+                                  DurationFilter filters based on request duration.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-durationfilter
                                 properties:
                                   op:
+                                    description: Op represents comparison operators.
                                     enum:
                                     - EQ
                                     - GE
                                     - LE
                                     type: string
                                   value:
+                                    description: Value to compare against.
                                     format: int32
                                     maximum: 4294967295
                                     minimum: 0
@@ -284,11 +445,16 @@ spec:
                                 - op
                                 type: object
                               grpcStatusFilter:
+                                description: |-
+                                  GrpcStatusFilter filters gRPC requests based on their response status.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#enum-config-accesslog-v3-grpcstatusfilter-status
                                 properties:
                                   exclude:
                                     type: boolean
                                   statuses:
                                     items:
+                                      description: GrpcStatus represents possible
+                                        gRPC statuses.
                                       enum:
                                       - OK
                                       - CANCELED
@@ -312,21 +478,55 @@ spec:
                                     type: array
                                 type: object
                               headerFilter:
+                                description: |-
+                                  HeaderFilter filters requests based on headers.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-headerfilter
                                 properties:
                                   header:
+                                    description: |-
+                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                      headers.
                                     properties:
                                       name:
+                                        description: |-
+                                          Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                          case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                          If multiple entries specify equivalent header names, only the first
+                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                          entries with an equivalent header name MUST be ignored. Due to the
+                                          case-insensitivity of header names, "foo" and "Foo" are considered
+                                          equivalent.
+
+                                          When a header is repeated in an HTTP request, it is
+                                          implementation-specific behavior as to how this is represented.
+                                          Generally, proxies should follow the guidance from the RFC:
+                                          https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                          processing a repeated header, with special handling for "Set-Cookie".
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                         type: string
                                       type:
                                         default: Exact
+                                        description: |-
+                                          Type specifies how to match against the value of the header.
+
+                                          Support: Core (Exact)
+
+                                          Support: Implementation-specific (RegularExpression)
+
+                                          Since RegularExpression HeaderMatchType has implementation-specific
+                                          conformance, implementations can support POSIX, PCRE or any other dialects
+                                          of regular expressions. Please read the implementation's documentation to
+                                          determine the supported dialect.
                                         enum:
                                         - Exact
                                         - RegularExpression
                                         type: string
                                       value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
                                         maxLength: 4096
                                         minLength: 1
                                         type: string
@@ -338,8 +538,14 @@ spec:
                                 - header
                                 type: object
                               notHealthCheckFilter:
+                                description: |-
+                                  Filters for requests that are not health check requests.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-nothealthcheckfilter
                                 type: boolean
                               responseFlagFilter:
+                                description: |-
+                                  ResponseFlagFilter filters based on response flags.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter
                                 properties:
                                   flags:
                                     items:
@@ -350,14 +556,19 @@ spec:
                                 - flags
                                 type: object
                               statusCodeFilter:
+                                description: |-
+                                  StatusCodeFilter filters based on HTTP status code.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter
                                 properties:
                                   op:
+                                    description: Op represents comparison operators.
                                     enum:
                                     - EQ
                                     - GE
                                     - LE
                                     type: string
                                   value:
+                                    description: Value to compare against.
                                     format: int32
                                     maximum: 4294967295
                                     minimum: 0
@@ -366,11 +577,17 @@ spec:
                                 - op
                                 type: object
                               traceableFilter:
+                                description: |-
+                                  Filters for requests that are traceable.
+                                  Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter
                                 type: boolean
                             type: object
                           minItems: 2
                           type: array
                         responseFlagFilter:
+                          description: |-
+                            ResponseFlagFilter filters based on response flags.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-responseflagfilter
                           properties:
                             flags:
                               items:
@@ -381,14 +598,19 @@ spec:
                           - flags
                           type: object
                         statusCodeFilter:
+                          description: |-
+                            StatusCodeFilter filters based on HTTP status code.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#envoy-v3-api-msg-config-accesslog-v3-statuscodefilter
                           properties:
                             op:
+                              description: Op represents comparison operators.
                               enum:
                               - EQ
                               - GE
                               - LE
                               type: string
                             value:
+                              description: Value to compare against.
                               format: int32
                               maximum: 4294967295
                               minimum: 0
@@ -397,51 +619,113 @@ spec:
                           - op
                           type: object
                         traceableFilter:
+                          description: |-
+                            Filters for requests that are traceable.
+                            Based on: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto#config-accesslog-v3-traceablefilter
                           type: boolean
                       type: object
                     grpcService:
+                      description: Send access logs to gRPC service
                       properties:
                         additionalRequestHeadersToLog:
+                          description: Additional request headers to log in the access
+                            log
                           items:
                             type: string
                           type: array
                         additionalResponseHeadersToLog:
+                          description: Additional response headers to log in the access
+                            log
                           items:
                             type: string
                           type: array
                         additionalResponseTrailersToLog:
+                          description: Additional response trailers to log in the
+                            access log
                           items:
                             type: string
                           type: array
                         backendRef:
+                          description: The backend gRPC service. Can be any type of
+                            supported backed (Kubernetes Service, kgateway Backend,
+                            etc..)
                           properties:
                             group:
                               default: ""
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
                               maxLength: 253
                               pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                             kind:
                               default: Service
+                              description: |-
+                                Kind is the Kubernetes resource kind of the referent. For example
+                                "Service".
+
+                                Defaults to "Service" when not specified.
+
+                                ExternalName services can refer to CNAME DNS records that may live
+                                outside of the cluster and as such are difficult to reason about in
+                                terms of conformance. They also may not be safe to forward to (see
+                                CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                support ExternalName Services.
+
+                                Support: Core (Services with a type other than ExternalName)
+
+                                Support: Implementation-specific (Services with type ExternalName)
                               maxLength: 63
                               minLength: 1
                               pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                               type: string
                             name:
+                              description: Name is the name of the referent.
                               maxLength: 253
                               minLength: 1
                               type: string
                             namespace:
+                              description: |-
+                                Namespace is the namespace of the backend. When unspecified, the local
+                                namespace is inferred.
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+                                Support: Core
                               maxLength: 63
                               minLength: 1
                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             port:
+                              description: |-
+                                Port specifies the destination port number to use for this resource.
+                                Port is required when the referent is a Kubernetes Service. In this
+                                case, the port number is the service port number, not the target port.
+                                For other resources, destination port might be derived from the referent
+                                resource or this field.
                               format: int32
                               maximum: 65535
                               minimum: 1
                               type: integer
                             weight:
                               default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
                               format: int32
                               maximum: 1000000
                               minimum: 0
@@ -454,6 +738,7 @@ spec:
                             rule: '(size(self.group) == 0 && self.kind == ''Service'')
                               ? has(self.port) : true'
                         logName:
+                          description: name of log stream
                           type: string
                       required:
                       - backendRef
@@ -464,17 +749,22 @@ spec:
               compress:
                 type: boolean
               targetRef:
+                description: not sure why i need to copy this; codegen fails if i
+                  dont
                 properties:
                   group:
+                    description: Group is the group of the target resource.
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
+                    description: Kind is kind of the target resource.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
+                    description: Name is the name of the target resource.
                     maxLength: 253
                     minLength: 1
                     type: string
@@ -490,33 +780,115 @@ spec:
                 items:
                   properties:
                     ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
                       properties:
                         group:
                           default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                           type: string
                         name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
                           maxLength: 253
                           minLength: 1
                           type: string
                         namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            <gateway:experimental:description>
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            <gateway:experimental:description>
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+                            </gateway:experimental:description>
+
+                            Implementations MAY choose to support other parent resources.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname.
                           maxLength: 253
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -525,30 +897,53 @@ spec:
                       - name
                       type: object
                     conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
                       items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                             format: date-time
                             type: string
                           message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
                             maxLength: 32768
                             type: string
                           observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
                             format: int64
                             minimum: 0
                             type: integer
                           reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -566,6 +961,20 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
                       type: string
                   required:
                   - ancestorRef
@@ -575,29 +984,49 @@ spec:
                 type: array
               conditions:
                 items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_listenerpolicies.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_listenerpolicies.yaml
@@ -27,8 +27,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,17 +49,22 @@ spec:
                 format: int32
                 type: integer
               targetRef:
+                description: not sure why i need to copy this; codegen fails if i
+                  dont
                 properties:
                   group:
+                    description: Group is the group of the target resource.
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
+                    description: Kind is kind of the target resource.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
+                    description: Name is the name of the target resource.
                     maxLength: 253
                     minLength: 1
                     type: string
@@ -64,33 +80,115 @@ spec:
                 items:
                   properties:
                     ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
                       properties:
                         group:
                           default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                           type: string
                         name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
                           maxLength: 253
                           minLength: 1
                           type: string
                         namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            <gateway:experimental:description>
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            <gateway:experimental:description>
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+                            </gateway:experimental:description>
+
+                            Implementations MAY choose to support other parent resources.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname.
                           maxLength: 253
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -99,30 +197,53 @@ spec:
                       - name
                       type: object
                     conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
                       items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                             format: date-time
                             type: string
                           message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
                             maxLength: 32768
                             type: string
                           observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
                             format: int64
                             minimum: 0
                             type: integer
                           reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -140,6 +261,20 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
                       type: string
                   required:
                   - ancestorRef
@@ -149,29 +284,49 @@ spec:
                 type: array
               conditions:
                 items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_routepolicies.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_routepolicies.yaml
@@ -27,25 +27,70 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             properties:
               ai:
+                description: |-
+                  AIRoutePolicy config is used to configure the behavior of the LLM provider
+                  on the level of individual routes. These route settings, such as prompt enrichment,
+                  retrieval augmented generation (RAG), and semantic caching, are applicable only
+                  for routes that send requests to an LLM provider backend.
                 properties:
                   defaults:
+                    description: |-
+                      Provide defaults to merge with user input fields.
+                      Defaults do _not_ override the user input fields, unless you explicitly set `override` to `true`.
                     items:
+                      description: |-
+                        FieldDefault provides default values for specific fields in the JSON request body sent to the LLM provider.
+                        These defaults are merged with the user-provided request to ensure missing fields are populated.
+
+                        User input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.
+                        Defaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.
+
+                        Example: Setting a default system field for Anthropic, which does not support system role messages:
+                        ```yaml
+                        defaults:
+                          - field: "system"
+                            value: "answer all questions in French"
+
+                        ```
+
+                        Example: Setting a default temperature and overriding `max_tokens`:
+                        ```yaml
+                        defaults:
+                          - field: "temperature"
+                            value: "0.
                       properties:
                         field:
+                          description: The name of the field.
                           minLength: 1
                           type: string
                         override:
                           default: false
+                          description: |-
+                            Whether to override the field's value if it already exists.
+                            Defaults to false.
                           type: boolean
                         value:
+                          description: The field default value, which can be any JSON
+                            Data Type.
                           minLength: 1
                           type: string
                       required:
@@ -54,13 +99,24 @@ spec:
                       type: object
                     type: array
                   promptEnrichment:
+                    description: |-
+                      Enrich requests sent to the LLM provider by appending and prepending system prompts.
+                      This can be configured only for LLM providers that use the `CHAT` or `CHAT_STREAMING` API route type.
                     properties:
                       append:
+                        description: A list of messages to be appended to the prompt
+                          sent by the client.
                         items:
+                          description: An entry for a message to prepend or append
+                            to each prompt.
                           properties:
                             content:
+                              description: String content of the message.
                               type: string
                             role:
+                              description: |-
+                                Role of the message. The available roles depend on the backend
+                                LLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.
                               type: string
                           required:
                           - content
@@ -68,11 +124,19 @@ spec:
                           type: object
                         type: array
                       prepend:
+                        description: A list of messages to be prepended to the prompt
+                          sent by the client.
                         items:
+                          description: An entry for a message to prepend or append
+                            to each prompt.
                           properties:
                             content:
+                              description: String content of the message.
                               type: string
                             role:
+                              description: |-
+                                Role of the message. The available roles depend on the backend
+                                LLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.
                               type: string
                           required:
                           - content
@@ -81,40 +145,83 @@ spec:
                         type: array
                     type: object
                   promptGuard:
+                    description: |-
+                      Set up prompt guards to block unwanted requests to the LLM provider and mask sensitive data.
+                      Prompt guards can be used to reject requests based on the content of the prompt, as well as
+                      mask responses based on the content of the response.
                     properties:
                       request:
+                        description: Prompt guards to apply to requests sent by the
+                          client.
                         properties:
                           customResponse:
+                            description: |-
+                              A custom response message to return to the client. If not specified, defaults to
+                              "The request was rejected due to inappropriate content".
                             properties:
                               message:
                                 default: The request was rejected due to inappropriate
                                   content
+                                description: |-
+                                  A custom response message to return to the client. If not specified, defaults to
+                                  "The request was rejected due to inappropriate content".
                                 type: string
                               statusCode:
                                 default: 403
+                                description: The status code to return to the client.
+                                  Defaults to 403.
                                 format: int32
                                 maximum: 599
                                 minimum: 200
                                 type: integer
                             type: object
                           moderation:
+                            description: |-
+                              Pass prompt data through an external moderation model endpoint,
+                              which compares the request prompt input to predefined content rules.
                             properties:
                               openAIModeration:
+                                description: |-
+                                  Pass prompt data through an external moderation model endpoint,
+                                  which compares the request prompt input to predefined content rules.
+                                  Configure an OpenAI moderation endpoint.
                                 properties:
                                   authToken:
+                                    description: |-
+                                      The authorization token that the AI gateway uses to access the OpenAI API.
+                                      This token is automatically sent in the `Authorization` header of the
+                                      request and prefixed with `Bearer`.
                                     properties:
                                       inline:
+                                        description: |-
+                                          Provide the token directly in the configuration for the Backend.
+                                          This option is the least secure. Only use this option for quick tests such as trying out AI Gateway.
                                         type: string
                                       kind:
+                                        description: |-
+                                          Kind specifies which type of authorization token is being used.
+                                          Must be one of: "Inline", "SecretRef", "Passthrough".
                                         enum:
                                         - Inline
                                         - SecretRef
                                         - Passthrough
                                         type: string
                                       secretRef:
+                                        description: |-
+                                          Store the API key in a Kubernetes secret in the same namespace as the Backend.
+                                          Then, refer to the secret in the Backend configuration. This option is more secure than an inline token,
+                                          because the API key is encoded and you can restrict access to secrets through RBAC rules.
+                                          You might use this option in proofs of concept, controlled development and staging environments,
+                                          or well-controlled prod environments that use secrets.
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -122,18 +229,35 @@ spec:
                                     - kind
                                     type: object
                                   model:
+                                    description: |-
+                                      Optional: Override the model name, such as `gpt-4o-mini`.
+                                      If unset, the model name is taken from the request.
+                                      This setting can be useful when setting up model failover within the same LLM provider.
                                     type: string
                                 required:
                                 - authToken
                                 type: object
                             type: object
                           regex:
+                            description: Regular expression (regex) matching for prompt
+                              guards and data masking.
                             properties:
                               action:
                                 default: MASK
+                                description: |-
+                                  The action to take if a regex pattern is matched in a request or response.
+                                  This setting applies only to request matches. PromptguardResponse matches are always masked by default.
+                                  Defaults to `MASK`.
                                 type: string
                               builtins:
+                                description: |-
+                                  A list of built-in regex patterns to match against the request or response.
+                                  Matches and built-ins are additive.
                                 items:
+                                  description: |-
+                                    BuiltIn regex patterns for specific types of strings in prompts.
+                                    For example, if you specify `CREDIT_CARD`, any credit card numbers
+                                    in the request or response are matched.
                                   enum:
                                   - SSN
                                   - CREDIT_CARD
@@ -142,32 +266,76 @@ spec:
                                   type: string
                                 type: array
                               matches:
+                                description: |-
+                                  A list of regex patterns to match against the request or response.
+                                  Matches and built-ins are additive.
                                 items:
+                                  description: RegexMatch configures the regular expression
+                                    (regex) matching for prompt guards and data masking.
                                   properties:
                                     name:
+                                      description: An optional name for this match,
+                                        which can be used for debugging purposes.
                                       type: string
                                     pattern:
+                                      description: The regex pattern to match against
+                                        the request or response.
                                       type: string
                                   type: object
                                 type: array
                             type: object
                           webhook:
+                            description: Configure a webhook to forward requests to
+                              for prompt guarding.
                             properties:
                               forwardHeaders:
+                                description: ForwardHeaders define headers to forward
+                                  with the request to the webhook.
                                 items:
+                                  description: |-
+                                    HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                    headers.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, only the first
+                                        entry with an equivalent name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+
+                                        When a header is repeated in an HTTP request, it is
+                                        implementation-specific behavior as to how this is represented.
+                                        Generally, proxies should follow the guidance from the RFC:
+                                        https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                        processing a repeated header, with special handling for "Set-Cookie".
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     type:
                                       default: Exact
+                                      description: |-
+                                        Type specifies how to match against the value of the header.
+
+                                        Support: Core (Exact)
+
+                                        Support: Implementation-specific (RegularExpression)
+
+                                        Since RegularExpression HeaderMatchType has implementation-specific
+                                        conformance, implementations can support POSIX, PCRE or any other dialects
+                                        of regular expressions. Please read the implementation's documentation to
+                                        determine the supported dialect.
                                       enum:
                                       - Exact
                                       - RegularExpression
                                       type: string
                                     value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -177,12 +345,15 @@ spec:
                                   type: object
                                 type: array
                               host:
+                                description: Host to send the traffic to.
                                 properties:
                                   host:
+                                    description: Host is the host name.
                                     maxLength: 253
                                     minLength: 1
                                     type: string
                                   port:
+                                    description: Port is the port number.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -196,14 +367,29 @@ spec:
                             type: object
                         type: object
                       response:
+                        description: Prompt guards to apply to responses returned
+                          by the LLM provider.
                         properties:
                           regex:
+                            description: Regular expression (regex) matching for prompt
+                              guards and data masking.
                             properties:
                               action:
                                 default: MASK
+                                description: |-
+                                  The action to take if a regex pattern is matched in a request or response.
+                                  This setting applies only to request matches. PromptguardResponse matches are always masked by default.
+                                  Defaults to `MASK`.
                                 type: string
                               builtins:
+                                description: |-
+                                  A list of built-in regex patterns to match against the request or response.
+                                  Matches and built-ins are additive.
                                 items:
+                                  description: |-
+                                    BuiltIn regex patterns for specific types of strings in prompts.
+                                    For example, if you specify `CREDIT_CARD`, any credit card numbers
+                                    in the request or response are matched.
                                   enum:
                                   - SSN
                                   - CREDIT_CARD
@@ -212,32 +398,76 @@ spec:
                                   type: string
                                 type: array
                               matches:
+                                description: |-
+                                  A list of regex patterns to match against the request or response.
+                                  Matches and built-ins are additive.
                                 items:
+                                  description: RegexMatch configures the regular expression
+                                    (regex) matching for prompt guards and data masking.
                                   properties:
                                     name:
+                                      description: An optional name for this match,
+                                        which can be used for debugging purposes.
                                       type: string
                                     pattern:
+                                      description: The regex pattern to match against
+                                        the request or response.
                                       type: string
                                   type: object
                                 type: array
                             type: object
                           webhook:
+                            description: Configure a webhook to forward responses
+                              to for prompt guarding.
                             properties:
                               forwardHeaders:
+                                description: ForwardHeaders define headers to forward
+                                  with the request to the webhook.
                                 items:
+                                  description: |-
+                                    HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                    headers.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, only the first
+                                        entry with an equivalent name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+
+                                        When a header is repeated in an HTTP request, it is
+                                        implementation-specific behavior as to how this is represented.
+                                        Generally, proxies should follow the guidance from the RFC:
+                                        https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                        processing a repeated header, with special handling for "Set-Cookie".
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     type:
                                       default: Exact
+                                      description: |-
+                                        Type specifies how to match against the value of the header.
+
+                                        Support: Core (Exact)
+
+                                        Support: Implementation-specific (RegularExpression)
+
+                                        Since RegularExpression HeaderMatchType has implementation-specific
+                                        conformance, implementations can support POSIX, PCRE or any other dialects
+                                        of regular expressions. Please read the implementation's documentation to
+                                        determine the supported dialect.
                                       enum:
                                       - Exact
                                       - RegularExpression
                                       type: string
                                     value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -247,12 +477,15 @@ spec:
                                   type: object
                                 type: array
                               host:
+                                description: Host to send the traffic to.
                                 properties:
                                   host:
+                                    description: Host is the host name.
                                     maxLength: 253
                                     minLength: 1
                                     type: string
                                   port:
+                                    description: Port is the port number.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -267,23 +500,30 @@ spec:
                         type: object
                     type: object
                   routeType:
+                    description: The type of route to the LLM provider API. Currently,
+                      `CHAT` and `CHAT_STREAMING` are supported.
                     enum:
                     - CHAT
                     - CHAT_STREAMING
                     type: string
                 type: object
               targetRef:
+                description: not sure why i need to copy this; codegen fails if i
+                  dont
                 properties:
                   group:
+                    description: Group is the group of the target resource.
                     maxLength: 253
                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
+                    description: Kind is kind of the target resource.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
+                    description: Name is the name of the target resource.
                     maxLength: 253
                     minLength: 1
                     type: string
@@ -302,33 +542,115 @@ spec:
                 items:
                   properties:
                     ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
                       properties:
                         group:
                           default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                           type: string
                         name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
                           maxLength: 253
                           minLength: 1
                           type: string
                         namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            <gateway:experimental:description>
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            <gateway:experimental:description>
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+                            </gateway:experimental:description>
+
+                            Implementations MAY choose to support other parent resources.
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname.
                           maxLength: 253
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -337,30 +659,53 @@ spec:
                       - name
                       type: object
                     conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
                       items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
                         properties:
                           lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                             format: date-time
                             type: string
                           message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
                             maxLength: 32768
                             type: string
                           observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
                             format: int64
                             minimum: 0
                             type: integer
                           reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
                             maxLength: 1024
                             minLength: 1
                             pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
                           status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
                             enum:
                             - "True"
                             - "False"
                             - Unknown
                             type: string
                           type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -378,6 +723,20 @@ spec:
                       - type
                       x-kubernetes-list-type: map
                     controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
                       type: string
                   required:
                   - ancestorRef
@@ -387,29 +746,49 @@ spec:
                 type: array
               conditions:
                 items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Enable the kubebuilder CRD field description functionality. Previously, this was set to
zero, which disabled description field documentation for the rendered CRD manifests.
Without this, users that rely on `kubectl explain ...` have a degraded UX as they cannot
easily determine the API surface behavior.

Note, I kept a maximum for the CRD description length. This was primarily to prevent
any scenario where the embedded fields within the GWParams API would exceed the
etcd size limit.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
