### PR TITLE
fix route status interaction with other controllers

### DIFF
--- a/internal/kgateway/reports/reporter.go
+++ b/internal/kgateway/reports/reporter.go
@@ -233,6 +233,14 @@ func getParentRefKey(parentRef *gwv1.ParentReference) ParentRefKey {
 	}
 }
 
+func (r *RouteReport) getParentRef(parentRef *gwv1.ParentReference) *ParentRefReport {
+	key := getParentRefKey(parentRef)
+	if r.Parents == nil {
+		r.Parents = make(map[ParentRefKey]*ParentRefReport)
+	}
+	return r.Parents[key]
+}
+
 func (r *RouteReport) parentRef(parentRef *gwv1.ParentReference) *ParentRefReport {
 	key := getParentRefKey(parentRef)
 	if r.Parents == nil {

--- a/internal/kgateway/reports/reporter.go
+++ b/internal/kgateway/reports/reporter.go
@@ -233,7 +233,10 @@ func getParentRefKey(parentRef *gwv1.ParentReference) ParentRefKey {
 	}
 }
 
-func (r *RouteReport) getParentRef(parentRef *gwv1.ParentReference) *ParentRefReport {
+// getParentRefOrNil returns a ParentRefReport for the given parentRef if and only if
+// that parentRef exists in the report (i.e. the parentRef was encountered during translation)
+// If no report is found, nil is returned, signaling this parentRef is unknown to the report
+func (r *RouteReport) getParentRefOrNil(parentRef *gwv1.ParentReference) *ParentRefReport {
 	key := getParentRefKey(parentRef)
 	if r.Parents == nil {
 		r.Parents = make(map[ParentRefKey]*ParentRefReport)

--- a/internal/kgateway/reports/reporter_test.go
+++ b/internal/kgateway/reports/reporter_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/reports"
 )
 
+const fake_condition = "kgateway.dev/SomeCondition"
+
 var _ = Describe("Reporting Infrastructure", func() {
 	BeforeEach(func() {
 	})
@@ -138,9 +140,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 				rm := reports.NewReportMap()
 
 				reporter := reports.NewReporter(&rm)
-				// initialize RouteReporter to mimic translation loop (i.e. report gets initialized for all Routes)
-				reporter.Route(obj)
-
+				fakeTranslate(reporter, obj)
 				status := rm.BuildRouteStatus(context.Background(), obj, "kgateway")
 
 				Expect(status).NotTo(BeNil())
@@ -158,9 +158,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 				rm := reports.NewReportMap()
 
 				reporter := reports.NewReporter(&rm)
-				// initialize RouteReporter to mimic translation loop (i.e. report gets initialized for all Routes)
-				reporter.Route(obj)
-
+				fakeTranslate(reporter, obj)
 				status := rm.BuildRouteStatus(context.Background(), obj, "gloo-gateway")
 
 				Expect(status).NotTo(BeNil())
@@ -169,22 +167,61 @@ var _ = Describe("Reporting Infrastructure", func() {
 			},
 			Entry("regular httproute", httpRoute(
 				metav1.Condition{
-					Type: "gloo.solo.io/SomeCondition",
+					Type: fake_condition,
 				},
 			)),
 			Entry("regular tcproute", tcpRoute(
 				metav1.Condition{
-					Type: "gloo.solo.io/SomeCondition",
+					Type: fake_condition,
 				},
 			)),
 			Entry("regular tlsroute", tlsRoute(
 				metav1.Condition{
-					Type: "gloo.solo.io/SomeCondition",
+					Type: fake_condition,
 				},
 			)),
 			Entry("delegatee route", delegateeRoute(
 				metav1.Condition{
-					Type: "gloo.solo.io/SomeCondition",
+					Type: fake_condition,
+				},
+			)),
+		)
+
+		DescribeTable("should not report for parentRefs that belong to other controllers",
+			func(obj client.Object) {
+				rm := reports.NewReportMap()
+
+				reporter := reports.NewReporter(&rm)
+
+				// translation will call Route() and ParentRef() for routes it translates out
+				// we use the same pattern here to establish reports that would reflect translation
+				route := &gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "route",
+						Namespace: "default",
+					},
+					Spec: gwv1.HTTPRouteSpec{
+						CommonRouteSpec: gwv1.CommonRouteSpec{
+							ParentRefs: []gwv1.ParentReference{
+								*parentRef(),
+								*otherParentRef(),
+							},
+						},
+					},
+				}
+				// reporter.Route(route)
+				reporter.Route(obj).ParentRef(parentRef())
+
+				status := rm.BuildRouteStatus(context.Background(), route, "gloo-gateway")
+
+				Expect(status).NotTo(BeNil())
+				Expect(status.Parents).To(HaveLen(1))
+				// 2 default positive conditions for the single parentRef we "translated"
+				Expect(status.Parents[0].Conditions).To(HaveLen(2))
+			},
+			Entry("regular httproute", httpRoute(
+				metav1.Condition{
+					Type: fake_condition,
 				},
 			)),
 		)
@@ -249,9 +286,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 				rm := reports.NewReportMap()
 
 				reporter := reports.NewReporter(&rm)
-				// initialize RouteReporter to mimic translation loop (i.e. report gets initialized for all Routes)
-				reporter.Route(obj)
-
+				fakeTranslate(reporter, obj)
 				status := rm.BuildRouteStatus(context.Background(), obj, "kgateway")
 
 				Expect(status).NotTo(BeNil())
@@ -312,8 +347,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 				rm := reports.NewReportMap()
 				reporter := reports.NewReporter(&rm)
 
-				// Initialize RouteReporter to mimic translation loop
-				reporter.Route(obj)
+				fakeTranslate(reporter, obj)
 
 				status := rm.BuildRouteStatus(context.Background(), obj, "kgateway")
 
@@ -358,9 +392,8 @@ var _ = Describe("Reporting Infrastructure", func() {
 				rm := reports.NewReportMap()
 				reporter := reports.NewReporter(&rm)
 
-				// Initialize RouteReporter to mimic translation loop
-				reporter.Route(route1)
-				reporter.Route(route2)
+				fakeTranslate(reporter, route1)
+				fakeTranslate(reporter, route2)
 
 				status1 := rm.BuildRouteStatus(context.Background(), route1, "kgateway")
 				status2 := rm.BuildRouteStatus(context.Background(), route2, "kgateway")
@@ -404,8 +437,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 			rm := reports.NewReportMap()
 			reporter := reports.NewReporter(&rm)
 
-			// Initialize RouteReporter to mimic translation loop
-			reporter.Route(route)
+			fakeTranslate(reporter, route)
 			status := rm.BuildRouteStatus(context.Background(), route, "kgateway")
 
 			Expect(status).NotTo(BeNil())
@@ -416,6 +448,28 @@ var _ = Describe("Reporting Infrastructure", func() {
 		Entry("TLSRoute with missing parent reference", tlsRoute()),
 	)
 })
+
+// fakeTranslate reports for the standard test route with the standard test parentRef
+// Initialize RouteReporter to mimic translation loop
+func fakeTranslate(reporter reports.Reporter, obj client.Object) {
+	switch route := obj.(type) {
+	case *gwv1.HTTPRoute:
+		routeReporter := reporter.Route(route)
+		for _, pr := range route.Spec.ParentRefs {
+			routeReporter.ParentRef(&pr)
+		}
+	case *gwv1a2.TCPRoute:
+		routeReporter := reporter.Route(route)
+		for _, pr := range route.Spec.ParentRefs {
+			routeReporter.ParentRef(&pr)
+		}
+	case *gwv1a2.TLSRoute:
+		routeReporter := reporter.Route(route)
+		for _, pr := range route.Spec.ParentRefs {
+			routeReporter.ParentRef(&pr)
+		}
+	}
+}
 
 func httpRoute(conditions ...metav1.Condition) client.Object {
 	route := &gwv1.HTTPRoute{
@@ -470,7 +524,13 @@ func tlsRoute(conditions ...metav1.Condition) client.Object {
 
 func parentRef() *gwv1.ParentReference {
 	return &gwv1.ParentReference{
-		Name: "parent",
+		Name: "kgateway-gtw",
+	}
+}
+
+func otherParentRef() *gwv1.ParentReference {
+	return &gwv1.ParentReference{
+		Name: "other-gtw",
 	}
 }
 
@@ -504,7 +564,7 @@ func gw() *gwv1.Gateway {
 	gw := &gwv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      "test",
+			Name:      "kgateway-gtw",
 		},
 	}
 	gw.Spec.Listeners = append(gw.Spec.Listeners, *listener())

--- a/internal/kgateway/reports/reporter_test.go
+++ b/internal/kgateway/reports/reporter_test.go
@@ -496,7 +496,8 @@ var _ = Describe("Reporting Infrastructure", func() {
 	)
 })
 
-// fakeTranslate reports for the standard test route with the standard test parentRef
+// fakeTranslate mimics the translation loop and reports for the provided route
+// along with all parentRefs defined in the route
 func fakeTranslate(reporter reports.Reporter, obj client.Object) {
 	// translation will call Route() and ParentRef() for routes it translates out
 	// we use the same pattern here to establish reports that would reflect translation

--- a/internal/kgateway/reports/reporter_test.go
+++ b/internal/kgateway/reports/reporter_test.go
@@ -14,9 +14,12 @@ import (
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/reports"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
 const fake_condition = "kgateway.dev/SomeCondition"
+
+var ctx = context.Background()
 
 var _ = Describe("Reporting Infrastructure", func() {
 	BeforeEach(func() {
@@ -141,7 +144,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 
 				reporter := reports.NewReporter(&rm)
 				fakeTranslate(reporter, obj)
-				status := rm.BuildRouteStatus(context.Background(), obj, "kgateway")
+				status := rm.BuildRouteStatus(ctx, obj, wellknown.GatewayControllerName)
 
 				Expect(status).NotTo(BeNil())
 				Expect(status.Parents).To(HaveLen(1))
@@ -159,7 +162,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 
 				reporter := reports.NewReporter(&rm)
 				fakeTranslate(reporter, obj)
-				status := rm.BuildRouteStatus(context.Background(), obj, "gloo-gateway")
+				status := rm.BuildRouteStatus(ctx, obj, wellknown.GatewayControllerName)
 
 				Expect(status).NotTo(BeNil())
 				Expect(status.Parents).To(HaveLen(1))
@@ -193,8 +196,6 @@ var _ = Describe("Reporting Infrastructure", func() {
 
 				reporter := reports.NewReporter(&rm)
 
-				// translation will call Route() and ParentRef() for routes it translates out
-				// we use the same pattern here to establish reports that would reflect translation
 				route := &gwv1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "route",
@@ -208,22 +209,68 @@ var _ = Describe("Reporting Infrastructure", func() {
 							},
 						},
 					},
+					Status: gwv1.HTTPRouteStatus{
+						RouteStatus: gwv1.RouteStatus{
+							Parents: []gwv1.RouteParentStatus{
+								gwv1.RouteParentStatus{
+									ControllerName: "other.io/controller",
+									ParentRef:      *otherParentRef(),
+									Conditions: []metav1.Condition{
+										metav1.Condition{
+											Type:   string(gwv1.RouteConditionAccepted),
+											Status: metav1.ConditionTrue,
+											Reason: string(gwv1.RouteConditionAccepted),
+										},
+									},
+								},
+							},
+						},
+					},
 				}
-				// reporter.Route(route)
+
+				// we only translate our parentRef
 				reporter.Route(obj).ParentRef(parentRef())
 
-				status := rm.BuildRouteStatus(context.Background(), route, "gloo-gateway")
+				status := rm.BuildRouteStatus(ctx, route, wellknown.GatewayControllerName)
 
 				Expect(status).NotTo(BeNil())
-				Expect(status.Parents).To(HaveLen(1))
+				// 1 parent is ours, 1 parent is other
+				Expect(status.Parents).To(HaveLen(2))
 				// 2 default positive conditions for the single parentRef we "translated"
+				// ours will be first due to alphabetical ordering of controller name ('k' vs. 'o')
 				Expect(status.Parents[0].Conditions).To(HaveLen(2))
 			},
-			Entry("regular httproute", httpRoute(
-				metav1.Condition{
-					Type: fake_condition,
+			Entry("httproute", &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "route",
+					Namespace: "default",
 				},
-			)),
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							*parentRef(),
+							*otherParentRef(),
+						},
+					},
+				},
+				Status: gwv1.HTTPRouteStatus{
+					RouteStatus: gwv1.RouteStatus{
+						Parents: []gwv1.RouteParentStatus{
+							gwv1.RouteParentStatus{
+								ControllerName: "other.io/controller",
+								ParentRef:      *otherParentRef(),
+								Conditions: []metav1.Condition{
+									metav1.Condition{
+										Type:   string(gwv1.RouteConditionAccepted),
+										Status: metav1.ConditionTrue,
+										Reason: string(gwv1.RouteConditionAccepted),
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		)
 
 		DescribeTable("should correctly set negative route conditions from report and not add extra conditions",
@@ -287,7 +334,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 
 				reporter := reports.NewReporter(&rm)
 				fakeTranslate(reporter, obj)
-				status := rm.BuildRouteStatus(context.Background(), obj, "kgateway")
+				status := rm.BuildRouteStatus(context.Background(), obj, wellknown.GatewayControllerName)
 
 				Expect(status).NotTo(BeNil())
 				Expect(status.Parents).To(HaveLen(1))
@@ -308,7 +355,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 					Fail(fmt.Sprintf("unsupported route type: %T", obj))
 				}
 
-				status = rm.BuildRouteStatus(context.Background(), obj, "kgateway")
+				status = rm.BuildRouteStatus(context.Background(), obj, wellknown.GatewayControllerName)
 
 				Expect(status).NotTo(BeNil())
 				Expect(status.Parents).To(HaveLen(1))
@@ -349,7 +396,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 
 				fakeTranslate(reporter, obj)
 
-				status := rm.BuildRouteStatus(context.Background(), obj, "kgateway")
+				status := rm.BuildRouteStatus(ctx, obj, wellknown.GatewayControllerName)
 
 				Expect(status).NotTo(BeNil())
 				Expect(status.Parents).To(HaveLen(2))
@@ -395,8 +442,8 @@ var _ = Describe("Reporting Infrastructure", func() {
 				fakeTranslate(reporter, route1)
 				fakeTranslate(reporter, route2)
 
-				status1 := rm.BuildRouteStatus(context.Background(), route1, "kgateway")
-				status2 := rm.BuildRouteStatus(context.Background(), route2, "kgateway")
+				status1 := rm.BuildRouteStatus(ctx, route1, wellknown.GatewayControllerName)
+				status2 := rm.BuildRouteStatus(ctx, route2, wellknown.GatewayControllerName)
 
 				Expect(status1).NotTo(BeNil())
 				Expect(status1.Parents[0].Conditions).To(HaveLen(2))
@@ -438,7 +485,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 			reporter := reports.NewReporter(&rm)
 
 			fakeTranslate(reporter, route)
-			status := rm.BuildRouteStatus(context.Background(), route, "kgateway")
+			status := rm.BuildRouteStatus(ctx, route, wellknown.GatewayControllerName)
 
 			Expect(status).NotTo(BeNil())
 			Expect(status.Parents).To(BeEmpty())
@@ -450,8 +497,9 @@ var _ = Describe("Reporting Infrastructure", func() {
 })
 
 // fakeTranslate reports for the standard test route with the standard test parentRef
-// Initialize RouteReporter to mimic translation loop
 func fakeTranslate(reporter reports.Reporter, obj client.Object) {
+	// translation will call Route() and ParentRef() for routes it translates out
+	// we use the same pattern here to establish reports that would reflect translation
 	switch route := obj.(type) {
 	case *gwv1.HTTPRoute:
 		routeReporter := reporter.Route(route)
@@ -481,8 +529,9 @@ func httpRoute(conditions ...metav1.Condition) client.Object {
 	route.Spec.CommonRouteSpec.ParentRefs = append(route.Spec.CommonRouteSpec.ParentRefs, *parentRef())
 	if len(conditions) > 0 {
 		route.Status.Parents = append(route.Status.Parents, gwv1.RouteParentStatus{
-			ParentRef:  *parentRef(),
-			Conditions: conditions,
+			ParentRef:      *parentRef(),
+			Conditions:     conditions,
+			ControllerName: wellknown.GatewayControllerName,
 		})
 	}
 	return route
@@ -498,8 +547,9 @@ func tcpRoute(conditions ...metav1.Condition) client.Object {
 	route.Spec.CommonRouteSpec.ParentRefs = append(route.Spec.CommonRouteSpec.ParentRefs, *parentRef())
 	if len(conditions) > 0 {
 		route.Status.Parents = append(route.Status.Parents, gwv1.RouteParentStatus{
-			ParentRef:  *parentRef(),
-			Conditions: conditions,
+			ParentRef:      *parentRef(),
+			Conditions:     conditions,
+			ControllerName: wellknown.GatewayControllerName,
 		})
 	}
 	return route
@@ -515,8 +565,9 @@ func tlsRoute(conditions ...metav1.Condition) client.Object {
 	route.Spec.CommonRouteSpec.ParentRefs = append(route.Spec.CommonRouteSpec.ParentRefs, *parentRef())
 	if len(conditions) > 0 {
 		route.Status.Parents = append(route.Status.Parents, gwv1.RouteParentStatus{
-			ParentRef:  *parentRef(),
-			Conditions: conditions,
+			ParentRef:      *parentRef(),
+			Conditions:     conditions,
+			ControllerName: wellknown.GatewayControllerName,
 		})
 	}
 	return route
@@ -544,8 +595,9 @@ func delegateeRoute(conditions ...metav1.Condition) client.Object {
 	route.Spec.CommonRouteSpec.ParentRefs = append(route.Spec.CommonRouteSpec.ParentRefs, *parentRouteRef())
 	if len(conditions) > 0 {
 		route.Status.Parents = append(route.Status.Parents, gwv1.RouteParentStatus{
-			ParentRef:  *parentRouteRef(),
-			Conditions: conditions,
+			ParentRef:      *parentRouteRef(),
+			Conditions:     conditions,
+			ControllerName: wellknown.GatewayControllerName,
 		})
 	}
 	return route

--- a/internal/kgateway/reports/status.go
+++ b/internal/kgateway/reports/status.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	// "github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/solo-io/go-utils/contextutils"
 	"istio.io/istio/pkg/ptr"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -16,6 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
 // TODO: refactor this struct + methods to better reflect the usage now in proxy_syncer
@@ -99,6 +100,10 @@ func (r *ReportMap) BuildRouteStatus(
 		obj.GetName())
 
 	var existingStatus gwv1.RouteStatus
+	// Default to using spec.ParentRefs when building the parent statuses for a route.
+	// However, for delegatee (child) routes, the parentRefs field is optional and such routes
+	// may not specify it. In this case, we infer the parentRefs form the RouteReport
+	// corresponding to the delegatee (child) route as the route's report is associated to a parentRef.
 	var parentRefs []gwv1.ParentReference
 	switch route := obj.(type) {
 	case *gwv1.HTTPRoute:
@@ -122,14 +127,6 @@ func (r *ReportMap) BuildRouteStatus(
 	default:
 		contextutils.LoggerFrom(ctx).Error(fmt.Errorf("unsupported route type %T", obj), "failed to build route status")
 		return nil
-	}
-
-	// Default to using spec.ParentRefs when building the parent statuses for a route.
-	// However, for delegatee (child) routes, the parentRefs field is optional and such routes
-	// may not specify it. In this case, we infer the parentRefs form the RouteReport
-	// corresponding to the delegatee (child) route as the route's report is associated to a parentRef.
-	if len(parentRefs) == 0 {
-		parentRefs = append(parentRefs, routeReport.parentRefs()...)
 	}
 
 	newStatus := gwv1.RouteStatus{}

--- a/internal/kgateway/reports/status.go
+++ b/internal/kgateway/reports/status.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 
 	// "github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/solo-io/go-utils/contextutils"
+	"istio.io/istio/pkg/ptr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,13 +77,17 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 }
 
 // BuildRouteStatus returns a newly constructed and fully defined RouteStatus for the supplied route object
-// according to the state of the ReportMap. If the ReportMap does not have a RouteReport for the given route,
-// e.g. because it did not encounter the route during translation, or the object is an unsupported route kind,
-// nil is returned. Supported object types are:
-//
-// * HTTPRoute
-// * TCPRoute
-func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cName string) *gwv1.RouteStatus {
+// according to the state of the ReportMap and the current status of the route.
+// The gwv1.RouteStatus returned will contain all non-gateway parents from the provided current route status
+// along with the newly built kgw status per ReportMap, sorted in deterministic fashion.
+// If the ReportMap does not have a RouteReport for the given route, e.g. because it did not encounter
+// the route during translation, or the object is an unsupported route kind, nil is returned.
+// Supported route types are: HTTPRoute, TCPRoute, TLSRoute
+func (r *ReportMap) BuildRouteStatus(
+	ctx context.Context,
+	obj client.Object,
+	cName string,
+) *gwv1.RouteStatus {
 	routeReport := r.route(obj)
 	if routeReport == nil {
 		contextutils.LoggerFrom(ctx).Infof("missing route report for %T %s/%s", obj, obj.GetName(), obj.GetNamespace())
@@ -91,10 +98,6 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 		obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(),
 		obj.GetName())
 
-	// Default to using spec.ParentRefs when building the parent statuses for a route.
-	// However, for delegatee (child) routes, the parentRefs field is optional and such routes
-	// may not specify it. In this case, we infer the parentRefs form the RouteReport
-	// corresponding to the delegatee (child) route as the route's report is associated to a parentRef.
 	var existingStatus gwv1.RouteStatus
 	var parentRefs []gwv1.ParentReference
 	switch route := obj.(type) {
@@ -121,43 +124,21 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 		return nil
 	}
 
-	// now consider parentRefs that are not ours
-	// for now, we only consider Gateways to identify those from a different controller
-	// for _, parentRef := range parentRefs {
-	// 	// confirm parentRef is to a Gateway
-	// 	if parentRef.Group != nil {
-	// 		if *parentRef.Group != "" {
-	// 			if parentRef.Group != (*gwv1.Group)(&gwv1.GroupVersion.Group) {
-	// 				// Group is set to something other than "" or k8s gw api group
-	// 				continue
-	// 			}
-	// 		}
-	// 	}
-	// 	if parentRef.Kind != nil {
-	// 		if *parentRef.Kind != "" {
-	// 			if *parentRef.Kind != wellknown.GatewayKind {
-	// 				// Kind is set to something other than "" or k8s gw gtw kind
-	// 				continue
-	// 			}
-	// 		}
-	// 	}
-	// 	gtw := gwv1.Gateway{
-	// 		ObjectMeta: metav1.ObjectMeta{
-	// 			Name: string(parentRef.Name),
-	// 			Namespace: string(*parentRef.Namespace),
-	// 		},
-	// 	}
-	// 	gr := r.Gateway(&gtw)
-	// 	gr.
-	// }
+	// Default to using spec.ParentRefs when building the parent statuses for a route.
+	// However, for delegatee (child) routes, the parentRefs field is optional and such routes
+	// may not specify it. In this case, we infer the parentRefs form the RouteReport
+	// corresponding to the delegatee (child) route as the route's report is associated to a parentRef.
+	if len(parentRefs) == 0 {
+		parentRefs = append(parentRefs, routeReport.parentRefs()...)
+	}
 
+	newStatus := gwv1.RouteStatus{}
 	// Process the parent references to build the RouteParentStatus
-	routeStatus := gwv1.RouteStatus{}
 	for _, parentRef := range parentRefs {
 		parentStatusReport := routeReport.getParentRef(&parentRef)
 		if parentStatusReport == nil {
-			// this report doesn't have an entry for this parentRef
-			// so we didn't translate it
+			// report doesn't have an entry for this parentRef, meaning we didn't translate it
+			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)
 			continue
 		}
 		addMissingParentRefConditions(parentStatusReport)
@@ -194,10 +175,42 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 			ControllerName: gwv1.GatewayController(cName),
 			Conditions:     finalConditions,
 		}
-		routeStatus.Parents = append(routeStatus.Parents, routeParentStatus)
+		newStatus.Parents = append(newStatus.Parents, routeParentStatus)
 	}
 
-	return &routeStatus
+	// now we have a status object reflecting the state of translation according to our reportMap
+	// let's add status from other controllers on the current object status
+	var kgwStatus *gwv1.RouteStatus = &newStatus
+	for _, rps := range existingStatus.Parents {
+		if rps.ControllerName != wellknown.GatewayControllerName {
+			kgwStatus.Parents = append(kgwStatus.Parents, rps)
+		}
+	}
+
+	// sort all parents for consistency with Equals and for Update
+	// match sorting semantics of istio/istio, see:
+	// https://github.com/istio/istio/blob/6dcaa0206bcaf20e3e3b4e45e9376f0f96365571/pilot/pkg/config/kube/gateway/conditions.go#L188-L193
+	slices.SortStableFunc(kgwStatus.Parents, func(a, b gwv1.RouteParentStatus) int {
+		return strings.Compare(
+			parentString(string(a.ControllerName), a.ParentRef),
+			parentString(string(b.ControllerName), b.ParentRef),
+		)
+	})
+
+	return &newStatus
+}
+
+// match istio/istio logic but include controller name, see:
+// https://github.com/istio/istio/blob/6dcaa0206bcaf20e3e3b4e45e9376f0f96365571/pilot/pkg/config/kube/gateway/conversion.go#L2714-L2722
+func parentString(controllerStr string, ref gwv1.ParentReference) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s/%d.%s",
+		controllerStr,
+		ptr.OrEmpty(ref.Group),
+		ptr.OrEmpty(ref.Kind),
+		ref.Name,
+		ptr.OrEmpty(ref.SectionName),
+		ptr.OrEmpty(ref.Port),
+		ptr.OrEmpty(ref.Namespace))
 }
 
 // Reports will initially only contain negative conditions found during translation,

--- a/internal/kgateway/reports/status.go
+++ b/internal/kgateway/reports/status.go
@@ -187,20 +187,16 @@ func (r *ReportMap) BuildRouteStatus(
 	// match sorting semantics of istio/istio, see:
 	// https://github.com/istio/istio/blob/6dcaa0206bcaf20e3e3b4e45e9376f0f96365571/pilot/pkg/config/kube/gateway/conditions.go#L188-L193
 	slices.SortStableFunc(kgwStatus.Parents, func(a, b gwv1.RouteParentStatus) int {
-		return strings.Compare(
-			parentString(string(a.ControllerName), a.ParentRef),
-			parentString(string(b.ControllerName), b.ParentRef),
-		)
+		return strings.Compare(parentString(a.ParentRef), parentString(b.ParentRef))
 	})
 
 	return &newStatus
 }
 
-// match istio/istio logic but include controller name, see:
+// match istio/istio logic, see:
 // https://github.com/istio/istio/blob/6dcaa0206bcaf20e3e3b4e45e9376f0f96365571/pilot/pkg/config/kube/gateway/conversion.go#L2714-L2722
-func parentString(controllerStr string, ref gwv1.ParentReference) string {
-	return fmt.Sprintf("%s/%s/%s/%s/%s/%d.%s",
-		controllerStr,
+func parentString(ref gwv1.ParentReference) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%d.%s",
 		ptr.OrEmpty(ref.Group),
 		ptr.OrEmpty(ref.Kind),
 		ref.Name,

--- a/internal/kgateway/reports/status.go
+++ b/internal/kgateway/reports/status.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 
-	// "github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/solo-io/go-utils/contextutils"
 	"istio.io/istio/pkg/ptr"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -132,7 +131,7 @@ func (r *ReportMap) BuildRouteStatus(
 	newStatus := gwv1.RouteStatus{}
 	// Process the parent references to build the RouteParentStatus
 	for _, parentRef := range parentRefs {
-		parentStatusReport := routeReport.getParentRef(&parentRef)
+		parentStatusReport := routeReport.getParentRefOrNil(&parentRef)
 		if parentStatusReport == nil {
 			// report doesn't have an entry for this parentRef, meaning we didn't translate it
 			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)

--- a/internal/kgateway/reports/status.go
+++ b/internal/kgateway/reports/status.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 
+	// "github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/solo-io/go-utils/contextutils"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,10 +121,45 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 		return nil
 	}
 
+	// now consider parentRefs that are not ours
+	// for now, we only consider Gateways to identify those from a different controller
+	// for _, parentRef := range parentRefs {
+	// 	// confirm parentRef is to a Gateway
+	// 	if parentRef.Group != nil {
+	// 		if *parentRef.Group != "" {
+	// 			if parentRef.Group != (*gwv1.Group)(&gwv1.GroupVersion.Group) {
+	// 				// Group is set to something other than "" or k8s gw api group
+	// 				continue
+	// 			}
+	// 		}
+	// 	}
+	// 	if parentRef.Kind != nil {
+	// 		if *parentRef.Kind != "" {
+	// 			if *parentRef.Kind != wellknown.GatewayKind {
+	// 				// Kind is set to something other than "" or k8s gw gtw kind
+	// 				continue
+	// 			}
+	// 		}
+	// 	}
+	// 	gtw := gwv1.Gateway{
+	// 		ObjectMeta: metav1.ObjectMeta{
+	// 			Name: string(parentRef.Name),
+	// 			Namespace: string(*parentRef.Namespace),
+	// 		},
+	// 	}
+	// 	gr := r.Gateway(&gtw)
+	// 	gr.
+	// }
+
 	// Process the parent references to build the RouteParentStatus
 	routeStatus := gwv1.RouteStatus{}
 	for _, parentRef := range parentRefs {
-		parentStatusReport := routeReport.parentRef(&parentRef)
+		parentStatusReport := routeReport.getParentRef(&parentRef)
+		if parentStatusReport == nil {
+			// this report doesn't have an entry for this parentRef
+			// so we didn't translate it
+			continue
+		}
 		addMissingParentRefConditions(parentStatusReport)
 
 		// Get the status of the current parentRef conditions if they exist

--- a/internal/kgateway/setup/setup.go
+++ b/internal/kgateway/setup/setup.go
@@ -127,6 +127,7 @@ func StartKgatewayWithConfig(
 
 	logger.Info("initializing controller")
 	c, err := controller.NewControllerBuilder(ctx, controller.StartConfig{
+		// TODO: why do we plumb this through if it's wellknown?
 		ControllerName: wellknown.GatewayControllerName,
 		ExtraPlugins:   extraPlugins,
 		RestConfig:     restConfig,

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/reports"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/gateway/testutils"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
 )
 
@@ -130,7 +131,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
@@ -154,7 +155,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
@@ -188,7 +189,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
@@ -213,7 +214,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
@@ -238,7 +239,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
@@ -273,7 +274,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
@@ -298,7 +299,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
@@ -323,7 +324,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 						Namespace: "default",
 					},
 				}
-				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, "")
+				routeStatus := reportsMap.BuildRouteStatus(context.TODO(), route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))

--- a/internal/kgateway/translator/gateway/testutils/test_translator.go
+++ b/internal/kgateway/translator/gateway/testutils/test_translator.go
@@ -269,7 +269,6 @@ func (tc TestCase) Run(t test.Failer, ctx context.Context) (map[types.Namespaced
 	cli.RunAndWait(ctx.Done())
 	commoncol.GatewayIndex.Gateways.WaitUntilSynced(ctx.Done())
 
-	kubeclient.WaitForCacheSync("routes", ctx.Done(), commoncol.HasSynced)
 	kubeclient.WaitForCacheSync("routes", ctx.Done(), commoncol.Routes.HasSynced)
 	kubeclient.WaitForCacheSync("extensions", ctx.Done(), extensions.HasSynced)
 	kubeclient.WaitForCacheSync("commoncol", ctx.Done(), commoncol.HasSynced)

--- a/internal/kgateway/translator/httproute/translate_httproute_test.go
+++ b/internal/kgateway/translator/httproute/translate_httproute_test.go
@@ -174,7 +174,7 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 				Expect(routes[0].Match.Path.Type).To(BeEquivalentTo(ptr.To(gwv1.PathMatchPathPrefix)))
 				Expect(routes[0].Match.Path.Value).To(BeEquivalentTo(ptr.To("/")))
 
-				routeStatus := reportsMap.BuildRouteStatus(ctx, route, "")
+				routeStatus := reportsMap.BuildRouteStatus(ctx, route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				By("verifying the route was accepted")
@@ -254,7 +254,7 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 				Expect(routes[0].Match.Path.Type).To(BeEquivalentTo(ptr.To(gwv1.PathMatchPathPrefix)))
 				Expect(routes[0].Match.Path.Value).To(BeEquivalentTo(ptr.To("/")))
 
-				routeStatus := reportsMap.BuildRouteStatus(ctx, route, "")
+				routeStatus := reportsMap.BuildRouteStatus(ctx, route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				By("verifying the route was accepted")
@@ -353,7 +353,7 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 				Expect(routes[0].Backends).To(HaveLen(1))
 				Expect(routes[0].Backends[0].Backend.ClusterName).To(Equal("inferencepool_cluster"))
 
-				routeStatus := reportsMap.BuildRouteStatus(ctx, route, "")
+				routeStatus := reportsMap.BuildRouteStatus(ctx, route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				By("verifying the route was accepted")
@@ -428,7 +428,7 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 				Expect(routes).To(HaveLen(1))
 				Expect(routes[0].Backends[0].Backend.ClusterName).To(Equal("blackhole_cluster"))
 
-				routeStatus := reportsMap.BuildRouteStatus(ctx, route, "")
+				routeStatus := reportsMap.BuildRouteStatus(ctx, route, wellknown.GatewayControllerName)
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 				By("verifying the route was accepted")


### PR DESCRIPTION
* change Route status reporter to only report parents for parentRefs that were encountered during translation
 this relies on a currently satisfied assumption that `RouteReport.ParentRefReport()` will be called for every route seen during translation

* when building the new status for a route, include all non-kgateway existing status from the resource
this prevents us from clobbering non kgateway parents

* sort route status for consistency with Equals() and to hopefully prevent thrashing with other controllers