### PR TITLE
install/helm: Fix the image.pullPolicy helm value

### DIFF
--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -49,7 +49,7 @@ controller:
   image:
     registry: ""
     repository: kgateway
-    pullPolicy: IfNotPresent
+    pullPolicy: ""
     tag: ""
   service:
     type: ClusterIP


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

The top-level image field provides the defaults for the controller and dataplane container images. However, the kgateway Deployment template first checks the controller.image.pullPolicy value and then falls back to the image.pullPolicy default:

https://github.com/kgateway-dev/kgateway/blob/2553feb9cbb08973ba20c39d933022a362d78880/install/helm/kgateway/templates/deployment.yaml#L34

This is problematic due to the way the controller.image.pullPolicy field is set:

https://github.com/kgateway-dev/kgateway/blob/2553feb9cbb08973ba20c39d933022a362d78880/install/helm/kgateway/values.yaml#L49-L53

In this scenario, we need to provide an empty default to get the desired behavior. This approach allows users to override the default value while achieving a consistent UX where the global image values should affect the component-level images.

Manually tested this locally:

```bash
$ make package-kgateway-charts VERSION=1.0.0-ci1
...
```

1. Normal workflow

```bash
$ helm upgrade -i --create-namespace -n kgateway-system kgateway _test/kgateway-1.0.0-ci1.tgz
...
$ k get deploy/kgateway -o yaml | grep imagePullPolicy      
        imagePullPolicy: IfNotPresent
```

2. Override the global image pull policy

```bash
$ helm upgrade -i --create-namespace -n kgateway-system kgateway _test/kgateway-1.0.0-ci1.tgz --set image.pullPolicy=Always
...
$  get deploy/kgateway -o yaml | grep imagePullPolicy                                                                                                               
        imagePullPolicy: Always
```

3. Override the controller & global image pull policy

```bash
$ helm upgrade -i --create-namespace -n kgateway-system kgateway _test/kgateway-1.0.0-ci1.tgz --set image.pullPolicy=Always --set controller.image.pullPolicy=IfNotPresent
...
$ k get deploy/kgateway -o yaml | grep imagePullPolicy                                                                                                                                                              
        imagePullPolicy: IfNotPresent
```

Notably, in the last scenario the KGW_DEFAULT_IMAGE_PULL_POLICY envvar on the kgateway container would be set to the "Always" pull policy value. I _think_ this is the right UX given that envvar controls the default dataplane container image configuration.

Closes https://github.com/kgateway-dev/kgateway/issues/10936.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
