### PR TITLE
python: Switch to psycopg[binary] in requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,7 +10,7 @@ langchainhub
 tldextract
 openai
 bs4
-psycopg[c]
+psycopg[binary]
 gptcache
 fastapi[standard]
 uvicorn[standard]


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

When enabling verbose logs in the goreleaser step in the release pipeline, we see that pip is spending a considerable amount of time (~13m) building the psycopg3 wheel for the arm64 image invariant.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
