### PR TITLE
Enable annotations to be set on `Deployment` in `kgateway` Helm chart

### DIFF
--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kgateway.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
   selector:

--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -11,6 +11,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
# Description

Allows users to set annotations on the `Deployment` when installing the `kgateway` Helm chart.

# Change Type

```
/kind new_feature
```

# Changelog

```release-note
Enables setting annotations on `Deployment` generated by `kgateway` Helm chart.
```
