### PR TITLE
fix: add equals for policies on rules

### DIFF
--- a/internal/kgateway/ir/routes.go
+++ b/internal/kgateway/ir/routes.go
@@ -58,13 +58,21 @@ func (c HttpRouteIR) Equals(in HttpRouteIR) bool {
 	// as backends resolution may change when they are added/remove we need to check equality for them as well
 	// we don't need to check the whole backend, just the cluster name (that may swap in and out of black-hole)
 	// note - if we stop setting cluster to black whole here (and always set it to the expect cluster name) we can remove the backend equality check.
-	return c.ObjectSource == in.ObjectSource && versionEquals(c.SourceObject, in.SourceObject) && c.AttachedPolicies.Equals(in.AttachedPolicies) && c.backendsEqual(in)
+	return c.ObjectSource == in.ObjectSource && versionEquals(c.SourceObject, in.SourceObject) && c.AttachedPolicies.Equals(in.AttachedPolicies) && c.rulesEqual(in)
 }
-func (c HttpRouteIR) backendsEqual(in HttpRouteIR) bool {
+func (c HttpRouteIR) rulesEqual(in HttpRouteIR) bool {
+	// we don't need to check the rules themselves as this is covered by versionEquals.
+	// we do need to check backends and policies
 	if len(c.Rules) != len(in.Rules) {
 		return false
 	}
 	for i, rule := range c.Rules {
+		if !rule.AttachedPolicies.Equals(in.Rules[i].AttachedPolicies) {
+			return false
+		}
+		if !rule.ExtensionRefs.Equals(in.Rules[i].ExtensionRefs) {
+			return false
+		}
 		backendsa := rule.Backends
 		backendsb := in.Rules[i].Backends
 		if len(backendsa) != len(backendsb) {

--- a/internal/kgateway/setup/setup_test.go
+++ b/internal/kgateway/setup/setup_test.go
@@ -1,6 +1,7 @@
 package setup_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -136,6 +137,48 @@ func TestScenarios(t *testing.T) {
 	runScenario(t, "testdata", st)
 }
 
+func policyFile() string {
+	p := `apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata
+`
+	// write to temp file:
+	f, err := os.CreateTemp("", "policy.yaml")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	_, err = f.WriteString(p)
+	if err != nil {
+		panic(err)
+	}
+	return f.Name()
+}
+
+func addApiServerLogs(t *testing.T, testEnv *envtest.Environment) {
+	apiserverOut := new(bytes.Buffer)
+	apiserverErr := new(bytes.Buffer)
+
+	testEnv.ControlPlane = envtest.ControlPlane{
+		APIServer: &envtest.APIServer{
+			Out: apiserverOut,
+			Err: apiserverErr,
+		},
+	}
+	policy := policyFile()
+	t.Cleanup(func() {
+		os.Remove(policy)
+	})
+	args := testEnv.ControlPlane.APIServer.Configure()
+	args.Append("audit-log-path", "-")
+	args.Append("audit-policy-file", policy)
+	t.Cleanup(func() {
+		t.Log("apiserver out:", apiserverOut.String())
+		t.Log("apiserver err:", apiserverErr.String())
+	})
+}
+
 func runScenario(t *testing.T, scenarioDir string, globalSettings *settings.Settings) {
 	proxy_syncer.UseDetailedUnmarshalling = true
 	writer.set(t)
@@ -151,6 +194,8 @@ func runScenario(t *testing.T, scenarioDir string, globalSettings *settings.Sett
 		BinaryAssetsDirectory: getAssetsDir(t),
 		// web hook to add cluster ips to services
 	}
+	// Enable this if you want api server logs and audit logs.
+	//	addApiServerLogs(t, testEnv)
 	var wg sync.WaitGroup
 	t.Cleanup(wg.Wait)
 

--- a/internal/kgateway/setup/setup_test.go
+++ b/internal/kgateway/setup/setup_test.go
@@ -195,7 +195,9 @@ func runScenario(t *testing.T, scenarioDir string, globalSettings *settings.Sett
 		// web hook to add cluster ips to services
 	}
 	// Enable this if you want api server logs and audit logs.
-	//	addApiServerLogs(t, testEnv)
+	if os.Getenv("DEBUG_APISERVER") == "true" {
+		addApiServerLogs(t, testEnv)
+	}
 	var wg sync.WaitGroup
 	t.Cleanup(wg.Wait)
 

--- a/internal/kgateway/setup/testdata/transformation-out.yaml
+++ b/internal/kgateway/setup/testdata/transformation-out.yaml
@@ -1,0 +1,177 @@
+clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_default_kubernetes_443
+  transportSocketMatches:
+  - match:
+      tlsMode: istio
+    name: tlsMode-istio
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - istio
+          tlsCertificateSdsSecretConfigs:
+          - name: istio_server_cert
+            sdsConfig:
+              apiConfigSource:
+                apiType: GRPC
+                grpcServices:
+                - envoyGrpc:
+                    clusterName: gateway_proxy_sds
+                setNodeOnFirstMessageOnly: true
+                transportApiVersion: V3
+              resourceApiVersion: V3
+          tlsParams: {}
+          validationContextSdsSecretConfig:
+            name: istio_validation_context
+            sdsConfig:
+              apiConfigSource:
+                apiType: GRPC
+                grpcServices:
+                - envoyGrpc:
+                    clusterName: gateway_proxy_sds
+                setNodeOnFirstMessageOnly: true
+                transportApiVersion: V3
+              resourceApiVersion: V3
+        sni: outbound_.443_._.kubernetes.default.svc.cluster.local
+  - match: {}
+    name: tlsMode-disabled
+    transportSocket:
+      name: envoy.transport_sockets.raw_buffer
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_default_reviews_8080
+  transportSocketMatches:
+  - match:
+      tlsMode: istio
+    name: tlsMode-istio
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        commonTlsContext:
+          alpnProtocols:
+          - istio
+          tlsCertificateSdsSecretConfigs:
+          - name: istio_server_cert
+            sdsConfig:
+              apiConfigSource:
+                apiType: GRPC
+                grpcServices:
+                - envoyGrpc:
+                    clusterName: gateway_proxy_sds
+                setNodeOnFirstMessageOnly: true
+                transportApiVersion: V3
+              resourceApiVersion: V3
+          tlsParams: {}
+          validationContextSdsSecretConfig:
+            name: istio_validation_context
+            sdsConfig:
+              apiConfigSource:
+                apiType: GRPC
+                grpcServices:
+                - envoyGrpc:
+                    clusterName: gateway_proxy_sds
+                setNodeOnFirstMessageOnly: true
+                transportApiVersion: V3
+              resourceApiVersion: V3
+        sni: outbound_.8080_._.reviews.default.svc.cluster.local
+  - match: {}
+    name: tlsMode-disabled
+    transportSocket:
+      name: envoy.transport_sockets.raw_buffer
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+  type: EDS
+endpoints:
+- clusterName: kube_default_reviews_8080
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.1.11
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: transformation/helper
+          typedConfig:
+            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+        - name: dynamic_modules/simple_mutations
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_modules.v3.DynamicModuleFilter
+            dynamicModuleConfig:
+              name: rust_module
+            filterConfig: '{"route_specific": {}}'
+            filterName: http_simple_mutations
+        - name: transformation
+          typedConfig:
+            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: http
+        statPrefix: http
+        useRemoteAddress: true
+    name: http
+  name: http
+routes:
+- ignorePortInHostMatching: true
+  name: http
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: http~www_example_com
+    routes:
+    - match:
+        prefix: /
+      name: http~www_example_com-route-0-httproute-happypath-default-0-0-matcher-0
+      route:
+        cluster: kube_default_reviews_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        transformation:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
+          transformations:
+          - requestMatch:
+              responseTransformation:
+                transformationTemplate:
+                  headers:
+                    x-solo-response:
+                      text: '{{ request_header("x-solo-request") }}'
+                  headersToRemove:
+                  - x-solo-request
+                  parseBodyBehavior: DontParse
+                  passthrough: {}

--- a/internal/kgateway/setup/testdata/transformation.yaml
+++ b/internal/kgateway/setup/testdata/transformation.yaml
@@ -1,0 +1,91 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: default
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: reviews
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: reviews-slice
+  namespace: default
+  labels:
+    kubernetes.io/service-name: reviews
+    app: reviews
+    service: reviews
+addressType: IPv4
+endpoints:
+  - addresses:
+      - 10.244.1.11
+    conditions:
+      ready: true
+    nodeName: worker
+    targetRef:
+      kind: Pod
+      name: reviews-1
+      namespace: default
+ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: happypath
+  namespace: default
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+      namespace: gwtest
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: reviews
+          port: 8080
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          group: gateway.kgateway.dev
+          kind: RoutePolicy
+          name: transformation
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: RoutePolicy
+metadata:
+  name: transformation
+  namespace: default
+spec:
+  transformation:
+    response:
+      set:
+      - name: x-solo-response
+        value: '{{ request_header("x-solo-request") }}' 
+      remove:
+      - x-solo-request


### PR DESCRIPTION
Rule in an http route in general doesn't need its own equals, as it is covered by versionEquals to its parent. But attached object like policies and backends do need an equals.