### PR TITLE
route delegation flakes

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -29,14 +29,14 @@ jobs:
         # March 12, 2025: 13 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$'
           localstack: 'false'
-        # Mar 12, 2025: TODO minutes
+        # Mar 12, 2025: 3 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$'
+          go-test-run-regex: '^TestKgateway$$/^Backends$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$'
           localstack: 'false'
-        # March 12, 2025: 5 minutes
+        # March 12, 2025: 7 minutes
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$'

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -26,12 +26,12 @@ jobs:
         # Above each test below, we document the latest date/time for the GitHub action step to run
         # NOTE: We use the GitHub action step time (as opposed to the `go test` time), because it is easier to capture
         test:
-        # March 12, 2025: 13 minutes
+        # March 12, 2025: 7 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$'
           localstack: 'false'
-        # Mar 12, 2025: 3 minutes
+        # Mar 12, 2025: 6 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^Backends$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$'

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -29,17 +29,17 @@ jobs:
         # March 10, 2025: 20 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$|^TestKgateway$$/^Backends$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$'
           localstack: 'false'
         # Mar 4, 2025: TODO minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$'
+          go-test-run-regex: '^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$'
           localstack: 'false'
         # TODO: measure minutes.
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^Lambda$$'
+          go-test-run-regex: '^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$'
           localstack: 'true'
 
 #         # Dec 4, 2024: 23 minutes

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -26,20 +26,20 @@ jobs:
         # Above each test below, we document the latest date/time for the GitHub action step to run
         # NOTE: We use the GitHub action step time (as opposed to the `go test` time), because it is easier to capture
         test:
-        # March 10, 2025: 20 minutes
+        # March 12, 2025: 13 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$'
           localstack: 'false'
-        # Mar 4, 2025: TODO minutes
+        # Mar 12, 2025: TODO minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$'
           localstack: 'false'
-        # TODO: measure minutes.
+        # March 12, 2025: 5 minutes
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$'
+          go-test-run-regex: '^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$'
           localstack: 'true'
 
 #         # Dec 4, 2024: 23 minutes

--- a/test/kubernetes/e2e/defaults/defaults.go
+++ b/test/kubernetes/e2e/defaults/defaults.go
@@ -26,6 +26,8 @@ var (
 
 	CurlPodManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "curl_pod.yaml")
 
+	CurlPodLabelSelector = "app.kubernetes.io/name=curl"
+
 	HttpEchoPod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "http-echo",

--- a/test/kubernetes/e2e/features/basicrouting/suite.go
+++ b/test/kubernetes/e2e/features/basicrouting/suite.go
@@ -64,7 +64,7 @@ func (s *testingSuite) TestGatewayWithRoute() {
 
 	// make sure pods are running
 	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, testdefaults.CurlPod.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=curl",
+		LabelSelector: testdefaults.CurlPodLabelSelector,
 	})
 	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, nginxPod.ObjectMeta.GetNamespace(), metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=nginx",

--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -32,6 +32,9 @@ type tsuite struct {
 	manifests map[string][]string
 
 	manifestObjects map[string][]client.Object
+
+	// resources from common manifest
+	commonResources []client.Object
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
@@ -43,20 +46,19 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 
 func (s *tsuite) SetupSuite() {
 	s.manifests = map[string][]string{
-		"TestBasic":                       {commonManifest, basicRoutesManifest},
-		"TestRecursive":                   {commonManifest, recursiveRoutesManifest},
-		"TestCyclic":                      {commonManifest, cyclicRoutesManifest},
-		"TestInvalidChild":                {commonManifest, invalidChildRoutesManifest},
-		"TestHeaderQueryMatch":            {commonManifest, headerQueryMatchRoutesManifest},
-		"TestMultipleParents":             {commonManifest, multipleParentsManifest},
-		"TestInvalidChildValidStandalone": {commonManifest, invalidChildValidStandaloneManifest},
-		"TestUnresolvedChild":             {commonManifest, unresolvedChildManifest},
-		"TestMatcherInheritance":          {commonManifest, matcherInheritanceManifest},
+		"TestBasic":                       {basicRoutesManifest},
+		"TestRecursive":                   {recursiveRoutesManifest},
+		"TestCyclic":                      {cyclicRoutesManifest},
+		"TestInvalidChild":                {invalidChildRoutesManifest},
+		"TestHeaderQueryMatch":            {headerQueryMatchRoutesManifest},
+		"TestMultipleParents":             {multipleParentsManifest},
+		"TestInvalidChildValidStandalone": {invalidChildValidStandaloneManifest},
+		"TestUnresolvedChild":             {unresolvedChildManifest},
+		"TestMatcherInheritance":          {matcherInheritanceManifest},
 	}
 	// Not every resource that is applied needs to be verified. We are not testing `kubectl apply`,
 	// but the below code demonstrates how it can be done if necessary
 	s.manifestObjects = map[string][]client.Object{
-		commonManifest:                      {proxyService, proxyDeployment, httpbinTeam1, httpbinTeam2, gateway},
 		basicRoutesManifest:                 {routeRoot, routeTeam1, routeTeam2},
 		cyclicRoutesManifest:                {routeRoot, routeTeam1, routeTeam2},
 		recursiveRoutesManifest:             {routeRoot, routeTeam1, routeTeam2},
@@ -68,10 +70,31 @@ func (s *tsuite) SetupSuite() {
 		matcherInheritanceManifest:          {routeParent1, routeParent2, routeTeam1},
 	}
 
+	s.commonResources = []client.Object{
+		// resources from manifest
+		httpbinTeam1Service, httpbinTeam1Deployment, httpbinTeam2Service, httpbinTeam2Deployment, gateway,
+		// deployer-generated resources
+		proxyDeployment, proxyService,
+	}
+
+	// set up common resources once
+	err := s.ti.Actions.Kubectl().ApplyFile(s.ctx, commonManifest)
+	s.Require().NoError(err, "can apply common manifest")
+	s.ti.Assertions.EventuallyObjectsExist(s.ctx, s.commonResources...)
+	// make sure pods are running
+	s.ti.Assertions.EventuallyPodsRunning(s.ctx, httpbinTeam1Deployment.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app=httpbin,version=v1",
+	})
+	s.ti.Assertions.EventuallyPodsRunning(s.ctx, httpbinTeam2Deployment.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app=httpbin,version=v2",
+	})
+	s.ti.Assertions.EventuallyPodsRunning(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
+	})
+
 	// set up curl once
-	err := s.ti.Actions.Kubectl().ApplyFile(s.ctx, defaults.CurlPodManifest)
+	err = s.ti.Actions.Kubectl().ApplyFile(s.ctx, defaults.CurlPodManifest)
 	s.Require().NoError(err, "can apply curl pod manifest")
-	s.ti.Assertions.EventuallyObjectsExist(s.ctx, defaults.CurlPod)
 	s.ti.Assertions.EventuallyPodsRunning(s.ctx, defaults.CurlPod.GetNamespace(), metav1.ListOptions{
 		LabelSelector: defaults.CurlPodLabelSelector,
 	})
@@ -82,6 +105,20 @@ func (s *tsuite) TearDownSuite() {
 	err := s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, defaults.CurlPodManifest)
 	s.Require().NoError(err, "can delete curl pod manifest")
 	s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, defaults.CurlPod)
+
+	// clean up common resources
+	err = s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, commonManifest)
+	s.Require().NoError(err, "can delete common manifest")
+	s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, s.commonResources...)
+	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, httpbinTeam1Deployment.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app=httpbin,version=v1",
+	})
+	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, httpbinTeam2Deployment.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app=httpbin,version=v2",
+	})
+	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
+	})
 }
 
 func (s *tsuite) BeforeTest(suiteName, testName string) {
@@ -91,11 +128,6 @@ func (s *tsuite) BeforeTest(suiteName, testName string) {
 		s.Require().NoError(err)
 		s.ti.Assertions.EventuallyObjectsExist(s.ctx, s.manifestObjects[manifest]...)
 	}
-
-	// make sure the proxy pods are running
-	s.ti.Assertions.EventuallyPodsRunning(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
-	})
 }
 
 func (s *tsuite) AfterTest(suiteName, testName string) {
@@ -105,11 +137,6 @@ func (s *tsuite) AfterTest(suiteName, testName string) {
 		s.Require().NoError(err)
 		s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, s.manifestObjects[manifest]...)
 	}
-
-	// make sure the proxy pods are gone before the next test starts
-	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
-	})
 }
 
 func (s *tsuite) TestBasic() {

--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -2,11 +2,13 @@ package route_delegation
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -54,7 +56,7 @@ func (s *tsuite) SetupSuite() {
 	// Not every resource that is applied needs to be verified. We are not testing `kubectl apply`,
 	// but the below code demonstrates how it can be done if necessary
 	s.manifestObjects = map[string][]client.Object{
-		commonManifest:                      {proxyService, proxyDeployment, defaults.CurlPod, httpbinTeam1, httpbinTeam2, gateway},
+		commonManifest:                      {proxyService, proxyDeployment, httpbinTeam1, httpbinTeam2, gateway},
 		basicRoutesManifest:                 {routeRoot, routeTeam1, routeTeam2},
 		cyclicRoutesManifest:                {routeRoot, routeTeam1, routeTeam2},
 		recursiveRoutesManifest:             {routeRoot, routeTeam1, routeTeam2},
@@ -65,10 +67,21 @@ func (s *tsuite) SetupSuite() {
 		unresolvedChildManifest:             {routeRoot},
 		matcherInheritanceManifest:          {routeParent1, routeParent2, routeTeam1},
 	}
+
+	// set up curl once
+	err := s.ti.Actions.Kubectl().ApplyFile(s.ctx, defaults.CurlPodManifest)
+	s.Require().NoError(err, "can apply curl pod manifest")
+	s.ti.Assertions.EventuallyObjectsExist(s.ctx, defaults.CurlPod)
+	s.ti.Assertions.EventuallyPodsRunning(s.ctx, defaults.CurlPod.GetNamespace(), metav1.ListOptions{
+		LabelSelector: defaults.CurlPodLabelSelector,
+	})
 }
 
 func (s *tsuite) TearDownSuite() {
-	// nothing at the moment
+	// clean up curl
+	err := s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, defaults.CurlPodManifest)
+	s.Require().NoError(err, "can delete curl pod manifest")
+	s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, defaults.CurlPod)
 }
 
 func (s *tsuite) BeforeTest(suiteName, testName string) {
@@ -78,6 +91,11 @@ func (s *tsuite) BeforeTest(suiteName, testName string) {
 		s.Require().NoError(err)
 		s.ti.Assertions.EventuallyObjectsExist(s.ctx, s.manifestObjects[manifest]...)
 	}
+
+	// make sure the proxy pods are running
+	s.ti.Assertions.EventuallyPodsRunning(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
+	})
 }
 
 func (s *tsuite) AfterTest(suiteName, testName string) {
@@ -87,6 +105,11 @@ func (s *tsuite) AfterTest(suiteName, testName string) {
 		s.Require().NoError(err)
 		s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, s.manifestObjects[manifest]...)
 	}
+
+	// make sure the proxy pods are gone before the next test starts
+	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
+	})
 }
 
 func (s *tsuite) TestBasic() {

--- a/test/kubernetes/e2e/features/route_delegation/testdata/common.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/testdata/common.yaml
@@ -4,9 +4,6 @@
 # - team1/httpbin
 # - team2/httpbin
 #
-# Pods:
-# - curl/curl
-#
 # Services:
 # - team1/svc1
 # - team2/svc2
@@ -123,27 +120,6 @@ spec:
           value: /tmp
         ports:
         - containerPort: 8080
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: curl
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: curl
-  namespace: curl
-  labels:
-    app: curl
-spec:
-  containers:
-    - name: curl
-      image: curlimages/curl:7.83.1
-      imagePullPolicy: IfNotPresent
-      command:
-        - "sleep"
-        - "365d"
 ---
 apiVersion: v1
 kind: Namespace

--- a/test/kubernetes/e2e/features/route_delegation/types.go
+++ b/test/kubernetes/e2e/features/route_delegation/types.go
@@ -13,28 +13,33 @@ import (
 )
 
 const (
-	// ref: test/kubernetes/e2e/features/delegation/testdata/common.yaml
 	gatewayPort = 8080
 )
 
-// ref: test/kubernetes/e2e/features/delegation/testdata/common.yaml
+// ref: common.yaml
 var (
 	commonManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "common.yaml")
-	proxyMeta      = metav1.ObjectMeta{
-		Name:      "http-gateway",
-		Namespace: "infra",
-	}
-	proxyDeployment = &appsv1.Deployment{ObjectMeta: proxyMeta}
-	proxyService    = &corev1.Service{ObjectMeta: proxyMeta}
-	proxyHostPort   = fmt.Sprintf("%s.%s.svc:%d", proxyService.Name, proxyService.Namespace, gatewayPort)
 
-	httpbinTeam1 = &appsv1.Deployment{
+	// resources from common manifest
+	httpbinTeam1Service = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "team1",
+		},
+	}
+	httpbinTeam1Deployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "httpbin",
 			Namespace: "team1",
 		},
 	}
-	httpbinTeam2 = &appsv1.Deployment{
+	httpbinTeam2Service = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc2",
+			Namespace: "team2",
+		},
+	}
+	httpbinTeam2Deployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "httpbin",
 			Namespace: "team2",
@@ -46,9 +51,18 @@ var (
 			Namespace: "infra",
 		},
 	}
+
+	// resources produced by deployer when Gateway is applied
+	proxyMeta = metav1.ObjectMeta{
+		Name:      "http-gateway",
+		Namespace: "infra",
+	}
+	proxyDeployment = &appsv1.Deployment{ObjectMeta: proxyMeta}
+	proxyService    = &corev1.Service{ObjectMeta: proxyMeta}
+	proxyHostPort   = fmt.Sprintf("%s.%s.svc:%d", proxyService.Name, proxyService.Namespace, gatewayPort)
 )
 
-// ref: test/kubernetes/e2e/features/delegation/testdata/basic.yaml
+// ref: basic.yaml
 var (
 	routeRoot = &gwv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -86,7 +100,7 @@ var (
 	pathTeam2 = "anything/team2/foo"
 )
 
-// ref: test/kubernetes/e2e/features/route_delegation/inputs/invalid_child_valid_standalone.yaml
+// ref: invalid_child_valid_standalone.yaml
 var (
 	gatewayTestPort = 8090
 


### PR DESCRIPTION
- Fix flakes in the route delegation e2e suite by setting up / tearing down the common stuff (curl, httpbin, proxy) just once for the suite
- Rebalance tests

Fixes https://github.com/kgateway-dev/kgateway/issues/10799
Fixes https://github.com/kgateway-dev/kgateway/issues/10814
Fixes https://github.com/kgateway-dev/kgateway/issues/10813