### PR TITLE
dont block for unsynced backends

### DIFF
--- a/internal/kgateway/controller/gatewayclass_provisioner.go
+++ b/internal/kgateway/controller/gatewayclass_provisioner.go
@@ -124,7 +124,7 @@ func (r *gatewayClassProvisioner) createGatewayClass(ctx context.Context, name s
 }
 
 func (r *gatewayClassProvisioner) Start(ctx context.Context) error {
-	log := log.FromContext(ctx)
+	log := log.FromContext(ctx).WithName("GatewayClassProvisioner")
 	log.Info("waiting for cache to sync")
 
 	// Wait for cache to sync

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -123,6 +123,10 @@ func (i *BackendIndex) getBackend(kctx krt.HandlerContext, gk schema.GroupKind, 
 		return nil, ErrUnknownBackendKind
 	}
 
+	// dont block if backends aren't synced
+	if !col.HasSynced() {
+		return nil, &NotFoundError{NotFoundObj: key}
+	}
 	up := krt.FetchOne(kctx, col, krt.FilterKey(ir.BackendResourceName(key, port, "")))
 	if up == nil {
 		return nil, &NotFoundError{NotFoundObj: key}

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -544,15 +544,18 @@ func preRouteIndex(t *testing.T, inputs []any) *RoutesIndex {
 
 	policies := NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{})
 	refgrants := NewRefGrantIndex(krttest.GetMockCollection[*gwv1beta1.ReferenceGrant](mock))
-	upstreams := NewBackendIndex(krtutil.KrtOptions{}, nil, policies, refgrants)
-	upstreams.AddBackends(svcGk, k8sSvcUpstreams(services))
+	backends := NewBackendIndex(krtutil.KrtOptions{}, nil, policies, refgrants)
+	backends.AddBackends(svcGk, k8sSvcUpstreams(services))
 	pools := krttest.GetMockCollection[*infextv1a2.InferencePool](mock)
-	upstreams.AddBackends(infPoolGk, infPoolUpstreams(pools))
+	backends.AddBackends(infPoolGk, infPoolUpstreams(pools))
 
 	httproutes := krttest.GetMockCollection[*gwv1.HTTPRoute](mock)
 	tcpproutes := krttest.GetMockCollection[*gwv1a2.TCPRoute](mock)
 	tlsroutes := krttest.GetMockCollection[*gwv1a2.TLSRoute](mock)
-	rtidx := NewRoutesIndex(krtutil.KrtOptions{}, httproutes, tcpproutes, tlsroutes, policies, upstreams, refgrants)
+	if !backends.HasSynced() {
+		time.Sleep(time.Second)
+	}
+	rtidx := NewRoutesIndex(krtutil.KrtOptions{}, httproutes, tcpproutes, tlsroutes, policies, backends, refgrants)
 	services.WaitUntilSynced(nil)
 	for !rtidx.HasSynced() || !refgrants.HasSynced() {
 		time.Sleep(time.Second / 10)


### PR DESCRIPTION
when building initial state, we may not have backends synced yet
in which case we shouldn't block via Fetch