### PR TITLE
correctly set xport socket match on ai cluster

### DIFF
--- a/internal/kgateway/setup/testdata/standard/ai-multi-port-override-plaintext-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/ai-multi-port-override-plaintext-out.yaml
@@ -1,0 +1,175 @@
+clusters:
+- loadAssignment:
+    clusterName: ai_ext_proc_uds_cluster
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            pipe:
+              path: '@kgateway-ai-sock'
+  name: ai_ext_proc_uds_cluster
+  type: STATIC
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  dnsLookupFamily: V4_PREFERRED
+  loadAssignment:
+    clusterName: backend_gwtest_openai_0
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: model-failover.default.svc.cluster.local
+              portValue: 80
+          hostname: model-failover.default.svc.cluster.local
+        metadata:
+          filterMetadata:
+            io.solo.transformation:
+              auth_token: mysecretkey
+              model: gpt-4o
+  metadata: {}
+  name: backend_gwtest_openai_0
+  transportSocketMatches:
+  - match:
+      tls: "true"
+    name: tls
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        autoHostSni: true
+        commonTlsContext: {}
+  - match: {}
+    name: plaintext
+    transportSocket:
+      name: envoy.transport_sockets.raw_buffer
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      commonHttpProtocolOptions:
+        idleTimeout: 30s
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+      httpFilters:
+      - name: io.kgateway.wait
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.http.upstream_wait.v2.UpstreamWaitFilterConfig
+      - name: ai.policy.transformation.kgateway.io
+        typedConfig:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+      - name: ai.backend.transformation.kgateway.io
+        typedConfig:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+      - name: envoy.filters.http.upstream_codec
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: ai.extproc.kgateway.io
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            grpcService:
+              envoyGrpc:
+                clusterName: ai_ext_proc_uds_cluster
+            messageTimeout: 5s
+            metadataOptions:
+              forwardingNamespaces:
+                typed:
+                - envoy.filters.ai.solo.io
+                untyped:
+                - io.solo.transformation
+                - envoy.filters.ai.solo.io
+              receivingNamespaces:
+                untyped:
+                - ai.kgateway.io
+            processingMode:
+              requestBodyMode: STREAMED
+              requestHeaderMode: SEND
+              requestTrailerMode: SKIP
+              responseBodyMode: STREAMED
+              responseHeaderMode: SEND
+              responseTrailerMode: SKIP
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: http
+        statPrefix: http
+        useRemoteAddress: true
+    name: http
+  name: http
+routes:
+- ignorePortInHostMatching: true
+  name: http
+  virtualHosts:
+  - domains:
+    - test
+    name: http~test
+    routes:
+    - match:
+        pathSeparatedPrefix: /openai
+      name: http~test-route-0-httproute-route-to-backend-gwtest-0-0-matcher-0
+      route:
+        autoHostRewrite: true
+        cluster: backend_gwtest_openai_0
+      typedPerFilterConfig:
+        ai.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
+          transformations:
+          - requestMatch:
+              requestTransformation:
+                logRequestResponseInfo: false
+                transformationTemplate:
+                  headers:
+                    :path:
+                      text: /v1/chat/completions
+                    Authorization:
+                      text: Bearer {% if host_metadata("auth_token") != "" %}{{host_metadata("auth_token")}}{%
+                        else %}{{dynamic_metadata("auth_token","ai.kgateway.io")}}{%
+                        endif %}
+                  mergeJsonKeys:
+                    jsonKeys:
+                      model:
+                        tmpl:
+                          text: '{% if host_metadata("model") != "" %}"{{host_metadata("model")}}"{%
+                            else %}"{{model}}"{% endif %}'
+        ai.extproc.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcInitialMetadata:
+            - key: x-llm-provider
+              value: openai
+            - key: x-llm-model
+              value: gpt-4o
+            - key: x-request-id
+              value: '%REQ(X-REQUEST-ID)%'

--- a/internal/kgateway/setup/testdata/standard/ai-multi-port-override-plaintext.yaml
+++ b/internal/kgateway/setup/testdata/standard/ai-multi-port-override-plaintext.yaml
@@ -1,0 +1,67 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: Backend
+metadata:
+  labels:
+    app: kgateway
+  name: openai
+  namespace: gwtest
+spec:
+  type: AI
+  ai:
+    multipool:
+      priorities:
+      - pool:
+        - hostOverride:
+            host: model-failover.default.svc.cluster.local
+            port: 80
+          provider:
+            openai:
+              authToken:
+                kind: SecretRef
+                secretRef:
+                  name: openai-secret-one
+              model: gpt-4o
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-secret-one
+  namespace: gwtest
+type: Opaque
+data:
+  Authorization: bXlzZWNyZXRrZXk=
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: route-to-backend
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "test"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /openai
+      backendRefs:
+        - name: openai
+          kind: Backend
+          group: gateway.kgateway.dev

--- a/internal/kgateway/setup/testdata/standard/ai-multi-port-override-tls-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/ai-multi-port-override-tls-out.yaml
@@ -1,0 +1,177 @@
+clusters:
+- loadAssignment:
+    clusterName: ai_ext_proc_uds_cluster
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            pipe:
+              path: '@kgateway-ai-sock'
+  name: ai_ext_proc_uds_cluster
+  type: STATIC
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  dnsLookupFamily: V4_PREFERRED
+  loadAssignment:
+    clusterName: backend_gwtest_openai_0
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: model-failover.default.svc.cluster.local
+              portValue: 443
+          hostname: model-failover.default.svc.cluster.local
+        metadata:
+          filterMetadata:
+            envoy.transport_socket_match:
+              tls: "true"
+            io.solo.transformation:
+              auth_token: mysecretkey
+              model: gpt-4o
+  metadata: {}
+  name: backend_gwtest_openai_0
+  transportSocketMatches:
+  - match:
+      tls: "true"
+    name: tls
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        autoHostSni: true
+        commonTlsContext: {}
+  - match: {}
+    name: plaintext
+    transportSocket:
+      name: envoy.transport_sockets.raw_buffer
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      commonHttpProtocolOptions:
+        idleTimeout: 30s
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+      httpFilters:
+      - name: io.kgateway.wait
+        typedConfig:
+          '@type': type.googleapis.com/envoy.config.filter.http.upstream_wait.v2.UpstreamWaitFilterConfig
+      - name: ai.policy.transformation.kgateway.io
+        typedConfig:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+      - name: ai.backend.transformation.kgateway.io
+        typedConfig:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+      - name: envoy.filters.http.upstream_codec
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: ai.extproc.kgateway.io
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            grpcService:
+              envoyGrpc:
+                clusterName: ai_ext_proc_uds_cluster
+            messageTimeout: 5s
+            metadataOptions:
+              forwardingNamespaces:
+                typed:
+                - envoy.filters.ai.solo.io
+                untyped:
+                - io.solo.transformation
+                - envoy.filters.ai.solo.io
+              receivingNamespaces:
+                untyped:
+                - ai.kgateway.io
+            processingMode:
+              requestBodyMode: STREAMED
+              requestHeaderMode: SEND
+              requestTrailerMode: SKIP
+              responseBodyMode: STREAMED
+              responseHeaderMode: SEND
+              responseTrailerMode: SKIP
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: http
+        statPrefix: http
+        useRemoteAddress: true
+    name: http
+  name: http
+routes:
+- ignorePortInHostMatching: true
+  name: http
+  virtualHosts:
+  - domains:
+    - test
+    name: http~test
+    routes:
+    - match:
+        pathSeparatedPrefix: /openai
+      name: http~test-route-0-httproute-route-to-backend-gwtest-0-0-matcher-0
+      route:
+        autoHostRewrite: true
+        cluster: backend_gwtest_openai_0
+      typedPerFilterConfig:
+        ai.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
+          transformations:
+          - requestMatch:
+              requestTransformation:
+                logRequestResponseInfo: false
+                transformationTemplate:
+                  headers:
+                    :path:
+                      text: /v1/chat/completions
+                    Authorization:
+                      text: Bearer {% if host_metadata("auth_token") != "" %}{{host_metadata("auth_token")}}{%
+                        else %}{{dynamic_metadata("auth_token","ai.kgateway.io")}}{%
+                        endif %}
+                  mergeJsonKeys:
+                    jsonKeys:
+                      model:
+                        tmpl:
+                          text: '{% if host_metadata("model") != "" %}"{{host_metadata("model")}}"{%
+                            else %}"{{model}}"{% endif %}'
+        ai.extproc.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcInitialMetadata:
+            - key: x-llm-provider
+              value: openai
+            - key: x-llm-model
+              value: gpt-4o
+            - key: x-request-id
+              value: '%REQ(X-REQUEST-ID)%'

--- a/internal/kgateway/setup/testdata/standard/ai-multi-port-override-tls.yaml
+++ b/internal/kgateway/setup/testdata/standard/ai-multi-port-override-tls.yaml
@@ -1,0 +1,67 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: Backend
+metadata:
+  labels:
+    app: kgateway
+  name: openai
+  namespace: gwtest
+spec:
+  type: AI
+  ai:
+    multipool:
+      priorities:
+      - pool:
+        - hostOverride:
+            host: model-failover.default.svc.cluster.local
+            port: 443
+          provider:
+            openai:
+              authToken:
+                kind: SecretRef
+                secretRef:
+                  name: openai-secret-one
+              model: gpt-4o
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-secret-one
+  namespace: gwtest
+type: Opaque
+data:
+  Authorization: bXlzZWNyZXRrZXk=
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: route-to-backend
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "test"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /openai
+      backendRefs:
+        - name: openai
+          kind: Backend
+          group: gateway.kgateway.dev


### PR DESCRIPTION
fixes an issue where the tls transport socket match for ai clusters
did not have the tls match criteria set, resulting in all endpoints
matching tls even if they were plaintext