### PR TITLE
[cleanup] common delegation test resources

### DIFF
--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -374,7 +374,10 @@ var _ = DescribeTable("Route Delegation translator",
 		testutils.TestTranslation(
 			GinkgoT(),
 			context.TODO(),
-			[]string{filepath.Join(dir, "testutils/inputs/delegation", inputFile)},
+			[]string{
+				filepath.Join(dir, "testutils/inputs/delegation/common.yaml"),
+				filepath.Join(dir, "testutils/inputs/delegation", inputFile),
+			},
 			filepath.Join(dir, "testutils/outputs/delegation", inputFile),
 			types.NamespacedName{
 				Namespace: "infra",

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -34,18 +22,6 @@ spec:
       name: "*"
       namespace: a
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -59,14 +35,4 @@ spec:
         value: /a/1
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic_invalid_hostname.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -34,18 +22,6 @@ spec:
       name: "*"
       namespace: a
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -61,14 +37,4 @@ spec:
         value: /a/1
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic_parentref_match.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -34,18 +22,6 @@ spec:
       name: "*"
       namespace: a
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -64,14 +40,4 @@ spec:
         value: /a/1
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/basic_parentref_mismatch.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -34,18 +22,6 @@ spec:
       name: "*"
       namespace: a
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -64,14 +40,4 @@ spec:
         value: /a/1
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/child_rule_matcher.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -66,18 +54,6 @@ spec:
       name: "*"
       namespace: b
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -105,16 +81,6 @@ spec:
         value: valX
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -145,14 +111,4 @@ spec:
         value: valX
     backendRefs:
     - name: svc-b
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-b
-  namespace: b
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/common.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/common.yaml
@@ -1,0 +1,47 @@
+# Common Gateway/Service definitions (may be overridden by individual tests)
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-b
+  namespace: b
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/cyclic1.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -33,18 +21,6 @@ spec:
       kind: HTTPRoute
       name: "*"
       namespace: a
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -70,13 +46,3 @@ spec:
       kind: HTTPRoute
       name: "route-a"
       namespace: a
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/cyclic2.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -33,18 +21,6 @@ spec:
       kind: HTTPRoute
       name: "*"
       namespace: a
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -70,16 +46,6 @@ spec:
       name: "route-a-b"
       namespace: a-b
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -96,13 +62,3 @@ spec:
       kind: HTTPRoute
       name: "*"
       namespace: a
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a-b
-  namespace: a-b
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/discard_invalid_child_matches.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/discard_invalid_child_matches.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -73,14 +61,4 @@ spec:
         value: /random2
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/invalid_child_valid_standalone.yaml
@@ -1,19 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
-    allowedRoutes:
-      namespaces:
-        from: All
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -36,18 +21,6 @@ spec:
       kind: HTTPRoute
       name: "*"
       namespace: a
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -73,14 +46,4 @@ spec:
         value: /a/1
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/multi_level_multiple_parents.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: api-example-com

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/multiple_children.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -43,18 +31,6 @@ spec:
       name: "*"
       namespace: b
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -70,16 +46,6 @@ spec:
     - name: svc-a
       port: 8080
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -93,14 +59,4 @@ spec:
         value: /b/.*
     backendRefs:
     - name: svc-b
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-b
-  namespace: b
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/multiple_parents.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -73,18 +61,6 @@ spec:
       name: "*"
       namespace: b
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -98,16 +74,6 @@ spec:
         value: /a/1
     backendRefs:
     - name: svc-a
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
       port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -128,14 +94,4 @@ spec:
         value: /b/.*
     backendRefs:
     - name: svc-b
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-b
-  namespace: b
-spec:
-  ports:
-    - protocol: TCP
       port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/nested_absolute_relative.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -86,16 +74,6 @@ spec:
       name: "route-a-b"
       namespace: a-b
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -138,16 +116,6 @@ spec:
       name: "route-a-b-d"
       namespace: a-b-d
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a-b
-  namespace: a-b
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -182,6 +150,16 @@ spec:
       method: GET
     backendRefs:
     - name: svc-a-b-d
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a-b
+  namespace: a-b
+spec:
+  ports:
+    - protocol: TCP
       port: 8080
 ---
 apiVersion: v1

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/recursive.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/recursive.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -33,18 +21,6 @@ spec:
       kind: HTTPRoute
       name: "*"
       namespace: a
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -69,16 +45,6 @@ spec:
       kind: HTTPRoute
       name: "route-a-b"
       namespace: a-b
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/relative_paths.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -63,18 +51,6 @@ spec:
       kind: HTTPRoute
       name: "*"
       namespace: a
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -132,20 +108,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
   name: svc-b
   namespace: a
 spec:
   ports:
     - protocol: TCP
       port: 8090
----

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -68,25 +56,3 @@ spec:
       set:
         - name: x-foo-resp
           value: xyz
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_filter.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_filter.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -34,18 +22,6 @@ spec:
       name: "*"
       namespace: a
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -66,16 +42,6 @@ spec:
           group: gateway.solo.io
           kind: RouteOption
           name: route-a-opt
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
 ---
 apiVersion: gateway.solo.io/v1
 kind: RouteOption

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_filter_override_merge.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -50,18 +38,6 @@ spec:
         percentage: 100
         httpStatus: 418
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -82,16 +58,6 @@ spec:
           group: gateway.solo.io
           kind: RouteOption
           name: route-a-opt-1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
 ---
 apiVersion: gateway.solo.io/v1
 kind: RouteOption

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -64,25 +52,3 @@ spec:
       add:
       - name: abc
         value: custom-value-abc
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance_child_override_ignore.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -50,18 +38,6 @@ spec:
         percentage: 100
         httpStatus: 418
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -92,13 +68,3 @@ spec:
       abort:
         percentage: 80
         httpStatus: 404
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance_child_override_ok.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -50,18 +38,6 @@ spec:
         percentage: 100
         httpStatus: 418
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -95,13 +71,3 @@ spec:
         - foo
       allowOrigin:
         - baz
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance_filter_override.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_inheritance_filter_override.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -50,18 +38,6 @@ spec:
         percentage: 100
         httpStatus: 418
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -82,16 +58,6 @@ spec:
           group: gateway.solo.io
           kind: RouteOption
           name: route-a-opt
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080
 ---
 apiVersion: gateway.solo.io/v1
 kind: RouteOption

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_multi_level_inheritance_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/route_policy_multi_level_inheritance_override_ok.yaml
@@ -1,16 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: example-gateway
-  namespace: infra
-spec:
-  gatewayClassName: example-gateway-class
-  listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route
@@ -49,18 +37,6 @@ spec:
       abort:
         percentage: 100
         httpStatus: 418
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: infra
-spec:
-  selector:
-    test: test
-  ports:
-    - protocol: TCP
-      port: 80
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -126,13 +102,3 @@ spec:
         - foo
       allowOrigin:
         - baz
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: svc-a
-  namespace: a
-spec:
-  ports:
-    - protocol: TCP
-      port: 8080


### PR DESCRIPTION
move common delegation test resources (gateway/services) into a shared file so it's easier to see the actual test-specific config (i.e. the httproutes)