### PR TITLE
internal/kgateway: Add initial support for the Gateway spec.infrastructure field

### DIFF
--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -106,8 +106,6 @@ waypointClass:
 
 # Gateway proxy configuration
 gateway:
-  # The name of the Gateway annotation that specifies the name of a GatewayParameters CR
-  parametersAnnotationName: "gateway.kgateway.dev/gateway-parameters-name"
   envoyContainer:
     image:
       registry: ""

--- a/internal/kgateway/controller/controller.go
+++ b/internal/kgateway/controller/controller.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/deployer"
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
 const (
@@ -86,9 +85,8 @@ func (c *controllerBuilder) addIndexes(ctx context.Context) error {
 }
 
 // gatewayToParams is an IndexerFunc that gets a GatewayParameters name from a Gateway.
-// It first checks the Gateway's spec.infrastructure.parametersRef, then falls back to the
-// Gateway's annotations for the wellknown.GatewayParametersAnnotationName. Returns an empty
-// slice if neither is set.
+// It checks the Gateway's spec.infrastructure.parametersRef, or returns an empty
+// slice when it's not set.
 func gatewayToParams(obj client.Object) []string {
 	gw, ok := obj.(*apiv1.Gateway)
 	if !ok {
@@ -97,9 +95,6 @@ func gatewayToParams(obj client.Object) []string {
 	infrastructureRef := gw.Spec.Infrastructure
 	if infrastructureRef != nil && infrastructureRef.ParametersRef != nil {
 		return []string{infrastructureRef.ParametersRef.Name}
-	}
-	if gwpName, ok := gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName]; ok {
-		return []string{gwpName}
 	}
 	return []string{}
 }

--- a/internal/kgateway/controller/controller.go
+++ b/internal/kgateway/controller/controller.go
@@ -85,14 +85,20 @@ func (c *controllerBuilder) addIndexes(ctx context.Context) error {
 	return nil
 }
 
-// gatewayToParams is an IndexerFunc that gets a GatewayParameters name from a Gateway
+// gatewayToParams is an IndexerFunc that gets a GatewayParameters name from a Gateway.
+// It first checks the Gateway's spec.infrastructure.parametersRef, then falls back to the
+// Gateway's annotations for the wellknown.GatewayParametersAnnotationName. Returns an empty
+// slice if neither is set.
 func gatewayToParams(obj client.Object) []string {
 	gw, ok := obj.(*apiv1.Gateway)
 	if !ok {
 		panic(fmt.Sprintf("wrong type %T provided to indexer. expected Gateway", obj))
 	}
-	gwpName := gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName]
-	if gwpName != "" {
+	infrastructureRef := gw.Spec.Infrastructure
+	if infrastructureRef != nil && infrastructureRef.ParametersRef != nil {
+		return []string{infrastructureRef.ParametersRef.Name}
+	}
+	if gwpName, ok := gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName]; ok {
 		return []string{gwpName}
 	}
 	return []string{}

--- a/internal/kgateway/deployer/deployer.go
+++ b/internal/kgateway/deployer/deployer.go
@@ -164,28 +164,21 @@ func (d *Deployer) getGatewayParametersForGateway(ctx context.Context, gw *api.G
 	logger := log.FromContext(ctx)
 
 	// attempt to get the GatewayParameters name from the Gateway. If we can't find it,
-	// we'll check for the default GWP for the GatewayClass. In the case that we find an
-	// explicit reference to a GWP on the GW, we'll use that name and attempt to retrieve
-	// it from the client.
-	var gwpName string
-	switch {
-	case gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.ParametersRef != nil:
-		gwpName = gw.Spec.Infrastructure.ParametersRef.Name
-		if group := gw.Spec.Infrastructure.ParametersRef.Group; group != v1alpha1.GroupName {
-			return nil, eris.Errorf("invalid group %s for GatewayParameters", group)
-		}
-		if kind := gw.Spec.Infrastructure.ParametersRef.Kind; kind != api.Kind(wellknown.GatewayParametersGVK.Kind) {
-			return nil, eris.Errorf("invalid kind %s for GatewayParameters", kind)
-		}
-	case gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName] != "":
-		gwpName = gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName]
-	default:
-		// there is no custom GatewayParameters; use GatewayParameters attached to GatewayClass.
+	// we'll check for the default GWP for the GatewayClass.
+	if gw.Spec.Infrastructure == nil || gw.Spec.Infrastructure.ParametersRef == nil {
 		logger.V(1).Info("no GatewayParameters found for Gateway, using default",
 			"gatewayName", gw.GetName(),
 			"gatewayNamespace", gw.GetNamespace(),
 		)
 		return d.getDefaultGatewayParameters(ctx, gw)
+	}
+
+	gwpName := gw.Spec.Infrastructure.ParametersRef.Name
+	if group := gw.Spec.Infrastructure.ParametersRef.Group; group != v1alpha1.GroupName {
+		return nil, eris.Errorf("invalid group %s for GatewayParameters", group)
+	}
+	if kind := gw.Spec.Infrastructure.ParametersRef.Kind; kind != api.Kind(wellknown.GatewayParametersGVK.Kind) {
+		return nil, eris.Errorf("invalid kind %s for GatewayParameters", kind)
 	}
 
 	// the GatewayParameters must live in the same namespace as the Gateway

--- a/internal/kgateway/deployer/deployer.go
+++ b/internal/kgateway/deployer/deployer.go
@@ -163,11 +163,25 @@ func (d *Deployer) renderChartToObjects(gw *api.Gateway, vals map[string]any) ([
 func (d *Deployer) getGatewayParametersForGateway(ctx context.Context, gw *api.Gateway) (*v1alpha1.GatewayParameters, error) {
 	logger := log.FromContext(ctx)
 
-	// check for a gateway params annotation on the Gateway
-	gwpName := gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName]
-	if gwpName == "" {
-		// there is no custom GatewayParameters; use GatewayParameters attached to GatewayClass
-		logger.V(1).Info("no GatewayParameters found for Gateway",
+	// attempt to get the GatewayParameters name from the Gateway. If we can't find it,
+	// we'll check for the default GWP for the GatewayClass. In the case that we find an
+	// explicit reference to a GWP on the GW, we'll use that name and attempt to retrieve
+	// it from the client.
+	var gwpName string
+	switch {
+	case gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.ParametersRef != nil:
+		gwpName = gw.Spec.Infrastructure.ParametersRef.Name
+		if group := gw.Spec.Infrastructure.ParametersRef.Group; group != v1alpha1.GroupName {
+			return nil, eris.Errorf("invalid group %s for GatewayParameters", group)
+		}
+		if kind := gw.Spec.Infrastructure.ParametersRef.Kind; kind != api.Kind(wellknown.GatewayParametersGVK.Kind) {
+			return nil, eris.Errorf("invalid kind %s for GatewayParameters", kind)
+		}
+	case gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName] != "":
+		gwpName = gw.GetAnnotations()[wellknown.GatewayParametersAnnotationName]
+	default:
+		// there is no custom GatewayParameters; use GatewayParameters attached to GatewayClass.
+		logger.V(1).Info("no GatewayParameters found for Gateway, using default",
 			"gatewayName", gw.GetName(),
 			"gatewayNamespace", gw.GetNamespace(),
 		)

--- a/internal/kgateway/deployer/deployer_test.go
+++ b/internal/kgateway/deployer/deployer_test.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	api "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	gw2_v1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/deployer"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
@@ -436,49 +435,6 @@ var _ = Describe("Deployer", func() {
 	})
 
 	Context("Gateway API infrastructure field", func() {
-		It("prefers spec.infrastructure.parametersRef over annotation", func() {
-			gwp := defaultGatewayParams()
-			gwp.Spec.Kube.ServiceAccount.ExtraAnnotations = map[string]string{
-				"override-foo": "override-bar",
-			}
-			gw := &api.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: defaultNamespace,
-					UID:       "1235",
-					Annotations: map[string]string{
-						wellknown.GatewayParametersAnnotationName: "annotation-gwp", // This should be ignored
-					},
-				},
-				Spec: api.GatewaySpec{
-					GatewayClassName: wellknown.GatewayClassName,
-					Infrastructure: &api.GatewayInfrastructure{
-						ParametersRef: &api.LocalParametersReference{ // Changed from ParametersReference to LocalParametersReference
-							Group: gw2_v1alpha1.GroupName,
-							Kind:  api.Kind(wellknown.GatewayParametersGVK.Kind),
-							Name:  gwp.Name,
-						},
-					},
-				},
-			}
-
-			d, err := deployer.NewDeployer(newFakeClientWithObjs(defaultGatewayClass(), gwp), &deployer.Inputs{
-				ControllerName: wellknown.GatewayControllerName,
-				Dev:            false,
-				ControlPlane: deployer.ControlPlaneInfo{
-					XdsHost: "something.cluster.local",
-					XdsPort: 1234,
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			var objs clientObjects
-			objs, err = d.GetObjsToDeploy(context.Background(), gw)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(objs).NotTo(BeEmpty())
-			Expect(objs.findServiceAccount(defaultNamespace, "foo").Annotations["override-foo"]).To(Equal("override-bar"))
-		})
-
 		It("rejects invalid group in spec.infrastructure.parametersRef", func() {
 			gw := &api.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -543,43 +499,6 @@ var _ = Describe("Deployer", func() {
 
 			_, err = d.GetObjsToDeploy(context.Background(), gw)
 			Expect(err).To(MatchError(`invalid kind InvalidKind for GatewayParameters`))
-		})
-
-		It("falls back to annotation when spec.infrastructure is nil", func() {
-			gwp := defaultGatewayParams()
-			gwp.Spec.Kube.ServiceAccount.ExtraAnnotations = map[string]string{
-				"override-foo": "override-bar",
-			}
-
-			gw := &api.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: defaultNamespace,
-					UID:       "1235",
-					Annotations: map[string]string{
-						wellknown.GatewayParametersAnnotationName: gwp.Name,
-					},
-				},
-				Spec: api.GatewaySpec{
-					GatewayClassName: wellknown.GatewayClassName,
-				},
-			}
-
-			d, err := deployer.NewDeployer(newFakeClientWithObjs(defaultGatewayClass(), gwp), &deployer.Inputs{
-				ControllerName: wellknown.GatewayControllerName,
-				Dev:            false,
-				ControlPlane: deployer.ControlPlaneInfo{
-					XdsHost: "something.cluster.local",
-					XdsPort: 1234,
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			var objs clientObjects
-			objs, err = d.GetObjsToDeploy(context.Background(), gw)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(objs).NotTo(BeEmpty())
-			Expect(objs.findServiceAccount(defaultNamespace, "foo").Annotations["override-foo"]).To(Equal("override-bar"))
 		})
 	})
 
@@ -853,7 +772,7 @@ var _ = Describe("Deployer", func() {
 				gw := defaultGateway()
 				gw.Spec.Infrastructure = &api.GatewayInfrastructure{
 					ParametersRef: &api.LocalParametersReference{
-						Group: v1alpha1.GroupName,
+						Group: gw2_v1alpha1.GroupName,
 						Kind:  api.Kind(wellknown.GatewayParametersGVK.Kind),
 						Name:  gwpName,
 					},

--- a/internal/kgateway/deployer/deployer_test.go
+++ b/internal/kgateway/deployer/deployer_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	api "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	gw2_v1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/deployer"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
@@ -45,10 +46,6 @@ import (
 	// is currently broken. see: https://github.com/kgateway-dev/kgateway/issues/10491
 	_ "github.com/kgateway-dev/kgateway/v2/internal/envoyinit/hack/filter_types"
 )
-
-// testBootstrap implements resources.Resource in order to use protoutils.UnmarshalYAML
-// this is hacky but it seems more stable/concise than map-casting all the way down
-// to the field we need.
 
 func unmarshalYaml(data []byte, into proto.Message) error {
 	jsn, err := yaml.YAMLToJSON(data)
@@ -438,6 +435,154 @@ var _ = Describe("Deployer", func() {
 		})
 	})
 
+	Context("Gateway API infrastructure field", func() {
+		It("prefers spec.infrastructure.parametersRef over annotation", func() {
+			gwp := defaultGatewayParams()
+			gwp.Spec.Kube.ServiceAccount.ExtraAnnotations = map[string]string{
+				"override-foo": "override-bar",
+			}
+			gw := &api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: defaultNamespace,
+					UID:       "1235",
+					Annotations: map[string]string{
+						wellknown.GatewayParametersAnnotationName: "annotation-gwp", // This should be ignored
+					},
+				},
+				Spec: api.GatewaySpec{
+					GatewayClassName: wellknown.GatewayClassName,
+					Infrastructure: &api.GatewayInfrastructure{
+						ParametersRef: &api.LocalParametersReference{ // Changed from ParametersReference to LocalParametersReference
+							Group: gw2_v1alpha1.GroupName,
+							Kind:  api.Kind(wellknown.GatewayParametersGVK.Kind),
+							Name:  gwp.Name,
+						},
+					},
+				},
+			}
+
+			d, err := deployer.NewDeployer(newFakeClientWithObjs(defaultGatewayClass(), gwp), &deployer.Inputs{
+				ControllerName: wellknown.GatewayControllerName,
+				Dev:            false,
+				ControlPlane: deployer.ControlPlaneInfo{
+					XdsHost: "something.cluster.local",
+					XdsPort: 1234,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var objs clientObjects
+			objs, err = d.GetObjsToDeploy(context.Background(), gw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(objs).NotTo(BeEmpty())
+			Expect(objs.findServiceAccount(defaultNamespace, "foo").Annotations["override-foo"]).To(Equal("override-bar"))
+		})
+
+		It("rejects invalid group in spec.infrastructure.parametersRef", func() {
+			gw := &api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: defaultNamespace,
+					UID:       "1235",
+				},
+				Spec: api.GatewaySpec{
+					GatewayClassName: wellknown.GatewayClassName,
+					Infrastructure: &api.GatewayInfrastructure{
+						ParametersRef: &api.LocalParametersReference{
+							Group: "invalid.group",
+							Kind:  api.Kind(wellknown.GatewayParametersGVK.Kind),
+							Name:  "test-gwp",
+						},
+					},
+				},
+			}
+
+			d, err := deployer.NewDeployer(newFakeClientWithObjs(defaultGatewayClass()), &deployer.Inputs{
+				ControllerName: wellknown.GatewayControllerName,
+				Dev:            false,
+				ControlPlane: deployer.ControlPlaneInfo{
+					XdsHost: "something.cluster.local",
+					XdsPort: 1234,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = d.GetObjsToDeploy(context.Background(), gw)
+			Expect(err).To(MatchError(`invalid group invalid.group for GatewayParameters`))
+		})
+
+		It("rejects invalid kind in spec.infrastructure.parametersRef", func() {
+			gw := &api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: defaultNamespace,
+					UID:       "1235",
+				},
+				Spec: api.GatewaySpec{
+					GatewayClassName: wellknown.GatewayClassName,
+					Infrastructure: &api.GatewayInfrastructure{
+						ParametersRef: &api.LocalParametersReference{
+							Group: gw2_v1alpha1.GroupName,
+							Kind:  "InvalidKind",
+							Name:  "test-gwp",
+						},
+					},
+				},
+			}
+
+			d, err := deployer.NewDeployer(newFakeClientWithObjs(defaultGatewayClass()), &deployer.Inputs{
+				ControllerName: wellknown.GatewayControllerName,
+				Dev:            false,
+				ControlPlane: deployer.ControlPlaneInfo{
+					XdsHost: "something.cluster.local",
+					XdsPort: 1234,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = d.GetObjsToDeploy(context.Background(), gw)
+			Expect(err).To(MatchError(`invalid kind InvalidKind for GatewayParameters`))
+		})
+
+		It("falls back to annotation when spec.infrastructure is nil", func() {
+			gwp := defaultGatewayParams()
+			gwp.Spec.Kube.ServiceAccount.ExtraAnnotations = map[string]string{
+				"override-foo": "override-bar",
+			}
+
+			gw := &api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: defaultNamespace,
+					UID:       "1235",
+					Annotations: map[string]string{
+						wellknown.GatewayParametersAnnotationName: gwp.Name,
+					},
+				},
+				Spec: api.GatewaySpec{
+					GatewayClassName: wellknown.GatewayClassName,
+				},
+			}
+
+			d, err := deployer.NewDeployer(newFakeClientWithObjs(defaultGatewayClass(), gwp), &deployer.Inputs{
+				ControllerName: wellknown.GatewayControllerName,
+				Dev:            false,
+				ControlPlane: deployer.ControlPlaneInfo{
+					XdsHost: "something.cluster.local",
+					XdsPort: 1234,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var objs clientObjects
+			objs, err = d.GetObjsToDeploy(context.Background(), gw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(objs).NotTo(BeEmpty())
+			Expect(objs.findServiceAccount(defaultNamespace, "foo").Annotations["override-foo"]).To(Equal("override-bar"))
+		})
+	})
+
 	Context("Single gwc and gw", func() {
 		type input struct {
 			dInputs        *deployer.Inputs
@@ -706,10 +851,13 @@ var _ = Describe("Deployer", func() {
 
 			defaultGatewayWithGatewayParams = func(gwpName string) *api.Gateway {
 				gw := defaultGateway()
-				gw.Annotations = map[string]string{
-					wellknown.GatewayParametersAnnotationName: gwpName,
+				gw.Spec.Infrastructure = &api.GatewayInfrastructure{
+					ParametersRef: &api.LocalParametersReference{
+						Group: v1alpha1.GroupName,
+						Kind:  api.Kind(wellknown.GatewayParametersGVK.Kind),
+						Name:  gwpName,
+					},
 				}
-
 				return gw
 			}
 			defaultInput = func() *input {

--- a/internal/kgateway/wellknown/controller.go
+++ b/internal/kgateway/wellknown/controller.go
@@ -16,12 +16,6 @@ const (
 	// It is configured to manage GatewayClasses with the name GatewayClassName
 	GatewayControllerName = "kgateway.dev/kgateway"
 
-	// GatewayParametersAnnotationName is the name of the Gateway annotation that specifies
-	// the name of a GatewayParameters CR, which is used to dynamically provision the data plane
-	// resources for the Gateway. The GatewayParameters is assumed to be in the same namespace
-	// as the Gateway.
-	GatewayParametersAnnotationName = "gateway.kgateway.dev/gateway-parameters-name"
-
 	// DefaultGatewayParametersName is the name of the GatewayParameters which is attached by
 	// parametersRef to the GatewayClass.
 	DefaultGatewayParametersName = "kgateway"

--- a/test/kubernetes/e2e/features/aiextension/testdata/common.yaml
+++ b/test/kubernetes/e2e/features/aiextension/testdata/common.yaml
@@ -19,10 +19,13 @@ apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: ai-gateway
   namespace: ai-test
-  annotations:
-    gateway.kgateway.dev/gateway-parameters-name: kgateway-gateway-override
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      name: kgateway-gateway-override
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
   listeners:
   - protocol: HTTP
     port: 8080

--- a/test/kubernetes/e2e/features/deployer/istio_integration_suite.go
+++ b/test/kubernetes/e2e/features/deployer/istio_integration_suite.go
@@ -6,17 +6,15 @@ import (
 	"context"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	testdefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
-
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/gloo/cli/pkg/cmd/istio"
 	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 )
 
 var _ e2e.NewSuiteFunc = NewIstioIntegrationTestingSuite

--- a/test/kubernetes/e2e/features/deployer/minimal_default_gatewayparameters_suite.go
+++ b/test/kubernetes/e2e/features/deployer/minimal_default_gatewayparameters_suite.go
@@ -3,14 +3,12 @@ package deployer
 import (
 	"context"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	testdefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
-
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 )
 
 var _ e2e.NewSuiteFunc = NewMinimalDefaultGatewayParametersTestingSuite

--- a/test/kubernetes/e2e/features/deployer/testdata/gateway-with-parameters.yaml
+++ b/test/kubernetes/e2e/features/deployer/testdata/gateway-with-parameters.yaml
@@ -2,10 +2,13 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gw
-  annotations:
-    gateway.kgateway.dev/gateway-parameters-name: "gw-params"
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: gw-params
   listeners:
     - protocol: HTTP
       port: 8080

--- a/test/kubernetes/e2e/features/deployer/testdata/istio-gateway-parameters.yaml
+++ b/test/kubernetes/e2e/features/deployer/testdata/istio-gateway-parameters.yaml
@@ -2,10 +2,13 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gw
-  annotations:
-    gateway.kgateway.dev/gateway-parameters-name: "gw-params"
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: gw-params
   listeners:
     - protocol: HTTP
       port: 8080

--- a/test/kubernetes/e2e/features/deployer/testdata/self-managed-gateway.yaml
+++ b/test/kubernetes/e2e/features/deployer/testdata/self-managed-gateway.yaml
@@ -2,10 +2,13 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gw
-  annotations:
-    gateway.kgateway.dev/gateway-parameters-name: "gw-params"
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: gw-params
   listeners:
     - protocol: HTTP
       port: 8080

--- a/test/kubernetes/e2e/features/lambda/testdata/setup.yaml
+++ b/test/kubernetes/e2e/features/lambda/testdata/setup.yaml
@@ -22,10 +22,13 @@ kind: Gateway
 metadata:
   name: lambda-gateway
   namespace: lambda-test
-  annotations:
-    gateway.kgateway.dev/gateway-parameters-name: lambda-gateway
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      name: lambda-gateway
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
   listeners:
   - protocol: HTTP
     port: 8080


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Add initial support for the spec.infrastructure field and handle GWP attachment from the parametersRef field. The current annotations-based attachment UX predates this field being introduced into the core GW API spec. Now, we check whether a GW has this configured, and fallback to the annotations-based approach if it's present. In the case that both are present, the spec field wins.

Support for the spec.infrastructure.[labels, annotations] fields is being tracked in #10821.
Closes https://github.com/kgateway-dev/kgateway/issues/10820.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
