### PR TITLE
docs: update some copyright/product names

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # Github Workflows
 
-## [Gloo Gateway Conformance Tests](./regression-tests.yaml)
+## [Kgateway Conformance Tests](./regression-tests.yaml)
 Conformance tests a pinned version of the [Kubernetes Gateway API Conformance suite](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/conformance_test.go).
 
 ### Draft Pull Requests

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -178,7 +178,7 @@ Apache License
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Solo.io, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/devel/contributing/pull-request-reviews.md
+++ b/devel/contributing/pull-request-reviews.md
@@ -60,12 +60,7 @@ After pulling down the code, you should try running the tests locally to ensure 
 ## Approving Pull Requests
 
 ### Code Maintainers
-Solo.io has a dedicated team maintaining the Gloo Gateway project. When you submit a PR for Gloo Gateway, one of these maintainers will initiate the automation on your PR, and provide a review.
-
-If there are particular areas of the codebase that are being modified, it is important to identify subject-matter experts (SME) for those changes. If you do not know the SME, use the `@solo-io/gloo-edge-leads` GitHub handle to tag the Gloo Gateway technical leads, and they will identify the SMEs. If you can explicitly identify the domains that are being affected, it is easier to identify the relevant parties to review the code.
-
-### Requirements
-Each PR requires 2 maintainers to approve the changes. The intention here is to distribute knowledge across more people, and provide an opportunity for broader perspective when reviewing the changes.
+When you submit a PR for kgateway, one of the maintainers will initiate automation on your PR (if you are not already a member), and provide a review.
 
 ### Shared Ownership
 By approving a pull request, you are indicating that you have reviewed the changes and are confident that they are correct and to your understanding will not cause any issues. You are signing on as a co-author of the changes, and we expect that if you are comfortable approving a PR, you are also comfortable with this responsibility, which includes being a point of contact regarding these changes in the future.

--- a/devel/debugging/envoy-segfault.md
+++ b/devel/debugging/envoy-segfault.md
@@ -14,4 +14,4 @@ $(IMAGE_REGISTRY)/gloo-ee-envoy-wrapper:$(VERSION)-debug
 
 This new image should emit more information about the segmentation fault. 
 
-Please note that Envoy seg faults are considered a security risk, and therefore, you should follow the [steps to notify Solo.io of a security issue](/devel/contributing/issues.md#security-issues)
+Please note that Envoy seg faults are considered a security risk, and therefore, you should follow the [steps to notify the maintainers of a security issue](/devel/contributing/issues.md#security-issues)


### PR DESCRIPTION
Fixes #10954.

A full pass for `s/Gloo Gateway/kgateway/` needs to happen at a later date, by someone who knows things like whether we have an `envoy-wrapper-debug` image in kgateway. (I couldn't find a container of such so I just left that as was.)