### PR TITLE
remove timeout from routepolicy

### DIFF
--- a/api/applyconfiguration/api/v1alpha1/routepolicyspec.go
+++ b/api/applyconfiguration/api/v1alpha1/routepolicyspec.go
@@ -6,7 +6,6 @@ package v1alpha1
 // with apply.
 type RoutePolicySpecApplyConfiguration struct {
 	TargetRef      *LocalPolicyTargetReferenceApplyConfiguration `json:"targetRef,omitempty"`
-	Timeout        *int                                          `json:"timeout,omitempty"`
 	AI             *AIRoutePolicyApplyConfiguration              `json:"ai,omitempty"`
 	Transformation *TransformationPolicyApplyConfiguration       `json:"transformation,omitempty"`
 }
@@ -22,14 +21,6 @@ func RoutePolicySpec() *RoutePolicySpecApplyConfiguration {
 // If called multiple times, the TargetRef field is set to the value of the last call.
 func (b *RoutePolicySpecApplyConfiguration) WithTargetRef(value *LocalPolicyTargetReferenceApplyConfiguration) *RoutePolicySpecApplyConfiguration {
 	b.TargetRef = value
-	return b
-}
-
-// WithTimeout sets the Timeout field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Timeout field is set to the value of the last call.
-func (b *RoutePolicySpecApplyConfiguration) WithTimeout(value int) *RoutePolicySpecApplyConfiguration {
-	b.Timeout = &value
 	return b
 }
 

--- a/api/applyconfiguration/internal/internal.go
+++ b/api/applyconfiguration/internal/internal.go
@@ -1026,9 +1026,6 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         namedType: com.github.kgateway-dev.kgateway.v2.api.v1alpha1.LocalPolicyTargetReference
       default: {}
-    - name: timeout
-      type:
-        scalar: numeric
     - name: transformation
       type:
         namedType: com.github.kgateway-dev.kgateway.v2.api.v1alpha1.TransformationPolicy

--- a/api/v1alpha1/route_policy_types.go
+++ b/api/v1alpha1/route_policy_types.go
@@ -30,11 +30,9 @@ type RoutePolicyList struct {
 }
 
 type RoutePolicySpec struct {
-	TargetRef LocalPolicyTargetReference `json:"targetRef,omitempty"`
-	// +kubebuilder:validation:Minimum=1
-	Timeout        int                  `json:"timeout,omitempty"`
-	AI             *AIRoutePolicy       `json:"ai,omitempty"`
-	Transformation TransformationPolicy `json:"transformation,omitempty"`
+	TargetRef      LocalPolicyTargetReference `json:"targetRef,omitempty"`
+	AI             *AIRoutePolicy             `json:"ai,omitempty"`
+	Transformation TransformationPolicy       `json:"transformation,omitempty"`
 }
 
 // TransformationPolicy config is used to modify envoy behavior at a route level.

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_routepolicies.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_routepolicies.yaml
@@ -290,9 +290,6 @@ spec:
                 - kind
                 - name
                 type: object
-              timeout:
-                minimum: 1
-                type: integer
               transformation:
                 properties:
                   request:

--- a/internal/kgateway/extensions2/plugins/routepolicy/route_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/route_policy_plugin.go
@@ -12,7 +12,6 @@ import (
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -47,7 +46,6 @@ type routePolicy struct {
 }
 
 type routeSpecIr struct {
-	timeout                    *durationpb.Duration
 	AI                         *v1alpha1.AIRoutePolicy
 	transform                  *anypb.Any
 	rustformation              *anypb.Any
@@ -65,9 +63,6 @@ func (d *routePolicy) Equals(in any) bool {
 		return false
 	}
 
-	if !proto.Equal(d.spec.timeout, d2.spec.timeout) {
-		return false
-	}
 	if !proto.Equal(d.spec.transform, d2.spec.transform) {
 		return false
 	}
@@ -159,9 +154,6 @@ func (p *routePolicyPluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.Ro
 	policy, ok := pCtx.Policy.(*routePolicy)
 	if !ok {
 		return nil
-	}
-	if policy.spec.timeout != nil && outputRoute.GetRoute() != nil {
-		outputRoute.GetRoute().Timeout = policy.spec.timeout
 	}
 
 	if policy.spec.transform != nil {
@@ -336,10 +328,6 @@ func buildTranslateFunc(ctx context.Context, secrets *krtcollections.SecretIndex
 		policyIr := routePolicy{ct: policyCR.CreationTimestamp.Time}
 
 		outSpec := routeSpecIr{}
-
-		if policyCR.Spec.Timeout > 0 {
-			outSpec.timeout = durationpb.New(time.Second * time.Duration(policyCR.Spec.Timeout))
-		}
 
 		// Pass along the AI spec as is
 		outSpec.AI = policyCR.Spec.AI

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3356,12 +3356,6 @@ func schema_kgateway_v2_api_v1alpha1_RoutePolicySpec(ref common.ReferenceCallbac
 							Ref:     ref("github.com/kgateway-dev/kgateway/v2/api/v1alpha1.LocalPolicyTargetReference"),
 						},
 					},
-					"timeout": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
-						},
-					},
 					"ai": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/kgateway-dev/kgateway/v2/api/v1alpha1.AIRoutePolicy"),


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
