### PR TITLE
Clone ir before adding it to typedfilterconfig map

### DIFF
--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
@@ -66,13 +66,14 @@ func data(s *ir.Secret) map[string][]byte {
 func ApplyAIBackend(ir *IR, pCtx *ir.RouteBackendContext, out *envoy_config_route_v3.Route) error {
 	pCtx.TypedFilterConfig.AddTypedConfig(wellknown.AIBackendTransformationFilterName, ir.Transformation)
 
+	copyBackendExtproc := proto.Clone(ir.Extproc).(*envoy_ext_proc_v3.ExtProcPerRoute)
 	routepolicyExtprocSettingsProto := pCtx.TypedFilterConfig.GetTypedConfig(wellknown.AIExtProcFilterName)
 	if routepolicyExtprocSettingsProto != nil {
 		// merge the Backend extproc config with any config added by the RoutePolicy
 		routeExtprocSettings := routepolicyExtprocSettingsProto.(*envoy_ext_proc_v3.ExtProcPerRoute)
-		ir.Extproc.GetOverrides().GrpcInitialMetadata = append(ir.Extproc.GetOverrides().GetGrpcInitialMetadata(), routeExtprocSettings.GetOverrides().GetGrpcInitialMetadata()...)
+		copyBackendExtproc.GetOverrides().GrpcInitialMetadata = append(copyBackendExtproc.GetOverrides().GetGrpcInitialMetadata(), routeExtprocSettings.GetOverrides().GetGrpcInitialMetadata()...)
 	}
-	pCtx.TypedFilterConfig.AddTypedConfig(wellknown.AIExtProcFilterName, ir.Extproc)
+	pCtx.TypedFilterConfig.AddTypedConfig(wellknown.AIExtProcFilterName, copyBackendExtproc)
 
 	// Add things which require basic AI backend.
 	if out.GetRoute() == nil {


### PR DESCRIPTION
# Description
We were adding IR without cloning in the backend plugin to the typedfilterconfig map and then changing it later in the route policy plugin.

## API changes
NONE

## Code changes
- Clone backend extproc IR before adding it to the map

## CI changes
NONE

## Docs changes
NONE

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
