### PR TITLE
Delegation cleanup and move annotation

### DIFF
--- a/api/annotations/delegation.go
+++ b/api/annotations/delegation.go
@@ -1,0 +1,8 @@
+package annotations
+
+const (
+	// InheritMatcherAnnotation is the annotation used on a child HTTPRoute that
+	// participates in a delegation chain to indicate that child route should inherit
+	// the route matcher from the parent route.
+	DelegationInheritMatcherAnnotation = "delegation.kgateway.dev/inherit-parent-matcher"
+)

--- a/internal/kgateway/translator/httproute/delegation_helpers.go
+++ b/internal/kgateway/translator/httproute/delegation_helpers.go
@@ -88,7 +88,7 @@ func filterDelegatedChildren(
 					// the parent's matcher with the child's.
 					mergeParentChildRouteMatch(&parentMatch, &match)
 					validMatches = append(validMatches, match)
-				} else if ok := isDelegatedRouteMatch(parentMatch, parentRef, match, child.Namespace, child.ParentRefs); ok {
+				} else if ok := isDelegatedRouteMatch(parentMatch, match); ok {
 					// Non-inherited matcher delegation requires matching child matcher to parent matcher
 					// to delegate from the parent route to the child.
 					validMatches = append(validMatches, match)
@@ -157,10 +157,7 @@ func isAllowedParent(
 // - if the parent method matcher is set, the child's method matcher value must be equal to the parent method matcher value
 func isDelegatedRouteMatch(
 	parent gwv1.HTTPRouteMatch,
-	parentRef types.NamespacedName,
 	child gwv1.HTTPRouteMatch,
-	childNs string,
-	parentRefs []gwv1.ParentReference,
 ) bool {
 	// Validate path
 	if parent.Path == nil || parent.Path.Type == nil || *parent.Path.Type != gwv1.PathMatchPathPrefix {

--- a/internal/kgateway/translator/httproute/delegation_helpers.go
+++ b/internal/kgateway/translator/httproute/delegation_helpers.go
@@ -10,15 +10,11 @@ import (
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kgateway-dev/kgateway/v2/api/annotations"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/query"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
-
-// inheritMatcherAnnotation is the annotation used on a child HTTPRoute that
-// participates in a delegation chain to indicate that child route should inherit
-// the route matcher from the parent route.
-const inheritMatcherAnnotation = "delegation.kgateway.dev/inherit-parent-matcher"
 
 // filterDelegatedChildren takes a parent route matcher and a list of children
 // referenced by the parent's backendRefs, and filters the children based on
@@ -211,7 +207,7 @@ func isDelegatedRouteMatch(
 // shouldInheritMatcher returns true if the route indicates that it should inherit
 // its parent's matcher.
 func shouldInheritMatcher(route *ir.HttpRouteIR) bool {
-	val, ok := route.SourceObject.GetAnnotations()[inheritMatcherAnnotation]
+	val, ok := route.SourceObject.GetAnnotations()[annotations.DelegationInheritMatcherAnnotation]
 	if !ok {
 		return false
 	}

--- a/internal/kgateway/translator/httproute/delegation_test.go
+++ b/internal/kgateway/translator/httproute/delegation_test.go
@@ -4,22 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
 func TestIsDelegatedRouteMatch(t *testing.T) {
 	testCases := []struct {
-		name       string
-		parent     gwv1.HTTPRouteMatch
-		parentRef  types.NamespacedName
-		child      gwv1.HTTPRouteMatch
-		childNs    string
-		parentRefs []gwv1.ParentReference
-		expected   bool
+		name     string
+		parent   gwv1.HTTPRouteMatch
+		child    gwv1.HTTPRouteMatch
+		expected bool
 	}{
 		{
 			name: "child route without parentRef matches parent",
@@ -447,16 +441,6 @@ func TestIsDelegatedRouteMatch(t *testing.T) {
 					},
 				},
 			},
-			parentRef: types.NamespacedName{Namespace: "default", Name: "parent"},
-			childNs:   "child",
-			parentRefs: []gwv1.ParentReference{
-				{
-					Group:     ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:      ptr.To[gwv1.Kind](gwv1.Kind(wellknown.HTTPRouteKind)),
-					Name:      "parent",
-					Namespace: ptr.To[gwv1.Namespace](gwv1.Namespace("default")),
-				},
-			},
 			expected: true,
 		},
 		{
@@ -531,15 +515,6 @@ func TestIsDelegatedRouteMatch(t *testing.T) {
 					},
 				},
 			},
-			parentRef: types.NamespacedName{Namespace: "default", Name: "parent"},
-			childNs:   "default",
-			parentRefs: []gwv1.ParentReference{
-				{
-					Group: ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:  ptr.To[gwv1.Kind](gwv1.Kind(wellknown.HTTPRouteKind)),
-					Name:  "parent",
-				},
-			},
 			expected: true,
 		},
 	}
@@ -547,7 +522,7 @@ func TestIsDelegatedRouteMatch(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
-			actual := isDelegatedRouteMatch(tc.parent, tc.parentRef, tc.child, tc.childNs, tc.parentRefs)
+			actual := isDelegatedRouteMatch(tc.parent, tc.child)
 
 			a.Equal(tc.expected, actual)
 		})


### PR DESCRIPTION
- remove unused args in `isDelegatedRouteMatch ` (missed cleanup from https://github.com/kgateway-dev/kgateway/pull/11040)
- move annotation to `api/`