### PR TITLE
fix GwExt krt collection

### DIFF
--- a/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/pluginutils"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
 )
 
 type extAuthIR struct {
@@ -22,7 +21,7 @@ type extAuthIR struct {
 
 // extAuthForSpec translates the ExtAuthz spec into the Envoy configuration
 func extAuthForSpec(
-	gatewayExtensions *krtcollections.GatewayExtensionIndex,
+	gatewayExtensions krt.Collection[ir.GatewayExtension],
 	krtctx krt.HandlerContext,
 	routepolicy *v1alpha1.RoutePolicy,
 	out *routeSpecIr) {

--- a/internal/kgateway/ir/gatewayextension.go
+++ b/internal/kgateway/ir/gatewayextension.go
@@ -3,7 +3,7 @@ package ir
 import (
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 )
@@ -16,9 +16,6 @@ type GatewayExtension struct {
 	// Type indicates the type of the GatewayPolicy.
 	Type v1alpha1.GatewayExtensionType
 
-	// Placement configuration for where this extension should be placed in the filter chain.
-	// Placement v1alpha1.Placement
-
 	// ExtAuth configuration for ExtAuth extension type.
 	ExtAuth *v1alpha1.ExtAuthProvider
 
@@ -26,29 +23,20 @@ type GatewayExtension struct {
 	ExtProc *v1alpha1.ExtProcProvider
 }
 
+var (
+	_ krt.ResourceNamer             = GatewayExtension{}
+	_ krt.Equaler[GatewayExtension] = GatewayExtension{}
+)
+
 // ResourceName returns the unique name for this extension.
-func (e *GatewayExtension) ResourceName() string {
+func (e GatewayExtension) ResourceName() string {
 	return e.ObjectSource.ResourceName()
 }
 
-// GVK returns the GroupVersionKind for this extension.
-func (e *GatewayExtension) GVK() schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   "gateway.kgateway.dev",
-		Version: "v1alpha1",
-		Kind:    "GatewayExtension",
-	}
-}
-
-func (e *GatewayExtension) Equals(
-	other *GatewayExtension,
-) bool {
+func (e GatewayExtension) Equals(other GatewayExtension) bool {
 	if e.Type != other.Type {
 		return false
 	}
-	// if e.Placement != other.Placement {
-	// 	return false
-	// }
 	if !reflect.DeepEqual(e.ExtAuth, other.ExtAuth) {
 		return false
 	}

--- a/internal/kgateway/krtcollections/gateway_extensions.go
+++ b/internal/kgateway/krtcollections/gateway_extensions.go
@@ -1,0 +1,54 @@
+package krtcollections
+
+import (
+	"context"
+
+	"istio.io/istio/pkg/config/schema/kubeclient"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/client/clientset/versioned"
+)
+
+func NewGatewayExtensionsCollection(
+	ctx context.Context,
+	client kube.Client,
+	ourClient versioned.Interface,
+	krtOpts krtutil.KrtOptions,
+) krt.Collection[ir.GatewayExtension] {
+	kubeclient.Register[*v1alpha1.GatewayExtension](
+		wellknown.GatewayExtensionGVR,
+		wellknown.GatewayExtensionGVK,
+		func(c kubeclient.ClientGetter, namespace string, o metav1.ListOptions) (runtime.Object, error) {
+			return ourClient.GatewayV1alpha1().GatewayExtensions(namespace).List(context.Background(), o)
+		},
+		func(c kubeclient.ClientGetter, namespace string, o metav1.ListOptions) (watch.Interface, error) {
+			return ourClient.GatewayV1alpha1().GatewayExtensions(namespace).Watch(context.Background(), o)
+		},
+	)
+
+	rawGwExts := krt.WrapClient(kclient.New[*v1alpha1.GatewayExtension](client), krtOpts.ToOptions("GatewayExtension")...)
+	gwExtCol := krt.NewCollection(rawGwExts, func(krtctx krt.HandlerContext, cr *v1alpha1.GatewayExtension) *ir.GatewayExtension {
+		gwExt := &ir.GatewayExtension{
+			ObjectSource: ir.ObjectSource{
+				Group:     wellknown.GatewayExtensionGVK.GroupKind().Group,
+				Kind:      wellknown.GatewayExtensionGVK.GroupKind().Kind,
+				Namespace: cr.Namespace,
+				Name:      cr.Name,
+			},
+			Type:    cr.Spec.Type,
+			ExtAuth: cr.Spec.ExtAuth,
+			ExtProc: cr.Spec.ExtProc,
+		}
+		return gwExt
+	})
+	return gwExtCol
+}


### PR DESCRIPTION
* move GwExt col outside of `policy.go` as it's not augmented with policies
* move GwExt to "standard" collection (as it doesn't need to be initialized after plugins are created)
* fix GetGatewayExtension helper to use correct ObjectSource key
* change GwExt col standard methods (ResourceName & Equals) to not be pointer receivers and thus satisfy the interface
* fully fill in GwExt IR on transformation