### PR TITLE
.github/actions: Remove docker rm node:16 command

### DIFF
--- a/.github/actions/prep-go-runner/action.yaml
+++ b/.github/actions/prep-go-runner/action.yaml
@@ -21,7 +21,7 @@ runs:
         echo "Before clearing disk space:"
         df -h
         docker system df -v
-        
+
         # https://github.com/actions/runner-images/discussions/3242 github runners are bad at cleanup
         echo "Removing large packages"
         sudo apt-get remove -y '^dotnet-.*' || true
@@ -46,8 +46,6 @@ runs:
         sudo rm -rf $AGENT_TOOLSDIRECTORY || true
 
         # Clean up images
-        docker image rm node:16 || true
-        docker image rm node:16-alpine || true
         docker image rm node:18 || true
         docker image rm node:18-alpine || true
         docker image rm node:20 || true
@@ -55,7 +53,7 @@ runs:
         # remove the dangling images and containers
         docker images | tail -n +2 | awk '$1 == "<none>" {print $3}' | xargs --no-run-if-empty docker rmi
         docker ps -a | tail -n +2 | awk '$2 ~ "^[0-9a-f]+$" {print $1}' | xargs --no-run-if-empty docker rm --volumes=true
-        
+
         echo "After clearing disk space:"
         df -h
         docker system df -v


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

When inspecting log messages from the prep-go-runner composite action, we see the following:

```
Done removing large packages
Error response from daemon: No such image: node:16
Error response from daemon: No such image: node:16-alpine
Untagged: node:18
Untagged: node@sha256:867be01f97d45cb7d89a8ef0b328d23e8207412ebec4564441ed8cabc8cc4ecd
Deleted: sha256:e56a6e3bc5724c51df0a1ad86c6e38aee233bb343457e98c943c3c7c1c9a2a84
Deleted: sha256:2520a921b445a127737d136c2826fc8c71b6473c22e8c19d16b9029b83afaf57
Deleted: sha256:36d39ffd22dec225fa298487ec57436c241338aa3c00bb542dd074253bda084b
Deleted: sha256:f1de0d0b1ff2b922dbcf85a1039bc6d0d120c0fbbf951d7bbaf6034ac4c5aae4
Deleted: sha256:1add6d7719c109667e3d96b[1611](https://github.com/kgateway-dev/kgateway/actions/runs/14885913016/job/41805346950#step:3:1614)6f614e9f6254f6d0c5e181a737db77c9c8c66
Untagged: node:18-alpine
```

The node 16 image is no longer present on runner images. See https://github.com/kgateway-dev/kgateway/actions/runs/14885913016/job/41805346950 for a concrete reference.