### PR TITLE
status: correctly merge parentRefs for routes

### DIFF
--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -235,49 +235,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 	// here we will merge reports that are per-Proxy to a singleton Report used to persist to k8s on a timer
 	s.statusReport = krt.NewSingleton(func(kctx krt.HandlerContext) *report {
 		proxies := krt.Fetch(kctx, s.mostXdsSnapshots)
-		merged := reports.NewReportMap()
-		for _, p := range proxies {
-			// 1. merge GW Reports for all Proxies' status reports
-			maps.Copy(merged.Gateways, p.reports.Gateways)
-
-			// 2. merge httproute parentRefs into RouteReports
-			for rnn, rr := range p.reports.HTTPRoutes {
-				// if we haven't encountered this route, just copy it over completely
-				old := merged.HTTPRoutes[rnn]
-				if old == nil {
-					merged.HTTPRoutes[rnn] = rr
-					continue
-				}
-				// else, let's merge our parentRefs into the existing map
-				// obsGen will stay as-is...
-				maps.Copy(p.reports.HTTPRoutes[rnn].Parents, rr.Parents)
-			}
-
-			// 3. merge tcproute parentRefs into RouteReports
-			for rnn, rr := range p.reports.TCPRoutes {
-				// if we haven't encountered this route, just copy it over completely
-				old := merged.TCPRoutes[rnn]
-				if old == nil {
-					merged.TCPRoutes[rnn] = rr
-					continue
-				}
-				// else, let's merge our parentRefs into the existing map
-				// obsGen will stay as-is...
-				maps.Copy(p.reports.TCPRoutes[rnn].Parents, rr.Parents)
-			}
-
-			for rnn, rr := range p.reports.TLSRoutes {
-				// if we haven't encountered this route, just copy it over completely
-				old := merged.TLSRoutes[rnn]
-				if old == nil {
-					merged.TLSRoutes[rnn] = rr
-					continue
-				}
-				// else, let's merge our parentRefs into the existing map
-				// obsGen will stay as-is...
-				maps.Copy(p.reports.TLSRoutes[rnn].Parents, rr.Parents)
-			}
-		}
+		merged := mergeProxyReports(proxies)
 		return &report{merged}
 	})
 
@@ -289,6 +247,56 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 		s.plugins.HasSynced,
 		s.translator.HasSynced,
 	}
+}
+
+func mergeProxyReports(
+	proxies []GatewayXdsResources,
+) reports.ReportMap {
+	merged := reports.NewReportMap()
+	for _, p := range proxies {
+		// 1. merge GW Reports for all Proxies' status reports
+		maps.Copy(merged.Gateways, p.reports.Gateways)
+
+		// 2. merge httproute parentRefs into RouteReports
+		for rnn, rr := range p.reports.HTTPRoutes {
+			// if we haven't encountered this route, just copy it over completely
+			old := merged.HTTPRoutes[rnn]
+			if old == nil {
+				merged.HTTPRoutes[rnn] = rr
+				continue
+			}
+			// else, let's merge our parentRefs into the existing map
+			// obsGen will stay as-is...
+			maps.Copy(p.reports.HTTPRoutes[rnn].Parents, rr.Parents)
+		}
+
+		// 3. merge tcproute parentRefs into RouteReports
+		for rnn, rr := range p.reports.TCPRoutes {
+			// if we haven't encountered this route, just copy it over completely
+			old := merged.TCPRoutes[rnn]
+			if old == nil {
+				merged.TCPRoutes[rnn] = rr
+				continue
+			}
+			// else, let's merge our parentRefs into the existing map
+			// obsGen will stay as-is...
+			maps.Copy(p.reports.TCPRoutes[rnn].Parents, rr.Parents)
+		}
+
+		for rnn, rr := range p.reports.TLSRoutes {
+			// if we haven't encountered this route, just copy it over completely
+			old := merged.TLSRoutes[rnn]
+			if old == nil {
+				merged.TLSRoutes[rnn] = rr
+				continue
+			}
+			// else, let's merge our parentRefs into the existing map
+			// obsGen will stay as-is...
+			maps.Copy(p.reports.TLSRoutes[rnn].Parents, rr.Parents)
+		}
+	}
+
+	return merged
 }
 
 func (s *ProxySyncer) Start(ctx context.Context) error {

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -265,9 +265,9 @@ func mergeProxyReports(
 				merged.HTTPRoutes[rnn] = rr
 				continue
 			}
-			// else, let's merge our parentRefs into the existing map
-			// obsGen will stay as-is...
-			maps.Copy(p.reports.HTTPRoutes[rnn].Parents, rr.Parents)
+			// else, this route has already been seen for a proxy, merge this proxy's parents
+			// into the merged report
+			maps.Copy(merged.HTTPRoutes[rnn].Parents, rr.Parents)
 		}
 
 		// 3. merge tcproute parentRefs into RouteReports
@@ -278,9 +278,9 @@ func mergeProxyReports(
 				merged.TCPRoutes[rnn] = rr
 				continue
 			}
-			// else, let's merge our parentRefs into the existing map
-			// obsGen will stay as-is...
-			maps.Copy(p.reports.TCPRoutes[rnn].Parents, rr.Parents)
+			// else, this route has already been seen for a proxy, merge this proxy's parents
+			// into the merged report
+			maps.Copy(merged.TCPRoutes[rnn].Parents, rr.Parents)
 		}
 
 		for rnn, rr := range p.reports.TLSRoutes {
@@ -290,9 +290,9 @@ func mergeProxyReports(
 				merged.TLSRoutes[rnn] = rr
 				continue
 			}
-			// else, let's merge our parentRefs into the existing map
-			// obsGen will stay as-is...
-			maps.Copy(p.reports.TLSRoutes[rnn].Parents, rr.Parents)
+			// else, this route has already been seen for a proxy, merge this proxy's parents
+			// into the merged report
+			maps.Copy(merged.TLSRoutes[rnn].Parents, rr.Parents)
 		}
 	}
 


### PR DESCRIPTION
When a route has multiple parentRefs, the exitsing status
merging code does not correctly merge parentRefs belonging
to different proxies. As a result, a route with multiple
parents does not have both parents in their status.

This change fixes it.

**Testing done:**

- Unit test added in commit 1 fails without the fixes in commit 2.
- Reproducible with the following config where a route with multiple parents does not have a status with both ancestors:
```
kubectl  apply -f- <<EOF
kind: Gateway
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: test-1
  namespace: test
spec:
  gatewayClassName: kgateway
  listeners:
  - protocol: HTTP
    port: 80
    name: http
    allowedRoutes:
      namespaces:
        from: All
---
kind: Gateway
apiVersion: gateway.networking.k8s.io/v1
metadata:
  name: test-2
  namespace: test
spec:
  gatewayClassName: kgateway
  listeners:
  - protocol: HTTP
    port: 80
    name: http
    allowedRoutes:
      namespaces:
        from: All
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: "test"
  namespace: test
spec:
  parentRefs:
  - name: test-1
    namespace: test
  - name: test-2
    namespace: test
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    backendRefs:
    - name: httpbin
      port: 8000
EOF
```
Bad status:
```
  status:
    parents:
    - conditions:
      - lastTransitionTime: "2025-04-28T16:13:12Z"
        message: ""
        observedGeneration: 1
        reason: Accepted
        status: "True"
        type: Accepted
      - lastTransitionTime: "2025-04-28T16:13:12Z"
        message: ""
        observedGeneration: 1
        reason: ResolvedRefs
        status: "True"
        type: ResolvedRefs
      controllerName: kgateway.dev/kgateway
      parentRef:
        group: gateway.networking.k8s.io
        kind: Gateway
        name: test-1
        namespace: test
kind: List
metadata:
  resourceVersion: ""
```

Status with the fix:
```
  status:
    parents:
    - conditions:
      - lastTransitionTime: "2025-04-28T16:26:29Z"
        message: ""
        observedGeneration: 2
        reason: Accepted
        status: "True"
        type: Accepted
      - lastTransitionTime: "2025-04-28T16:26:29Z"
        message: ""
        observedGeneration: 2
        reason: ResolvedRefs
        status: "True"
        type: ResolvedRefs
      controllerName: kgateway.dev/kgateway
      parentRef:
        group: gateway.networking.k8s.io
        kind: Gateway
        name: test-1
        namespace: test
    - conditions:
      - lastTransitionTime: "2025-04-28T16:14:42Z"
        message: ""
        observedGeneration: 2
        reason: Accepted
        status: "True"
        type: Accepted
      - lastTransitionTime: "2025-04-28T16:14:42Z"
        message: ""
        observedGeneration: 2
        reason: ResolvedRefs
        status: "True"
        type: ResolvedRefs
      controllerName: kgateway.dev/kgateway
      parentRef:
        group: gateway.networking.k8s.io
        kind: Gateway
        name: test-2
        namespace: test
kind: List
metadata:
  resourceVersion: ""
```