### PR TITLE
.github: Add version input validation in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,10 @@ on:
       version:
         type: string
         required: false
-        description: "Override the default version (e.g. v0.0.0-manual-<git-sha>)"
+        description: |
+          Version override for the release (must start with 'v' followed by semantic version).
+          Examples: v1.2.3, v2.0.0-alpha.1, v1.0.0-beta.2
+          If not provided, defaults to v0.0.0-manual-<git-sha>
   push:
     tags:
       - 'v*'
@@ -48,13 +51,18 @@ jobs:
           GIT_SHA=$(git rev-parse --short HEAD)
           GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed -e "s/\//-/g")
 
-          # Set version based on event type
-          if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
-            if [[ -n "${{ inputs.version }}" ]]; then
-              VERSION="${{ inputs.version }}"
-            else
-              VERSION="v0.0.0-manual-${GIT_SHA}"
+          # Validate version input for workflow_dispatch
+          if [[ ${{ github.event_name }} == 'workflow_dispatch' && -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+            # Validate semver format. Modified version from the recommended semver format.
+            # See https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
+            if ! echo "$VERSION" | grep -E "^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$" > /dev/null; then
+              echo "Error: Version '$VERSION' does not match required semver format (e.g., v1.2.3, v2.0.0-alpha.1)"
+              exit 1
             fi
+            echo "goreleaser_args=--clean --skip=validate" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            VERSION="v0.0.0-manual-${GIT_SHA}"
             echo "goreleaser_args=--clean --skip=validate" >> $GITHUB_OUTPUT
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Add regex validation for the version workflow_dispatch input parameter in the release workflow. GH doesn't support a first-class approach for input validation right now (e.g. a `pattern` field would be useful here), so in lieu of that, we can implement our own validation logic that prevents the release pipeline from being run when invalid version overrides are provided.  

Tested this in my fork: https://github.com/timflannagan/kgateway/actions/runs/14269943102. Provided the "asdf" variable.

Tested this locally as well:

```bash
dev :: /work/kgateway ‹chore/add-release-override-tag-validation› » echo v2.1.0-rc.1 | grep -E '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'

v2.1.0-rc.1
dev :: /work/kgateway ‹chore/add-release-override-tag-validation› » echo v2.1.0-beta-1 | grep -E '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'

v2.1.0-beta-1

dev :: /work/kgateway ‹chore/add-release-override-tag-validation› » echo 2.1.0-rc.1 | grep -E '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
```

The last "2.1.0-rc.1" would be invalid according to the validation regex used in the workflow.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
