### PR TITLE
Update e2e test to verify the expected local rate limit is applied

### DIFF
--- a/test/kubernetes/e2e/features/local_rate_limit/testdata/route-local-rate-limit.yaml
+++ b/test/kubernetes/e2e/features/local_rate_limit/testdata/route-local-rate-limit.yaml
@@ -12,4 +12,4 @@ spec:
       tokenBucket:
         maxTokens: 1
         tokensPerFill: 1
-        fillInterval: 300s
+        fillInterval: 10s


### PR DESCRIPTION
# Description

Minor update to the local rate limit e2e tests to verify that in case of both Gateway and HTTPRoute RL policies applied, the one of the route takes effect.
Specifically, while the Gateway has 1 req per 5m, the route one has 1 per 10s therefore after 10s a second request should return OK.