### PR TITLE
linter: forbid usage of kclient.New to honor discoveryNamespaceSelectors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,7 +29,9 @@ linters:
     forbidigo:
       forbid:
         - pattern: anypb.New
-          msg: Do not use anypb.New; Use utils.MessageToAny instead.
+          msg: use utils.MessageToAny instead
+        - pattern: kclient.New$
+          msg: use kclient.NewFiltered with discovery namespace ObjectFilter instead
     importas:
       alias:
         - pkg: k8s.io/api/apps/v1

--- a/internal/kgateway/krtcollections/setup.go
+++ b/internal/kgateway/krtcollections/setup.go
@@ -98,6 +98,7 @@ func InitCollections(
 	tlsRoutes := krt.WrapClient(kclient.NewDelayedInformer[*gwv1a2.TLSRoute](istioClient, gvr.TLSRoute, kubetypes.StandardInformer, filter), krtopts.ToOptions("TLSRoute")...)
 	grpcRoutes := krt.WrapClient(kclient.NewFiltered[*gwv1.GRPCRoute](istioClient, filter), krtopts.ToOptions("GRPCRoute")...)
 	kubeRawGateways := krt.WrapClient(kclient.NewFiltered[*gwv1.Gateway](istioClient, filter), krtopts.ToOptions("KubeGateways")...)
+	//nolint:forbidigo // ObjectFilter is not needed for this client as it is cluster scoped
 	gatewayClasses := krt.WrapClient(kclient.New[*gwv1.GatewayClass](istioClient), krtopts.ToOptions("KubeGatewayClasses")...)
 
 	policies := NewPolicyIndex(krtopts, plugins.ContributesPolicies)


### PR DESCRIPTION
# Description

Adds a linter rule to forbid the usage of kclient.New in favor of kclient.NewFiltered to honor the discoveryNamespaceSelectors ObjectFilter (added in 1bf1e2488) to filter out objects that are not relevant for discovery. This will prevent accidental usage of kclient.New on namespaced resources.

Although cluster scoped resources may use kclient.NewFiltered with an ObjectFilter since the filter rule does not apply to cluster scoped objects, it is acceptable to use kclient.New with a //nolint:forbidigo directive.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes

Without //nolint:forbidgo 
```
internal/kgateway/krtcollections/setup.go:101:35: use of `kclient.New` forbidden because "use kclient.NewFiltered with discovery namespace ObjectFilter instead" (forbidigo)
	gatewayClasses := krt.WrapClient(kclient.New[*gwv1.GatewayClass](istioClient), krtopts.ToOptions("KubeGatewayClasses")...)
```
