### PR TITLE
*: Enable the prealloc linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - prealloc
     - predeclared
     - unused
     - usestdlibvars

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_converter.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_converter.go
@@ -65,8 +65,7 @@ func getLogId(logName string, idx int) string {
 }
 
 func translateAccessLogs(logger *zap.Logger, configs []v1alpha1.AccessLog, grpcBackends map[string]*ir.BackendObjectIR) ([]*envoyaccesslog.AccessLog, error) {
-	var results []*envoyaccesslog.AccessLog
-
+	results := make([]*envoyaccesslog.AccessLog, 0, len(configs))
 	for idx, logConfig := range configs {
 		accessLogCfg, err := translateAccessLog(logger, logConfig, grpcBackends, idx)
 		if err != nil {
@@ -74,7 +73,6 @@ func translateAccessLogs(logger *zap.Logger, configs []v1alpha1.AccessLog, grpcB
 		}
 		results = append(results, accessLogCfg)
 	}
-
 	return results, nil
 }
 

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -261,7 +261,7 @@ func convertHeaderModifier(kctx krt.HandlerContext, f *gwv1.HTTPHeaderFilter) fu
 	if f == nil {
 		return nil
 	}
-	var headersToAddd []*envoy_config_core_v3.HeaderValueOption
+	headersToAddd := make([]*envoy_config_core_v3.HeaderValueOption, 0, len(f.Add)+len(f.Set))
 	// TODO: add validation for header names/values with CheckForbiddenCustomHeaders
 	for _, h := range f.Add {
 		headersToAddd = append(headersToAddd, &envoy_config_core_v3.HeaderValueOption{
@@ -294,7 +294,7 @@ func convertResponseHeaderModifier(kctx krt.HandlerContext, f *gwv1.HTTPHeaderFi
 	if f == nil {
 		return nil
 	}
-	var headersToAddd []*envoy_config_core_v3.HeaderValueOption
+	headersToAddd := make([]*envoy_config_core_v3.HeaderValueOption, 0, len(f.Add)+len(f.Set))
 	// TODO: add validation for header names/values with CheckForbiddenCustomHeaders
 	for _, h := range f.Add {
 		headersToAddd = append(headersToAddd, &envoy_config_core_v3.HeaderValueOption{

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -260,7 +260,8 @@ func (p *PolicyIndex) getTargetingPolicies(
 	targetRef ir.ObjectSource,
 	sectionName string,
 ) []ir.PolicyAtt {
-	var ret []ir.PolicyAtt
+	// TODO: Add Len() field to KRT package.
+	var ret []ir.PolicyAtt //nolint:prealloc
 	for _, gp := range p.globalPolicies {
 		if gp.points.Has(pnt) {
 			if p := gp.ir(kctx, pnt); p != nil {

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -89,7 +89,7 @@ func (r GatewayXdsResources) Equals(in GatewayXdsResources) bool {
 		r.Routes.Version == in.Routes.Version && r.Listeners.Version == in.Listeners.Version
 }
 func sliceToResourcesHash[T proto.Message](slice []T) ([]envoycachetypes.ResourceWithTTL, uint64) {
-	var slicePb []envoycachetypes.ResourceWithTTL
+	slicePb := make([]envoycachetypes.ResourceWithTTL, 0, len(slice))
 	var resourcesHash uint64
 	for _, r := range slice {
 		var m proto.Message = r
@@ -97,7 +97,6 @@ func sliceToResourcesHash[T proto.Message](slice []T) ([]envoycachetypes.Resourc
 		slicePb = append(slicePb, envoycachetypes.ResourceWithTTL{Resource: m})
 		resourcesHash ^= hash
 	}
-
 	return slicePb, resourcesHash
 }
 

--- a/internal/kgateway/query/query_test.go
+++ b/internal/kgateway/query/query_test.go
@@ -861,7 +861,7 @@ var (
 )
 
 func newQueries(initObjs ...client.Object) query.GatewayQueries {
-	var anys []any
+	anys := make([]any, 0, len(initObjs))
 	for _, obj := range initObjs {
 		anys = append(anys, obj)
 	}

--- a/internal/kgateway/reports/reporter.go
+++ b/internal/kgateway/reports/reporter.go
@@ -251,7 +251,7 @@ func (r *RouteReport) parentRef(parentRef *gwv1.ParentReference) *ParentRefRepor
 // It is used to update the Status of delegatee routes who may not specify
 // the parentRefs field.
 func (r *RouteReport) parentRefs() []gwv1.ParentReference {
-	var refs []gwv1.ParentReference
+	refs := make([]gwv1.ParentReference, 0, len(r.Parents))
 	for key := range r.Parents {
 		var ns *gwv1.Namespace
 		if key.Namespace != "" {

--- a/internal/kgateway/translator/gateway/testutils/test_file_loader.go
+++ b/internal/kgateway/translator/gateway/testutils/test_file_loader.go
@@ -103,7 +103,7 @@ func parseFile(ctx context.Context, filename string) ([]runtime.Object, error) {
 	resourceYamlStrings := bytes.Split(file, []byte("\n---\n"))
 
 	// Create resources from YAML documents
-	var genericResources []runtime.Object
+	genericResources := make([]runtime.Object, 0, len(resourceYamlStrings))
 	for _, objYaml := range resourceYamlStrings {
 		// Skip empty documents
 		if len(bytes.TrimSpace(objYaml)) == 0 {

--- a/internal/kgateway/translator/httproute/delegation_helpers.go
+++ b/internal/kgateway/translator/httproute/delegation_helpers.go
@@ -247,7 +247,7 @@ func mergeHeaders(
 			merged[key] = h
 		}
 	}
-	var result []gwv1.HTTPHeaderMatch
+	result := make([]gwv1.HTTPHeaderMatch, 0, len(merged))
 	for _, h := range merged {
 		result = append(result, h)
 	}
@@ -272,7 +272,7 @@ func mergeQueries(
 			merged[key] = h
 		}
 	}
-	var result []gwv1.HTTPQueryParamMatch
+	result := make([]gwv1.HTTPQueryParamMatch, 0, len(merged))
 	for _, h := range merged {
 		result = append(result, h)
 	}

--- a/internal/kgateway/translator/irtranslator/fc.go
+++ b/internal/kgateway/translator/irtranslator/fc.go
@@ -154,7 +154,7 @@ func (n *filterChainTranslator) computePreHCMFilters(ctx context.Context, l ir.H
 }
 
 func convertCustomNetworkFilters(customNetworkFilters []ir.CustomEnvoyFilter) []plugins.StagedNetworkFilter {
-	var out []plugins.StagedNetworkFilter
+	out := make([]plugins.StagedNetworkFilter, 0, len(customNetworkFilters))
 	for _, customFilter := range customNetworkFilters {
 		out = append(out, plugins.StagedNetworkFilter{
 			Filter: &envoy_config_listener_v3.Filter{
@@ -171,7 +171,7 @@ func convertCustomNetworkFilters(customNetworkFilters []ir.CustomEnvoyFilter) []
 
 func sortNetworkFilters(filters plugins.StagedNetworkFilterList) []*envoy_config_listener_v3.Filter {
 	sort.Sort(filters)
-	var sortedFilters []*envoy_config_listener_v3.Filter
+	sortedFilters := make([]*envoy_config_listener_v3.Filter, 0, len(filters))
 	for _, filter := range filters {
 		sortedFilters = append(sortedFilters, filter.Filter)
 	}
@@ -333,7 +333,7 @@ func (h *hcmNetworkFilterTranslator) computeHttpFilters(ctx context.Context, l i
 
 func sortHttpFilters(filters plugins.StagedHttpFilterList) []*envoyhttp.HttpFilter {
 	sort.Sort(filters)
-	var sortedFilters []*envoyhttp.HttpFilter
+	sortedFilters := make([]*envoyhttp.HttpFilter, 0, len(filters))
 	for _, filter := range filters {
 		sortedFilters = append(sortedFilters, filter.Filter)
 	}

--- a/internal/kgateway/translator/irtranslator/gateway_json.go
+++ b/internal/kgateway/translator/irtranslator/gateway_json.go
@@ -50,7 +50,7 @@ func (tr *TranslationResult) MarshalJSON() ([]byte, error) {
 }
 
 func marshalProtoMessages[T proto.Message](messages []T, m protojson.MarshalOptions) ([]interface{}, error) {
-	var result []interface{}
+	result := make([]interface{}, 0, len(messages))
 	for _, msg := range messages {
 		data, err := m.Marshal(msg)
 		if err != nil {

--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -62,7 +62,7 @@ func (h *httpRouteConfigurationTranslator) ComputeRouteConfiguration(ctx context
 }
 
 func (h *httpRouteConfigurationTranslator) computeVirtualHosts(ctx context.Context, virtualHosts []*ir.VirtualHost) []*envoy_config_route_v3.VirtualHost {
-	var envoyVirtualHosts []*envoy_config_route_v3.VirtualHost
+	envoyVirtualHosts := make([]*envoy_config_route_v3.VirtualHost, 0, len(virtualHosts))
 	for _, virtualHost := range virtualHosts {
 		envoyVirtualHosts = append(envoyVirtualHosts, h.computeVirtualHost(ctx, virtualHost))
 	}
@@ -75,7 +75,7 @@ func (h *httpRouteConfigurationTranslator) computeVirtualHost(
 ) *envoy_config_route_v3.VirtualHost {
 	sanitizedName := utils.SanitizeForEnvoy(ctx, virtualHost.Name, "virtual host")
 
-	var envoyRoutes []*envoy_config_route_v3.Route
+	envoyRoutes := make([]*envoy_config_route_v3.Route, 0, len(virtualHost.Rules))
 	for i, route := range virtualHost.Rules {
 		// TODO: not sure if we need listener parent ref here or the http parent ref
 		routeReport := h.reporter.Route(route.Parent.SourceObject).ParentRef(&route.ParentRef)
@@ -265,8 +265,7 @@ func (h *httpRouteConfigurationTranslator) translateRouteAction(
 	in ir.HttpRouteRuleMatchIR,
 	outRoute *envoy_config_route_v3.Route,
 ) *envoy_config_route_v3.Route_Route {
-	var clusters []*envoy_config_route_v3.WeightedCluster_ClusterWeight
-
+	clusters := make([]*envoy_config_route_v3.WeightedCluster_ClusterWeight, 0, len(in.Backends))
 	for _, backend := range in.Backends {
 		clusterName := backend.Backend.ClusterName
 
@@ -454,7 +453,7 @@ func setEnvoyPathMatcher(match gwv1.HTTPRouteMatch, out *envoy_config_route_v3.R
 }
 
 func envoyHeaderMatcher(in []gwv1.HTTPHeaderMatch) []*envoy_config_route_v3.HeaderMatcher {
-	var out []*envoy_config_route_v3.HeaderMatcher
+	out := make([]*envoy_config_route_v3.HeaderMatcher, 0, len(in))
 	for _, matcher := range in {
 		envoyMatch := &envoy_config_route_v3.HeaderMatcher{
 			Name: string(matcher.Name),
@@ -486,16 +485,16 @@ func envoyHeaderMatcher(in []gwv1.HTTPHeaderMatch) []*envoy_config_route_v3.Head
 }
 
 func envoyQueryMatcher(in []gwv1.HTTPQueryParamMatch) []*envoy_config_route_v3.QueryParameterMatcher {
-	var out []*envoy_config_route_v3.QueryParameterMatcher
+	out := make([]*envoy_config_route_v3.QueryParameterMatcher, 0, len(in))
 	for _, matcher := range in {
-		envoyMatch := &envoy_config_route_v3.QueryParameterMatcher{
-			Name: string(matcher.Name),
-		}
-		regex := false
+		var regex bool
 		if matcher.Type != nil && *matcher.Type == gwv1.QueryParamMatchRegularExpression {
 			regex = true
 		}
 
+		envoyMatch := &envoy_config_route_v3.QueryParameterMatcher{
+			Name: string(matcher.Name),
+		}
 		// TODO: not sure if we should do PresentMatch according to the spec.
 		if matcher.Value == "" {
 			envoyMatch.QueryParameterMatchSpecifier = &envoy_config_route_v3.QueryParameterMatcher_PresentMatch{

--- a/internal/kgateway/translator/listener/gateway_listener_translator.go
+++ b/internal/kgateway/translator/listener/gateway_listener_translator.go
@@ -191,8 +191,7 @@ func (ml *MergedListeners) AppendTcpListener(
 	routeInfos []*query.RouteInfo,
 	reporter reports.ListenerReporter,
 ) {
-	var validRouteInfos []*query.RouteInfo
-
+	validRouteInfos := make([]*query.RouteInfo, 0, len(routeInfos))
 	for _, routeInfo := range routeInfos {
 		tRoute, ok := routeInfo.Object.(*ir.TcpRouteIR)
 		if !ok {
@@ -253,8 +252,7 @@ func (ml *MergedListeners) AppendTlsListener(
 	routeInfos []*query.RouteInfo,
 	reporter reports.ListenerReporter,
 ) {
-	var validRouteInfos []*query.RouteInfo
-
+	validRouteInfos := make([]*query.RouteInfo, 0, len(routeInfos))
 	for _, routeInfo := range routeInfos {
 		tRoute, ok := routeInfo.Object.(*ir.TlsRouteIR)
 		if !ok {
@@ -319,7 +317,7 @@ func (ml *MergedListeners) translateListeners(
 	queries query.GatewayQueries,
 	reporter reports.Reporter,
 ) []ir.ListenerIR {
-	var listeners []ir.ListenerIR
+	listeners := make([]ir.ListenerIR, 0, len(ml.Listeners))
 	for _, mergedListener := range ml.Listeners {
 		listener := mergedListener.TranslateListener(kctx, ctx, queries, reporter)
 
@@ -359,11 +357,7 @@ func (ml *MergedListener) TranslateListener(
 	queries query.GatewayQueries,
 	reporter reports.Reporter,
 ) ir.ListenerIR {
-	var (
-		httpFilterChains    []ir.HttpFilterChainIR
-		matchedTcpListeners []ir.TcpIR
-	)
-
+	var httpFilterChains []ir.HttpFilterChainIR //nolint:prealloc
 	// Translate HTTP filter chains
 	if ml.httpFilterChain != nil {
 		httpFilterChain := ml.httpFilterChain.translateHttpFilterChain(
@@ -419,6 +413,7 @@ func (ml *MergedListener) TranslateListener(
 	}
 
 	// Translate TCP listeners (if any exist)
+	matchedTcpListeners := make([]ir.TcpIR, 0, len(ml.TcpFilterChains))
 	for _, tfc := range ml.TcpFilterChains {
 		if tcpListener := tfc.translateTcpFilterChain(ml.listener, reporter); tcpListener != nil {
 			matchedTcpListeners = append(matchedTcpListeners, *tcpListener)

--- a/internal/kgateway/translator/routeutils/sortable_route.go
+++ b/internal/kgateway/translator/routeutils/sortable_route.go
@@ -30,7 +30,7 @@ func (a SortableRoutes) ToRoutes() []ir.HttpRouteRuleMatchIR {
 }
 
 func ToSortable(obj metav1.Object, routes []ir.HttpRouteRuleMatchIR) SortableRoutes {
-	var wrappers SortableRoutes
+	wrappers := make(SortableRoutes, 0, len(routes))
 	for i, route := range routes {
 		wrappers = append(wrappers, &SortableRoute{
 			Route:       route,

--- a/internal/sds/pkg/server/server.go
+++ b/internal/sds/pkg/server/server.go
@@ -92,8 +92,8 @@ func (s *Server) Run(ctx context.Context) (<-chan struct{}, error) {
 
 // UpdateSDSConfig updates with the current certs
 func (s *Server) UpdateSDSConfig(ctx context.Context) error {
-	var certs [][]byte
-	var items []cache_types.Resource
+	certs := make([][]byte, 0, len(s.secrets))
+	items := make([]cache_types.Resource, 0, len(s.secrets))
 	for _, sec := range s.secrets {
 		key, err := readAndVerifyCert(ctx, sec.SslKeyFile)
 		if err != nil {

--- a/pkg/utils/envoyutils/bootstrap/resources.go
+++ b/pkg/utils/envoyutils/bootstrap/resources.go
@@ -51,7 +51,7 @@ func resourcesFromSnapshot(snap envoycache.ResourceSnapshot) (*EnvoyResources, e
 // listenersFromSnapshot accepts a Snapshot and extracts from it a slice of pointers to
 // the Listener structs contained in the Snapshot.
 func listenersFromSnapshot(snap envoycache.ResourceSnapshot) ([]*envoy_config_listener_v3.Listener, error) {
-	var listeners []*envoy_config_listener_v3.Listener
+	listeners := make([]*envoy_config_listener_v3.Listener, 0, len(snap.GetResources(envoyresource.ListenerType)))
 	for _, v := range snap.GetResources(envoyresource.ListenerType) {
 		l, ok := v.(*envoy_config_listener_v3.Listener)
 		if !ok {
@@ -65,7 +65,7 @@ func listenersFromSnapshot(snap envoycache.ResourceSnapshot) ([]*envoy_config_li
 // clustersFromSnapshot accepts a Snapshot and extracts from it a slice of pointers to
 // the Cluster structs contained in the Snapshot.
 func clustersFromSnapshot(snap envoycache.ResourceSnapshot) ([]*envoy_config_cluster_v3.Cluster, error) {
-	var clusters []*envoy_config_cluster_v3.Cluster
+	clusters := make([]*envoy_config_cluster_v3.Cluster, 0, len(snap.GetResources(envoyresource.ClusterType)))
 	for _, v := range snap.GetResources(envoyresource.ClusterType) {
 		c, ok := v.(*envoy_config_cluster_v3.Cluster)
 		if !ok {
@@ -79,7 +79,7 @@ func clustersFromSnapshot(snap envoycache.ResourceSnapshot) ([]*envoy_config_clu
 // routesFromSnapshot accepts a Snapshot and extracts from it a slice of pointers to
 // the RouteConfiguration structs contained in the Snapshot.
 func routesFromSnapshot(snap envoycache.ResourceSnapshot) ([]*envoy_config_route_v3.RouteConfiguration, error) {
-	var routes []*envoy_config_route_v3.RouteConfiguration
+	routes := make([]*envoy_config_route_v3.RouteConfiguration, 0, len(snap.GetResources(envoyresource.RouteType)))
 	for _, v := range snap.GetResources(envoyresource.RouteType) {
 		r, ok := v.(*envoy_config_route_v3.RouteConfiguration)
 		if !ok {
@@ -93,7 +93,7 @@ func routesFromSnapshot(snap envoycache.ResourceSnapshot) ([]*envoy_config_route
 // endpointsFromSnapshot accepts a Snapshot and extracts from it a slice of pointers to
 // the ClusterLoadAssignment structs contained in the Snapshot.
 func endpointsFromSnapshot(snap envoycache.ResourceSnapshot) ([]*envoy_config_endpoint_v3.ClusterLoadAssignment, error) {
-	var endpoints []*envoy_config_endpoint_v3.ClusterLoadAssignment
+	endpoints := make([]*envoy_config_endpoint_v3.ClusterLoadAssignment, 0, len(snap.GetResources(envoyresource.EndpointType)))
 	for _, v := range snap.GetResources(envoyresource.EndpointType) {
 		e, ok := v.(*envoy_config_endpoint_v3.ClusterLoadAssignment)
 		if !ok {

--- a/pkg/utils/requestutils/curl/request.go
+++ b/pkg/utils/requestutils/curl/request.go
@@ -82,7 +82,7 @@ type requestConfig struct {
 }
 
 func (c *requestConfig) generateArgs() []string {
-	var args []string
+	var args []string //nolint:prealloc
 
 	if c.verbose {
 		args = append(args, "-v")

--- a/test/gomega/matchers/have_http_response.go
+++ b/test/gomega/matchers/have_http_response.go
@@ -103,7 +103,7 @@ func HaveHttpResponse(expected *HttpResponse) types.GomegaMatcher {
 		expectedCustomMatcher = gstruct.Ignore()
 	}
 
-	var partialResponseMatchers []types.GomegaMatcher
+	var partialResponseMatchers []types.GomegaMatcher //nolint:prealloc
 	partialResponseMatchers = append(partialResponseMatchers, &matchers.HaveHTTPStatusMatcher{
 		Expected: []interface{}{
 			expected.StatusCode,


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Enables the https://golangci-lint.run/usage/linters/#prealloc linter. We're relying on the
`simple: true` default setting here. Any additional settings could overkill.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
