### PR TITLE
Remove Gloo Edge references

### DIFF
--- a/.github/actions/regression-tests/action.yaml
+++ b/.github/actions/regression-tests/action.yaml
@@ -1,40 +1,40 @@
 name: Gloo Regression Tests
 
-description: Tests which run Gloo Edge in a Kubernetes cluster
+description: Tests which run kgateway in a Kubernetes cluster
 
 runs:
   using: "composite"
   steps:
-  - name: Prep Go Runner
-    uses: ./.github/actions/prep-go-runner
-  - name: Install kind
-    uses: helm/kind-action@v1.10.0
-    with:
-      install_only: true
-      version: ${{ matrix.kube-version.kind }}
-  - uses: azure/setup-kubectl@v4
-    id: kubectl
-    with:
-      version: ${{ matrix.kube-version.kubectl }}
-  - uses: azure/setup-helm@v4
-    with:
-      version: ${{ matrix.kube-version.helm }}
-  - name: Setup test env
-    shell: bash
-    env:
-      CLUSTER_NAME: 'kind'
-      CLUSTER_NODE_VERSION: ${{ matrix.kube-version.node }}
-      IMAGE_VARIANT: ${{ matrix.image-variant }}
-    run: ./hack/kind/setup-kind.sh
-  - name: Testing - kube e2e regression tests
-    env:
-      KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
-      IMAGE_VARIANT: ${{ matrix.image-variant }}
-    shell: bash
-    run: make install-test-tools run-kube-e2e-tests
-  - uses: actions/upload-artifact@v4
-    if: ${{ failure() }}
-    with:
-      name: ${{matrix.kube-e2e-test-type}}-attempt-${{ github.run_attempt }}@k8s${{matrix.kube-version.kubectl}}-kube-dump
-      path: "_output/kube2e-artifacts"
-      if-no-files-found: warn
+    - name: Prep Go Runner
+      uses: ./.github/actions/prep-go-runner
+    - name: Install kind
+      uses: helm/kind-action@v1.10.0
+      with:
+        install_only: true
+        version: ${{ matrix.kube-version.kind }}
+    - uses: azure/setup-kubectl@v4
+      id: kubectl
+      with:
+        version: ${{ matrix.kube-version.kubectl }}
+    - uses: azure/setup-helm@v4
+      with:
+        version: ${{ matrix.kube-version.helm }}
+    - name: Setup test env
+      shell: bash
+      env:
+        CLUSTER_NAME: "kind"
+        CLUSTER_NODE_VERSION: ${{ matrix.kube-version.node }}
+        IMAGE_VARIANT: ${{ matrix.image-variant }}
+      run: ./hack/kind/setup-kind.sh
+    - name: Testing - kube e2e regression tests
+      env:
+        KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
+        IMAGE_VARIANT: ${{ matrix.image-variant }}
+      shell: bash
+      run: make install-test-tools run-kube-e2e-tests
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: ${{matrix.kube-e2e-test-type}}-attempt-${{ github.run_attempt }}@k8s${{matrix.kube-version.kubectl}}-kube-dump
+        path: "_output/kube2e-artifacts"
+        if-no-files-found: warn

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -74,6 +74,6 @@ This is a complex PR and may require a huddle to discuss ...
 - Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
   - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
 - Run codegen via `make -B install-go-tools generated-code`
-- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
+- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
 - If not ready for review, open a draft PR or apply the `work in progress` label
 -->

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ test-report.json
 # Vscode Ginkgo test explorer report
 **/ginkgo.report
 
-# At time we run Gloo Edge locally and store configuration in a local directory named `data`
+# At time we run kgateway locally and store configuration in a local directory named `data`
 # These should be ignored, as often times `source_data` is the configuration we check into the repo
 data
 

--- a/devel/README.md
+++ b/devel/README.md
@@ -9,6 +9,7 @@ Find tools and information to help you develop the Gloo Gateway project.
 * `tools`: A set of scripts and tools that are intended to help you develop the Gloo Gateway project's codebase. Learn more about these tools in the short descriptions later in this readme.
 
 Other resources:
-* [Developer guide (Gloo Edge API)](https://docs.solo.io/gloo-edge/latest/guides/dev/) to set up your development environment and learn more about extending the functionality of the Gloo Gateway project and related plug-ins. While written for external contributors, internal Solo developers might also find this guide helpful when onboarding.
+* [Developer guide (Gloo Edge API)](https://docs.solo.io/gloo-edge/latest/guides/dev/) - 
+while this guide is written for Gloo Edge, it can be used temporarily for setting up your development environment and learning about extending kgateway functionality and related plug-ins. An updated guide specific to kgateway will be provided in the future. 
 * [Product documentation (K8s Gateway API)](https://docs.solo.io/gateway/latest/)
 * [Contribution guidelines (K8s Gateway API)](https://docs.solo.io/gateway/latest/reference/contribution/)

--- a/devel/architecture/istio-integration.md
+++ b/devel/architecture/istio-integration.md
@@ -75,7 +75,7 @@ If the application that we’re running can logs requests that it receives, we c
 
 # Testing automtls
 
-The Istio e2e integration tests automtls functionality with Gloo Gateway (Gloo Edge API) and Gloo Gateway (Kubernetes Gateway API) resources. This
+The Istio e2e integration tests automtls functionality with kgateway resources. This
 can be manually tested by following the steps below on a kind cluster:
 
 1. Setup environment and kind cluster

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-Gloo Edge is built to integrate with a user's environment. By enabling users to select their preferred tools for scheduling, persistence, and security, we must ensure that we have end-to-end tests to validate these scenarios.
+Kgateway is built to integrate with a user's environment. By enabling users to select their preferred tools for scheduling, persistence, and security, we must ensure that we have end-to-end tests to validate these scenarios.
 
 We support the following types of end-to-end tests:
 - [In Memory end-to-end](./e2e)

--- a/test/ginkgo/labels/labels.go
+++ b/test/ginkgo/labels/labels.go
@@ -9,6 +9,6 @@ const (
 	// These often require more resources/time to complete, and likely report their findings to a remote location
 	Performance = "performance"
 
-	// E2E is a label applied to any tests which run Gloo Edge end-to-end
+	// E2E is a label applied to any tests which run kgateway end-to-end
 	E2E = "end-to-end"
 )

--- a/test/gomega/assertions/stats.go
+++ b/test/gomega/assertions/stats.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/cliutil"
 )
 
-// Gloo Edge exports statistics to provide details about how the system is behaving
+// Kgateway exports statistics to provide details about how the system is behaving
 // Most stats utilities are defined in: https://github.com/solo-io/go-utils/tree/main/stats
 // This file contains a set of assertions that can be performed by tests to ensure that recorded stats
 // match what we would expect

--- a/test/helpers/resources.go
+++ b/test/helpers/resources.go
@@ -97,7 +97,7 @@ func getResourceStatus(getter InputResourceGetter) (core.Status, error) {
 	statusClient := statusutils.GetStatusClientFromEnvOrDefault(defaults.GlooSystem)
 	status := statusClient.GetStatus(resource)
 
-	// In newer versions of Gloo Edge we provide a default "empty" status, which allows us to patch it to perform updates
+	// In newer versions of kgateway we provide a default "empty" status, which allows us to patch it to perform updates
 	// As a result, a nil check isn't enough to determine that that status hasn't been reported
 	// Note: RateLimitConfig statuses can have an empty reporter
 	if status == nil {

--- a/test/helpers/snapshot_writer.go
+++ b/test/helpers/snapshot_writer.go
@@ -27,7 +27,7 @@ type SnapshotWriterImpl struct {
 	ResourceClientSet
 
 	// retryOptions is the criteria for retrying a Snapshot Write or Delete operation.
-	// Due to the eventually consistent nature of Gloo Edge, when applying changes in bulk,
+	// Due to the eventually consistent nature of kgateway, when applying changes in bulk,
 	// parent resources may be rejected by the validation webhook, if the Gloo hasn't processed the child
 	// resources. A more thorough solution would be to support bulk applies of resources.
 	// In the interim however, we retry the operation

--- a/test/kube2e/README.md
+++ b/test/kube2e/README.md
@@ -8,85 +8,97 @@
 
 See the [developer kube-e2e testing guide](/devel/testing/kube-e2e-tests.md) for more information about the philosophy of these tests.
 
-*Note: All commands should be run from the root directory of the Gloo repository*
+_Note: All commands should be run from the root directory of the Gloo repository_
 
 - [Local Development](#local-development)
-    - [Setup](#setup)
-        - [Use the CI Install Script](#use-the-ci-install-script)
-        - [Verify Your Setup](#verify-your-setup)
-        - [Common Setup Errors](#common-setup-errors)
-    - [Run Tests](#run-tests)
-        - [Use the Make Target](#use-the-make-target)
-        - [Test Environment Variables](#test-environment-variables)
-        - [Common Test Errors](#common-test-errors)
+  - [Setup](#setup)
+    - [Use the CI Install Script](#use-the-ci-install-script)
+    - [Verify Your Setup](#verify-your-setup)
+    - [Common Setup Errors](#common-setup-errors)
+  - [Run Tests](#run-tests)
+    - [Use the Make Target](#use-the-make-target)
+    - [Test Environment Variables](#test-environment-variables)
+    - [Common Test Errors](#common-test-errors)
 
 ## Local Development
+
 ### Setup (Previously Released Assets)
-It is possible to run these tests against a previously released version of Gloo Edge. This is useful for testing a release candidate, or a nightly build.
+
+It is possible to run these tests against a previously released version of kgateway. This is useful for testing a release candidate, or a nightly build.
 
 There is no setup required for this option, as the test suite will download the helm chart archive and `glooctl` binary from the specified release. You will use the `RELEASED_VERSION` environment variable when running the tests. See the [variable definition](/test/testutils/env.go) for more details.
 
 ### Setup (Locally Build Assets)
 
 For these tests to run, we require the following conditions:
-- Gloo Edge Helm chart archive is present in the `_test` folder,
+
+- kgateway Helm chart archive is present in the `_test` folder,
 - `glooctl` is built in the `_output` folder
 - A KinD cluster is set up and loaded with the images to be installed by the helm chart
 
 #### Use the CI Install Script
+
 [hack/kind/setup-kind.sh](/hack/kind/setup-kind.sh) gets run in CI to setup the test environment for the above requirements.
 It accepts a number of environment variables, to control the creation of a kind cluster and deployment of Gloo resources to that kind cluster.
 
-| Name                 | Default   | Description                                                                                                                  |
-|----------------------|-----------|------------------------------------------------------------------------------------------------------------------------------|
-| CLUSTER_NAME         | kind      | The name of the cluster that will be generated                                                                               |
-| CLUSTER_NODE_VERSION | v1.28.0   | The version of the [Node Docker image](https://hub.docker.com/r/kindest/node/) to use for booting the cluster                |
-| VERSION              | 1.0.0-ci1 | The version used to tag Gloo images that are deployed to the cluster                                                         |
-| SKIP_DOCKER          | false     | Skip building docker images (used when testing a release version)                                                            |
-| RELEASED_VERSION     | ''        | Used if you want to test a previously released version. 'LATEST' will find the latest release                                |
+| Name                 | Default   | Description                                                                                                   |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
+| CLUSTER_NAME         | kind      | The name of the cluster that will be generated                                                                |
+| CLUSTER_NODE_VERSION | v1.28.0   | The version of the [Node Docker image](https://hub.docker.com/r/kindest/node/) to use for booting the cluster |
+| VERSION              | 1.0.0-ci1 | The version used to tag Gloo images that are deployed to the cluster                                          |
+| SKIP_DOCKER          | false     | Skip building docker images (used when testing a release version)                                             |
+| RELEASED_VERSION     | ''        | Used if you want to test a previously released version. 'LATEST' will find the latest release                 |
 
 Example:
+
 ```bash
 CLUSTER_NAME=solo-test-cluster CLUSTER_NODE_VERSION=v1.28.0 VERSION=v1.0.0-solo-test hack/kind/setup-kind.sh
 ```
 
 #### Verify Your Setup
+
 Before running your tests, it's worthwhile to verify that a cluster was created, and the proper images have been loaded.
 
 ```bash
 CLUSTER_NAME=solo-test-cluster make kind-list-images
 ```
+
 You should see the list of images in the cluster, including the ones you just uploaded
 
 #### Common Setup Errors
+
 `Error: validation: chart.metadata.version "solo" is invalid`\
 In newer versions of helm (>3.5), the version used to build the helm chart (ie the VERSION env variable), needs to respect semantic versioning. This error implies that the version provided does not.
 
 Prepend a valid semver to avoid the error. (ie `kind` can become `0.0.0-kind1`)
 
 ### Run Tests
+
 To run the regression tests, your kubeconfig file must point to a running Kubernetes cluster.
 `kubectl config current-context` should run `kind-<CLUSTER_NAME>`
 
 #### Use the Make Target
 
 Use the same command that CI relies on:
+
 ```bash
 CLUSTER_NAME=solo-test-cluster KUBE2E_TESTS=<test-to-run> make run-kube-e2e-tests
 ```
 
 #### Test Environment Variables
+
 The below table contains the environment variables that can be used to configure the test execution.
 
-| Name             | Default | Description                                                                                                                                                                                                                                        |
-|------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| KUBE2E_TESTS     | gateway | Name of the test suite to be run. Options: `'gateway', 'gloo', 'ingress', 'helm', 'glooctl', 'upgrade', 'istio'`                                                                                                                                   |
-| DEBUG            | 0       | Set to 1 for debug log output                                                                                                                                                                                                                      |
-| WAIT_ON_FAIL     | 0       | Set to 1 to prevent Ginkgo from cleaning up the Gloo Edge installation in case of failure. Useful to exec into inspect resources created by the test. A command to resume the test run (and thus clean up resources) will be logged to the output. |
-| TEAR_DOWN        | false   | Set to true to uninstall Gloo after the test suite completes                                                                                                                                                                                       |
-| RELEASED_VERSION | ''      | Used by nightlies to tests a specific released version. 'LATEST' will find the latest release                                                                                                                                                      |
-| CLUSTER_NAME     | kind    | Used to control which Kind cluster to run the tests inside |
+| Name             | Default | Description                                                                                                                                                                                                                                       |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| KUBE2E_TESTS     | gateway | Name of the test suite to be run. Options: `'gateway', 'gloo', 'ingress', 'helm', 'glooctl', 'upgrade', 'istio'`                                                                                                                                  |
+| DEBUG            | 0       | Set to 1 for debug log output                                                                                                                                                                                                                     |
+| WAIT_ON_FAIL     | 0       | Set to 1 to prevent Ginkgo from cleaning up the kgateway installation in case of failure. Useful to exec into inspect resources created by the test. A command to resume the test run (and thus clean up resources) will be logged to the output. |
+| TEAR_DOWN        | false   | Set to true to uninstall Gloo after the test suite completes                                                                                                                                                                                      |
+| RELEASED_VERSION | ''      | Used by nightlies to tests a specific released version. 'LATEST' will find the latest release                                                                                                                                                     |
+| CLUSTER_NAME     | kind    | Used to control which Kind cluster to run the tests inside                                                                                                                                                                                        |
 
 #### Common Test Errors
+
 `getting Helm chart version: expected a single entry with name [gloo], found: 5`\
 The test helm charts are written to the `_test` directory, with the `index.yaml` file containing references to all available charts. The tests require that this file contain only 1 entry. Delete the other entries manually, or run `make clean` to delete this folder entirely, and then re-build the test helm chart.

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -193,7 +193,7 @@ func GetTestReleasedVersion(ctx context.Context, repoName string) string {
 		return current.String()
 	}
 
-	// Assume that releasedVersion is a valid version, for a previously released version of Gloo Edge
+	// Assume that releasedVersion is a valid version, for a previously released version of kgateway
 	return releasedVersion
 }
 func GetTestHelper(ctx context.Context, namespace string) (*helper.SoloTestHelper, error) {

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -98,7 +98,7 @@ import (
 
 // 	namespacedStatuses := resource.GetNamespacedStatuses()
 
-// 	// In newer versions of Gloo Edge we provide a default "empty" status, which allows us to patch it to perform updates
+// 	// In newer versions of kgateway we provide a default "empty" status, which allows us to patch it to perform updates
 // 	// As a result, a nil check isn't enough to determine that that status hasn't been reported
 // 	if namespacedStatuses == nil || namespacedStatuses.GetStatuses() == nil {
 // 		return &core.NamespacedStatuses{}, errors.Wrapf(err, "waiting for %v status to be non-empty", resource.GetMetadata().GetName())

--- a/test/services/gloo.go
+++ b/test/services/gloo.go
@@ -126,7 +126,7 @@ type ExtensionsBuilders struct {
 	Fds  func(ctx context.Context, opts bootstrap.Opts) fds_syncer.Extensions
 }
 
-// RunGlooGatewayUdsFds runs the Gloo Edge control plane components in goroutines and stores
+// RunGlooGatewayUdsFds runs the kgateway control plane components in goroutines and stores
 // configuration in-memory. This is used by the e2e tests in `test/e2e` package.
 func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClients {
 	runOptions.ports = Ports{
@@ -138,7 +138,7 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 	settings := constructTestSettings(runOptions)
 	ctx = settingsutil.WithSettings(ctx, settings)
 
-	// All Gloo Edge components run using a Bootstrap.Opts object
+	// All kgateway components run using a Bootstrap.Opts object
 	// These values are extracted from the Settings object and as part of our SetupSyncer
 	// we pull values off the Settings object to build the Bootstrap.Opts. It would be ideal if we
 	// could use the same setup code, but in the meantime, we use constructTestOpts to mirror the functionality

--- a/test/testutils/env.go
+++ b/test/testutils/env.go
@@ -66,10 +66,10 @@ const (
 	// This is set when running tests in Cloudbuild
 	GcloudBuildId = "GCLOUD_BUILD_ID"
 
-	// ReleasedVersion can be used when running KubeE2E tests to have the test suite use a previously released version of Gloo Edge
+	// ReleasedVersion can be used when running KubeE2E tests to have the test suite use a previously released version of kgateway
 	// If set to 'LATEST', the most recently released version will be used
 	// If set to another value, the test suite will use that version (ie '1.15.0-beta1')
-	// This is an optional value, so if it is not set, the test suite will use the locally built version of Gloo Edge
+	// This is an optional value, so if it is not set, the test suite will use the locally built version of kgateway
 	ReleasedVersion = "RELEASED_VERSION"
 
 	// Istio auto mtls
@@ -90,14 +90,14 @@ func ShouldTearDown() bool {
 
 // ShouldSkipInstall returns true if any assets that need to be created before a test (for example Gloo being installed)
 // should be skipped. This is typically used in tandem with ShouldTearDown when running consecutive tests and skipping
-// both the tear down and install of Gloo Edge.
+// both the tear down and install of kgateway.
 func ShouldSkipInstall() bool {
 	return IsEnvTruthy(SkipInstall)
 }
 
 // ShouldSkipIstioInstall returns true if any assets that need to be created before a test (for example Gloo being installed)
 // should be skipped. This is typically used in tandem with ShouldTearDown when running consecutive tests and skipping
-// both the tear down and install of Gloo Edge.
+// both the tear down and install of kgateway.
 func ShouldSkipIstioInstall() bool {
 	return IsEnvTruthy(SkipIstioInstall)
 }


### PR DESCRIPTION
# Description

Replaced most of the references to Gloo Edge with kgateway across the codebase.

## API changes

None

## Code changes

no code changes. Mostly text, some of comments and formatting.

## CI changes

None

## Docs changes

Updated some text in READMEs

# Context

This is part of the ongoing effort to align terminology with kgateway.

## Interesting decisions

none :-)

## Testing steps

not required. Just search to return any references:
```
grep -r -i "gloo edge" --exclude-dir=".git" ../kgateway | wc -l
```
## Notes for reviewers

No functional changes—this is a purely textual update. Original discussion is [Slack](https://solo-io-corp.slack.com/archives/C085A044BHT/p1741394597734499)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
