### PR TITLE
Add helm NOTES.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ clean-gen:
 	rm -rf api/applyconfiguration
 	rm -rf pkg/generated/openapi
 	rm -rf pkg/client
-	rm -rf install/helm/kgateway-crds/templates
+	rm -f install/helm/kgateway-crds/templates/gateway.kgateway.dev_*.yaml
 
 .PHONY: clean-tests
 clean-tests:

--- a/install/helm/kgateway-crds/templates/NOTES.txt
+++ b/install/helm/kgateway-crds/templates/NOTES.txt
@@ -1,0 +1,14 @@
+Thank you for installing the {{ .Chart.Name }} chart.
+
+This chart installs the Custom Resource Definitions (CRDs) required by kgateway.
+
+To verify that the CRDs have been installed:
+
+  kubectl get crds | grep 'kgateway'
+
+For more information on the installed CRDs, refer to the documentation:
+https://github.com/kgateway-dev/kgateway
+
+To uninstall the CRDs:
+
+  helm uninstall {{ .Release.Name }} --namespace {{ .Release.Namespace }}

--- a/install/helm/kgateway/templates/NOTES.txt
+++ b/install/helm/kgateway/templates/NOTES.txt
@@ -1,0 +1,19 @@
+Thank you for installing the {{ .Chart.Name }} chart.
+
+Your release "{{ .Release.Name }}" has been deployed in the "{{ .Release.Namespace }}" namespace.
+
+To check the status of the deployment:
+
+  helm status {{ .Release.Name }} --namespace {{ .Release.Namespace }}
+
+To view the resources created by this chart:
+
+  kubectl get all -n {{ .Release.Namespace }}
+
+To learn how to access and use kgateway, please visit the official documentation:
+
+  https://kgateway.dev/docs/
+
+To uninstall the kgateway deployment:
+
+  helm uninstall {{ .Release.Name }} --namespace {{ .Release.Namespace }}


### PR DESCRIPTION
# Description

this is to add a standard info to the helm deployments both - `kgateway-crds` and `kgateway` per issue https://github.com/kgateway-dev/kgateway/issues/11030

## CI changes

Adjusted `clean-gen:` in `Makefile` to preserve deleting NOTES.txt while yamls are auto-regenerated.

## Docs changes

None.

# Context

This is good helm practice.

## Testing steps

Run helm locally or with `dry-run` flag.

## Notes for reviewers

@timflannagan - hope the `Makefile` change is ok.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works