### PR TITLE
use set_metadata for extauth global disable

### DIFF
--- a/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy.go
@@ -3,15 +3,35 @@ package routepolicy
 import (
 	"fmt"
 
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
-	envoytransformation "github.com/solo-io/envoy-gloo/go/config/filter/http/transformation/v2"
+	set_metadata "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/set_metadata/v3"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/common"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/pluginutils"
+)
+
+var (
+	// from envoy code:
+	// If the field `config` is configured but is empty, we treat the filter is enabled
+	// explicitly.
+	enableFilterPerRoute = &routev3.FilterConfig{Config: &anypb.Any{}}
+	setMetadataConfig    = &set_metadata.Config{
+		Metadata: []*set_metadata.Metadata{
+			{
+				MetadataNamespace: extAuthGlobalDisableFilterMetadataNamespace,
+				Value: &structpb.Struct{Fields: map[string]*structpb.Value{
+					extAuthGlobalDisableKey: structpb.NewBoolValue(true),
+				}},
+			},
+		},
+	}
 )
 
 type extAuthIR struct {
@@ -116,23 +136,4 @@ func translatePerFilterConfig(spec *v1alpha1.ExtAuthPolicy) *envoy_ext_authz_v3.
 		}
 	}
 	return nil
-}
-
-// extAuthEnablementPerRoute returns a transformation that sets the ext auth filter key to false
-// this then fires on the metadata match that all top level configuration shall have.
-func extAuthEnablementPerRoute() proto.Message {
-	return &envoytransformation.RouteTransformations{
-		RequestTransformation: &envoytransformation.Transformation{
-			TransformationType: &envoytransformation.Transformation_TransformationTemplate{
-				TransformationTemplate: &envoytransformation.TransformationTemplate{
-					DynamicMetadataValues: []*envoytransformation.TransformationTemplate_DynamicMetadataValue{
-						{
-							Key:   extAuthGlobalDisableFilterKey,
-							Value: &envoytransformation.InjaTemplate{Text: "false"},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy.go
+++ b/internal/kgateway/extensions2/plugins/routepolicy/extauth_policy.go
@@ -21,6 +21,7 @@ var (
 	// from envoy code:
 	// If the field `config` is configured but is empty, we treat the filter is enabled
 	// explicitly.
+	// see: https://github.com/envoyproxy/envoy/blob/8ed93ef372f788456b708fc93a7e54e17a013aa7/source/common/router/config_impl.cc#L2552
 	enableFilterPerRoute = &routev3.FilterConfig{Config: &anypb.Any{}}
 	setMetadataConfig    = &set_metadata.Config{
 		Metadata: []*set_metadata.Metadata{

--- a/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
@@ -50,20 +50,24 @@ listeners:
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         httpFilters:
-        - name: global_disable/ext_auth
+        - disabled: true
+          name: global_disable/ext_auth
           typedConfig:
-            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+            '@type': type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+            metadata:
+            - metadataNamespace: dev.kgateway.disable_ext_auth
+              value:
+                extauth_disable: true
         - name: ext_auth/gwtest/basic-extauth
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             filterEnabledMetadata:
-              filter: io.solo.transformation
+              filter: dev.kgateway.disable_ext_auth
               invert: true
               path:
-              - key: global_disable/ext_auth
+              - key: extauth_disable
               value:
-                stringMatch:
-                  exact: "false"
+                boolMatch: true
             grpcService:
               envoyGrpc:
                 clusterName: kube_gwtest_ext-authz_9000
@@ -97,10 +101,5 @@ routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         global_disable/ext_auth:
-          '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
-          requestTransformation:
-            transformationTemplate:
-              dynamicMetadataValues:
-              - key: global_disable/ext_auth
-                value:
-                  text: "false"
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}

--- a/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
@@ -58,21 +58,25 @@ listeners:
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         httpFilters:
-        - name: global_disable/ext_auth
+        - disabled: true
+          name: global_disable/ext_auth
           typedConfig:
-            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+            '@type': type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+            metadata:
+            - metadataNamespace: dev.kgateway.disable_ext_auth
+              value:
+                extauth_disable: true
         - disabled: true
           name: ext_auth/gwtest/app-team-extauth
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             filterEnabledMetadata:
-              filter: io.solo.transformation
+              filter: dev.kgateway.disable_ext_auth
               invert: true
               path:
-              - key: global_disable/ext_auth
+              - key: extauth_disable
               value:
-                stringMatch:
-                  exact: "false"
+                boolMatch: true
             grpcService:
               envoyGrpc:
                 clusterName: kube_gwtest_app-team-ext-authz_9000
@@ -80,13 +84,12 @@ listeners:
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             filterEnabledMetadata:
-              filter: io.solo.transformation
+              filter: dev.kgateway.disable_ext_auth
               invert: true
               path:
-              - key: global_disable/ext_auth
+              - key: extauth_disable
               value:
-                stringMatch:
-                  exact: "false"
+                boolMatch: true
             grpcService:
               envoyGrpc:
                 clusterName: kube_gwtest_ext-authz_9000

--- a/internal/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
@@ -50,20 +50,24 @@ listeners:
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         httpFilters:
-        - name: global_disable/ext_auth
+        - disabled: true
+          name: global_disable/ext_auth
           typedConfig:
-            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+            '@type': type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+            metadata:
+            - metadataNamespace: dev.kgateway.disable_ext_auth
+              value:
+                extauth_disable: true
         - name: ext_auth/gwtest/basic-extauth
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             filterEnabledMetadata:
-              filter: io.solo.transformation
+              filter: dev.kgateway.disable_ext_auth
               invert: true
               path:
-              - key: global_disable/ext_auth
+              - key: extauth_disable
               value:
-                stringMatch:
-                  exact: "false"
+                boolMatch: true
             grpcService:
               envoyGrpc:
                 clusterName: kube_gwtest_ext-authz_9000

--- a/internal/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
@@ -13,7 +13,7 @@ clusters:
       ads: {}
       resourceApiVersion: V3
   metadata: {}
-  name: kube_gwtest_reviews_8080
+  name: kube_gwtest_ext-authz_9000
   type: EDS
 - connectTimeout: 5s
   edsClusterConfig:
@@ -21,7 +21,7 @@ clusters:
       ads: {}
       resourceApiVersion: V3
   metadata: {}
-  name: kube_gwtest_ext-authz_9000
+  name: kube_gwtest_reviews_8080
   type: EDS
 endpoints:
 - clusterName: kube_gwtest_reviews_8080
@@ -50,21 +50,25 @@ listeners:
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         httpFilters:
-        - name: global_disable/ext_auth
+        - disabled: true
+          name: global_disable/ext_auth
           typedConfig:
-            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+            '@type': type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+            metadata:
+            - metadataNamespace: dev.kgateway.disable_ext_auth
+              value:
+                extauth_disable: true
         - disabled: true
           name: ext_auth/gwtest/basic-extauth
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             filterEnabledMetadata:
-              filter: io.solo.transformation
+              filter: dev.kgateway.disable_ext_auth
               invert: true
               path:
-              - key: global_disable/ext_auth
+              - key: extauth_disable
               value:
-                stringMatch:
-                  exact: "false"
+                boolMatch: true
             grpcService:
               envoyGrpc:
                 clusterName: kube_gwtest_ext-authz_9000


### PR DESCRIPTION
removes the usage of transformation filter for this case, which will make it easier to maintain as we stop using it.
existing e2e test should validate this