### PR TITLE
Change typedfilterconfig to sync map

### DIFF
--- a/internal/kgateway/extensions2/plugins/routepolicy/ai_policy.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/ai_policy.go
@@ -38,7 +38,7 @@ type AIPolicyIR struct {
 }
 
 func (p *routePolicyPluginGwPass) processAIRoutePolicy(
-	configMap ir.TypedFilterConfigMap,
+	configMap *ir.TypedFilterConfigMap,
 	inIr *AIPolicyIR,
 ) error {
 	if inIr.Transformation != nil {


### PR DESCRIPTION
# Description

Fixes multiple plugins updating typedfilterconfig synchronously.  

## API changes
NONE

## Code changes
Changes `TypedFilterConfigMap` to a sync.Map.

## CI changes
NONE

## Docs changes
NONE

# Context
Fixes data race in reading and writing TypedFilterConfigMap by backend and policy plugin:
```
WARNING: DATA RACE
Write at 0x00c003937308 by goroutine 4100:
  github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/routepolicy.(*routePolicyPluginGwPass).processAIRoutePolicy()
      /home/runner/work/kgateway/kgateway/internal/kgateway/extensions2/plugins/routepolicy/ai_policy.go:55 +0x619
  github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/routepolicy.(*routePolicyPluginGwPass).ApplyForRouteBackend()
      /home/runner/work/kgateway/kgateway/internal/kgateway/extensions2/plugins/routepolicy/route_policy_plugin.go:318 +0x144
  github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator.(*httpRouteConfigurationTranslator).runBackendPolicies()
      /home/runner/work/kgateway/kgateway/internal/kgateway/translator/irtranslator/route.go:306 +0x65e
  github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator.(*httpRouteConfigurationTranslator).translateRouteAction()
      /home/runner/work/kgateway/kgateway/internal/kgateway/translator/irtranslator/route.go:372 +0x54a
``` 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
