### PR TITLE
Add lint Makefile target and GitHub Action for Rust code

### DIFF
--- a/.github/workflows/lint-rust.yaml
+++ b/.github/workflows/lint-rust.yaml
@@ -1,0 +1,23 @@
+name: Lint Rust Code
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint_rust:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy,rustfmt
+          cache: true
+
+      - name: Lint
+        run: |
+          make -C internal/envoyinit/rustformations lint

--- a/internal/envoyinit/rustformations/Makefile
+++ b/internal/envoyinit/rustformations/Makefile
@@ -1,0 +1,38 @@
+# imports should be after the set up flags so are lower
+
+# https://www.gnu.org/software/make/manual/html_node/Special-Variables.html#Special-Variables
+.DEFAULT_GOAL := help
+
+#----------------------------------------------------------------------------------
+# Help
+#----------------------------------------------------------------------------------
+# Our Makefile is quite large, and hard to reason through
+# `make help` can be used to self-document targets
+# To update a target to be self-documenting (and appear with the `help` command),
+# place a comment after the target that is prefixed by `##`. For example:
+#	custom-target: ## comment that will appear in the documentation when running `make help`
+#
+# **NOTE TO DEVELOPERS**
+# As you encounter make targets that are frequently used, please make them self-documenting
+.PHONY: help
+help: NAME_COLUMN_WIDTH=35
+help: LINE_COLUMN_WIDTH=5
+help: ## Output the self-documenting make targets
+	@grep -hnE '^[%a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = "[:]|(## )"}; {printf "\033[36mL%-$(LINE_COLUMN_WIDTH)s%-$(NAME_COLUMN_WIDTH)s\033[0m %s\n", $$1, $$2, $$4}'
+
+#----------------------------------------------------------------------------------
+# Base
+#----------------------------------------------------------------------------------
+
+.PHONY: lint
+lint: ## Run lint checks.
+	cargo fmt --check
+	cargo clippy --all-targets -- -D warnings
+
+#----------------------------------------------------------------------------------
+# Printing makefile variables utility
+#----------------------------------------------------------------------------------
+
+# use `make print-MAKEFILE_VAR` to print the value of MAKEFILE_VAR
+
+print-%  : ; @echo $($*)


### PR DESCRIPTION
Inspired lint target in https://github.com/agentgateway/agentgateway

Signed-off-by: Craig Rodrigues <rodrigc@crodrigues.org>

# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Add lint Makefile target and GitHub Action for Rust code.
This fixes https://github.com/kgateway-dev/kgateway/issues/10868

## Interesting choices

* I decided to put the lint target in a separate Makefile closer to the Rust code, for an initial try at this.  The top-level Makefile has quite a lot of stuff in there, so I didn't want to modify any of that.  If we want to move this logic into the top-level Makefile, I can do that.
* I decided to incorporate logic from http://github.com/agentgateway/agentgateway , since that is a new and active project.  Maybe @EItanya , who actively works on that project, can provide feedback here.

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->
Added a new workflow for calling `make lint` for Rust.

## Testing steps

<!-- I manually verified behavior by ... -->
* I ran:
```shell
make -C internal/envoyinit/rustformations lint
```

* I tested the GitHub workflow locally by doing:
```shell
act -j lint_rust
```

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
