### PR TITLE
API docs for LocalPolicyTargetRef

### DIFF
--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -5,15 +5,19 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-// not sure why i need to copy this; codegen fails if i dont
+// Select the object to attach the policy to.
+// The object must be in the same namespace as the policy.
+// You can target only one object at a time.
 type LocalPolicyTargetReference struct {
-	// Group is the group of the target resource.
+	// The API group of the target resource.
+	// For Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.
 	Group gwv1.Group `json:"group"`
 
-	// Kind is kind of the target resource.
+	// The API kind of the target resource,
+	// such as Gateway or HTTPRoute.
 	Kind gwv1.Kind `json:"kind"`
 
-	// Name is the name of the target resource.
+	// The name of the target resource.
 	Name gwv1.ObjectName `json:"name"`
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2640,12 +2640,12 @@ func schema_kgateway_v2_api_v1alpha1_LocalPolicyTargetReference(ref common.Refer
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "not sure why i need to copy this; codegen fails if i dont",
+				Description: "Select the object to attach the policy to. The object must be in the same namespace as the policy. You can target only one object at a time.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Group is the group of the target resource.",
+							Description: "The API group of the target resource. For Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2653,7 +2653,7 @@ func schema_kgateway_v2_api_v1alpha1_LocalPolicyTargetReference(ref common.Refer
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind is kind of the target resource.",
+							Description: "The API kind of the target resource, such as Gateway or HTTPRoute.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2661,7 +2661,7 @@ func schema_kgateway_v2_api_v1alpha1_LocalPolicyTargetReference(ref common.Refer
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the target resource.",
+							Description: "The name of the target resource.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",


### PR DESCRIPTION
# Description

Now that the docs are automatically generated from the comments, replace TODO comment with descriptions.

Right now, it looks like [this](https://kgateway.dev/docs/reference/api/#localpolicytargetreference:~:text=perConnectionBufferLimitBytes%20integer-,LocalPolicyTargetReference,why%20i%20need%20to%20copy%20this%3B%20codegen%20fails%20if%20i%20dont,-Appears%20in%3A).

<img width="821" alt="image" src="https://github.com/user-attachments/assets/77282e93-3654-4ad7-9776-955cc780e184" />

## API changes

Just comments

# Context

Reported in Slack by an internal user

# Checklist:

- N/A I have performed a self-review of my own code
- N/A I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- N/A I have added tests that prove my fix is effective or that my feature works
