### PR TITLE
extensions/routepolicy: extauth cluster naming

### DIFF
--- a/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy_test.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy_test.go
@@ -23,12 +23,16 @@ func TestExtAuthForSpec(t *testing.T) {
 	truth := true
 	truthy := &truth
 
-	gExtGetter := func(name, namespace string) (*ir.GatewayExtension, error) {
+	gExtGetter := func(name, namespace string) (*ir.GatewayExtension, *ir.BackendObjectIR, error) {
+		backend := gwv1.BackendObjectReference{Name: "test-extauth"}
+
 		return &ir.GatewayExtension{
 			Type: v1alpha1.GatewayExtensionTypeExtAuth,
 			ExtAuth: &v1alpha1.ExtAuthProvider{BackendRef: &gwv1.BackendRef{
-				BackendObjectReference: gwv1.BackendObjectReference{Name: "test-extauth"}}}}, nil
+				BackendObjectReference: backend,
+			}}}, &ir.BackendObjectIR{ObjectSource: ir.ObjectSource{Name: "test-extauth"}}, nil
 	}
+
 	t.Run("creates basic ext auth configuration in one pass", func(t *testing.T) {
 		// Setup
 		spec := &v1alpha1.RoutePolicy{Spec: v1alpha1.RoutePolicySpec{ExtAuth: &v1alpha1.ExtAuthRoutePolicy{

--- a/internal/kgateway/extensions2/plugins/routepolicy/route_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/route_policy_plugin.go
@@ -552,7 +552,7 @@ func buildTranslateFunc(
 
 		// Apply ExtAuthz specific translation
 
-		extAuthForSpec(commoncol.GatewayExtensions, krtctx, policyCR, &outSpec)
+		extAuthForSpec(commoncol, krtctx, policyCR, &outSpec)
 		// Apply rate limit specific translation
 		localRateLimitForSpec(policyCR.Spec, &outSpec)
 


### PR DESCRIPTION
As we iterate to get e2e tests working for extauth this should fix up the cluster naming piece from backendrefs