### PR TITLE
fix epp integration

### DIFF
--- a/internal/kgateway/helm/inference-extension/templates/endpoint-picker/resources.yaml
+++ b/internal/kgateway/helm/inference-extension/templates/endpoint-picker/resources.yaml
@@ -48,7 +48,7 @@ spec:
           - "9003"
         env:
         - name: USE_STREAMING
-          value: "false"
+          value: "true"
         image: "registry.k8s.io/gateway-api-inference-extension/epp:v0.2.0"
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
# Description

fixed kgateway epp integration

## API changes

none

## Code changes

see diff

## CI changes

none

## Docs changes

none

# Context

llm inference extension stopped working recently after the mode of communication with the extension changed to streaming.  the env var USE_STREAMING was still set to false.

## Interesting decisions

none

## Testing steps

try it out

## Notes for reviewers

none

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas -- not needed
- [ ] I have made corresponding changes to the documentation -- not applicable
- [ ] I have added tests that prove my fix is effective or that my feature works -- i did not
