### PR TITLE
policy: avoid unnecessary Fetch for onlyBackends

### DIFF
--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -346,10 +346,10 @@ func (p *PolicyIndex) fetchByTargetRef(
 ) []ir.PolicyWrapper {
 	var ret []ir.PolicyWrapper
 	for _, policyCol := range p.availablePolicies {
-		policies := krt.Fetch(kctx, policyCol.policiesByTargetRef, krt.FilterIndex(policyCol.index, targetRef))
 		if onlyBackends && !policyCol.forBackends {
 			continue
 		}
+		policies := krt.Fetch(kctx, policyCol.policiesByTargetRef, krt.FilterIndex(policyCol.index, targetRef))
 		ret = append(ret, policies...)
 	}
 	return ret
@@ -363,6 +363,9 @@ func (p *PolicyIndex) fetchByTargetRefLabels(
 ) []ir.PolicyWrapper {
 	var ret []ir.PolicyWrapper
 	for _, policyCol := range p.availablePolicies {
+		if onlyBackends && !policyCol.forBackends {
+			continue
+		}
 		policies := krt.Fetch(kctx, policyCol.policiesByTargetRef, krt.FilterIndex(policyCol.index, targetRef),
 			krt.FilterGeneric(func(a any) bool {
 				p := a.(ir.PolicyWrapper)
@@ -380,9 +383,6 @@ func (p *PolicyIndex) fetchByTargetRefLabels(
 				return false
 			}),
 		)
-		if onlyBackends && !policyCol.forBackends {
-			continue
-		}
 		ret = append(ret, policies...)
 	}
 	return ret


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Avoids unnecessary `Fetch` when `onlyBackends=true`.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
```
/kind cleanup
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

