### PR TITLE
fix: compare backends of route ir

### DIFF
--- a/internal/kgateway/ir/backend.go
+++ b/internal/kgateway/ir/backend.go
@@ -222,24 +222,27 @@ func (a BackendRefIR) Equals(b BackendRefIR) bool {
 		return false
 	}
 
-	// compare backend objects
-	objA := a.BackendObject
-	objB := b.BackendObject
-
-	if (objA == nil) != (objB == nil) {
-		return false
-	}
-	if objA != nil && !objA.Equals(*objB) {
+	if !backendObjectEqual(a.BackendObject, b.BackendObject) {
 		return false
 	}
 
-	// Compare error fields: either both nil or both have same error message
-	if (a.Err == nil) != (b.Err == nil) {
-		return false
-	}
-	if a.Err != nil && b.Err != nil && a.Err.Error() != b.Err.Error() {
+	if !errorsEqual(a.Err, b.Err) {
 		return false
 	}
 
 	return true
+}
+
+func backendObjectEqual(a, b *BackendObjectIR) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equals(*b)
+}
+
+func errorsEqual(a, b error) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Error() == b.Error()
 }

--- a/internal/kgateway/ir/backend.go
+++ b/internal/kgateway/ir/backend.go
@@ -215,3 +215,26 @@ func (c Gateway) ResourceName() string {
 func (c Gateway) Equals(in Gateway) bool {
 	return c.ObjectSource.Equals(in.ObjectSource) && versionEquals(c.Obj, in.Obj) && c.AttachedListenerPolicies.Equals(in.AttachedListenerPolicies) && c.AttachedHttpPolicies.Equals(in.AttachedHttpPolicies)
 }
+
+// Equals returns true if the two BackendRefIR instances are equal in cluster name, weight, backend object equality, and error.
+func (a BackendRefIR) Equals(b BackendRefIR) bool {
+	if a.ClusterName != b.ClusterName || a.Weight != b.Weight {
+		return false
+	}
+
+	// compare backend objects
+	objA := a.BackendObject
+	objB := b.BackendObject
+
+	// Check if nil-ness differs (one is nil, the other is not)
+	if (objA == nil) != (objB == nil) {
+		return false
+	}
+	// If both are non-nil, compare their contents using the Equals method
+	if objA != nil && !objA.Equals(*objB) {
+		return false
+	}
+	// If both are nil, they are equal
+
+	return true
+}

--- a/internal/kgateway/ir/backend.go
+++ b/internal/kgateway/ir/backend.go
@@ -226,15 +226,20 @@ func (a BackendRefIR) Equals(b BackendRefIR) bool {
 	objA := a.BackendObject
 	objB := b.BackendObject
 
-	// Check if nil-ness differs (one is nil, the other is not)
 	if (objA == nil) != (objB == nil) {
 		return false
 	}
-	// If both are non-nil, compare their contents using the Equals method
 	if objA != nil && !objA.Equals(*objB) {
 		return false
 	}
-	// If both are nil, they are equal
+
+	// Compare error fields: either both nil or both have same error message
+	if (a.Err == nil) != (b.Err == nil) {
+		return false
+	}
+	if a.Err != nil && b.Err != nil && a.Err.Error() != b.Err.Error() {
+		return false
+	}
 
 	return true
 }

--- a/internal/kgateway/ir/routes.go
+++ b/internal/kgateway/ir/routes.go
@@ -122,7 +122,23 @@ func (c TcpRouteIR) ResourceName() string {
 }
 
 func (c TcpRouteIR) Equals(in TcpRouteIR) bool {
-	return c.ObjectSource == in.ObjectSource && versionEquals(c.SourceObject, in.SourceObject) && c.AttachedPolicies.Equals(in.AttachedPolicies)
+	return c.ObjectSource == in.ObjectSource &&
+		versionEquals(c.SourceObject, in.SourceObject) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		backendsEqual(c.Backends, in.Backends)
+}
+
+// backendsEqual compares two slices of BackendRefIR using the Equals method for readability.
+func backendsEqual(a, b []BackendRefIR) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Equals(b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 var _ Route = &TcpRouteIR{}
@@ -148,7 +164,10 @@ func (c TlsRouteIR) ResourceName() string {
 }
 
 func (c TlsRouteIR) Equals(in TlsRouteIR) bool {
-	return c.ObjectSource == in.ObjectSource && versionEquals(c.SourceObject, in.SourceObject) && c.AttachedPolicies.Equals(in.AttachedPolicies)
+	return c.ObjectSource == in.ObjectSource &&
+		versionEquals(c.SourceObject, in.SourceObject) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		backendsEqual(c.Backends, in.Backends)
 }
 
 func (c *TlsRouteIR) GetHostnames() []string {

--- a/internal/kgateway/ir/routes_test.go
+++ b/internal/kgateway/ir/routes_test.go
@@ -1,0 +1,177 @@
+package ir
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// makeTCPRoute constructs a TCPRoute with specified metadata.
+func makeTCPRoute(name, namespace, rv string, gen int64, uid types.UID) *gwv1alpha2.TCPRoute {
+	return &gwv1alpha2.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: rv,
+			Generation:      gen,
+			UID:             uid,
+		},
+	}
+}
+
+// makeBackendRef constructs a BackendRefIR with no BackendObject for testing.
+func makeBackendRef(cluster string, weight uint32) BackendRefIR {
+	return BackendRefIR{ClusterName: cluster, Weight: weight, BackendObject: nil}
+}
+
+func TestTcpRouteIREquals(t *testing.T) {
+	base := makeTCPRoute("route1", "test-ns", "1", 1, types.UID("uid1"))
+	same := makeTCPRoute("route1", "test-ns", "1", 1, types.UID("uid1"))
+
+	emptyPolicies := AttachedPolicies{}
+	nonEmptyPolicies := AttachedPolicies{
+		Policies: map[schema.GroupKind][]PolicyAtt{
+			schema.GroupKind{Group: "g", Kind: "k"}: {{GroupKind: schema.GroupKind{Group: "g", Kind: "k"}}},
+		},
+	}
+
+	emptyBackends := []BackendRefIR{}
+	backendA := []BackendRefIR{makeBackendRef("clusterA", 5)}
+	backendB := []BackendRefIR{makeBackendRef("clusterB", 5)}
+	backendWeightDiff := []BackendRefIR{makeBackendRef("clusterA", 10)}
+
+	tests := []struct {
+		name string
+		a, b TcpRouteIR
+		want bool
+	}{
+		{
+			name: "identical_empty",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         emptyBackends,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     same,
+				AttachedPolicies: emptyPolicies,
+				Backends:         emptyBackends,
+			},
+			want: true,
+		},
+		{
+			name: "diff_objectsource",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         emptyBackends,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route2"},
+				SourceObject:     same,
+				AttachedPolicies: emptyPolicies,
+				Backends:         emptyBackends,
+			},
+			want: false,
+		},
+		{
+			name: "diff_attached_policies",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         emptyBackends,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     same,
+				AttachedPolicies: nonEmptyPolicies,
+				Backends:         emptyBackends,
+			},
+			want: false,
+		},
+		{
+			name: "diff_backends_length",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         emptyBackends,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     same,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendA,
+			},
+			want: false,
+		},
+		{
+			name: "diff_backend_cluster",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendA,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     same,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendB,
+			},
+			want: false,
+		},
+		{
+			name: "diff_backend_weight",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendA,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     same,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendWeightDiff,
+			},
+			want: false,
+		},
+		{
+			name: "identical_backends",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendA,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     same,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendA,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.a.Equals(tt.b)
+			if got != tt.want {
+				t.Errorf("TcpRouteIR.Equals() = %v, want %v", got, tt.want)
+			}
+			// symmetry
+			if tt.a.Equals(tt.b) != tt.b.Equals(tt.a) {
+				t.Errorf("symmetry mismatch: a.Equals(b)=%v, b.Equals(a)=%v", tt.a.Equals(tt.b), tt.b.Equals(tt.a))
+			}
+		})
+	}
+}

--- a/internal/kgateway/ir/routes_test.go
+++ b/internal/kgateway/ir/routes_test.go
@@ -1,6 +1,7 @@
 package ir
 
 import (
+	"errors"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +35,7 @@ func TestTcpRouteIREquals(t *testing.T) {
 	emptyPolicies := AttachedPolicies{}
 	nonEmptyPolicies := AttachedPolicies{
 		Policies: map[schema.GroupKind][]PolicyAtt{
-			schema.GroupKind{Group: "g", Kind: "k"}: {{GroupKind: schema.GroupKind{Group: "g", Kind: "k"}}},
+			{Group: "g", Kind: "k"}: {{GroupKind: schema.GroupKind{Group: "g", Kind: "k"}}},
 		},
 	}
 
@@ -42,6 +43,7 @@ func TestTcpRouteIREquals(t *testing.T) {
 	backendA := []BackendRefIR{makeBackendRef("clusterA", 5)}
 	backendB := []BackendRefIR{makeBackendRef("clusterB", 5)}
 	backendWeightDiff := []BackendRefIR{makeBackendRef("clusterA", 10)}
+	backendErr := []BackendRefIR{{ClusterName: "clusterA", Weight: 5, BackendObject: nil, Err: errors.New("some error")}}
 
 	tests := []struct {
 		name string
@@ -159,6 +161,22 @@ func TestTcpRouteIREquals(t *testing.T) {
 				Backends:         backendA,
 			},
 			want: true,
+		},
+		{
+			name: "diff_backend_error",
+			a: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     base,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendA,
+			},
+			b: TcpRouteIR{
+				ObjectSource:     ObjectSource{Namespace: "test-ns", Name: "route1"},
+				SourceObject:     same,
+				AttachedPolicies: emptyPolicies,
+				Backends:         backendErr,
+			},
+			want: false,
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/kgateway-dev/kgateway/issues/11138

The issue was the TCP (and TLS) Route IR equals functions were not comparing the backend refs. So we would not update if a Ref Grant was created after route creation.

# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

Apply refgrant after route creation. Before this change, route will have error "missing ref grant" and won't work. Now it will work.

```
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: tcp
  namespace: kgateway-system
spec:
  gatewayClassName: kgateway
  listeners:
  - name: httpbin
    protocol: TCP
    port: 8080
    allowedRoutes:
      kinds:
      - kind: TCPRoute
---
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: TCPRoute
metadata:
  name: tcp-httpbin
  namespace: kgateway-system
spec:
  parentRefs:
  - name: tcp
    sectionName: httpbin
  rules:
  - backendRefs:
    - name: httpbin
      namespace: httpbin
      port: 8000
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: ReferenceGrant
metadata:
  name: httpbin
  namespace: httpbin
spec:
  from:
  - group: gateway.networking.k8s.io
    kind: TCPRoute
    namespace: kgateway-system
  to:
  - group: ""
    kind: Service
```

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the kgateway [contributing guide in the Community repo](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
