### PR TITLE
use controller name to find relevant Gateways

### DIFF
--- a/examples/plugin/main.go
+++ b/examples/plugin/main.go
@@ -64,12 +64,10 @@ spec:
 
 *****/
 
-var (
-	configMapGK = schema.GroupKind{
-		Group: "",
-		Kind:  "ConfigMap",
-	}
-)
+var configMapGK = schema.GroupKind{
+	Group: "",
+	Kind:  "ConfigMap",
+}
 
 // Our policy IR.
 type configMapIr struct {
@@ -118,7 +116,6 @@ func extractTargetRefs(cm *corev1.ConfigMap) []ir.PolicyTargetRef {
 		Kind:  "HTTPRoute",
 		Name:  cm.Annotations["targetRef"],
 	}}
-
 }
 
 // Create a collection of our policies. This will be done by converting a configmap collection
@@ -138,7 +135,7 @@ func ourPolicies(commoncol *common.CommonCollections) krt.Collection[ir.PolicyWr
 			return nil
 		}
 
-		var pol = &ir.PolicyWrapper{
+		pol := &ir.PolicyWrapper{
 			ObjectSource: ir.ObjectSource{
 				Group:     configMapGK.Group,
 				Kind:      configMapGK.Kind,
@@ -151,7 +148,6 @@ func ourPolicies(commoncol *common.CommonCollections) krt.Collection[ir.PolicyWr
 		}
 		return pol
 	}, commoncol.KrtOpts.ToOptions("MetadataPolicies")...)
-
 }
 
 // Our translation pass struct. This holds translation specific state.
@@ -212,8 +208,8 @@ func (s *ourPolicyPass) HttpFilters(ctx context.Context, fc ir.FilterChainCommon
 					},
 				},
 			},
-			plugins.BeforeStage(plugins.AcceptedStage))}, nil
-
+			plugins.BeforeStage(plugins.AcceptedStage)),
+	}, nil
 }
 
 // A function that initializes our plugins.
@@ -236,11 +232,10 @@ func pluginFactory(ctx context.Context, commoncol *common.CommonCollections) []e
 }
 
 func main() {
-
 	// TODO: move setup.StartGGv2 from internal to public.
 	// Start Kgateway and provide our plugin.
 	// This demonstrates how to start Kgateway with a custom plugin.
 	// This binary is the control plane. normally it would be packaged in a docker image and run
 	// in a k8s cluster.
-	setup.StartKgateway(context.Background(), pluginFactory, nil)
+	setup.StartKgateway(context.Background(), pluginFactory)
 }

--- a/internal/kgateway/controller/controller.go
+++ b/internal/kgateway/controller/controller.go
@@ -98,32 +98,13 @@ func gatewayToParams(obj client.Object) []string {
 	return []string{}
 }
 
+// gatewayToClass is an IndexerFunc that lists a Gateways that use a given className
 func gatewayToClass(obj client.Object) []string {
 	gw, ok := obj.(*apiv1.Gateway)
 	if !ok {
 		panic(fmt.Sprintf("wrong type %T provided to indexer. expected Gateway", obj))
 	}
 	return []string{string(gw.Spec.GatewayClassName)}
-}
-
-// ourGatewayPredicate only includes Gateways that reference
-// our own controller name.
-func (c *controllerBuilder) ourGatewayPredicate() predicate.Funcs {
-	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		gw := obj.(*apiv1.Gateway)
-		// Check the class in the cache
-		var gc apiv1.GatewayClass
-		err := c.cfg.Mgr.GetClient().Get(
-			context.Background(),
-			client.ObjectKey{Name: string(gw.Spec.GatewayClassName)},
-			&gc,
-		)
-		if err != nil {
-			// If we can’t find the GatewayClass in our cache, skip
-			return false
-		}
-		return gc.Spec.ControllerName == apiv1.GatewayController(c.cfg.ControllerName)
-	})
 }
 
 func (c *controllerBuilder) watchGw(ctx context.Context) error {
@@ -149,7 +130,8 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 	buildr := ctrl.NewControllerManagedBy(c.cfg.Mgr).
 		// Don't use WithEventFilter here as it also filters events for Owned objects.
 		For(&apiv1.Gateway{}, builder.WithPredicates(
-			c.ourGatewayPredicate(),
+			// TODO(stevenctl) investigate perf implications of filtering in Reconcile
+			// the tricky part is we want to check a relationship of gateway -> gatewayclass -> controller name
 			predicate.Or(
 				predicate.AnnotationChangedPredicate{},
 				predicate.GenerationChangedPredicate{},

--- a/internal/kgateway/controller/controller.go
+++ b/internal/kgateway/controller/controller.go
@@ -25,14 +25,13 @@ import (
 )
 
 const (
-	// field name used for indexing
+	// indexes on Gateway
 	GatewayParamsField = "gateway-params"
+	GatewayClassField  = "spec.gatewayClassName"
 )
 
 type GatewayConfig struct {
 	Mgr manager.Manager
-
-	OurGateway func(gw *apiv1.Gateway) bool
 
 	Dev            bool
 	ControllerName string
@@ -57,7 +56,7 @@ func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 	return run(ctx,
 		controllerBuilder.watchGwClass,
 		controllerBuilder.watchGw,
-		controllerBuilder.addGwParamsIndexes,
+		controllerBuilder.addIndexes,
 	)
 }
 
@@ -76,8 +75,14 @@ type controllerBuilder struct {
 	reconciler *controllerReconciler
 }
 
-func (c *controllerBuilder) addGwParamsIndexes(ctx context.Context) error {
-	return c.cfg.Mgr.GetFieldIndexer().IndexField(ctx, &apiv1.Gateway{}, GatewayParamsField, gatewayToParams)
+func (c *controllerBuilder) addIndexes(ctx context.Context) error {
+	if err := c.cfg.Mgr.GetFieldIndexer().IndexField(ctx, &apiv1.Gateway{}, GatewayParamsField, gatewayToParams); err != nil {
+		return err
+	}
+	if err := c.cfg.Mgr.GetFieldIndexer().IndexField(ctx, &apiv1.Gateway{}, GatewayClassField, gatewayToClass); err != nil {
+		return err
+	}
+	return nil
 }
 
 // gatewayToParams is an IndexerFunc that gets a GatewayParameters name from a Gateway
@@ -91,6 +96,34 @@ func gatewayToParams(obj client.Object) []string {
 		return []string{gwpName}
 	}
 	return []string{}
+}
+
+func gatewayToClass(obj client.Object) []string {
+	gw, ok := obj.(*apiv1.Gateway)
+	if !ok {
+		panic(fmt.Sprintf("wrong type %T provided to indexer. expected Gateway", obj))
+	}
+	return []string{string(gw.Spec.GatewayClassName)}
+}
+
+// ourGatewayPredicate only includes Gateways that reference
+// our own controller name.
+func (c *controllerBuilder) ourGatewayPredicate() predicate.Funcs {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		gw := obj.(*apiv1.Gateway)
+		// Check the class in the cache
+		var gc apiv1.GatewayClass
+		err := c.cfg.Mgr.GetClient().Get(
+			context.Background(),
+			client.ObjectKey{Name: string(gw.Spec.GatewayClassName)},
+			&gc,
+		)
+		if err != nil {
+			// If we can’t find the GatewayClass in our cache, skip
+			return false
+		}
+		return gc.Spec.ControllerName == apiv1.GatewayController(c.cfg.ControllerName)
+	})
 }
 
 func (c *controllerBuilder) watchGw(ctx context.Context) error {
@@ -115,20 +148,15 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 
 	buildr := ctrl.NewControllerManagedBy(c.cfg.Mgr).
 		// Don't use WithEventFilter here as it also filters events for Owned objects.
-		For(&apiv1.Gateway{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			// We only care about Gateways that use our GatewayClass
-			if gw, ok := object.(*apiv1.Gateway); ok {
-				return c.cfg.OurGateway(gw)
-			}
-			return false
-		}),
+		For(&apiv1.Gateway{}, builder.WithPredicates(
+			c.ourGatewayPredicate(),
 			predicate.Or(
 				predicate.AnnotationChangedPredicate{},
 				predicate.GenerationChangedPredicate{},
 			),
 		))
 
-	// watch for changes in GatewayParameters
+	// watch for changes in GatewayParameters and enqueue Gateways that use them
 	cli := c.cfg.Mgr.GetClient()
 	buildr.Watches(&v1alpha1.GatewayParameters{}, handler.EnqueueRequestsFromMapFunc(
 		func(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -150,6 +178,39 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 			}
 			return reqs
 		}))
+	// watch for gatewayclasses managed by our controller and enqueue related gateways
+	buildr.Watches(
+		&apiv1.GatewayClass{},
+		handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			gc, ok := obj.(*apiv1.GatewayClass)
+			if !ok {
+				return nil
+			}
+			var gwList apiv1.GatewayList
+			if err := c.cfg.Mgr.GetClient().List(
+				ctx,
+				&gwList,
+				client.MatchingFields{GatewayClassField: gc.Name},
+			); err != nil {
+				log.Error(err, "failed listing GatewayClasses in predicate")
+				return nil
+			}
+			reqs := make([]reconcile.Request, 0, len(gwList.Items))
+			for _, gw := range gwList.Items {
+				reqs = append(reqs,
+					reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&gw)},
+				)
+			}
+			return reqs
+		}),
+		builder.WithPredicates(
+			predicate.NewPredicateFuncs(func(o client.Object) bool {
+				gc, ok := o.(*apiv1.GatewayClass)
+				return ok && gc.Spec.ControllerName == apiv1.GatewayController(c.cfg.ControllerName)
+			}),
+			predicate.GenerationChangedPredicate{},
+		),
+	)
 
 	for _, gvk := range gvks {
 		obj, err := c.cfg.Mgr.GetScheme().New(gvk)
@@ -170,10 +231,11 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 	}
 
 	return buildr.Complete(&gatewayReconciler{
-		cli:           c.cfg.Mgr.GetClient(),
-		scheme:        c.cfg.Mgr.GetScheme(),
-		autoProvision: c.cfg.AutoProvision,
-		deployer:      d,
+		cli:            c.cfg.Mgr.GetClient(),
+		scheme:         c.cfg.Mgr.GetScheme(),
+		controllerName: c.cfg.ControllerName,
+		autoProvision:  c.cfg.AutoProvision,
+		deployer:       d,
 	})
 }
 

--- a/internal/kgateway/controller/controller_suite_test.go
+++ b/internal/kgateway/controller/controller_suite_test.go
@@ -118,10 +118,7 @@ var _ = BeforeSuite(func() {
 	err = controller.NewBaseGatewayController(ctx, controller.GatewayConfig{
 		Mgr:            mgr,
 		ControllerName: gatewayControllerName,
-		OurGateway: func(gw *apiv1.Gateway) bool {
-			return gwClasses.Has(string(gw.Spec.GatewayClassName))
-		},
-		AutoProvision: true,
+		AutoProvision:  true,
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/kgateway/controller/controller_suite_test.go
+++ b/internal/kgateway/controller/controller_suite_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	api "sigs.k8s.io/gateway-api/apis/v1"
-	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/controller"

--- a/internal/kgateway/controller/gw_controller.go
+++ b/internal/kgateway/controller/gw_controller.go
@@ -20,7 +20,6 @@ const (
 )
 
 type gatewayReconciler struct {
-	mgr           ctrl.Manager
 	cli           client.Client
 	autoProvision bool
 

--- a/internal/kgateway/controller/gw_controller.go
+++ b/internal/kgateway/controller/gw_controller.go
@@ -20,8 +20,11 @@ const (
 )
 
 type gatewayReconciler struct {
+	mgr           ctrl.Manager
 	cli           client.Client
 	autoProvision bool
+
+	controllerName string
 
 	scheme   *runtime.Scheme
 	deployer *deployer.Deployer
@@ -53,6 +56,21 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if gw.GetDeletionTimestamp() != nil {
 		// no need to do anything as we have owner refs, so children will be deleted
 		log.Info("gateway deleted, no need for reconciling")
+		return ctrl.Result{}, nil
+	}
+
+	// make sure we're the right controller for this
+	var gwc api.GatewayClass
+	if err := r.cli.Get(
+		ctx,
+		client.ObjectKey{Name: string(gw.Spec.GatewayClassName)},
+		&gwc,
+	); err != nil {
+		log.Error(err, "failed to check controller for GatewayClass")
+		return ctrl.Result{Requeue: true}, err
+	}
+	if gwc.Spec.ControllerName != api.GatewayController(r.controllerName) {
+		// ignore, not our GatewayClass
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -83,10 +83,12 @@ type GatewayXdsResources struct {
 func (r GatewayXdsResources) ResourceName() string {
 	return xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, r.Namespace, r.Name)
 }
+
 func (r GatewayXdsResources) Equals(in GatewayXdsResources) bool {
 	return r.NamespacedName == in.NamespacedName && report{r.reports}.Equals(report{in.reports}) && r.ClustersHash == in.ClustersHash &&
 		r.Routes.Version == in.Routes.Version && r.Listeners.Version == in.Listeners.Version
 }
+
 func sliceToResourcesHash[T proto.Message](slice []T) ([]envoycachetypes.ResourceWithTTL, uint64) {
 	var slicePb []envoycachetypes.ResourceWithTTL
 	var resourcesHash uint64
@@ -179,16 +181,15 @@ func (r report) Equals(in report) bool {
 	return true
 }
 
-// Note: isOurGw is shared between us and the deployer.
-func (s *ProxySyncer) Init(ctx context.Context, isOurGw func(gw *gwv1.Gateway) bool, krtopts krtutil.KrtOptions) error {
+func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) error {
 	ctx = contextutils.WithLogger(ctx, "k8s-gw-proxy-syncer")
 	logger := contextutils.LoggerFrom(ctx)
 
 	kubeGateways, routes, backendIndex, endpointIRs := krtcollections.InitCollections(
 		ctx,
+		s.controllerName,
 		s.plugins,
 		s.istioClient,
-		isOurGw,
 		s.commonCols.RefGrants,
 		krtopts,
 	)

--- a/internal/kgateway/setup/setup_test.go
+++ b/internal/kgateway/setup/setup_test.go
@@ -213,7 +213,7 @@ spec:
     response:
       set:
       - name: x-solo-response
-        value: '{{ request_header("x-solo-request") }}' 
+        value: '{{ request_header("x-solo-request") }}'
       remove:
       - x-solo-request`, `apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
@@ -248,7 +248,7 @@ spec:
     response:
       set:
       - name: x-solo-response
-        value: '{{ request_header("x-solo-request123") }}' 
+        value: '{{ request_header("x-solo-request123") }}'
       remove:
       - x-solo-request321`)
 
@@ -294,7 +294,7 @@ func runScenario(t *testing.T, scenarioDir string, globalSettings *settings.Sett
 					t.Cleanup(func() {
 						writer.set(parentT)
 					})
-					//sadly tests can't run yet in parallel, as kgateway will add all the k8s services as clusters. this means
+					// sadly tests can't run yet in parallel, as kgateway will add all the k8s services as clusters. this means
 					// that we get test pollution.
 					// once we change it to only include the ones in the proxy, we can re-enable this
 					//				t.Parallel()
@@ -310,7 +310,8 @@ func setupEnvTestAndRun(t *testing.T, globalSettings *settings.Settings, run fun
 	kdbg *krt.DebugHandler,
 	client istiokube.CLIClient,
 	xdsPort int,
-)) {
+),
+) {
 	proxy_syncer.UseDetailedUnmarshalling = true
 	writer.set(t)
 
@@ -388,7 +389,7 @@ func setupEnvTestAndRun(t *testing.T, globalSettings *settings.Settings, run fun
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		setup.StartKgatewayWithConfig(ctx, setupOpts, cfg, builder, nil, nil)
+		setup.StartKgatewayWithConfig(ctx, setupOpts, cfg, builder, nil)
 	}()
 	// give kgateway time to initialize so we don't get
 	// "kgateway not initialized" error
@@ -438,7 +439,7 @@ func testScenario(
 	testyaml := strings.ReplaceAll(string(testyamlbytes), gwname, testgwname)
 
 	yamlfile := filepath.Join(t.TempDir(), "test.yaml")
-	os.WriteFile(yamlfile, []byte(testyaml), 0644)
+	os.WriteFile(yamlfile, []byte(testyaml), 0o644)
 
 	err = client.ApplyYAMLFiles("", yamlfile)
 
@@ -482,7 +483,7 @@ func testScenario(
 		if err != nil {
 			t.Fatalf("failed to serialize xdsDump: %v", err)
 		}
-		os.WriteFile(fout, d, 0644)
+		os.WriteFile(fout, d, 0o644)
 		t.Fatal("wrote out file - nothing to test")
 	}
 	dump.Compare(t, expectedXdsDump)
@@ -533,7 +534,8 @@ func newXdsDumper(t *testing.T, ctx context.Context, xdsPort int, gwname string)
 		dr: &discovery_v3.DiscoveryRequest{Node: &envoycore.Node{
 			Id: "gateway.gwtest",
 			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{"role": {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("kgateway-kube-gateway-api~%s~%s", "gwtest", gwname)}}}},
+				Fields: map[string]*structpb.Value{"role": {Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("kgateway-kube-gateway-api~%s~%s", "gwtest", gwname)}}},
+			},
 		}},
 	}
 

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -64,6 +64,16 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			},
 		}),
 	Entry(
+		"http gateway with custom class",
+		translatorTestCase{
+			inputFile:  "custom-gateway-class",
+			outputFile: "custom-gateway-class.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		}),
+	Entry(
 		"https gateway with basic routing",
 		translatorTestCase{
 			inputFile:  "https-routing",

--- a/internal/kgateway/translator/gateway/testutils/inputs/custom-gateway-class/gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/custom-gateway-class/gateway.yaml
@@ -1,0 +1,45 @@
+# add a 3rd party or custom gateway class pointing at our controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: custom-gateway-class
+spec:
+  controllerName: "kgateway.dev/kgateway"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: custom-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: test

--- a/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
@@ -1,0 +1,40 @@
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: http
+        statPrefix: http
+        useRemoteAddress: true
+    name: http
+  name: http
+Routes:
+- ignorePortInHostMatching: true
+  name: http
+  virtualHosts:
+  - domains:
+    - example.com
+    name: http~example_com
+    routes:
+    - match:
+        prefix: /
+      name: http~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/internal/kgateway/translator/gateway/testutils/test_file_loader.go
+++ b/internal/kgateway/translator/gateway/testutils/test_file_loader.go
@@ -25,13 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/solo-io/go-utils/contextutils"
 )
 
-var (
-	NoFilesFound = errors.New("no k8s files found")
-)
+var NoFilesFound = errors.New("no k8s files found")
 
 func LoadFromFiles(ctx context.Context, filename string) ([]client.Object, error) {
 	fileOrDir, err := os.Stat(filename)
@@ -73,7 +72,9 @@ func LoadFromFiles(ctx context.Context, filename string) ([]client.Object, error
 			if !ok {
 				return nil, errors.Errorf("cannot convert runtime.Object to client.Object: %+v", obj)
 			}
-			if clientObj.GetNamespace() == "" {
+
+			_, isGwc := clientObj.(*gwv1.GatewayClass)
+			if !isGwc && clientObj.GetNamespace() == "" {
 				// fill in default namespace
 				clientObj.SetNamespace("default")
 			}
@@ -174,6 +175,7 @@ func MarshalYaml(m proto.Message) ([]byte, error) {
 	}
 	return yaml.JSONToYAML(jsn)
 }
+
 func MarshalAnyYaml(m any) ([]byte, error) {
 	jsn, err := json.Marshal(m)
 	if err != nil {

--- a/internal/kgateway/translator/translator.go
+++ b/internal/kgateway/translator/translator.go
@@ -60,7 +60,6 @@ func NewCombinedTranslator(
 	}
 }
 
-// Note: isOurGw is shared between us and the deployer.
 func (s *CombinedTranslator) Init(ctx context.Context, routes *krtcollections.RoutesIndex) error {
 	ctx = contextutils.WithLogger(ctx, "k8s-gw-proxy-syncer")
 
@@ -91,6 +90,7 @@ func (s *CombinedTranslator) Init(ctx context.Context, routes *krtcollections.Ro
 	)
 	return nil
 }
+
 func (s *CombinedTranslator) HasSynced() bool {
 	for _, sync := range s.waitForSync {
 		if !sync() {
@@ -114,7 +114,6 @@ func (s *CombinedTranslator) buildProxy(kctx krt.HandlerContext, ctx context.Con
 			gatewayTranslator = maybeGatewayTranslator
 		}
 	} else {
-
 	}
 	proxy := gatewayTranslator.Translate(kctx, ctx, &gw, r)
 	if proxy == nil {


### PR DESCRIPTION
# Description

Split out from #10783

This PR addresses TODOs that were already expressed in the code, and is relevant for Waypoints which add a new GatewayClass. We will not need to maintain an internal list of relevant classes. 

## API changes

The controllerName field on GatewayClass could theoretically trigger deployment and config gen for arbitrary GatewayClasses other than `kgateway`. 

## Code changes

* Remove `ExtraGatewayClasses`
* Remove `isOurGw` closure
* Add Watches(GatewayClass) to controller, add a filter on the GatewayClass.Spec.Controller name ot controller predicates
* Add a GatewayClasses collection used for filtering in Translator



# Context

Some form of multi-gatewayclass management is needed for waypoint

## Interesting decisions

We had TODOs in the code; this is far simpler to maintain long term than having a list of static gatewayclasses. 

## Testing steps

Updating translator tests. 

