### PR TITLE
Add a prepare-commit-msg git hook for DCO

### DIFF
--- a/devel/README.md
+++ b/devel/README.md
@@ -1,12 +1,12 @@
-# Developing Gloo Gateway
+# Developing kgateway
 
-Find tools and information to help you develop the Gloo Gateway project.
+Find tools and information to help you develop the kgateway project.
 
 * `architecture`: Descriptions about high-level design and implementation details of various packages and features.
 * `contributing`: Information to help you contribute to the project, such as how to open issues, review pull requests, generate code, and backport fixes.
 * `debugging`: Troubleshooting steps for debugging frequent issues.
 * `testing`: Descriptions on how the tests work and how to use them.
-* `tools`: A set of scripts and tools that are intended to help you develop the Gloo Gateway project's codebase. Learn more about these tools in the short descriptions later in this readme.
+* `tools`: A set of scripts and tools that are intended to help you develop the kgateway project's codebase. Learn more about these tools in the short descriptions later in this readme.
 
 Other resources:
 * [Developer guide (Gloo Edge API)](https://docs.solo.io/gloo-edge/latest/guides/dev/) - 

--- a/devel/contributing/pull-requests.md
+++ b/devel/contributing/pull-requests.md
@@ -4,15 +4,14 @@ This doc explains the best practices for submitting a pull request to the [kgate
 It should serve as a reference for all contributors, and be useful especially useful to new and infrequent submitters.
 This document serves as a [kgateway](https://github.com/kgateway-dev/kgateway) repo extension of the [org-level contribution guidelines](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
 
-
-
 # Submission Process
 Merging a pull request requires the following steps to be completed before the pull request will be merged automatically.
+- Ensure that each of your commits contains a `Signed-off-by` trailer to adhere to [DCO](https://developercertificate.org/) requirements. This can be done by either:
+    - Copying the [hack/devel/githooks/prepare-commit-msg](/hack/devel/githooks/prepare-commit-msg) file to `.git/hooks/prepare-commit-msg` in your copy of this repo (preferred), or
+    - Making sure to use the `-s` / `--signoff` [flag](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) on each commit.
 - [Open a pull request](https://help.github.com/articles/about-pull-requests/)
 - Pass all [automated tests](automation.md)
 - Get all necessary approvals from reviewers and code owners
-
-
 
 ## Best Practices for Pull Requests
 Below are some best practices we have found to help PRs get reviewed quickly

--- a/hack/devel/githooks/prepare-commit-msg
+++ b/hack/devel/githooks/prepare-commit-msg
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# This script automatically adds a Signed-off-by trailer to each commit message, so that your commits
+# will adhere to the DCO (Developer Certificate of Origin) requirements.
+# To use, copy this file to .git/hooks/prepare-commit-msg in your copy of the repo.
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"


### PR DESCRIPTION
Update devel docs and add a prepare-commit-msg hook that can be copied to `.git/hooks/prepare-commit-msg` to automatically insert the `Signed-off-by` trailer on each commit.

Related to https://github.com/kgateway-dev/community/issues/30