### PR TITLE
install/helm: use Release.Namespace for namespaced templates

### DIFF
--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kgateway.labels" . | nindent 4 }}
 spec:

--- a/install/helm/kgateway/templates/hpa.yaml
+++ b/install/helm/kgateway/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kgateway.labels" . | nindent 4 }}
 spec:

--- a/install/helm/kgateway/templates/service.yaml
+++ b/install/helm/kgateway/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kgateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kgateway.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
The Helm templates do not consistently set
`namespace: {{ .Release.Namespace }}` for namespaced resource templates.

If not set, helm template fails to render the Namespace set using --namespace, which would break tools like Argo and Operators that use Helm template to manage installations.

Resolves #10909
