### PR TITLE
cleanup: use gateway api duration for better CEL validation.

### DIFF
--- a/api/applyconfiguration/api/v1alpha1/ratelimitprovider.go
+++ b/api/applyconfiguration/api/v1alpha1/ratelimitprovider.go
@@ -2,13 +2,17 @@
 
 package v1alpha1
 
+import (
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
 // RateLimitProviderApplyConfiguration represents a declarative configuration of the RateLimitProvider type for use
 // with apply.
 type RateLimitProviderApplyConfiguration struct {
 	GrpcService *ExtGrpcServiceApplyConfiguration `json:"grpcService,omitempty"`
 	Domain      *string                           `json:"domain,omitempty"`
 	FailOpen    *bool                             `json:"failOpen,omitempty"`
-	Timeout     *string                           `json:"timeout,omitempty"`
+	Timeout     *v1.Duration                      `json:"timeout,omitempty"`
 }
 
 // RateLimitProviderApplyConfiguration constructs a declarative configuration of the RateLimitProvider type for use with
@@ -44,7 +48,7 @@ func (b *RateLimitProviderApplyConfiguration) WithFailOpen(value bool) *RateLimi
 // WithTimeout sets the Timeout field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Timeout field is set to the value of the last call.
-func (b *RateLimitProviderApplyConfiguration) WithTimeout(value string) *RateLimitProviderApplyConfiguration {
+func (b *RateLimitProviderApplyConfiguration) WithTimeout(value v1.Duration) *RateLimitProviderApplyConfiguration {
 	b.Timeout = &value
 	return b
 }

--- a/api/applyconfiguration/api/v1alpha1/tokenbucket.go
+++ b/api/applyconfiguration/api/v1alpha1/tokenbucket.go
@@ -2,12 +2,16 @@
 
 package v1alpha1
 
+import (
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
 // TokenBucketApplyConfiguration represents a declarative configuration of the TokenBucket type for use
 // with apply.
 type TokenBucketApplyConfiguration struct {
-	MaxTokens     *uint32 `json:"maxTokens,omitempty"`
-	TokensPerFill *uint32 `json:"tokensPerFill,omitempty"`
-	FillInterval  *string `json:"fillInterval,omitempty"`
+	MaxTokens     *uint32      `json:"maxTokens,omitempty"`
+	TokensPerFill *uint32      `json:"tokensPerFill,omitempty"`
+	FillInterval  *v1.Duration `json:"fillInterval,omitempty"`
 }
 
 // TokenBucketApplyConfiguration constructs a declarative configuration of the TokenBucket type for use with
@@ -35,7 +39,7 @@ func (b *TokenBucketApplyConfiguration) WithTokensPerFill(value uint32) *TokenBu
 // WithFillInterval sets the FillInterval field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FillInterval field is set to the value of the last call.
-func (b *TokenBucketApplyConfiguration) WithFillInterval(value string) *TokenBucketApplyConfiguration {
+func (b *TokenBucketApplyConfiguration) WithFillInterval(value v1.Duration) *TokenBucketApplyConfiguration {
 	b.FillInterval = &value
 	return b
 }

--- a/api/v1alpha1/gateway_extensions_types.go
+++ b/api/v1alpha1/gateway_extensions_types.go
@@ -82,7 +82,7 @@ type RateLimitProvider struct {
 	// Timeout for requests to the rate limit service.
 	// +optional
 	// +kubebuilder:default="20ms"
-	Timeout string `json:"timeout,omitempty"`
+	Timeout gwv1.Duration `json:"timeout,omitempty"`
 }
 
 // GatewayExtensionSpec defines the desired state of GatewayExtension.

--- a/api/v1alpha1/traffic_policy_types.go
+++ b/api/v1alpha1/traffic_policy_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
@@ -258,8 +259,7 @@ type TokenBucket struct {
 	// This value must be a valid duration string (e.g., "1s", "500ms").
 	// It determines the frequency of token replenishment.
 	// +required
-	// +kubebuilder:validation:Format=duration
-	FillInterval string `json:"fillInterval"`
+	FillInterval gwv1.Duration `json:"fillInterval"`
 }
 
 // RateLimitPolicy defines a global rate limiting policy using an external service.

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
@@ -200,6 +200,7 @@ spec:
                     type: object
                   timeout:
                     default: 20ms
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                     type: string
                 required:
                 - domain

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
@@ -433,7 +433,7 @@ spec:
                       tokenBucket:
                         properties:
                           fillInterval:
-                            format: duration
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                           maxTokens:
                             format: int32

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
@@ -3,7 +3,6 @@ package trafficpolicy
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	routeconfv3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
@@ -11,9 +10,8 @@ import (
 )
 
 const (
-	rateLimitFilterName     = "envoy.filters.http.ratelimit"
-	rateLimitStatPrefix     = "http_rate_limit"
-	defaultRateLimitTimeout = 2 * time.Second
+	rateLimitFilterName = "envoy.filters.http.ratelimit"
+	rateLimitStatPrefix = "http_rate_limit"
 )
 
 // RateLimitIR represents the intermediate representation of a rate limit policy

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin_test.go
@@ -303,7 +303,7 @@ func TestToRateLimitFilterConfig(t *testing.T) {
 				assert.Equal(t, ratev3.RateLimit_DRAFT_VERSION_03, rl.EnableXRatelimitHeaders)
 				assert.Equal(t, "both", rl.RequestType)
 				assert.Equal(t, rateLimitStatPrefix, rl.StatPrefix)
-				assert.Equal(t, time.Duration(2*time.Second), rl.Timeout.AsDuration())
+				assert.Equal(t, (*durationpb.Duration)(nil), rl.Timeout)
 				assert.True(t, rl.FailureModeDeny) // Default should be failureModeAllow=false (deny)
 			},
 		},
@@ -540,16 +540,13 @@ func TestToRateLimitFilterConfig(t *testing.T) {
 					// Use timeout from extension if specified
 					if extension.Timeout != "" {
 						var parseDurationErr error
-						duration, parseDurationErr := time.ParseDuration(extension.Timeout)
+						duration, parseDurationErr := time.ParseDuration(string(extension.Timeout))
 						if parseDurationErr != nil {
 							err = fmt.Errorf("invalid timeout in GatewayExtension %s: %w",
 								tt.gatewayExtension.Name, parseDurationErr)
 						} else {
 							timeout = durationpb.New(duration)
 						}
-					} else {
-						// Default timeout if not specified in extension
-						timeout = durationpb.New(defaultRateLimitTimeout)
 					}
 
 					if err == nil {

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/local_rate_limit_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/local_rate_limit_plugin.go
@@ -31,7 +31,7 @@ func toLocalRateLimitFilterConfig(t *v1alpha1.LocalRateLimitPolicy) (*localratel
 
 	tokenBucket := &typev3.TokenBucket{}
 	if t.TokenBucket != nil {
-		fillInterval, err := time.ParseDuration(t.TokenBucket.FillInterval)
+		fillInterval, err := time.ParseDuration(string(t.TokenBucket.FillInterval))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Make sure CEL validation catches invalid durations in our CRDs

# Change Type

```
/kind feature
```


# Changelog

no functional changes.

```release-note
Invalid durations in our CRDs will now be rejected using CEL, before the CR is admitted.
```
