### PR TITLE
enable local ratelimit test

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -39,7 +39,7 @@ jobs:
         # May 19, 2025: ~18 minutes
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^AccessLog$$'
+          go-test-run-regex: '^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^AccessLog$$|^TestKgateway$$/^LocalRateLimit$$'
           localstack: 'true'
         # May 19, 2025: ~20 minutes
         - cluster-name: 'cluster-four'

--- a/test/kubernetes/e2e/features/rate_limit/testdata/common.yaml
+++ b/test/kubernetes/e2e/features/rate_limit/testdata/common.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kgateway-test
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Run the LocalRateLimit e2e tests in CI

Related to #11248

# Change Type

```
/kind cleanup
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

- I tried enabling GlobalRateLimit but those tests were flaky, so left them out for now. We can keep the issue open to track it