### PR TITLE
Remove the stale .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-docs/v1/**	             linguist-generated=true
-docs/cli/glooctl*.md     linguist-generated=true
-*.pb.*	                 linguist-generated=true
-*sk.md	                 linguist-generated=true
-*sk.go	                 linguist-generated=true


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Remove the stale .gitattributes file. It's contents no longer match the current state of the repository since the migration from the solo-io organization.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
