### PR TITLE
Reformat .go API comments for cleaner docs auto-generations

### DIFF
--- a/api/v1alpha1/ai_backend.go
+++ b/api/v1alpha1/ai_backend.go
@@ -227,26 +227,25 @@ type Priority struct {
 //
 // ```yaml
 // multi:
-//
-//	priorities:
-//	- pool:
-//	  - azureOpenai:
-//	      deploymentName: gpt-4o-mini
-//	      apiVersion: 2024-02-15-preview
-//	      endpoint: ai-gateway.openai.azure.com
-//	      authToken:
-//	        secretRef:
-//	          name: azure-secret
-//	          namespace: kgateway-system
-//	- pool:
-//	  - azureOpenai:
-//	      deploymentName: gpt-4o-mini-2
-//	      apiVersion: 2024-02-15-preview
-//	      endpoint: ai-gateway-2.openai.azure.com
-//	      authToken:
-//	        secretRef:
-//	          name: azure-secret-2
-//	          namespace: kgateway-system
+//  priorities:
+//  - pool:
+//    - azureOpenai:
+//        deploymentName: gpt-4o-mini
+//        apiVersion: 2024-02-15-preview
+//        endpoint: ai-gateway.openai.azure.com
+//        authToken:
+//          secretRef:
+//            name: azure-secret
+//            namespace: kgateway-system
+//  - pool:
+//    - azureOpenai:
+//        deploymentName: gpt-4o-mini-2
+//        apiVersion: 2024-02-15-preview
+//        endpoint: ai-gateway-2.openai.azure.com
+//        authToken:
+//          secretRef:
+//            name: azure-secret-2
+//            namespace: kgateway-system
 //
 // ```
 type MultiPoolConfig struct {

--- a/api/v1alpha1/ai_policy.go
+++ b/api/v1alpha1/ai_policy.go
@@ -53,25 +53,22 @@ func (in *AIRoutePolicy) Equals(ai *AIRoutePolicy) bool {
 // and appends `Describe the painting as if you were a famous art critic from the 17th century.`
 // to each request that is sent to the `openai` HTTPRoute.
 // ```yaml
-//
-//	name: openai-opt
-//	namespace: kgateway-system
-//
+// metadata:
+//  name: openai-opt
+//  namespace: kgateway-system
 // spec:
-//
-//	targetRefs:
-//	- group: gateway.networking.k8s.io
-//	  kind: HTTPRoute
-//	  name: openai
-//	aiRoutePolicy:
-//	    promptEnrichment:
-//	      prepend:
-//	      - role: SYSTEM
-//	        content: "Answer all questions in French."
-//	      append:
-//	      - role: USER
-//	        content: "Describe the painting as if you were a famous art critic from the 17th century."
-//
+//  targetRefs:
+//  - group: gateway.networking.k8s.io
+//    kind: HTTPRoute
+//    name: openai
+//  aiRoutePolicy:
+//      promptEnrichment:
+//        prepend:
+//        - role: SYSTEM
+//          content: "Answer all questions in French."
+//        append:
+//        - role: USER
+//          content: "Describe the painting as if you were a famous art critic from the 17th century."
 // ```
 type AIPromptEnrichment struct {
 	// A list of messages to be prepended to the prompt sent by the client.
@@ -233,21 +230,19 @@ type PromptguardResponse struct {
 // the string "credit card", and masks any credit card numbers in the response.
 // ```yaml
 // promptGuard:
-//
-//	request:
-//	  customResponse:
-//	    message: "Rejected due to inappropriate content"
-//	  regex:
-//	    action: REJECT
-//	    matches:
-//	    - pattern: "credit card"
-//	      name: "CC"
-//	response:
-//	  regex:
-//	    builtins:
-//	    - CREDIT_CARD
-//	    action: MASK
-//
+//  request:
+//    customResponse:
+//      message: "Rejected due to inappropriate content"
+//    regex:
+//      action: REJECT
+//      matches:
+//      - pattern: "credit card"
+//        name: "CC"
+//  response:
+//    regex:
+//      builtins:
+//      - CREDIT_CARD
+//      action: MASK
 // ```
 type AIPromptGuard struct {
 	// Prompt guards to apply to requests sent by the client.
@@ -267,7 +262,6 @@ type AIPromptGuard struct {
 // defaults:
 //   - field: "system"
 //     value: "answer all questions in French"
-//
 // ```
 //
 // Example: Setting a default temperature and overriding `max_tokens`:
@@ -278,7 +272,6 @@ type AIPromptGuard struct {
 //   - field: "max_tokens"
 //     value: "100"
 //     override: true
-//
 // ```
 //
 // Example: Overriding a custom list field:
@@ -286,7 +279,6 @@ type AIPromptGuard struct {
 // defaults:
 //   - field: "custom_list"
 //     value: "[a,b,c]"
-//
 // ```
 //
 // Note: The `field` values correspond to keys in the JSON request body, not fields in this CRD.

--- a/api/v1alpha1/gateway_parameters_types.go
+++ b/api/v1alpha1/gateway_parameters_types.go
@@ -275,7 +275,7 @@ type EnvoyBootstrap struct {
 	// the values are one of "trace", "debug", "info", "warn", "error",
 	// "critical", or "off", e.g.
 	//
-	//	```yaml
+	//	``yaml
 	//	componentLogLevels:
 	//	  upstream: debug
 	//	  connection: trace
@@ -599,16 +599,16 @@ type AiExtension struct {
 	// +optional
 	//
 	// Example:
-	// ```yaml
-	// stats:
-	//   customLabels:
-	//     - name: "subject"
-	//       metadataNamespace: "envoy.filters.http.jwt_authn"
-	//       metadataKey: "principal:sub"
-	//     - name: "issuer"
-	//       metadataNamespace: "envoy.filters.http.jwt_authn"
-	//       metadataKey: "principal:iss"
-	// ```
+  // ```yaml
+  // stats:
+  //   customLabels:
+  //     - name: "subject"
+  //       metadataNamespace: "envoy.filters.http.jwt_authn"
+  //       metadataKey: "principal:sub"
+  //     - name: "issuer"
+  //       metadataNamespace: "envoy.filters.http.jwt_authn"
+  //       metadataKey: "principal:iss"
+  // ```
 	Stats *AiExtensionStats `json:"stats,omitempty"`
 }
 


### PR DESCRIPTION
# Description

Corrected comments with yaml samples that caused docs generation issues.

## API changes

No changes to API themselves, just commented lines formatting

## Code changes

No code changes. Just `kubebuilder` comments.

## CI changes

Workflow for automatic docs generation will be a separate PR.

## Docs changes

no docs changes, just comments in Go code.

# Context

Compare docs generated [before](https://github.com/PetrMc/kgateway.dev-docs/blob/api-docs-petr-mar12/content/docs/reference/api/top-level/_index.md#aipromptenrichment) change and [after](https://github.com/PetrMc/kgateway.dev-docs/blob/api-gen-update-20250314-1402/content/docs/reference/api/top-level/_index.md#aipromptenrichment).

## Interesting decisions

no interesting decisions, just formatting adjustments.

## Testing steps

per Context section - finally generated docs were validated by Docs team. No code changes - no requirement for any additional tests.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
