### PR TITLE
api,install: Disable short name CRD generation

### DIFF
--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -15,7 +15,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}
-// +kubebuilder:resource:categories=kgateway,shortName=be
+// +kubebuilder:resource:categories=kgateway
 // +kubebuilder:subresource:status
 type Backend struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/direct_response_types.go
+++ b/api/v1alpha1/direct_response_types.go
@@ -12,7 +12,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}
-// +kubebuilder:resource:categories=kgateway,shortName=dr
+// +kubebuilder:resource:categories=kgateway
 // +kubebuilder:subresource:status
 type DirectResponse struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/gateway_parameters_types.go
+++ b/api/v1alpha1/gateway_parameters_types.go
@@ -15,7 +15,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}
-// +kubebuilder:resource:categories=kgateway,shortName=gwp
+// +kubebuilder:resource:categories=kgateway
 // +kubebuilder:subresource:status
 type GatewayParameters struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/http_listener_policy_types.go
+++ b/api/v1alpha1/http_listener_policy_types.go
@@ -12,7 +12,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}
-// +kubebuilder:resource:categories=kgateway,shortName=hlp
+// +kubebuilder:resource:categories=kgateway
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=Direct"
 type HTTPListenerPolicy struct {

--- a/api/v1alpha1/listener_policy_types.go
+++ b/api/v1alpha1/listener_policy_types.go
@@ -10,7 +10,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}
-// +kubebuilder:resource:categories=kgateway,shortName=lp
+// +kubebuilder:resource:categories=kgateway
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=Direct"
 type ListenerPolicy struct {

--- a/api/v1alpha1/route_policy_types.go
+++ b/api/v1alpha1/route_policy_types.go
@@ -11,7 +11,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}
-// +kubebuilder:resource:categories=kgateway,shortName=rp
+// +kubebuilder:resource:categories=kgateway
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=Direct"
 type RoutePolicy struct {

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_backends.yaml
@@ -16,8 +16,6 @@ spec:
     kind: Backend
     listKind: BackendList
     plural: backends
-    shortNames:
-    - be
     singular: backend
   scope: Namespaced
   versions:

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_directresponses.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_directresponses.yaml
@@ -16,8 +16,6 @@ spec:
     kind: DirectResponse
     listKind: DirectResponseList
     plural: directresponses
-    shortNames:
-    - dr
     singular: directresponse
   scope: Namespaced
   versions:

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_gatewayparameters.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_gatewayparameters.yaml
@@ -16,8 +16,6 @@ spec:
     kind: GatewayParameters
     listKind: GatewayParametersList
     plural: gatewayparameters
-    shortNames:
-    - gwp
     singular: gatewayparameters
   scope: Namespaced
   versions:

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_httplistenerpolicies.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_httplistenerpolicies.yaml
@@ -17,8 +17,6 @@ spec:
     kind: HTTPListenerPolicy
     listKind: HTTPListenerPolicyList
     plural: httplistenerpolicies
-    shortNames:
-    - hlp
     singular: httplistenerpolicy
   scope: Namespaced
   versions:

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_listenerpolicies.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_listenerpolicies.yaml
@@ -17,8 +17,6 @@ spec:
     kind: ListenerPolicy
     listKind: ListenerPolicyList
     plural: listenerpolicies
-    shortNames:
-    - lp
     singular: listenerpolicy
   scope: Namespaced
   versions:

--- a/install/helm/kgateway/crds/gateway.kgateway.dev_routepolicies.yaml
+++ b/install/helm/kgateway/crds/gateway.kgateway.dev_routepolicies.yaml
@@ -17,8 +17,6 @@ spec:
     kind: RoutePolicy
     listKind: RoutePolicyList
     plural: routepolicies
-    shortNames:
-    - rp
     singular: routepolicy
   scope: Namespaced
   versions:


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Discussed this locally with lawrence and came to the conclusion we should remove all short names in preparation for the 2.0 release to avoid making any breaking behavior changes in subsequent 2.x minor versions. The rationale is outlined a bit more in https://github.com/kgateway-dev/kgateway/issues/10600 and links out the Kubernetes API conventions on this topic: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#short-names-and-categories.

One potential alternative is using a prefixed-based approach, kbe or kgwbe for the Backend API, but we can evaluate this over time if there's a need for short names.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
