### PR TITLE
transformation e2e flakes

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -26,22 +26,22 @@ jobs:
         # Above each test below, we document the latest date/time for the GitHub action step to run
         # NOTE: We use the GitHub action step time (as opposed to the `go test` time), because it is easier to capture
         test:
-        # March 12, 2025: 7 minutes
+        # March 18, 2025: 7 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$'
           localstack: 'false'
-        # Mar 12, 2025: 6 minutes
+        # Mar 18, 2025: 7 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^Backends$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$|^TestKgatewayWaypoint$$'
           localstack: 'false'
-        # March 12, 2025: 7 minutes
+        # March 18, 2025: 7 minutes
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$'
           localstack: 'true'
-          # March 13, 2025: 8 minutes
+        # March 18, 2025: 6 minutes
         - cluster-name: 'cluster-ai'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestAIExtension'

--- a/test/kubernetes/e2e/features/transformation/types.go
+++ b/test/kubernetes/e2e/features/transformation/types.go
@@ -6,7 +6,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
 )
 
@@ -15,7 +17,26 @@ var (
 	simpleServiceManifest    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "service.yaml")
 	gatewayWithRouteManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "gateway-with-transformed-route.yaml")
 
-	// objects
+	// objects from gateway manifest
+	gateway = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
+			Namespace: "default",
+		},
+	}
+	route = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-route",
+			Namespace: "default",
+		},
+	}
+	routePolicy = &v1alpha1.RoutePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "requestresponse-transformer",
+			Namespace: "default",
+		},
+	}
+	// objects created by deployer after applying gateway manifest
 	proxyObjectMeta = metav1.ObjectMeta{
 		Name:      "gw",
 		Namespace: "default",
@@ -24,9 +45,16 @@ var (
 	proxyService        = &corev1.Service{ObjectMeta: proxyObjectMeta}
 	proxyServiceAccount = &corev1.ServiceAccount{ObjectMeta: proxyObjectMeta}
 
+	// objects from service manifest
 	simpleSvc = &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple-svc",
+			Namespace: "default",
+		},
+	}
+	simpleDeployment = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend-0",
 			Namespace: "default",
 		},
 	}

--- a/test/kubernetes/testutils/assertions/pods.go
+++ b/test/kubernetes/testutils/assertions/pods.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,4 +89,70 @@ func (p *Provider) EventuallyPodsNotExist(
 		WithPolling(pollingInterval).
 		Should(gomega.Succeed(), fmt.Sprintf("pods matching %v in namespace %s should not be found in cluster",
 			listOpt, podNamespace))
+}
+
+// EventuallyPodContainerContainsEnvVar asserts that eventually all pods matching the given pod namespace and selector
+// have a container with the given container name and the given env var.
+func (p *Provider) EventuallyPodContainerContainsEnvVar(
+	ctx context.Context,
+	podNamespace string,
+	podListOpt metav1.ListOptions,
+	containerName string,
+	envVar corev1.EnvVar,
+	timeout ...time.Duration,
+) {
+	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+
+	p.Gomega.Eventually(func(g gomega.Gomega) {
+		pods, err := p.clusterContext.Clientset.CoreV1().Pods(podNamespace).List(ctx, podListOpt)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to list pods")
+		g.Expect(pods.Items).NotTo(gomega.BeEmpty(), "No pods found")
+		for _, pod := range pods.Items {
+			g.Expect(pod.Spec.Containers).To(gomega.ContainElement(
+				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Name": gomega.Equal(containerName),
+					"Env": gomega.ContainElement(
+						gomega.Equal(envVar),
+					),
+				}),
+			))
+		}
+	}).
+		WithTimeout(currentTimeout).
+		WithPolling(pollingInterval).
+		Should(gomega.Succeed(), fmt.Sprintf("Failed to match pod in namespace %s", podNamespace))
+}
+
+// EventuallyPodContainerDoesNotContainEnvVar asserts that eventually no pods matching the given pod namespace and selector
+// have a container with the given name and env var with the given name.
+func (p *Provider) EventuallyPodContainerDoesNotContainEnvVar(
+	ctx context.Context,
+	podNamespace string,
+	podListOpt metav1.ListOptions,
+	containerName string,
+	envVarName string,
+	timeout ...time.Duration,
+) {
+	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+
+	p.Gomega.Eventually(func(g gomega.Gomega) {
+		pods, err := p.clusterContext.Clientset.CoreV1().Pods(podNamespace).List(ctx, podListOpt)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to list pods")
+		g.Expect(pods.Items).NotTo(gomega.BeEmpty(), "No pods found")
+		for _, pod := range pods.Items {
+			g.Expect(pod.Spec.Containers).NotTo(gomega.ContainElement(
+				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Name": gomega.Equal(containerName),
+					"Env": gomega.ContainElement(
+						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"Name": gomega.Equal(envVarName),
+						}),
+					),
+				}),
+			))
+		}
+	}).
+		WithTimeout(currentTimeout).
+		WithPolling(pollingInterval).
+		Should(gomega.Succeed(), fmt.Sprintf("Failed to match pod in namespace %s", podNamespace))
 }


### PR DESCRIPTION
Attempt to fix transformation e2e test flakes
- set up and tear down common resources once per suite
- wait for pods to be ready
- after patching kgateway deployment, wait for pods to reflect the env var

Fixes https://github.com/kgateway-dev/kgateway/issues/10826