### PR TITLE
waypoint: infer PROXY listener

### DIFF
--- a/examples/waypoint/waypoint-gw.yaml
+++ b/examples/waypoint/waypoint-gw.yaml
@@ -6,10 +6,3 @@ metadata:
   namespace: httpbin
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - protocol: istio.io/PROXY
-    port: 15088
-    name: mesh
-    allowedRoutes:
-      namespaces:
-        from: Same

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/authz.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/authz.yaml
@@ -14,10 +14,6 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # we should get a filter chain with a default virtualhost that just
 # sends traffic to the corresponding `kube` Service backend

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/gw-with-listener.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/gw-with-listener.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -6,6 +5,10 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
+  listeners:
+  - name: proxy
+    port: 15099
+    protocol: istio.io/PROXY
 ---
 # we should get a filter chain with a default virtualhost that just
 # sends traffic to the corresponding `kube` Service backend

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-gateway.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-gateway.yaml
@@ -14,10 +14,6 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # HTTPRoute parented to the gateway should affect every filter chain
 apiVersion: gateway.networking.k8s.io/v1

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-se-hostname.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-se-hostname.yaml
@@ -14,10 +14,6 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # HTTPRoute parented to the Service only affects one chain
 apiVersion: gateway.networking.k8s.io/v1

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-se.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-se.yaml
@@ -14,10 +14,6 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # HTTPRoute parented to the Service only affects one chain
 apiVersion: gateway.networking.k8s.io/v1

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-svc.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/httproute-svc.yaml
@@ -14,10 +14,6 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # HTTPRoute parented to the Service only affects one chain
 apiVersion: gateway.networking.k8s.io/v1

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/ns-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/ns-use-waypoint.yaml
@@ -14,10 +14,6 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # we should get a filter chain with a default virtualhost that just
 # sends traffic to the corresponding `kube` Service backend

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/input/se-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/input/se-use-waypoint.yaml
@@ -6,10 +6,6 @@ metadata:
   namespace: infra
 spec:
   gatewayClassName: kgateway-waypoint
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # we should get a filter chain with a default virtualhost that just
 # sends traffic to the corresponding `istio-se` backend

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/gw-with-listener.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/gw-with-listener.yaml
@@ -1,0 +1,63 @@
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 15099
+  filterChains:
+  - filterChainMatch:
+      destinationPort: 5000
+      prefixRanges:
+      - addressPrefix: 1.2.3.4
+        prefixLen: 32
+    filters:
+    - name: proxy_protocol_authority
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.set_filter_state.v3.Config
+        onNewConnection:
+        - factoryKey: envoy.string
+          formatString:
+            textFormatSource:
+              inlineString: '%DYNAMIC_METADATA(envoy.filters.listener.proxy_protocol:peer_principal)%'
+          objectKey: io.istio.peer_principal
+          sharedWithUpstream: ONCE
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: fc_http_5000_helloworld_infra
+        statPrefix: http
+        useRemoteAddress: true
+    name: fc_http_5000_helloworld_infra
+  listenerFilters:
+  - name: envoy.filters.listener.proxy_protocol
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol
+      rules:
+      - onTlvPresent:
+          key: peer_principal
+        tlvType: 208
+  name: proxy_protocol_inbound
+Routes:
+- ignorePortInHostMatching: true
+  name: fc_http_5000_helloworld_infra
+  virtualHosts:
+  - domains:
+    - '*'
+    name: vh_http_5000_helloworld_infra
+    routes:
+    - match:
+        prefix: /
+      name: vh_http_5000_helloworld_infra-route-0-matcher-0
+      route:
+        cluster: kube_infra_helloworld_5000
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/internal/kgateway/extensions2/plugins/waypoint/waypoint_translator_test.go
+++ b/internal/kgateway/extensions2/plugins/waypoint/waypoint_translator_test.go
@@ -31,6 +31,7 @@ var cases = []struct {
 	{"HTTPRoute on ServiceEntry", "httproute-se", exampleGw, ""},
 	{"HTTPRoute on ServiceEntry via Hostname", "httproute-se-hostname", exampleGw, ""},
 	{"Authz Policies", "authz", exampleGw, ""},
+	{"Custom listener", "gw-with-listener", exampleGw, ""},
 }
 
 func TestWaypointTranslator(t *testing.T) {

--- a/internal/kgateway/krtcollections/setup.go
+++ b/internal/kgateway/krtcollections/setup.go
@@ -97,7 +97,7 @@ func InitCollections(
 	backendIndex := NewBackendIndex(krtopts, backendRefPlugins, policies, refgrants)
 	initBackends(plugins, backendIndex)
 	endpointIRs := initEndpoints(plugins, krtopts)
-	gateways := NewGatewayIndex(krtopts, controllerName, policies, kubeRawGateways, gatewayClasses)
+	gateways := NewGatewayIndex(krtopts, controllerName, policies, kubeRawGateways, gatewayClasses, plugins.ContributesGwTranslator)
 
 	routes := NewRoutesIndex(krtopts, httpRoutes, tcproutes, tlsRoutes, policies, backendIndex, refgrants)
 	return gateways, routes, backendIndex, endpointIRs

--- a/internal/kgateway/query/httproute.go
+++ b/internal/kgateway/query/httproute.go
@@ -131,7 +131,7 @@ func (r *gatewayQueries) GetRouteChain(
 	}
 }
 
-func (r *gatewayQueries) allowedRoutes(gw *gwv1.Gateway, l *gwv1.Listener) (func(krt.HandlerContext, string) bool, []metav1.GroupKind, error) {
+func (r *gatewayQueries) allowedRoutes(gw *ir.Gateway, l *ir.Listener) (func(krt.HandlerContext, string) bool, []metav1.GroupKind, error) {
 	var allowedKinds []metav1.GroupKind
 
 	// Determine the allowed route kinds based on the listener's protocol
@@ -283,7 +283,7 @@ func (r *gatewayQueries) fetchChildRoutes(
 	return refChildren, nil
 }
 
-func (r *gatewayQueries) GetRoutesForGateway(kctx krt.HandlerContext, ctx context.Context, gw *gwv1.Gateway) (*RoutesForGwResult, error) {
+func (r *gatewayQueries) GetRoutesForGateway(kctx krt.HandlerContext, ctx context.Context, gw *ir.Gateway) (*RoutesForGwResult, error) {
 	nns := types.NamespacedName{
 		Namespace: gw.Namespace,
 		Name:      gw.Name,
@@ -304,7 +304,7 @@ func (r *gatewayQueries) GetRoutesForGateway(kctx krt.HandlerContext, ctx contex
 func (r *gatewayQueries) processRoute(
 	kctx krt.HandlerContext,
 	ctx context.Context,
-	gw *gwv1.Gateway,
+	gw *ir.Gateway,
 	route ir.Route,
 	ret *RoutesForGwResult,
 ) error {
@@ -316,7 +316,7 @@ func (r *gatewayQueries) processRoute(
 		anyListenerMatched := false
 		anyHostsMatch := false
 
-		for _, l := range gw.Spec.Listeners {
+		for _, l := range gw.Listeners {
 			lr := ret.ListenerResults[string(l.Name)]
 			if lr == nil {
 				lr = &ListenerResult{}

--- a/internal/kgateway/query/mocks/mock_queries.go
+++ b/internal/kgateway/query/mocks/mock_queries.go
@@ -55,7 +55,7 @@ func (mr *MockGatewayQueriesMockRecorder) GetRouteChain(arg0, arg1, arg2, arg3, 
 }
 
 // GetRoutesForGateway mocks base method.
-func (m *MockGatewayQueries) GetRoutesForGateway(arg0 krt.HandlerContext, arg1 context.Context, arg2 *v1.Gateway) (*query.RoutesForGwResult, error) {
+func (m *MockGatewayQueries) GetRoutesForGateway(arg0 krt.HandlerContext, arg1 context.Context, arg2 *ir.Gateway) (*query.RoutesForGwResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRoutesForGateway", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*query.RoutesForGwResult)

--- a/internal/kgateway/query/query.go
+++ b/internal/kgateway/query/query.go
@@ -102,7 +102,7 @@ type GatewayQueries interface {
 	GetSecretForRef(kctx krt.HandlerContext, ctx context.Context, fromGk schema.GroupKind, fromns string, secretRef apiv1.SecretObjectReference) (*ir.Secret, error)
 
 	// GetRoutesForGateway finds the top level xRoutes attached to the provided Gateway
-	GetRoutesForGateway(kctx krt.HandlerContext, ctx context.Context, gw *gwv1.Gateway) (*RoutesForGwResult, error)
+	GetRoutesForGateway(kctx krt.HandlerContext, ctx context.Context, gw *ir.Gateway) (*RoutesForGwResult, error)
 	// GetRouteChain resolves backends and delegated routes for a the provided xRoute object
 	GetRouteChain(kctx krt.HandlerContext,
 		ctx context.Context,
@@ -152,7 +152,7 @@ type gatewayQueries struct {
 	collections *common.CommonCollections
 }
 
-func parentRefMatchListener(ref *apiv1.ParentReference, l *apiv1.Listener) bool {
+func parentRefMatchListener(ref *apiv1.ParentReference, l *ir.Listener) bool {
 	if ref != nil && ref.Port != nil && *ref.Port != l.Port {
 		return false
 	}
@@ -168,7 +168,7 @@ func parentRefMatchListener(ref *apiv1.ParentReference, l *apiv1.Listener) bool 
 //   - HTTPRoute
 //   - TCPRoute
 //   - TLSRoute
-func getParentRefsForGw(gw *apiv1.Gateway, obj ir.Route) []apiv1.ParentReference {
+func getParentRefsForGw(gw *ir.Gateway, obj ir.Route) []apiv1.ParentReference {
 	var ret []apiv1.ParentReference
 
 	for _, pRef := range obj.GetParentRefs() {
@@ -181,7 +181,7 @@ func getParentRefsForGw(gw *apiv1.Gateway, obj ir.Route) []apiv1.ParentReference
 }
 
 // isParentRefForGw checks if a ParentReference is associated with the provided Gateway.
-func isParentRefForGw(pRef *apiv1.ParentReference, gw *apiv1.Gateway, defaultNs string) bool {
+func isParentRefForGw(pRef *apiv1.ParentReference, gw *ir.Gateway, defaultNs string) bool {
 	if gw == nil || pRef == nil {
 		return false
 	}
@@ -201,7 +201,7 @@ func isParentRefForGw(pRef *apiv1.ParentReference, gw *apiv1.Gateway, defaultNs 
 	return ns == gw.Namespace && string(pRef.Name) == gw.Name
 }
 
-func hostnameIntersect(l *apiv1.Listener, routeHostnames []string) (bool, []string) {
+func hostnameIntersect(l *ir.Listener, routeHostnames []string) (bool, []string) {
 	var hostnames []string
 	if l == nil {
 		return false, hostnames

--- a/internal/kgateway/query/query_test.go
+++ b/internal/kgateway/query/query_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Query", func() {
 			}
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(BeEmpty())
@@ -101,7 +101,7 @@ var _ = Describe("Query", func() {
 
 			gq := newQueries(hr)
 
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(BeEmpty())
@@ -109,7 +109,7 @@ var _ = Describe("Query", func() {
 			Expect(routes.ListenerResults["foo"].Routes).To(HaveLen(1))
 		})
 
-		It("should ignore http routes for wrong kind", func() {
+		FIt("should ignore http routes for wrong kind", func() {
 			gwWithListener := gw()
 			gwWithListener.Spec.Listeners = []apiv1.Listener{
 				{
@@ -127,7 +127,7 @@ var _ = Describe("Query", func() {
 			}
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(BeEmpty())
@@ -154,7 +154,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.ListenerResults["foo"].Error).To(MatchError("selector must be set"))
@@ -184,7 +184,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors[0].Error.E).To(MatchError(query.ErrNotAllowedByListeners))
@@ -213,7 +213,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(BeEmpty())
@@ -245,7 +245,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors[0].Error.E).To(MatchError(query.ErrNoMatchingParent))
@@ -275,7 +275,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(BeEmpty())
@@ -308,7 +308,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors[0].Error.E).To(MatchError(query.ErrNoMatchingListenerHostname))
@@ -341,7 +341,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(BeEmpty())
@@ -370,7 +370,7 @@ var _ = Describe("Query", func() {
 			})
 
 			gq := newQueries(hr)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(HaveLen(1))
@@ -407,7 +407,7 @@ var _ = Describe("Query", func() {
 				})
 
 				gq := newQueries(hr)
-				routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gwWithListener)
+				routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gwWithListener))
 
 				Expect(err).NotTo(HaveOccurred())
 				if expectedHostnames == nil {
@@ -460,7 +460,7 @@ var _ = Describe("Query", func() {
 			}
 
 			gq := newQueries(tcpRoute)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.ListenerResults[string(gw.Spec.Listeners[0].Name)].Routes).To(HaveLen(1))
@@ -495,7 +495,7 @@ var _ = Describe("Query", func() {
 
 			gq := newQueries(tcpRoute)
 
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.ListenerResults["foo-tcp"].Error).NotTo(HaveOccurred())
@@ -531,7 +531,7 @@ var _ = Describe("Query", func() {
 			}
 
 			gq := newQueries(tcpRoute)
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(HaveLen(1))
@@ -565,7 +565,7 @@ var _ = Describe("Query", func() {
 
 			gq := newQueries(tcpRoute)
 
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(HaveLen(1))
 			Expect(routes.RouteErrors[0].Error.E).To(MatchError(query.ErrNotAllowedByListeners))
@@ -603,7 +603,7 @@ var _ = Describe("Query", func() {
 
 			gq := newQueries(tcpRoute)
 
-			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+			routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routes.RouteErrors).To(BeEmpty())
 			Expect(routes.ListenerResults["foo-tcp"].Routes).To(HaveLen(1))
@@ -641,7 +641,7 @@ var _ = Describe("Query", func() {
 		}
 
 		gq := newQueries(tlsRoute)
-		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(routes.ListenerResults[string(gw.Spec.Listeners[0].Name)].Routes).To(HaveLen(1))
@@ -675,7 +675,7 @@ var _ = Describe("Query", func() {
 		}
 
 		gq := newQueries(tlsRoute)
-		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(routes.ListenerResults["foo-tls"].Error).NotTo(HaveOccurred())
@@ -711,7 +711,7 @@ var _ = Describe("Query", func() {
 		}
 
 		gq := newQueries(tlsRoute)
-		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(routes.RouteErrors).To(HaveLen(1))
@@ -744,7 +744,7 @@ var _ = Describe("Query", func() {
 		}
 
 		gq := newQueries(tlsRoute)
-		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(routes.RouteErrors).To(HaveLen(1))
@@ -782,7 +782,7 @@ var _ = Describe("Query", func() {
 		}
 
 		gq := newQueries(tlsRoute)
-		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), gw)
+		routes, err := gq.GetRoutesForGateway(krt.TestingDummyContext{}, context.Background(), toIr(gw))
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(routes.RouteErrors).To(BeEmpty())
@@ -835,6 +835,17 @@ func gw() *apiv1.Gateway {
 			Name:      "test",
 		},
 	}
+}
+
+func toIr(gw *apiv1.Gateway) *ir.Gateway {
+	if gw == nil {
+		return nil
+	}
+	listeners := make([]ir.Listener, 0, len(gw.Spec.Listeners))
+	for _, l := range gw.Spec.Listeners {
+		listeners = append(listeners, ir.Listener{Listener: l})
+	}
+	return &ir.Gateway{}
 }
 
 func secret(ns string) *corev1.Secret {

--- a/internal/kgateway/translator/gateway/gateway_translator.go
+++ b/internal/kgateway/translator/gateway/gateway_translator.go
@@ -27,6 +27,10 @@ type translator struct {
 	queries query.GatewayQueries
 }
 
+func (t *translator) Transform(gateway ir.Gateway) ir.Gateway {
+	return gateway
+}
+
 func (t *translator) Translate(
 	kctx krt.HandlerContext,
 	ctx context.Context,
@@ -39,7 +43,7 @@ func (t *translator) Translate(
 
 	ctx = contextutils.WithLogger(ctx, "k8s-gateway-translator")
 	logger := contextutils.LoggerFrom(ctx)
-	routesForGw, err := t.queries.GetRoutesForGateway(kctx, ctx, gateway.Obj)
+	routesForGw, err := t.queries.GetRoutesForGateway(kctx, ctx, gateway)
 	if err != nil {
 		logger.Errorf("failed to get routes for gateway %.%ss: %v", gateway.Namespace, gateway.Name, err)
 		// TODO: decide how/if to report this error on Gateway

--- a/test/kubernetes/e2e/features/waypoint/testdata/common/test_waypoint.yaml
+++ b/test/kubernetes/e2e/features/waypoint/testdata/common/test_waypoint.yaml
@@ -5,6 +5,7 @@ metadata:
   name: test-waypoint
 spec:
   gatewayClassName: kgateway-waypoint
+  listeners: []
   infrastructure:
     parametersRef:
       name: test-waypoint-params

--- a/test/kubernetes/e2e/features/waypoint/testdata/common/test_waypoint.yaml
+++ b/test/kubernetes/e2e/features/waypoint/testdata/common/test_waypoint.yaml
@@ -10,10 +10,6 @@ spec:
       name: test-waypoint-params
       group: gateway.kgateway.dev
       kind: GatewayParameters
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # to provide a waypoint gateway with a readiness probe
 kind: GatewayParameters
@@ -31,4 +27,4 @@ spec:
         periodSeconds: 10
         timeoutSeconds: 2
         failureThreshold: 3
-        successThreshold: 1      
+        successThreshold: 1

--- a/test/kubernetes/e2e/features/waypoint/testdata/test_waypoint.yaml
+++ b/test/kubernetes/e2e/features/waypoint/testdata/test_waypoint.yaml
@@ -5,6 +5,7 @@ metadata:
   name: test-waypoint
 spec:
   gatewayClassName: kgateway-waypoint
+  listeners: []
   infrastructure:
     parametersRef:
       name: test-waypoint-params

--- a/test/kubernetes/e2e/features/waypoint/testdata/test_waypoint.yaml
+++ b/test/kubernetes/e2e/features/waypoint/testdata/test_waypoint.yaml
@@ -10,10 +10,6 @@ spec:
       name: test-waypoint-params
       group: gateway.kgateway.dev
       kind: GatewayParameters
-  listeners:
-  - name: proxy
-    port: 15088
-    protocol: istio.io/PROXY
 ---
 # to provide a waypoint gateway with a readiness probe
 kind: GatewayParameters
@@ -31,4 +27,4 @@ spec:
         periodSeconds: 10
         timeoutSeconds: 2
         failureThreshold: 3
-        successThreshold: 1      
+        successThreshold: 1


### PR DESCRIPTION
# Description

EDIT:

https://github.com/kubernetes-sigs/gateway-api/blob/36514bbcaba862aea7a630105a3c8859a766feec/apis/v1/gateway_types.go#L232

This blocks this PR from being useful with any real gateway resource. 

---


https://github.com/kgateway-dev/kgateway/issues/10808

The only reason to have them set the listener manually is to change `allowedRoutes`. Changing the port would also require editing code, as we currently [hardcode](https://github.com/kgateway-dev/kgateway/blob/main/internal/kgateway/controller/start.go#L296) the inbound-binding port that zTunnel sees. It's basically treated as wellknown port. 

## API changes

* Gateways with class `kgateway-waypoint` can omit `listeners` entirely

## Code changes

* Allow `KGwTranslator` to specify a `Transform` func to edit the `ir.Gateway` before GWs are used by any other (krt) code. 
* Change `httproute` queries to operate on `ir` structs instead of `gwv1`
* Make all waypoint tests omit listeners, except for one test that tests a manually specified listener.



## Docs changes

* Updated waypoint samples

# Context

https://github.com/kgateway-dev/kgateway/issues/10808


## Interesting decisions

It's important to add "virtual" listeners via the transform rather than just inferring the listener locally in the waypoint_translator. If we don't have that listener, it messes up route attachment code that is very listener-based. 

## Testing steps

* Integration tests cover it
* All test inputs changed, but their outputs remain the same


