### PR TITLE
no need to attach policies in most cases that an upstream is fetched

### DIFF
--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -183,7 +183,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) erro
 	logger := contextutils.LoggerFrom(ctx)
 
 	// all backends with policies attached in a single collection
-	finalBackends := krt.JoinCollection(s.commonCols.BackendIndex.Backends(), krtopts.ToOptions("FinalBackends")...)
+	finalBackends := krt.JoinCollection(s.commonCols.BackendIndex.BackendsWithPolicy(), krtopts.ToOptions("FinalBackends")...)
 
 	s.translator.Init(ctx)
 


### PR DESCRIPTION
to prevent circular deps, return backend with no policies when GetBackendForRef is called