### PR TITLE
api,install: Remove the unused IRSA auth type

### DIFF
--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -102,8 +102,6 @@ type AwsAuthType string
 const (
 	// AwsAuthTypeSecret uses credentials stored in a Kubernetes Secret.
 	AwsAuthTypeSecret AwsAuthType = "Secret"
-	// AwsAuthTypeIRSA uses pod identity (IRSA) to obtain credentials.
-	AwsAuthTypeIRSA AwsAuthType = "IRSA"
 )
 
 // AwsAuth specifies the authentication method to use for the backend.
@@ -114,7 +112,7 @@ type AwsAuth struct {
 	// Type specifies the authentication method to use for the backend.
 	// +unionDiscriminator
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Secret;IRSA
+	// +kubebuilder:validation:Enum=Secret
 	Type AwsAuthType `json:"type"`
 	// Secret references a Kubernetes Secret containing the AWS credentials.
 	// The Secret must have keys "accessKey", "secretKey", and optionally "sessionToken".

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
@@ -476,7 +476,6 @@ spec:
                       type:
                         enum:
                         - Secret
-                        - IRSA
                         type: string
                     required:
                     - type


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

We removed the implementation for the IRSA auth type in the initial lambda PR and forgot to remove some of the API fields. IRSA-based auth is still supported, but currently requires users to configure their GWP resource with the role arn service account annotation.

See https://cloud-native.slack.com/archives/C080D3PJMS4/p1741897619750649. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
