### PR TITLE
use string key for policy report

### DIFF
--- a/internal/kgateway/extensions2/plugin/plugin.go
+++ b/internal/kgateway/extensions2/plugin/plugin.go
@@ -93,7 +93,7 @@ type Plugin struct {
 
 type AncestorReports map[ir.ObjectSource][]error
 type PolicyReport map[ir.AttachedPolicyRef]AncestorReports
-type ProcessPolicyStatus func(ctx context.Context, gk schema.GroupKind, polReport PolicyReport)
+type ProcessPolicyStatus func(ctx context.Context, gkString string, polReport PolicyReport)
 
 func (p PolicyPlugin) AttachmentPoints() AttachmentPoints {
 	var ret AttachmentPoints

--- a/internal/kgateway/extensions2/plugins/backendtlspolicy/plugin.go
+++ b/internal/kgateway/extensions2/plugins/backendtlspolicy/plugin.go
@@ -174,9 +174,9 @@ func buildTranslateFunc(
 	}
 }
 
-func buildProcessStatus(cl client.Client) func(ctx context.Context, gk schema.GroupKind, polReport plug.PolicyReport) {
-	return func(ctx context.Context, gk schema.GroupKind, polReport plug.PolicyReport) {
-		if gk != backendTlsPolicyGroupKind.GroupKind() {
+func buildProcessStatus(cl client.Client) func(ctx context.Context, gkStr string, polReport plug.PolicyReport) {
+	return func(ctx context.Context, gkStr string, polReport plug.PolicyReport) {
+		if gkStr != backendTlsPolicyGroupKind.GroupKind().String() {
 			return
 		}
 		ctx = contextutils.WithLogger(ctx, "backendTlsPolicyStatus")

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -537,7 +537,7 @@ func (s *ProxySyncer) syncGatewayStatus(ctx context.Context, rm reports.ReportMa
 func (s *ProxySyncer) syncBackendPolicyStatus(ctx context.Context, report GKPolicyReport) {
 	for gk, polReport := range report.SeenPolicies {
 		for k, v := range s.plugins.ContributesPolicies {
-			if gk != k {
+			if gk != k.String() {
 				continue
 			}
 			if v.ProcessPolicyStatus != nil {

--- a/internal/kgateway/proxy_syncer/status_test.go
+++ b/internal/kgateway/proxy_syncer/status_test.go
@@ -93,14 +93,14 @@ func TestPolicyStatus(t *testing.T) {
 	if len(seenPols) != 2 {
 		t.Fatalf("expected 2 unique GKs, found %d", len(seenPols))
 	}
-	tlsReport, ok := seenPols[wellknown.BackendTLSPolicyGVK.GroupKind()]
+	tlsReport, ok := seenPols[wellknown.BackendTLSPolicyGVK.GroupKind().String()]
 	if !ok {
 		t.Fatal("no policies found for BackendTLSPolicy")
 	}
 	if len(tlsReport) != 1 {
 		t.Fatalf("expected 1 tls policy, found %d", len(tlsReport))
 	}
-	connReport, ok := seenPols[connPolGK]
+	connReport, ok := seenPols[connPolGK.String()]
 	if !ok {
 		t.Fatal("no policies found for ConnPolicy")
 	}


### PR DESCRIPTION
The report used to generate backend policy status (introduced in https://github.com/kgateway-dev/kgateway/pull/10849) is a map keyed by `schema.GroupKind` which does not have a standard text marshaller.

This causes the krt DebugHandler to break as it cannot encode the collection as JSON.

This commit changes to report to be keyed by the GroupKind string to restore krt debug functionality.