### PR TITLE
fix tlsroute flake

### DIFF
--- a/test/kubernetes/e2e/features/services/tlsroute/suite.go
+++ b/test/kubernetes/e2e/features/services/tlsroute/suite.go
@@ -236,6 +236,11 @@ func (s *testingSuite) TestConfigureTLSRouteBackingDestinations() {
 				s.testInstallation.Assertions.EventuallyGatewayListenerAttachedRoutes(s.ctx, tc.gtwName, tc.gtwNs, listenerName, expectedRouteCount, timeout)
 			}
 
+			// Assert curl pod is running
+			s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, tc.gtwNs, metav1.ListOptions{
+				LabelSelector: "app=curl",
+			})
+
 			// Assert expected responses
 			for i, port := range tc.ports {
 				if tc.expectedErrorCode != 0 {
@@ -282,6 +287,10 @@ func (s *testingSuite) setupTestEnvironment(nsManifest, gtwName, gtwNs, gtwManif
 
 	s.applyManifests(gtwNs, svcManifest)
 	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, proxySvc, proxyDeploy)
+
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, proxyDeploy.GetNamespace(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyDeploy.GetName()),
+	})
 }
 
 func (s *testingSuite) applyManifests(ns string, manifests ...string) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Attempt to fix TLSRoute e2e test flake by waiting for pods to be ready

Fixes #10812

# Change Type

```
/kind flake
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
