### PR TITLE
fix artifact upload on failure

### DIFF
--- a/.github/actions/kube-gateway-api-conformance-tests/action.yaml
+++ b/.github/actions/kube-gateway-api-conformance-tests/action.yaml
@@ -80,7 +80,7 @@ runs:
       kubectl -n kgateway-system logs deploy/gloo
   - name: Upload reports
     if: ${{ failure() }}
-    uses: ./.github/workflows/composite-actions/upload-artifact
+    uses: ./.github/actions/upload-artifact
     with:
       # Name of the path to upload. The VERSION variable refers to the Makefile
       # VERSION variable.

--- a/.github/actions/kubernetes-e2e-tests/action.yaml
+++ b/.github/actions/kubernetes-e2e-tests/action.yaml
@@ -39,7 +39,7 @@ runs:
     run: make go-test
   - name: Archive bug report directory on failure
     if: ${{ failure() }}
-    uses: ./.github/workflows/composite-actions/upload-artifact
+    uses: ./.github/actions/upload-artifact
     with:
       name: bug-report-${{ inputs.cluster-name }}-${{ inputs.matrix-label }}
       path: ./_test/bug_report/${{ inputs.cluster-name }}

--- a/.github/actions/performance-tests/action.yaml
+++ b/.github/actions/performance-tests/action.yaml
@@ -7,7 +7,7 @@ runs:
   - name: Testing - performance tests
     shell: bash
     run: make install-test-tools run-performance-tests
-  - uses: ./.github/workflows/composite-actions/upload-artifact
+  - uses: ./.github/actions/upload-artifact
     if: ${{ failure() }}
     with:
       name: performance-dump

--- a/.github/actions/regression-tests/action.yaml
+++ b/.github/actions/regression-tests/action.yaml
@@ -27,7 +27,7 @@ runs:
         IMAGE_VARIANT: ${{ matrix.image-variant }}
       shell: bash
       run: make install-test-tools run-kube-e2e-tests
-    - uses: ./.github/workflows/composite-actions/upload-artifact
+    - uses: ./.github/actions/upload-artifact
       if: ${{ failure() }}
       with:
         name: ${{matrix.kube-e2e-test-type}}@k8s${{matrix.kube-version.kubectl}}-kube-dump


### PR DESCRIPTION
Incorrect path pulled in from other projects. 
introduced in https://github.com/kgateway-dev/kgateway/pull/11054


Show that upload on fail works via https://github.com/nfuden/k8sgateway/actions/runs/14334971559/job/40179564865?pr=3 where we specifically exercise it. We do not exercise upload on the happy path today