### PR TITLE
Add kgateway label to data plane pod

### DIFF
--- a/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
+++ b/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       {{- end }}
       {{- end}}
       labels:
+        {{- include "kgateway.gateway.constLabels" . | nindent 8 }}
         {{- include "kgateway.gateway.selectorLabels" . | nindent 8 }}
         {{- with $gateway.extraPodLabels }}
         {{- toYaml . | nindent 8 }}

--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -3,8 +3,9 @@ package deployer
 import (
 	"context"
 	"fmt"
-	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"time"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"


### PR DESCRIPTION
# Description

- Add the `kgateway` label to the data plane pod

# Change Type

/kind cleanup

# Changelog

```release-note
Add `kgateway` label to data plane pods
```

# Additional Notes

The omission of the `kgateway` label from the data plane pods is seemingly an oversight, and should be added for consistency, to allow selecting by labels for kgateway data plane pods to function as expected

I've manually verified e2e that kgateway pods are correctly created with the `kgateway: kube-gateway` label as of this change
