### PR TITLE
remove compress field

### DIFF
--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     # TODO(tim): rename this job or consolidate with the other workflows.
     name: projects/gateway2
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
     - name: Setup Go

--- a/api/applyconfiguration/api/v1alpha1/httplistenerpolicyspec.go
+++ b/api/applyconfiguration/api/v1alpha1/httplistenerpolicyspec.go
@@ -6,7 +6,6 @@ package v1alpha1
 // with apply.
 type HTTPListenerPolicySpecApplyConfiguration struct {
 	TargetRefs []LocalPolicyTargetReferenceApplyConfiguration `json:"targetRefs,omitempty"`
-	Compress   *bool                                          `json:"compress,omitempty"`
 	AccessLog  []AccessLogApplyConfiguration                  `json:"accessLog,omitempty"`
 }
 
@@ -26,14 +25,6 @@ func (b *HTTPListenerPolicySpecApplyConfiguration) WithTargetRefs(values ...*Loc
 		}
 		b.TargetRefs = append(b.TargetRefs, *values[i])
 	}
-	return b
-}
-
-// WithCompress sets the Compress field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Compress field is set to the value of the last call.
-func (b *HTTPListenerPolicySpecApplyConfiguration) WithCompress(value bool) *HTTPListenerPolicySpecApplyConfiguration {
-	b.Compress = &value
 	return b
 }
 

--- a/api/applyconfiguration/internal/internal.go
+++ b/api/applyconfiguration/internal/internal.go
@@ -611,9 +611,6 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: com.github.kgateway-dev.kgateway.v2.api.v1alpha1.AccessLog
           elementRelationship: atomic
-    - name: compress
-      type:
-        scalar: boolean
     - name: targetRefs
       type:
         list:

--- a/api/v1alpha1/http_listener_policy_types.go
+++ b/api/v1alpha1/http_listener_policy_types.go
@@ -35,8 +35,6 @@ type HTTPListenerPolicySpec struct {
 	// +kubebuilder:validation:MaxItems=16
 	TargetRefs []LocalPolicyTargetReference `json:"targetRefs,omitempty"`
 
-	Compress bool `json:"compress,omitempty"`
-
 	// AccessLoggingConfig contains various settings for Envoy's access logging service.
 	// See here for more information: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto
 	// +kubebuilder:validation:Items={type=object}

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
@@ -459,8 +459,6 @@ spec:
                       type: object
                   type: object
                 type: array
-              compress:
-                type: boolean
               targetRefs:
                 items:
                   properties:

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
@@ -32,7 +32,6 @@ import (
 
 type httpListenerPolicy struct {
 	ct        time.Time
-	compress  bool
 	accessLog []*envoyaccesslog.AccessLog
 }
 
@@ -43,11 +42,6 @@ func (d *httpListenerPolicy) CreationTime() time.Time {
 func (d *httpListenerPolicy) Equals(in any) bool {
 	d2, ok := in.(*httpListenerPolicy)
 	if !ok {
-		return false
-	}
-
-	// Check the TargetRef and Compress fields
-	if d.compress != d2.compress {
 		return false
 	}
 
@@ -112,7 +106,6 @@ func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensi
 			Policy:       i,
 			PolicyIR: &httpListenerPolicy{
 				ct:        i.CreationTimestamp.Time,
-				compress:  i.Spec.Compress,
 				accessLog: accessLog,
 			},
 			TargetRefs: convert(i.Spec.TargetRefs),

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2153,12 +2153,6 @@ func schema_kgateway_v2_api_v1alpha1_HTTPListenerPolicySpec(ref common.Reference
 							},
 						},
 					},
-					"compress": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
-						},
-					},
 					"accessLog": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AccessLoggingConfig contains various settings for Envoy's access logging service. See here for more information: https://www.envoyproxy.io/docs/envoy/v1.33.0/api-v3/config/accesslog/v3/accesslog.proto",


### PR DESCRIPTION
The compress field exposed on `HTTPListenerPolicy` was not functional and the API itself warranted further design.
This commit removes the field entirely.