### PR TITLE
docs: add pointer to contributing guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The project was previously known as Gloo, and has been [production-ready since 2
 - [Learn more about the community](https://github.com/kgateway-dev/community)
 
 ## Contributing to kgateway
+Please refer to the [contributing guide](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md) in the community repo.
+
 The [devel](devel) folder should be the starting point for understanding the code, and contributing to the product.
 
 ## Thanks


### PR DESCRIPTION
Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>

Duplicate the content in the CONTRIBUTING.md file in README.md, to make it easier to find when browing the code at

https://github.com/kgateway-dev/kgateway/?tab=readme-ov-file#--------------------an-envoy-powered-kubernetes-native-api-gateway


## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->


# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
