### PR TITLE
Removes port requirement from InferencePool backendRef

### DIFF
--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/plugin.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/plugin.go
@@ -106,7 +106,6 @@ func NewPluginFromCollections(
 				Name:      pool.Name,
 			},
 			Obj:               pool,
-			Port:              pool.Spec.TargetPortNumber,
 			GvPrefix:          "endpoint-picker",
 			CanonicalHostname: "",
 			ObjIr:             newInferencePool(pool),

--- a/internal/kgateway/setup/testdata/inferencepool.yaml
+++ b/internal/kgateway/setup/testdata/inferencepool.yaml
@@ -28,7 +28,6 @@ spec:
         - name: gateway-pool
           kind: InferencePool
           group: inference.networking.x-k8s.io
-          port: 8080
           weight: 1
 ---
 # This service is auto created by the inference extension deployer but it's created

--- a/internal/kgateway/translator/httproute/translate_httproute_test.go
+++ b/internal/kgateway/translator/httproute/translate_httproute_test.go
@@ -282,7 +282,9 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 					Name:      "my-inferencepool",
 					Namespace: "bar",
 				},
-				Spec: infextv1a2.InferencePoolSpec{},
+				Spec: infextv1a2.InferencePoolSpec{
+					TargetPortNumber: int32(8000),
+				},
 			}
 		})
 
@@ -306,7 +308,6 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 										Namespace: ptr.To(gwv1.Namespace(backingPool.Namespace)),
 										Kind:      ptr.To(gwv1.Kind(wellknown.InferencePoolKind)),
 										Group:     ptr.To(gwv1.Group(infextv1a2.GroupVersion.Group)),
-										Port:      ptr.To(gwv1.PortNumber(9002)),
 									},
 								},
 							},
@@ -328,7 +329,7 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 											Kind:      wellknown.InferencePoolKind,
 											Group:     infextv1a2.GroupVersion.Group,
 										},
-										Port: 9002,
+										Port: 8000,
 										Obj:  backingPool,
 									},
 									ClusterName: "inferencepool_cluster",


### PR DESCRIPTION
Removes the requirement to specify `port` for an InferencePool backendRef. Based on the Gateway API spec, `port` is only required for Service type backendRefs:

```go
	// Port specifies the destination port number to use for this resource.
	// Port is required when the referent is a Kubernetes Service. In this
	// case, the port number is the service port number, not the target port.
	// For other resources, destination port might be derived from the referent
	// resource or this field.
	//
	// +optional
	Port *PortNumber `json:"port,omitempty"`
```

Fixes #10987