### PR TITLE
update gatewayparameters validation message

### DIFF
--- a/api/v1alpha1/gateway_parameters_types.go
+++ b/api/v1alpha1/gateway_parameters_types.go
@@ -35,7 +35,7 @@ type GatewayParametersList struct {
 // A GatewayParametersSpec describes the type of environment/platform in which
 // the proxy will be provisioned.
 //
-// +kubebuilder:validation:XValidation:message="only one of 'kube' or 'selfManaged' may be set",rule="(has(self.kube) && !has(self.selfManaged)) || (!has(self.kube) && has(self.selfManaged))"
+// +kubebuilder:validation:XValidation:message="exactly one of 'kube' or 'selfManaged' must be set",rule="has(self.kube) ? !has(self.selfManaged) : has(self.selfManaged)"
 type GatewayParametersSpec struct {
 	// The proxy will be deployed on Kubernetes.
 	//

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayparameters.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayparameters.yaml
@@ -2114,9 +2114,8 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             type: object
             x-kubernetes-validations:
-            - message: only one of 'kube' or 'selfManaged' may be set
-              rule: (has(self.kube) && !has(self.selfManaged)) || (!has(self.kube)
-                && has(self.selfManaged))
+            - message: exactly one of 'kube' or 'selfManaged' must be set
+              rule: 'has(self.kube) ? !has(self.selfManaged) : has(self.selfManaged)'
           status:
             type: object
         type: object


### PR DESCRIPTION
make the kubebuilder validation message more accurate - exactly one of `kube` or `selfManaged` must be set