### PR TITLE
Add platform docker build parameter for AI images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,6 +135,7 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - "--pull"
+      - "--platform=linux/arm64"
       - "--build-arg=PYTHON_DIR=/python"
     extra_files:
       - python/requirements.txt
@@ -147,6 +148,7 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--pull"
+      - "--platform=linux/amd64"
       - "--build-arg=PYTHON_DIR=/python"
     extra_files:
       - python/requirements.txt


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Several users have been having issues pulling the kgateway-ai-extension manifest image for both beta2 and the main branch release. When inspecting the manifest image locally, we can see the following output:

```bash
$ docker manifest inspect cr.kgateway.dev/kgateway-dev/kgateway-ai-extension:v2.0.0-main
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3875,
         "digest": "sha256:ff48463a1511adf41158f5c5473e6231136edc07cea8685f7fc19ac1203d33ce",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3875,
         "digest": "sha256:ff48463a1511adf41158f5c5473e6231136edc07cea8685f7fc19ac1203d33ce",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```

Notably, the amd64 architecture is present in both images attached to the manifest. Adding the platform docker build parameter to the goreleaser is consistent with the rest of the container images being referenced in the goreleaser config file.

I tested this change out in my fork first: https://github.com/timflannagan/kgateway/actions/runs/13954639135/job/39062608830. We can validate that the new manifest image has both the arm64 and amd64 architectures present:

```
$ docker manifest inspect ghcr.io/timflannagan/kgateway-ai-extension:v2.0.0-ai
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3875,
         "digest": "sha256:07bc9bbb1dd7f2fcf06df67ec1b5f6078404ba643c01ded72778a8fdcfa1822b",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3874,
         "digest": "sha256:25c1d865f6e3ccdc7a85557d18c0d2fb98e08e3d857b1e2f47f2841282112e94",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
