### PR TITLE
workflow: pin actions on release

### DIFF
--- a/.github/actions/prep-go-runner/action.yaml
+++ b/.github/actions/prep-go-runner/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Cancel Previous Actions
-      uses: styfle/cancel-workflow-action@0.12.1
+      uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
       with:
         access_token: ${{ github.token }}
     - name: Free disk space
@@ -61,7 +61,7 @@ runs:
         docker system df -v
     - name: Set up Go
       id: setup-go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         # https://github.com/actions/setup-go/blob/main/action.yml
         go-version-file: ${{ inputs.working-directory }}/go.mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       version: ${{ steps.set_vars.outputs.version }}
       goreleaser_args: ${{ steps.set_vars.outputs.goreleaser_args }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Set the release related variables
@@ -77,7 +77,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Helm login to ${{ env.IMAGE_REGISTRY }}
         if: ${{ github.event_name != 'pull_request' }}
@@ -102,7 +102,7 @@ jobs:
     needs: [setup, helm]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Prep Go Runner
@@ -123,14 +123,14 @@ jobs:
 
       - name: Log into ghcr.io
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: "docker/setup-qemu-action@v3"
-      - uses: "docker/setup-buildx-action@v3"
+      - uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392" # v3.6.0
+      - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10 .0
 
       - name: Run goreleaser
         run: make release
@@ -147,7 +147,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.validate }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
 


### PR DESCRIPTION
The release workflow is the only workflow with write access to published artifacts, so make sure that all the actions in it and in actions it uses are pinned to a specific version. This helps with both build reproducibility and security.
