### PR TITLE
Go: bump to 1.24.2 and use use errors.Join instead of go-multierror

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kgateway-dev/kgateway/v2
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/avast/retry-go v2.4.3+incompatible
@@ -19,7 +19,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/onsi/ginkgo/v2 v2.23.0
@@ -324,6 +323,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/hack/utils/oss_compliance/osa_included.md
+++ b/hack/utils/oss_compliance/osa_included.md
@@ -1,3 +1,0 @@
-Name|Version|License
----|---|---
-[hashicorp/go-multierror](https://github.com/hashicorp/go-multierror)|v1.1.1|Mozilla Public License 2.0

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/hashicorp/go-multierror"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
@@ -537,20 +536,20 @@ func (p *builtinPluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteC
 		return nil
 	}
 
-	var errs *multierror.Error
+	var errs error
 	if policy.filterMutation != nil {
 		if err := policy.filterMutation(pCtx.In, outputRoute); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
 	if policy.ruleMutation != nil {
 		if err := policy.ruleMutation(pCtx.In, outputRoute); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
-	return errs.ErrorOrNil()
+	return errs
 }
 
 func (p *builtinPluginGwPass) ApplyForRouteBackend(

--- a/test/testutils/requirements.go
+++ b/test/testutils/requirements.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/onsi/ginkgo/v2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -76,7 +75,6 @@ type RequiredConfiguration struct {
 
 // Validate returns an error is the RequiredConfiguration is not met
 func (r RequiredConfiguration) Validate() error {
-
 	err := errors.Join(
 		r.validateOS(),
 		r.validateArch(),
@@ -90,9 +88,7 @@ func (r RequiredConfiguration) Validate() error {
 
 	// If there are reasons defined, include them in the error message
 	if len(r.reasons) > 0 {
-		err = multierror.Append(
-			err,
-			fmt.Errorf("user defined reasons: %+v", r.reasons))
+		err = errors.Join(err, fmt.Errorf("user defined reasons: %+v", r.reasons))
 	}
 
 	return err


### PR DESCRIPTION
Stdlib supports multi-errors using errors.Join, so go-multierror is not required.

Bumps Go to 1.24.2.
