### PR TITLE
controller: Wrap client Update calls in Eventually block

### DIFF
--- a/internal/kgateway/controller/gatewayclass_provisioner_test.go
+++ b/internal/kgateway/controller/gatewayclass_provisioner_test.go
@@ -148,7 +148,6 @@ var _ = Describe("GatewayClassProvisioner", func() {
 				if err != nil {
 					return false
 				}
-				GinkgoWriter.Println("gcs.Items", len(gcs.Items))
 				return len(gcs.Items) == 2
 			}, timeout, interval).Should(BeTrue())
 		})

--- a/internal/kgateway/controller/gw_controller_test.go
+++ b/internal/kgateway/controller/gw_controller_test.go
@@ -89,7 +89,13 @@ var _ = Describe("GwController", func() {
 					IP: "127.0.0.1",
 				}},
 			}
-			Expect(k8sClient.Status().Update(ctx, &svc)).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				err := k8sClient.Status().Update(ctx, &svc)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
 
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: gwName, Namespace: "default"}, &gw)

--- a/internal/kgateway/controller/gw_controller_test.go
+++ b/internal/kgateway/controller/gw_controller_test.go
@@ -89,13 +89,9 @@ var _ = Describe("GwController", func() {
 					IP: "127.0.0.1",
 				}},
 			}
-			Eventually(func() bool {
-				err := k8sClient.Status().Update(ctx, &svc)
-				if err != nil {
-					return false
-				}
-				return true
-			}, timeout, interval).Should(BeTrue())
+			Eventually(func() error {
+				return k8sClient.Status().Update(ctx, &svc)
+			}, timeout, interval).Should(Succeed())
 
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: gwName, Namespace: "default"}, &gw)

--- a/internal/kgateway/controller/inferencepool_controller_test.go
+++ b/internal/kgateway/controller/inferencepool_controller_test.go
@@ -97,8 +97,9 @@ var _ = Describe("InferencePool controller", func() {
 					},
 				},
 			}
-			err = k8sClient.Status().Update(ctx, httpRoute)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				return k8sClient.Status().Update(ctx, httpRoute)
+			}, "10s", "1s").Should(Succeed())
 
 			// Create an InferencePool resource that is referenced by the HTTPRoute.
 			pool := &infextv1a2.InferencePool{


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Wrap update client calls in an eventually block to help mitigate against flakes. Should fix the https://github.com/kgateway-dev/kgateway/issues/10969 test failure.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
