### PR TITLE
api,install: Fix invalid kubebuilder marker

### DIFF
--- a/api/v1alpha1/ai_policy.go
+++ b/api/v1alpha1/ai_policy.go
@@ -24,7 +24,7 @@ type AIPolicy struct {
 
 	// The type of route to the LLM provider API. Currently, `CHAT` and `CHAT_STREAMING` are supported.
 	// +kubebuilder:validation:Enum=CHAT;CHAT_STREAMING
-	// +kube:default=CHAT
+	// +kubebuilder:default=CHAT
 	RouteType *RouteType `json:"routeType,omitempty"`
 }
 

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
@@ -263,6 +263,7 @@ spec:
                         type: object
                     type: object
                   routeType:
+                    default: CHAT
                     enum:
                     - CHAT
                     - CHAT_STREAMING


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Fix the kubebuilder marker used in the RouteType struct in the TrafficPolicy API.

Closes https://github.com/kgateway-dev/kgateway/issues/10972.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
