### PR TITLE
Avoid publishing GH releases for main branch pushes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   VANITY_REGISTRY: cr.kgateway.dev/kgateway-dev
   MAIN_VERSION: v2.1.0-main
+  GORELEASER_DISABLE_RELEASE: false
 
 permissions:
   contents: write
@@ -113,18 +114,10 @@ jobs:
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
 
-      # We publish a rolling main release for every commit to main. Deleting the release
-      # ensures that the tagged commit is not stale. Goreleaser will create a new tag
-      # and release for the tagged commit.
-      - name: Delete ${MAIN_VERSION} release if it exists
+      - name: Conditionally disable release for pushes to main
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        continue-on-error: true
         run: |
-          set -x
-          echo "Deleting the ${MAIN_VERSION} release"
-          gh release delete ${MAIN_VERSION} --repo ${{ github.repository }} --yes --cleanup-tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "GORELEASER_DISABLE_RELEASE=true" >> $GITHUB_ENV
 
       - name: Log into ghcr.io
         if: ${{ github.event_name != 'pull_request' }}
@@ -145,6 +138,7 @@ jobs:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           GORELEASER_ARGS: ${{ needs.setup.outputs.goreleaser_args }}
           GORELEASER_CURRENT_TAG: ${{ needs.setup.outputs.version }}
+          GORELEASER_DISABLE_RELEASE: ${{ env.GORELEASER_DISABLE_RELEASE }}
 
   validate:
     name: Validate release artifacts

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -173,6 +173,7 @@ docker_manifests:
 changelog:
   disable: true
 release:
+  disable: '{{ if isEnvSet "GORELEASER_DISABLE_RELEASE" }}{{ .Env.GORELEASER_DISABLE_RELEASE }}{{ else }}false{{ end }}'
   prerelease: "auto"
   mode: "replace"
   replace_existing_artifacts: true


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Updates the release pipeline to avoid publishing GH releases for pushes to main branch. Previously, both artifacts and a concrete GH release/tag would be published whenever a PR merged to main. Now, we publish artifacts but avoid publishing a concrete GH release for this event trigger.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

See https://github.com/kgateway-dev/kgateway/discussions/11286 for some context on this.