### PR TITLE
allow multiple endpoint plugins to apply on a single backend

### DIFF
--- a/internal/kgateway/endpoints/prioritize.go
+++ b/internal/kgateway/endpoints/prioritize.go
@@ -14,14 +14,26 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func PrioritizeEndpoints(logger *zap.Logger, priorityInfo *PriorityInfo, ep ir.EndpointsForBackend, ucc ir.UniqlyConnectedClient) *envoy_config_endpoint_v3.ClusterLoadAssignment {
+// EndpointsInputs is the collective IR that can be modified
+// by endpoint plugins to influence the ClusterLoadAssignment.
+type EndpointsInputs struct {
+	EndpointsForBackend ir.EndpointsForBackend
+	PriorityInfo        *PriorityInfo
+}
+
+// PrioritizeEndpoints converts EndpointsInputs into a ClusterLoadAssignment.
+func PrioritizeEndpoints(
+	logger *zap.Logger,
+	ucc ir.UniqlyConnectedClient,
+	inputs EndpointsInputs,
+) *envoy_config_endpoint_v3.ClusterLoadAssignment {
 	lbInfo := LoadBalancingInfo{
 		PodLabels:    ucc.Labels,
 		PodLocality:  ucc.Locality,
-		PriorityInfo: priorityInfo,
+		PriorityInfo: inputs.PriorityInfo,
 	}
 
-	return prioritizeWithLbInfo(logger, ep, lbInfo)
+	return prioritizeWithLbInfo(logger, inputs.EndpointsForBackend, lbInfo)
 }
 
 type LoadBalancingInfo struct {

--- a/internal/kgateway/extensions2/plugin/plugin.go
+++ b/internal/kgateway/extensions2/plugin/plugin.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/endpoints"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 
 	"istio.io/istio/pkg/kube/krt"
@@ -35,8 +35,8 @@ type (
 		kctx krt.HandlerContext,
 		ctx context.Context,
 		ucc ir.UniqlyConnectedClient,
-		in ir.EndpointsForBackend,
-	) (*envoy_config_endpoint_v3.ClusterLoadAssignment, uint64)
+		out *endpoints.EndpointsInputs,
+	) uint64
 )
 
 // TODO: consider changing PerClientProcessBackend to look like this:

--- a/internal/kgateway/extensions2/plugins/destrule/destrule_plugin.go
+++ b/internal/kgateway/extensions2/plugins/destrule/destrule_plugin.go
@@ -9,9 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/solo-io/go-utils/contextutils"
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube/krt"
@@ -55,25 +53,30 @@ type destrulePlugin struct {
 	destinationRulesIndex DestinationRuleIndex
 }
 
-func (d *destrulePlugin) processEndpoints(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniqlyConnectedClient, in ir.EndpointsForBackend) (*envoy_config_endpoint_v3.ClusterLoadAssignment, uint64) {
-	destrule := d.destinationRulesIndex.FetchDestRulesFor(kctx, ucc.Namespace, in.Hostname, ucc.Labels)
+// processEndpoints tries to find a destination rule
+// for the backend and if it does, it updates the PriorityInfo on `out`.
+func (d *destrulePlugin) processEndpoints(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniqlyConnectedClient,
+	out *endpoints.EndpointsInputs,
+) uint64 {
+	destrule := d.destinationRulesIndex.FetchDestRulesFor(kctx, ucc.Namespace, out.EndpointsForBackend.Hostname, ucc.Labels)
 	if destrule == nil {
-		return nil, 0
+		return 0
 	}
 
-	logger := contextutils.LoggerFrom(ctx).Desugar()
-	trafficPolicy := getTrafficPolicy(destrule, in.Port)
+	trafficPolicy := getTrafficPolicy(destrule, out.EndpointsForBackend.Port)
 	localityLb := getLocalityLbSetting(trafficPolicy)
-	var priorityInfo *endpoints.PriorityInfo
-	var additionalHash uint64
-	if localityLb != nil {
-		priorityInfo = getPriorityInfoFromDestrule(localityLb)
-		hasher := fnv.New64()
-		hasher.Write([]byte(destrule.UID))
-		hasher.Write([]byte(fmt.Sprintf("%v", destrule.Generation)))
-		additionalHash = hasher.Sum64()
+	if localityLb == nil {
+		return 0
 	}
-	return endpoints.PrioritizeEndpoints(logger, priorityInfo, in, ucc), additionalHash
+
+	out.PriorityInfo = getPriorityInfoFromDestrule(localityLb)
+	hasher := fnv.New64()
+	hasher.Write([]byte(destrule.UID))
+	hasher.Write([]byte(fmt.Sprintf("%v", destrule.Generation)))
+	return hasher.Sum64()
 }
 
 func (d *destrulePlugin) processBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniqlyConnectedClient, in ir.BackendObjectIR, outCluster *envoy_config_cluster_v3.Cluster) {

--- a/internal/kgateway/proxy_syncer/cla_test.go
+++ b/internal/kgateway/proxy_syncer/cla_test.go
@@ -61,7 +61,11 @@ func TestTranslatesDestrulesFailoverPriority(t *testing.T) {
 		}),
 	}
 
-	cla := endpoints.PrioritizeEndpoints(nil, priorityInfo, *efu, ucc)
+	epInputs := endpoints.EndpointsInputs{
+		EndpointsForBackend: *efu,
+		PriorityInfo:        priorityInfo,
+	}
+	cla := endpoints.PrioritizeEndpoints(nil, ucc, epInputs)
 	g.Expect(cla.Endpoints).To(gomega.HaveLen(2))
 
 	remoteLocality := cla.Endpoints[0]
@@ -123,7 +127,11 @@ func TestTranslatesDestrulesFailover(t *testing.T) {
 
 	priorityInfo := &endpoints.PriorityInfo{}
 
-	cla := endpoints.PrioritizeEndpoints(nil, priorityInfo, *efu, ucc)
+	epInputs := endpoints.EndpointsInputs{
+		EndpointsForBackend: *efu,
+		PriorityInfo:        priorityInfo,
+	}
+	cla := endpoints.PrioritizeEndpoints(nil, ucc, epInputs)
 	g.Expect(cla.Endpoints).To(gomega.HaveLen(2))
 
 	remoteLocality := cla.Endpoints[0]


### PR DESCRIPTION
Signed-off-by: Steven Landow <steven.landow@solo.io>

# Description

Currently if multiple `PerClientProcessEndpoints` apply to the same backend, only one will win and we'll use that CLA. 
The only existing endpoint plugin is for DestinationRule. Effectively, it just adds `PriorityInfo` to the `PrioritizeEndpoints` call.

This change passes a mutable `EndpointsInputs` to endpoints plugins that allows mutation of:

* PriorityInfo
* EndpointsForBackend

Theoretically DR could set priority info, and another plugin could rearrange the `EndpointsForBackend` (for example, mapping multi-network endpoints to gateway IPs like Istio does for its sidecar multi-network).

Care should be taken when writing endpoint plugins, as ordering is not guaranteed. For the foreseeable future, we don't need to add a priority/ordering mechanism to endpoint plugins. 


## Code changes

* Always build the CLA from within the translator (`PrioritizeEndpoints` call)
* Don't build CLA from within endpoint plugin
* Pass a mutable `EndpointsInputs` to endpoints plugins


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
