### PR TITLE
waypoint: allow bind to localhost

### DIFF
--- a/internal/kgateway/extensions2/plugins/waypoint/plugin.go
+++ b/internal/kgateway/extensions2/plugins/waypoint/plugin.go
@@ -29,7 +29,7 @@ func NewPlugin(
 				return nil
 			}
 
-			return NewTranslator(queries, waypointQueries)
+			return NewTranslator(queries, waypointQueries, commonCols.Settings)
 		},
 		ExtraHasSynced: func() bool {
 			return waypointQueries.HasSynced()

--- a/internal/kgateway/extensions2/settings/settings.go
+++ b/internal/kgateway/extensions2/settings/settings.go
@@ -41,6 +41,11 @@ type Settings struct {
 	DefaultImageTag string `split_words:"true" default:""`
 	// DefaultImagePullPolicy is the default image pull policy to use for the kgateway image.
 	DefaultImagePullPolicy string `split_words:"true" default:"IfNotPresent"`
+
+	// WaypointLocalBinding will make the waypoint bind to a loopback address,
+	// so that only the zTunnel can make connections to it. This requires the zTunnel
+	// shipped with Istio 1.26.0+.
+	WaypointLocalBinding bool `split_words:"true" default:"false"`
 }
 
 // BuildSettings returns a zero-valued Settings obj if error is encountered when parsing env

--- a/internal/kgateway/extensions2/settings/settings_test.go
+++ b/internal/kgateway/extensions2/settings/settings_test.go
@@ -42,6 +42,7 @@ func TestSettings(t *testing.T) {
 				DefaultImageRegistry:   "cr.kgateway.dev",
 				DefaultImageTag:        "",
 				DefaultImagePullPolicy: "IfNotPresent",
+				WaypointLocalBinding:   false,
 			},
 		},
 		{
@@ -60,6 +61,7 @@ func TestSettings(t *testing.T) {
 				"KGW_DEFAULT_IMAGE_REGISTRY":    "my-registry",
 				"KGW_DEFAULT_IMAGE_TAG":         "my-tag",
 				"KGW_DEFAULT_IMAGE_PULL_POLICY": "Always",
+				"KGW_WAYPOINT_LOCAL_BINDING":    "true",
 			},
 			expectedSettings: &settings.Settings{
 				DnsLookupFamily:        "V4_ONLY",
@@ -74,6 +76,7 @@ func TestSettings(t *testing.T) {
 				DefaultImageRegistry:   "my-registry",
 				DefaultImageTag:        "my-tag",
 				DefaultImagePullPolicy: "Always",
+				WaypointLocalBinding:   true,
 			},
 		},
 		{
@@ -106,6 +109,7 @@ func TestSettings(t *testing.T) {
 				DefaultImageRegistry:   "cr.kgateway.dev",
 				DefaultImageTag:        "",
 				DefaultImagePullPolicy: "IfNotPresent",
+				WaypointLocalBinding:   false,
 			},
 		},
 	}


### PR DESCRIPTION
# Description

This adds an env to make waypoints bind their single inbound
listener to localhost. This is a security measure to prevent
bypassing the zTunnel by sending PROXY over plaintext. The
required changes in zTunnel just merged, so we won't have them in most releases of ztunnel, so this cannot be enabled by default. 

See:

https://github.com/solo-io/solo-projects/pull/8113
https://github.com/istio/ztunnel/pull/1501

