### PR TITLE
docs: Add note about XDS service IP and steps for local debugging, README cleanup

### DIFF
--- a/devel/debugging/local-controller.md
+++ b/devel/debugging/local-controller.md
@@ -22,6 +22,8 @@ go run cmd/kgateway/main.go
 
 > Note: `172.17.0.1` is IP address of the `docker0` bridge interface that allows pods running in `Kind` to access the host network, thereby allowing the Gateway proxy to connect to the xDS service running on the host.
 
+> Additional note: Replacing `172.17.0.1` with `192.168.65.254`, as the value for `KGW_XDS_SERVICE_HOST` may help, if the gateway proxy pods in a local kind cluster are unable to connect to the xDS service running on the local machine. `192.168.65.254` is the IP address that `host.docker.internal` resolves to on gateway proxy pods when running in a local kind cluster.
+
 ## Vscode Debugger
 
 Use the following `launch.json` configuration to run the controller in the debugger:
@@ -41,4 +43,44 @@ Use the following `launch.json` configuration to run the controller in the debug
     "KGW_DEFAULT_IMAGE_PULL_POLICY": "IfNotPresent",
   },
 }
+```
+
+## Steps to run and inspect local builds:
+
+Setup a local kind cluster:
+```sh
+VERSION=2.0.0-dev ./hack/kind/setup-kind.sh
+```
+
+Install the required CRDs:
+```sh
+helm install kgateway-crds install/helm/kgateway-crds
+```
+
+Create a namespace for testing:
+```sh
+kubectl create ns kgateway-system
+```
+
+Run kgateway locally using one of the methods described above: either `go run` or the vscode debugger.
+
+Create an example gateway:
+```sh
+kubectl -n kgateway-system apply -f examples/example-gw.yaml
+```
+
+Create an example route:
+```sh
+kubectl -n kgateway-system apply -f examples/example-http-route.yaml
+```
+
+Using a local web browser:
+- GET http://localhost:9097/snapshots/krt to inspect the KRT snapshot.
+- GET http://localhost:9097/snapshots/xds to inspect the XDS snapshot.
+
+When finished testing:
+
+```sh
+kubectl -n kgateway-system delete -f examples/example-gw.yaml
+kind delete cluster
 ```

--- a/test/kubernetes/e2e/README.md
+++ b/test/kubernetes/e2e/README.md
@@ -12,7 +12,7 @@ Its sole responsibility is to create [TestInstallations](#testinstallation).
 
 ## TestInstallation
 
-A [TestInstallation](./test.go) is the structure that manages a group of tests that run against an installation of Gloo Gateway, within a Kubernetes Cluster.
+A [TestInstallation](./test.go) is the structure that manages a group of tests that run against an installation within a Kubernetes Cluster.
 
 We try to define a single `TestInstallation` per file in a `TestCluster`. This way, it is easy to identify what behaviors are expected for that installation.
 


### PR DESCRIPTION
# Description

* Add an additional note to the instructions in local_controller.md about the IP address for the XDS service host when debugging a local build of kgateway using a local kind cluster for testing.
* Add additional steps to local_controller.md for testing a locally running build of kgateway using a local kind cluster and inspecting KRT and XDS snapshots.
* Fix a reference to Gloo found in the README.md in the test/kubernetes/e2e directory.

# Change Type

```
/kind cleanup
/kind documentation
```

# Changelog

```release-note
NONE
```