### PR TITLE
controller: Improve GatewayClass provisioner reconciliation filtering

### DIFF
--- a/internal/kgateway/controller/gatewayclass_provisioner_test.go
+++ b/internal/kgateway/controller/gatewayclass_provisioner_test.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/controller"
 )
 
 const (
@@ -22,12 +24,9 @@ var _ = Describe("GatewayClassProvisioner", func() {
 		ctx    context.Context
 		cancel context.CancelFunc
 	)
+
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
-
-		var err error
-		cancel, err = createManager(ctx, nil)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -38,7 +37,13 @@ var _ = Describe("GatewayClassProvisioner", func() {
 		Eventually(func() bool { return true }).WithTimeout(3 * time.Second).Should(BeTrue())
 	})
 
-	Context("create", func() {
+	When("no GatewayClasses exist on the cluster", func() {
+		BeforeEach(func() {
+			var err error
+			cancel, err = createManager(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("should create the default GCs", func() {
 			Eventually(func() bool {
 				gcs := &apiv1.GatewayClassList{}
@@ -59,7 +64,69 @@ var _ = Describe("GatewayClassProvisioner", func() {
 		})
 	})
 
-	Context("delete", func() {
+	When("existing GatewayClasses from other controllers exist on the cluster", func() {
+		var (
+			otherGC           *apiv1.GatewayClass
+			wrongControllerGC *apiv1.GatewayClass
+		)
+		BeforeEach(func() {
+			// Create GatewayClass owned by another controller
+			otherGC = &apiv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-controller",
+				},
+				Spec: apiv1.GatewayClassSpec{
+					ControllerName: "other.controller/name",
+				},
+			}
+			Expect(k8sClient.Create(ctx, otherGC)).To(Succeed())
+
+			// Create our GatewayClass but with wrong controller
+			wrongControllerGC = &apiv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wrong-controller",
+				},
+				Spec: apiv1.GatewayClassSpec{
+					ControllerName: "wrong.controller/name",
+				},
+			}
+			Expect(k8sClient.Create(ctx, wrongControllerGC)).To(Succeed())
+
+			var err error
+			cancel, err = createManager(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			// Cleanup the test GatewayClasses
+			Expect(k8sClient.Delete(ctx, otherGC)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, wrongControllerGC)).To(Succeed())
+		})
+
+		It("should create our GCs and not affect others", func() {
+			By("verifying our GatewayClasses are created with correct controller")
+			Eventually(func() bool {
+				for className := range gwClasses {
+					gc := &apiv1.GatewayClass{}
+					if err := k8sClient.Get(ctx, types.NamespacedName{Name: className}, gc); err != nil {
+						return false
+					}
+					if gc.Spec.ControllerName != apiv1.GatewayController(gatewayControllerName) {
+						return false
+					}
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	When("the default GCs are deleted", func() {
+		BeforeEach(func() {
+			var err error
+			cancel, err = createManager(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		AfterEach(func() {
 			Eventually(func() bool {
 				gcs := &apiv1.GatewayClassList{}
@@ -67,7 +134,8 @@ var _ = Describe("GatewayClassProvisioner", func() {
 				return err == nil && len(gcs.Items) == 2
 			}, timeout, interval).Should(BeTrue())
 		})
-		It("should be recreated", func() {
+
+		It("should be recreated by the provisioner", func() {
 			By("deleting the default GCs")
 			for name := range gwClasses {
 				err := k8sClient.Delete(ctx, &apiv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: name}})
@@ -86,17 +154,23 @@ var _ = Describe("GatewayClassProvisioner", func() {
 		})
 	})
 
-	Context("update", func() {
+	When("a default GC is updated", func() {
 		var (
 			description string
 		)
 		BeforeEach(func() {
+			var err error
+			cancel, err = createManager(ctx, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("getting the default GC")
 			gc := &apiv1.GatewayClass{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
+			}, timeout, interval).Should(Succeed())
 			description = *gc.Spec.Description
 		})
+
 		AfterEach(func() {
 			By("restoring the default GC value")
 			gc := &apiv1.GatewayClass{}
@@ -106,7 +180,8 @@ var _ = Describe("GatewayClassProvisioner", func() {
 			err = k8sClient.Update(ctx, gc)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("should not be overwritten", func() {
+
+		It("should not be overwritten by the provisioner", func() {
 			By("updating a default GC")
 			var gc *apiv1.GatewayClass
 			Eventually(func() bool {
@@ -131,6 +206,41 @@ var _ = Describe("GatewayClassProvisioner", func() {
 					return false
 				}
 				return *gc.Spec.Description == "updated"
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	When("custom GatewayClass configurations are provided", func() {
+		var customClassConfigs map[string]*controller.ClassInfo
+
+		BeforeEach(func() {
+			customClassConfigs = map[string]*controller.ClassInfo{
+				"custom-class": {
+					Description: "custom gateway class",
+					Labels: map[string]string{
+						"custom": "true",
+					},
+					Annotations: map[string]string{
+						"custom.annotation": "value",
+					},
+				},
+			}
+
+			var err error
+			cancel, err = createManager(ctx, nil, customClassConfigs)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create GatewayClasses with custom configurations", func() {
+			Eventually(func() bool {
+				gc := &apiv1.GatewayClass{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "custom-class"}, gc); err != nil {
+					return false
+				}
+				return gc.Spec.ControllerName == apiv1.GatewayController(gatewayControllerName) &&
+					*gc.Spec.Description == "custom gateway class" &&
+					gc.Labels["custom"] == "true" &&
+					gc.Annotations["custom.annotation"] == "value"
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/kgateway/controller/gw_controller_test.go
+++ b/internal/kgateway/controller/gw_controller_test.go
@@ -27,7 +27,7 @@ var _ = Describe("GwController", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 
 		var err error
-		cancel, err = createManager(ctx, inferenceExt)
+		cancel, err = createManager(ctx, inferenceExt, nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/internal/kgateway/controller/inferencepool_controller_test.go
+++ b/internal/kgateway/controller/inferencepool_controller_test.go
@@ -29,7 +29,7 @@ var _ = Describe("InferencePool controller", func() {
 		BeforeEach(func() {
 			var err error
 			inferenceExt = new(deployer.InferenceExtInfo)
-			cancel, err = createManager(ctx, inferenceExt)
+			cancel, err = createManager(ctx, inferenceExt, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -174,7 +174,7 @@ var _ = Describe("InferencePool controller", func() {
 		BeforeEach(func() {
 			var err error
 			inferenceExt = nil
-			cancel, err = createManager(ctx, inferenceExt)
+			cancel, err = createManager(ctx, inferenceExt, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Fix a bug with the GC provisioner logic when existing GCs from other GW implementors are present on the cluster before kgateway has been installed. Previously, we relied on a simplistic check in the provisioner's runnable function to determine whether the initial reconciliation kick channel should be called when no GCs exist in the cluster.

This approach is too simplistic and interferred with aggressive event filters that filtered out non-Delete events. In this scenario, the Start method would see that there's GCs present on the cluster, and avoid kicking the initial reconcile channel, and the controller's event filters would filters out GCs from other projects.

Now, we improved the logic in the Start method to kick the initial reconciliation when no GCs exist in the cluster || when one of the GCs in the configured class info struct are missing from the cluster.

- Update predicate filtering to properly handle GatewayClasses from other controllers
- Improve initial reconciliation logic to avoid unnecessary triggers
- Fix issue where provisioner was processing unmanaged GatewayClasses
- Add better handling of CREATE and UPDATE events

This change reduces unnecessary reconciliation loops and improves isolation between different Gateway API implementations.

Closes #10937 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
