### PR TITLE
Fix some ggv2setup_test issues

### DIFF
--- a/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
+++ b/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
@@ -110,7 +110,7 @@ spec:
         resources:
           {{- toYaml $gateway.resources | nindent 10 }}
 {{- end }} {{/* if $gateway.resources */}}
-{{- if $gateway.istio.enabled }}
+{{- if and $gateway.istio.enabled ($gateway.sdsContainer).image }}
       - name: sds
         image: "{{ template "kgateway.gateway.image" $gateway.sdsContainer.image }}"
         {{- if $gateway.sdsContainer.image.pullPolicy }}
@@ -157,7 +157,7 @@ spec:
           - mountPath: /etc/envoy
             name: envoy-config
 {{- end }} {{/* if $gateway.istio.enabled */}}
-{{- if $gateway.istio.enabled }}
+{{- if and $gateway.istio.enabled ($gateway.istioContainer).image }}
           - mountPath: /etc/istio-certs/
             name: istio-certs
       - name: istio-proxy
@@ -259,7 +259,7 @@ spec:
           - mountPath: /var/run/secrets/workload-spiffe-credentials
             name: workload-certs
 {{- end }} {{/* if $gateway.istio.enabled */}}
-{{- if (($gateway.aiExtension).enabled) }}
+{{- if and ($gateway.aiExtension).enabled ($gateway.aiExtension).image }}
       - name: kgateway-ai-extension
         image: "{{ template "kgateway.gateway.image" $gateway.aiExtension.image }}"
         {{- if $gateway.aiExtension.image.pullPolicy }}

--- a/internal/kgateway/setup/testdata/autodns/backend-out.yaml
+++ b/internal/kgateway/setup/testdata/autodns/backend-out.yaml
@@ -23,14 +23,6 @@ clusters:
   metadata: {}
   name: kube_default_kubernetes_443
   type: EDS
-- connectTimeout: 5s
-  edsClusterConfig:
-    edsConfig:
-      ads: {}
-      resourceApiVersion: V3
-  metadata: {}
-  name: kube_gwtest_http-backend_8080
-  type: EDS
 listeners:
 - address:
     socketAddress:

--- a/internal/kgateway/setup/testdata/setupyaml/setup.yaml
+++ b/internal/kgateway/setup/testdata/setupyaml/setup.yaml
@@ -15,29 +15,4 @@ apiVersion: gateway.kgateway.dev/v1alpha1
 metadata:
   name: kgateway
 spec:
-  kube:
-    deployment:
-      replicas: 1
-    envoyContainer:
-      image:
-        registry: ghcr.io/kgateway-dev
-        repository: envoy-wrapper
-        tag: v0.0.1
-        pullPolicy: IfNotPresent
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          add:
-          - NET_BIND_SERVICE
-          drop:
-          - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 10101
-    service:
-      type: LoadBalancer
-    stats:
-      enableStatsRoute: true
-      enabled: true
-      routePrefixRewrite: /stats/prometheus
-      statsRoutePrefixRewrite: /stats
+  selfManaged: {}


### PR DESCRIPTION
Fix some issues with the setup tests:
- Use selfManaged gatewayparameters so that the deployer doesn't run (it isnt needed for these tests, and sometimes attempts to create extra resources causing tests to fail)
- Don't set env vars to initialize the Settings during the tests; instead, contruct the Settings directly. I found that env vars set in `TestScenarios` seemed to be interfering with tests in `TestWithAutoDns` (maybe they run in parallel?)
- Previous ggv2setup test flakes ran into a nil error in the proxy-deployment template where the sdsContainer was nil. Although this code path shouldn't get called anymore (since we're using selfManaged now), we should add nil checks to the helm template anyway