### PR TITLE
Update the rolling main release name to v2.1.0-main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ on:
   push:
     tags:
       - 'v*'
-      - '!v2.0.0-main'
+      - '!v2.1.0-main'
     branches:
       - main
   pull_request:
@@ -24,6 +24,7 @@ env:
   # this is uses the `github.repository_owner` to support releases from forks (useful for testing).
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   VANITY_REGISTRY: cr.kgateway.dev/kgateway-dev
+  MAIN_VERSION: v2.1.0-main
 
 permissions:
   contents: write
@@ -59,7 +60,7 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/}"
             echo "goreleaser_args=--clean" >> $GITHUB_OUTPUT
           elif [[ $GITHUB_REF == refs/heads/main ]]; then
-            VERSION="v2.0.0-main"
+            VERSION="${MAIN_VERSION}"
             echo "goreleaser_args=--clean --skip=validate" >> $GITHUB_OUTPUT
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
             GIT_TAG=$(git describe --tags --abbrev=0)
@@ -111,13 +112,13 @@ jobs:
       # We publish a rolling main release for every commit to main. Deleting the release
       # ensures that the tagged commit is not stale. Goreleaser will create a new tag
       # and release for the tagged commit.
-      - name: Delete v2.0.0-main release if it exists
+      - name: Delete ${MAIN_VERSION} release if it exists
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         continue-on-error: true
         run: |
           set -x
-          echo "Deleting the v2.0.0-main release"
-          gh release delete v2.0.0-main --repo ${{ github.repository }} --yes --cleanup-tag
+          echo "Deleting the ${MAIN_VERSION} release"
+          gh release delete ${MAIN_VERSION} --repo ${{ github.repository }} --yes --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -177,8 +177,8 @@ release:
   mode: "replace"
   replace_existing_artifacts: true
   header: |
-    {{ if eq .Env.VERSION "v2.0.0-main" }}
-    🚀 Nightly build of kgateway!
+    {{ if eq .Env.VERSION "v2.1.0-main" }}
+    🚀 Rolling main build of kgateway!
     ---
     It includes the latest changes but may be unstable. Use it for testing and providing feedback.
     {{ else }}


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Update the rolling main release name from v2.0.0-main -> v2.1.0-main now that v2.0.0 has been cut.

Tested this out in my fork: https://github.com/timflannagan/kgateway/actions/runs/14224168866/job/39859461695.

Closes https://github.com/kgateway-dev/kgateway/issues/11027

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
