### PR TITLE
deployer: Respect GWP overrides for Istio integration

### DIFF
--- a/internal/kgateway/deployer/deployer_test.go
+++ b/internal/kgateway/deployer/deployer_test.go
@@ -1076,12 +1076,10 @@ var _ = Describe("Deployer", func() {
 									Repository: ptr.To("bar"),
 									Tag:        ptr.To("baz"),
 								},
-								Ports: []corev1.ContainerPort{
-									{
-										Name:          "foo",
-										ContainerPort: 80,
-									},
-								},
+								Ports: []corev1.ContainerPort{{
+									Name:          "foo",
+									ContainerPort: 80,
+								}},
 							},
 						},
 					},
@@ -1449,6 +1447,23 @@ var _ = Describe("Deployer", func() {
 					Expect(aiContainer.SecurityContext.RunAsUser).To(BeNil())
 				}
 			}
+
+			By("validating the override values are set in the istio container")
+			Expect(istioProxyContainer.Env).To(ContainElement(corev1.EnvVar{
+				Name:      "CA_ADDR",
+				Value:     *inp.overrideGwp.Spec.Kube.Istio.IstioProxyContainer.IstioDiscoveryAddress,
+				ValueFrom: nil,
+			}))
+			Expect(istioProxyContainer.Env).To(ContainElement(corev1.EnvVar{
+				Name:      "ISTIO_META_MESH_ID",
+				Value:     *inp.overrideGwp.Spec.Kube.Istio.IstioProxyContainer.IstioMetaMeshId,
+				ValueFrom: nil,
+			}))
+			Expect(istioProxyContainer.Env).To(ContainElement(corev1.EnvVar{
+				Name:      "ISTIO_META_CLUSTER_ID",
+				Value:     *inp.overrideGwp.Spec.Kube.Istio.IstioProxyContainer.IstioMetaClusterId,
+				ValueFrom: nil,
+			}))
 
 			bootstrapCfg := objs.getEnvoyConfig(defaultNamespace, defaultConfigMapName)
 			clusters := bootstrapCfg.GetStaticResources().GetClusters()

--- a/internal/kgateway/deployer/merge.go
+++ b/internal/kgateway/deployer/merge.go
@@ -530,7 +530,6 @@ func deepMergeIstioContainer(dst, src *v1alpha1.IstioContainer) *v1alpha1.IstioC
 	if src == nil {
 		return dst
 	}
-
 	if dst == nil {
 		return src
 	}
@@ -543,20 +542,15 @@ func deepMergeIstioContainer(dst, src *v1alpha1.IstioContainer) *v1alpha1.IstioC
 		dst.LogLevel = src.GetLogLevel()
 	}
 
-	// Do not allow per-gateway overrides of these values if they are set in the default
-	// GatewayParameters populated by helm values
-	if dst.GetIstioDiscoveryAddress() == nil {
-		// Doesn't matter if we're overriding empty with empty
+	if src.GetIstioDiscoveryAddress() != nil {
 		dst.IstioDiscoveryAddress = src.GetIstioDiscoveryAddress()
 	}
 
-	if dst.GetIstioMetaMeshId() == nil {
-		// Doesn't matter if we're overriding empty with empty
+	if src.GetIstioMetaMeshId() != nil {
 		dst.IstioMetaMeshId = src.GetIstioMetaMeshId()
 	}
 
-	if dst.GetIstioMetaClusterId() == nil {
-		// Doesn't matter if we're overriding empty with empty
+	if src.GetIstioMetaClusterId() != nil {
 		dst.IstioMetaClusterId = src.GetIstioMetaClusterId()
 	}
 


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

The issue was that the merge logic was preventing valid GWP overrides because:

1. The in-memory default GatewayParameters always had these Istio fields set
2. The merge function used the in-memory parameters as the destination
3. The merge logic only copied from source if destination was nil
4. Therefore, valid overrides in user-provided GatewayParameters were being ignored

This effectively made these Istio configuration fields immutable once set in the default parameters, which was not the intended behavior.

Additionally, the GWP configuration outlined in the #11004 issue are configuring fields environment variables on the proxy deployment under-the-hood and the merging-related functions in the deployer suite did not assert on the expected envvars on the istio proxy container.

Closes #11004.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
