### PR TITLE
route-delegation: enable label-based delegation

### DIFF
--- a/api/labels/delegation.go
+++ b/api/labels/delegation.go
@@ -1,0 +1,12 @@
+package labels
+
+import "github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
+
+// DelegationLabelSelector is the label used to select HTTPRoutes to delegate to
+// using a single label key-value pair
+const DelegationLabelSelector = "delegation.kgateway.dev/label"
+
+// DelegationLabelSelectorWildcardNamespace wildcards the namespace to select delegatee routes
+// using the DelegationLabelSelector label.
+// Note: this must be a valid RFC 1123 DNS label
+var DelegationLabelSelectorWildcardNamespace = envutils.GetOrDefault("DELEGATION_WILDCARD_NAMESPACE", "all", false)

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -14,6 +14,7 @@ import (
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
+	apilabels "github.com/kgateway-dev/kgateway/v2/api/labels"
 	extensionsplug "github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/backendref"
@@ -207,6 +208,16 @@ type targetRefIndexKey struct {
 
 func (k targetRefIndexKey) String() string {
 	return fmt.Sprintf("%s/%s/%s/%s", k.Group, k.Kind, k.Name, k.Namespace)
+}
+
+type DelegationLabelSelector struct {
+	LabelValue string
+	// Namespace is optional and only required when filtering the Fetch to a specific namespace
+	Namespace string
+}
+
+func (k DelegationLabelSelector) String() string {
+	return fmt.Sprintf("%s/%s", k.LabelValue, k.Namespace)
 }
 
 type globalPolicy struct {
@@ -524,10 +535,11 @@ func (c RouteWrapper) Equals(in RouteWrapper) bool {
 // MARK: RoutesIndex
 
 type RoutesIndex struct {
-	routes          krt.Collection[RouteWrapper]
-	httpRoutes      krt.Collection[ir.HttpRouteIR]
-	httpByNamespace krt.Index[string, ir.HttpRouteIR]
-	byParentRef     krt.Index[targetRefIndexKey, RouteWrapper]
+	routes                        krt.Collection[RouteWrapper]
+	httpRoutes                    krt.Collection[ir.HttpRouteIR]
+	httpByNamespace               krt.Index[string, ir.HttpRouteIR]
+	httpByDelegationLabelSelector krt.Index[DelegationLabelSelector, ir.HttpRouteIR]
+	byParentRef                   krt.Index[targetRefIndexKey, RouteWrapper]
 
 	policies  *PolicyIndex
 	refgrants *RefGrantIndex
@@ -574,6 +586,17 @@ func NewRoutesIndex(
 	httpByNamespace := krt.NewIndex(h.httpRoutes, func(i ir.HttpRouteIR) []string {
 		return []string{i.GetNamespace()}
 	})
+	h.httpByNamespace = httpByNamespace
+
+	httpByDelegationLabelSelector := krt.NewIndex(h.httpRoutes, func(i ir.HttpRouteIR) []DelegationLabelSelector {
+		value, ok := i.SourceObject.GetLabels()[apilabels.DelegationLabelSelector]
+		if !ok {
+			return nil
+		}
+		return []DelegationLabelSelector{{LabelValue: value, Namespace: i.GetNamespace()}, {LabelValue: value}}
+	})
+	h.httpByDelegationLabelSelector = httpByDelegationLabelSelector
+
 	byParentRef := krt.NewIndex(h.routes, func(in RouteWrapper) []targetRefIndexKey {
 		parentRefs := in.Route.GetParentRefs()
 		ret := make([]targetRefIndexKey, len(parentRefs))
@@ -604,13 +627,17 @@ func NewRoutesIndex(
 		}
 		return ret
 	})
-	h.httpByNamespace = httpByNamespace
 	h.byParentRef = byParentRef
+
 	return h
 }
 
 func (h *RoutesIndex) FetchHttpNamespace(kctx krt.HandlerContext, ns string) []ir.HttpRouteIR {
 	return krt.Fetch(kctx, h.httpRoutes, krt.FilterIndex(h.httpByNamespace, ns))
+}
+
+func (h *RoutesIndex) FetchHttpByDelegationLabelSelector(kctx krt.HandlerContext, selector DelegationLabelSelector) []ir.HttpRouteIR {
+	return krt.Fetch(kctx, h.httpRoutes, krt.FilterIndex(h.httpByDelegationLabelSelector, selector))
 }
 
 func (h *RoutesIndex) RoutesForGateway(kctx krt.HandlerContext, nns types.NamespacedName) []ir.Route {
@@ -821,7 +848,7 @@ func (h *RoutesIndex) getBackends(kctx krt.HandlerContext, src ir.ObjectSource, 
 		fromns := src.Namespace
 
 		to := toFromBackendRef(fromns, ref.BackendObjectReference)
-		if backendref.RefIsHTTPRoute(ref.BackendRef.BackendObjectReference) {
+		if backendref.IsDelegatedHTTPRoute(ref.BackendRef.BackendObjectReference) {
 			backends = append(backends, ir.HttpBackendOrDelegate{
 				Delegate:         &to,
 				AttachedPolicies: extensionRefs,

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -210,13 +210,20 @@ func (k targetRefIndexKey) String() string {
 	return fmt.Sprintf("%s/%s/%s/%s", k.Group, k.Kind, k.Name, k.Namespace)
 }
 
-type DelegationLabelSelector struct {
+// HTTPRouteSelector is used to lookup HttpRouteIR using one of the following ways:
+// - Only LabelValue
+// - Only Namespace
+// - LabelValue + Namespace
+type HTTPRouteSelector struct {
+	// LabelValue is the value of the HTTPRouteSelector label.
+	// +optional
 	LabelValue string
-	// Namespace is optional and only required when filtering the Fetch to a specific namespace
+	// Namespace is to fetch routes from.
+	// +optional
 	Namespace string
 }
 
-func (k DelegationLabelSelector) String() string {
+func (k HTTPRouteSelector) String() string {
 	return fmt.Sprintf("%s/%s", k.LabelValue, k.Namespace)
 }
 
@@ -535,11 +542,10 @@ func (c RouteWrapper) Equals(in RouteWrapper) bool {
 // MARK: RoutesIndex
 
 type RoutesIndex struct {
-	routes                        krt.Collection[RouteWrapper]
-	httpRoutes                    krt.Collection[ir.HttpRouteIR]
-	httpByNamespace               krt.Index[string, ir.HttpRouteIR]
-	httpByDelegationLabelSelector krt.Index[DelegationLabelSelector, ir.HttpRouteIR]
-	byParentRef                   krt.Index[targetRefIndexKey, RouteWrapper]
+	routes         krt.Collection[RouteWrapper]
+	httpRoutes     krt.Collection[ir.HttpRouteIR]
+	httpBySelector krt.Index[HTTPRouteSelector, ir.HttpRouteIR]
+	byParentRef    krt.Index[targetRefIndexKey, RouteWrapper]
 
 	policies  *PolicyIndex
 	refgrants *RefGrantIndex
@@ -583,19 +589,24 @@ func NewRoutesIndex(
 
 	h.routes = krt.JoinCollection([]krt.Collection[RouteWrapper]{httpRouteCollection, tcpRoutesCollection, tlsRoutesCollection}, krtopts.ToOptions("all-routes-with-policy")...)
 
-	httpByNamespace := krt.NewIndex(h.httpRoutes, func(i ir.HttpRouteIR) []string {
-		return []string{i.GetNamespace()}
-	})
-	h.httpByNamespace = httpByNamespace
-
-	httpByDelegationLabelSelector := krt.NewIndex(h.httpRoutes, func(i ir.HttpRouteIR) []DelegationLabelSelector {
+	httpBySelector := krt.NewIndex(h.httpRoutes, func(i ir.HttpRouteIR) []HTTPRouteSelector {
 		value, ok := i.SourceObject.GetLabels()[apilabels.DelegationLabelSelector]
 		if !ok {
-			return nil
+			return []HTTPRouteSelector{
+				// Key for wildcard namespace Fetch
+				{Namespace: i.GetNamespace()},
+			}
 		}
-		return []DelegationLabelSelector{{LabelValue: value, Namespace: i.GetNamespace()}, {LabelValue: value}}
+		return []HTTPRouteSelector{
+			// Key for namespace only Fetch
+			{Namespace: i.GetNamespace()},
+			// Key for label+namespace Fetch
+			{LabelValue: value, Namespace: i.GetNamespace()},
+			// Key for label only Fetch
+			{LabelValue: value},
+		}
 	})
-	h.httpByDelegationLabelSelector = httpByDelegationLabelSelector
+	h.httpBySelector = httpBySelector
 
 	byParentRef := krt.NewIndex(h.routes, func(in RouteWrapper) []targetRefIndexKey {
 		parentRefs := in.Route.GetParentRefs()
@@ -632,12 +643,8 @@ func NewRoutesIndex(
 	return h
 }
 
-func (h *RoutesIndex) FetchHttpNamespace(kctx krt.HandlerContext, ns string) []ir.HttpRouteIR {
-	return krt.Fetch(kctx, h.httpRoutes, krt.FilterIndex(h.httpByNamespace, ns))
-}
-
-func (h *RoutesIndex) FetchHttpByDelegationLabelSelector(kctx krt.HandlerContext, selector DelegationLabelSelector) []ir.HttpRouteIR {
-	return krt.Fetch(kctx, h.httpRoutes, krt.FilterIndex(h.httpByDelegationLabelSelector, selector))
+func (h *RoutesIndex) FetchHTTPRoutesBySelector(kctx krt.HandlerContext, selector HTTPRouteSelector) []ir.HttpRouteIR {
+	return krt.Fetch(kctx, h.httpRoutes, krt.FilterIndex(h.httpBySelector, selector))
 }
 
 func (h *RoutesIndex) RoutesForGateway(kctx krt.HandlerContext, nns types.NamespacedName) []ir.Route {

--- a/internal/kgateway/query/httproute.go
+++ b/internal/kgateway/query/httproute.go
@@ -14,7 +14,9 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	apilabels "github.com/kgateway-dev/kgateway/v2/api/labels"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
 	delegationutils "github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/delegation"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
@@ -270,18 +272,33 @@ func (r *gatewayQueries) fetchRoutesByRef(
 	delegatedNs := backendRef.Namespace
 
 	var refChildren []ir.HttpRouteIR
-	if string(backendRef.Name) == "" || string(backendRef.Name) == "*" {
-		// Handle wildcard references by listing all HTTPRoutes in the specified namespace
-		routes := r.collections.Routes.FetchHttpNamespace(kctx, delegatedNs)
+	// If the ref is a label selector, fetch routes by label selector
+	if isDelegationLabelSelectorRef(backendRef) {
+		selector := krtcollections.DelegationLabelSelector{
+			LabelValue: backendRef.Name,
+		}
+		// If a wildcard namespace is not specified, restrict the Fetch to the delegatedNs namespace,
+		// otherwise Fetch routes using the label selector in all namespaces
+		if delegatedNs != apilabels.DelegationLabelSelectorWildcardNamespace {
+			selector.Namespace = delegatedNs
+		}
+		routes := r.collections.Routes.FetchHttpByDelegationLabelSelector(kctx, selector)
 		refChildren = append(refChildren, routes...)
 	} else {
-		// Lookup a specific child route by its name
-		route := r.collections.Routes.FetchHttp(kctx, delegatedNs, string(backendRef.Name))
-		if route == nil {
-			return nil, errors.New("not found")
+		if string(backendRef.Name) == "" || string(backendRef.Name) == "*" {
+			// Handle wildcard references by listing all HTTPRoutes in the specified namespace
+			routes := r.collections.Routes.FetchHttpNamespace(kctx, delegatedNs)
+			refChildren = append(refChildren, routes...)
+		} else {
+			// Lookup a specific child route by its name
+			route := r.collections.Routes.FetchHttp(kctx, delegatedNs, string(backendRef.Name))
+			if route == nil {
+				return nil, errors.New("not found")
+			}
+			refChildren = append(refChildren, *route)
 		}
-		refChildren = append(refChildren, *route)
 	}
+
 	// Check if no child routes were resolved and log an error if needed
 	if len(refChildren) == 0 {
 		return nil, ErrUnresolvedReference
@@ -422,4 +439,9 @@ type Namespaced interface {
 
 func namespacedName(o Namespaced) types.NamespacedName {
 	return types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}
+}
+
+// isDelegationLabelSelectorRef checks if ObjectSource is an HTTPRoute delegation label selector
+func isDelegationLabelSelectorRef(ref ir.ObjectSource) bool {
+	return ref.Group+"/"+ref.Kind == apilabels.DelegationLabelSelector
 }

--- a/internal/kgateway/query/httproute.go
+++ b/internal/kgateway/query/httproute.go
@@ -274,7 +274,7 @@ func (r *gatewayQueries) fetchRoutesByRef(
 	var refChildren []ir.HttpRouteIR
 	// If the ref is a label selector, fetch routes by label selector
 	if isDelegationLabelSelectorRef(backendRef) {
-		selector := krtcollections.DelegationLabelSelector{
+		selector := krtcollections.HTTPRouteSelector{
 			LabelValue: backendRef.Name,
 		}
 		// If a wildcard namespace is not specified, restrict the Fetch to the delegatedNs namespace,
@@ -282,12 +282,14 @@ func (r *gatewayQueries) fetchRoutesByRef(
 		if delegatedNs != apilabels.DelegationLabelSelectorWildcardNamespace {
 			selector.Namespace = delegatedNs
 		}
-		routes := r.collections.Routes.FetchHttpByDelegationLabelSelector(kctx, selector)
+		routes := r.collections.Routes.FetchHTTPRoutesBySelector(kctx, selector)
 		refChildren = append(refChildren, routes...)
 	} else {
 		if string(backendRef.Name) == "" || string(backendRef.Name) == "*" {
 			// Handle wildcard references by listing all HTTPRoutes in the specified namespace
-			routes := r.collections.Routes.FetchHttpNamespace(kctx, delegatedNs)
+			routes := r.collections.Routes.FetchHTTPRoutesBySelector(kctx, krtcollections.HTTPRouteSelector{
+				Namespace: delegatedNs,
+			})
 			refChildren = append(refChildren, routes...)
 		} else {
 			// Lookup a specific child route by its name

--- a/internal/kgateway/translator/backendref/types.go
+++ b/internal/kgateway/translator/backendref/types.go
@@ -5,13 +5,26 @@ import (
 
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	apilabels "github.com/kgateway-dev/kgateway/v2/api/labels"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
-// RefIsHTTPRoute checks if the BackendObjectReference is an HTTPRoute
+// IsHTTPRoute checks if the BackendObjectReference is an HTTPRoute
 // Parent routes may delegate to child routes using an HTTPRoute backend reference.
-func RefIsHTTPRoute(ref gwv1.BackendObjectReference) bool {
+func IsHTTPRoute(ref gwv1.BackendObjectReference) bool {
 	return (ref.Kind != nil && *ref.Kind == wellknown.HTTPRouteKind) && (ref.Group != nil && *ref.Group == gwv1.GroupName)
+}
+
+// IsHTTPRouteDelegationLabelSelector checks if the BackendObjectReference is an HTTPRoute delegation label selector
+// Parent routes may delegate to child routes using an HTTPRoute backend reference.
+func IsHTTPRouteDelegationLabelSelector(ref gwv1.BackendObjectReference) bool {
+	return ref.Group != nil && ref.Kind != nil && (string(*ref.Group)+"/"+string(*ref.Kind)) == apilabels.DelegationLabelSelector
+}
+
+// IsDelegatedHTTPRoute checks if the BackendObjectReference is a delegated HTTPRoute
+// selected by an HTTPRoute or DelegationLabelSelector GVK reference.
+func IsDelegatedHTTPRoute(ref gwv1.BackendObjectReference) bool {
+	return IsHTTPRoute(ref) || IsHTTPRouteDelegationLabelSelector(ref)
 }
 
 // ToString returns a string representation of the BackendObjectReference

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -417,4 +417,5 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("TrafficPolicy multi level inheritance with child override enabled", "traffic_policy_multi_level_inheritance_override_enabled.yaml", ""),
 	Entry("TrafficPolicy filter override merge", "traffic_policy_filter_override_merge.yaml", ""),
 	Entry("Built-in rule inheritance", "builtin_rule_inheritance.yaml", ""),
+	Entry("Label based delegation", "label_based.yaml", ""),
 )

--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/label_based.yaml
@@ -1,0 +1,106 @@
+# This test contains a parent route delegating to a child route, based on path prefix.
+#
+# Input:
+# - Parent infra/example-route:
+#   - Delegate /infra to routes with the label delegation.kgateway.dev/label=infra-routes in the infra namespace
+#   - Delegate /a to routes with the label delegation.kgateway.dev/label=a-routes in the 'a' namespace
+#   - Delegate /all to routes with the label delegation.kgateway.dev/label=all-routes in the any(wildcard) namespace
+#   - Everything else goes to infra/example-svc
+#
+# Expected output routes:
+# - /infra/1 -> infra/example-svc
+# - /a/1 -> a/svc-a
+# - /all/b -> b/svc-b
+# - /* -> infra/example-svc
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /infra
+    backendRefs:
+    - group: delegation.kgateway.dev
+      kind: label
+      name: infra-routes
+      # no namespace; defaults to route's namespace (infra)
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: delegation.kgateway.dev
+      kind: label
+      name: a-routes
+      namespace: a
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /all
+    backendRefs:
+    - group: delegation.kgateway.dev
+      kind: label
+      name: all-routes
+      namespace: all # DelegationLabelSelectorWildcardNamespace
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: infra-child
+  namespace: infra
+  labels:
+    delegation.kgateway.dev/label: infra-routes
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /infra/1
+    backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+  labels:
+    delegation.kgateway.dev/label: a-routes
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-b
+  namespace: b
+  labels:
+    delegation.kgateway.dev/label: all-routes
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /all/b
+    backendRefs:
+    - name: svc-b
+      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
@@ -1,0 +1,58 @@
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: http
+        statPrefix: http
+        useRemoteAddress: true
+    name: http
+  name: http
+Routes:
+- ignorePortInHostMatching: true
+  name: http
+  virtualHosts:
+  - domains:
+    - example.com
+    name: http~example_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /infra/1
+      name: http~example_com-route-0-httproute-infra-child-infra-0-0-matcher-0
+      route:
+        cluster: kube_infra_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /all/b
+      name: http~example_com-route-1-httproute-route-b-b-0-0-matcher-0
+      route:
+        cluster: kube_b_svc-b_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /a/1
+      name: http~example_com-route-3-httproute-route-a-a-0-0-matcher-0
+      route:
+        cluster: kube_a_svc-a_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        prefix: /
+      name: http~example_com-route-6-httproute-example-route-infra-0-0-matcher-0
+      route:
+        cluster: kube_infra_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR


### PR DESCRIPTION
Enables delegating to other HTTPRoutes using the label `delegation.kgateway.dev/label` that can be referenced as a BackendRef:
```
- group: delegation.kgateway.dev
  kind: label
  name: infra-routes
  namespace: <empty>|all|<specific> # optional
```

Part of #10942