### PR TITLE
turn off ambient DNS for waypoints by default

### DIFF
--- a/internal/kgateway/deployer/deployer.go
+++ b/internal/kgateway/deployer/deployer.go
@@ -16,6 +16,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	"istio.io/api/annotation"
+	"istio.io/api/label"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -729,7 +731,15 @@ func defaultWaypointGatewayParameters(imageInfo *ImageInfo) *v1alpha1.GatewayPar
 	if gwp.Spec.Kube.PodTemplate.ExtraLabels == nil {
 		gwp.Spec.Kube.PodTemplate.ExtraLabels = make(map[string]string)
 	}
-	gwp.Spec.Kube.PodTemplate.ExtraLabels["istio.io/dataplane-mode"] = "ambient"
+	gwp.Spec.Kube.PodTemplate.ExtraLabels[label.IoIstioDataplaneMode.Name] = "ambient"
+
+	// do not have zTunnel resolve DNS for us - this can cause traffic loops when we're doing
+	// outbound based on DNS service entries
+	// TODO do we want this on the north-south gateway class as well?
+	if gwp.Spec.Kube.PodTemplate.ExtraAnnotations == nil {
+		gwp.Spec.Kube.PodTemplate.ExtraAnnotations = make(map[string]string)
+	}
+	gwp.Spec.Kube.PodTemplate.ExtraAnnotations[annotation.AmbientDnsCapture.Name] = "false"
 
 	return gwp
 }


### PR DESCRIPTION
Signed-off-by: Steven Landow <steven.landow@solo.io>


# Description

A service entry with the following should egress to `httpbin.org` externally

```
 hosts:
  - httpbin.org
  ports:
  - number: 80
    name: http
    protocol: HTTP
  - number: 443
    name: tls  
    protocol: TLS
  resolution: DNS
```

The path would be 

client -> httbin.org (ztunnel captures DNS, gives the SE VIP) -> ztunnel (we have a waypoint for SE VIP) -> waypoint

at this point, if we're DNS captured, the waypoint will send to that VIP and the ztunnel will send traffic back to the waypoint causing a loop

by opting out of DNS capture, we end up with the externally resolved DNS rather than the in-mesh DNS that includes ServiceEntry hosts. 

# Change Type

```
/kind bug_fix
```

# Changelog


```release-note
Turn off ambient DNS capture by default for kgateway-waypoint, fixing traffic loops in ServiceEntry with DNS resolution. 
```

