### PR TITLE
hack/kind: Bump CONFORMANCE_VERSION to v1.2.1

### DIFF
--- a/hack/kind/setup-kind.sh
+++ b/hack/kind/setup-kind.sh
@@ -18,7 +18,7 @@ IMAGE_VARIANT="${IMAGE_VARIANT:-standard}"
 # If true, run extra steps to set up k8s gateway api conformance test environment
 CONFORMANCE="${CONFORMANCE:-false}"
 # The version of the k8s gateway api conformance tests to run. Requires CONFORMANCE=true
-CONFORMANCE_VERSION="${CONFORMANCE_VERSION:-v1.2.0}"
+CONFORMANCE_VERSION="${CONFORMANCE_VERSION:-$(go list -m sigs.k8s.io/gateway-api | awk '{print $2}')}"
 # The channel of the k8s gateway api conformance tests to run. Requires CONFORMANCE=true
 CONFORMANCE_CHANNEL="${CONFORMANCE_CHANNEL:-"experimental"}"
 # The kind CLI to use. Defaults to the latest version from the kind repo.


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Align the GW API CRD version being installed in hack/kind/setup-kind.sh with the client version present in the root go.mod file. This matches the approach taken in the conformance composite action.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
