### PR TITLE
test: Update the Python base image in the A2A example image

### DIFF
--- a/test/kubernetes/e2e/features/agentgateway/a2a-example/Dockerfile
+++ b/test/kubernetes/e2e/features/agentgateway/a2a-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 RUN apt-get update && apt-get install -y git && \
     apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The A2A example agent depends on a2a-samples from Google's A2A repository, which requires a2a-sdk>=0.2.1. The latest version of a2a-sdk requires Python 3.13, causing the Docker build to fail with Python 3.11.

Closes https://github.com/kgateway-dev/kgateway/issues/11254

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind flake

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
