### PR TITLE
plugins: export trafficpolicy merge, order plugin application

### DIFF
--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy_test.go
@@ -108,8 +108,8 @@ func TestHttpFilters(t *testing.T) {
 		plugin := &trafficPolicyPluginGwPass{
 			extAuthPerProvider: ProviderNeededMap{
 				Providers: map[string]map[string]*TrafficPolicyGatewayExtensionIR{
-					"test-filter-chain": map[string]*TrafficPolicyGatewayExtensionIR{
-						"test-extension": &TrafficPolicyGatewayExtensionIR{
+					"test-filter-chain": {
+						"test-extension": {
 							Name:    "test-extension",
 							ExtType: v1alpha1.GatewayExtensionTypeExtAuth,
 							ExtAuth: &envoy_ext_authz_v3.ExtAuthz{

--- a/internal/kgateway/extensions2/plugins/waypoint/waypoint_translator_test.go
+++ b/internal/kgateway/extensions2/plugins/waypoint/waypoint_translator_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/gateway/testutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	translatortest "github.com/kgateway-dev/kgateway/v2/test/translator"
 )
 
 // exampleGw is used in most tests, but we may want to have
@@ -51,7 +51,7 @@ func TestWaypointTranslator(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			dir := fsutils.MustGetThisDir()
-			testutils.TestTranslation(
+			translatortest.TestTranslation(
 				t,
 				ctx,
 				[]string{filepath.Join(dir, "testdata/input", tt.file+".yaml")},

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -25,12 +25,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/plugins"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/reports"
+	pluginsdkir "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
-
-var VirtualBuiltInGK = schema.GroupKind{
-	Group: "builtin",
-	Kind:  "builtin",
-}
 
 type builtinPlugin struct {
 	spec           gwv1.HTTPRouteFilter
@@ -86,7 +82,7 @@ func NewBuiltInRuleIr(rule gwv1.HTTPRouteRule) ir.PolicyIR {
 func NewBuiltinPlugin(ctx context.Context) extensionsplug.Plugin {
 	return extensionsplug.Plugin{
 		ContributesPolicies: map[schema.GroupKind]extensionsplug.PolicyPlugin{
-			VirtualBuiltInGK: {
+			pluginsdkir.VirtualBuiltInGK: {
 				// AttachmentPoints: []ir.AttachmentPoints{ir.HttpAttachmentPoint},
 				NewGatewayTranslationPass: NewGatewayTranslationPass,
 			},

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/backendref"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	pluginsdkir "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
 var (
@@ -41,7 +42,6 @@ func (n *NotFoundError) Error() string {
 // MARK: BackendIndex
 
 type BackendIndex struct {
-
 	// availableBackends are the backends as supplied by backend-contributed plugins.
 	// Any policies here are attached directly at Backend generation and not attached via
 	// policy index. Use availableBackendsWithPolicy when you need policy.
@@ -177,7 +177,8 @@ func (i *BackendIndex) getBackendFromAlias(kctx krt.HandlerContext, gk schema.Gr
 			Group:     gk.Group,
 			Kind:      gk.Kind,
 			Namespace: n.Namespace,
-			Name:      n.Name},
+			Name:      n.Name,
+		},
 	}
 
 	var didFetch bool
@@ -956,7 +957,7 @@ func (h *RoutesIndex) getBuiltInRulePolicies(rule gwv1.HTTPRouteRule) ir.Attache
 	}
 	policy := NewBuiltInRuleIr(rule)
 	if policy != nil {
-		ret.Policies[VirtualBuiltInGK] = append(ret.Policies[VirtualBuiltInGK], ir.PolicyAtt{PolicyIr: policy /*direct attachment - no target ref*/})
+		ret.Policies[pluginsdkir.VirtualBuiltInGK] = append(ret.Policies[pluginsdkir.VirtualBuiltInGK], ir.PolicyAtt{PolicyIr: policy /*direct attachment - no target ref*/})
 	}
 	return ret
 }
@@ -992,7 +993,7 @@ func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext g
 		Kind:  "HTTPRoute",
 	}
 
-	return VirtualBuiltInGK, NewBuiltInIr(kctx, ext, fromGK, ns, h.refgrants, h.backends)
+	return pluginsdkir.VirtualBuiltInGK, NewBuiltInIr(kctx, ext, fromGK, ns, h.refgrants, h.backends)
 }
 
 func toFromBackendRef(fromns string, ref gwv1.BackendObjectReference) ir.ObjectSource {

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -13,16 +13,16 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/reports"
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/gateway/testutils"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	translatortest "github.com/kgateway-dev/kgateway/v2/test/translator"
 )
 
 type translatorTestCase struct {
 	inputFile     string
 	outputFile    string
 	gwNN          types.NamespacedName
-	assertReports testutils.AssertReports
+	assertReports translatortest.AssertReports
 }
 
 var _ = DescribeTable("Basic GatewayTranslator Tests",
@@ -33,7 +33,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 
 		inputFiles := []string{filepath.Join(dir, "testutils/inputs/", in.inputFile)}
 		expectedProxyFile := filepath.Join(dir, "testutils/outputs/", in.outputFile)
-		testutils.TestTranslation(GinkgoT(), ctx, inputFiles, expectedProxyFile, in.gwNN, in.assertReports)
+		translatortest.TestTranslation(GinkgoT(), ctx, inputFiles, expectedProxyFile, in.gwNN, in.assertReports)
 	},
 	Entry(
 		"http gateway with basic routing",
@@ -521,7 +521,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 var _ = DescribeTable("Route Delegation translator",
 	func(inputFile string, errdesc string) {
 		dir := fsutils.MustGetThisDir()
-		testutils.TestTranslation(
+		translatortest.TestTranslation(
 			GinkgoT(),
 			context.TODO(),
 			[]string{
@@ -535,9 +535,9 @@ var _ = DescribeTable("Route Delegation translator",
 			},
 			func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
 				if errdesc == "" {
-					Expect(testutils.AreReportsSuccess(gwNN, reportsMap)).NotTo(HaveOccurred())
+					Expect(translatortest.AreReportsSuccess(gwNN, reportsMap)).NotTo(HaveOccurred())
 				} else {
-					Expect(testutils.AreReportsSuccess(gwNN, reportsMap)).To(MatchError(ContainSubstring(errdesc)))
+					Expect(translatortest.AreReportsSuccess(gwNN, reportsMap)).To(MatchError(ContainSubstring(errdesc)))
 				}
 			},
 		)
@@ -572,7 +572,7 @@ var _ = DescribeTable("Route Delegation translator",
 var _ = DescribeTable("Discovery Namespace Selector",
 	func(cfgJSON string, inputFile string, outputFile string, errdesc string) {
 		dir := fsutils.MustGetThisDir()
-		testutils.TestTranslation(
+		translatortest.TestTranslation(
 			GinkgoT(),
 			context.TODO(),
 			[]string{
@@ -585,12 +585,12 @@ var _ = DescribeTable("Discovery Namespace Selector",
 			},
 			func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
 				if errdesc == "" {
-					Expect(testutils.AreReportsSuccess(gwNN, reportsMap)).NotTo(HaveOccurred())
+					Expect(translatortest.AreReportsSuccess(gwNN, reportsMap)).NotTo(HaveOccurred())
 				} else {
-					Expect(testutils.AreReportsSuccess(gwNN, reportsMap)).To(MatchError(ContainSubstring(errdesc)))
+					Expect(translatortest.AreReportsSuccess(gwNN, reportsMap)).To(MatchError(ContainSubstring(errdesc)))
 				}
 			},
-			testutils.SettingsWithDiscoveryNamespaceSelectors(cfgJSON),
+			translatortest.SettingsWithDiscoveryNamespaceSelectors(cfgJSON),
 		)
 	},
 	Entry("Select all resources",

--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -46,7 +46,8 @@ func (h *httpRouteConfigurationTranslator) ComputeRouteConfiguration(ctx context
 	}
 	typedPerFilterConfigRoute := ir.TypedFilterConfigMap(map[string]proto.Message{})
 
-	for gk, pols := range attachedPolicies.Policies {
+	for _, gk := range attachedPolicies.ApplyOrderedGroupKinds() {
+		pols := attachedPolicies.Policies[gk]
 		pass := h.PluginPass[gk]
 		if pass == nil {
 			// TODO: user error - they attached a non http policy
@@ -203,8 +204,10 @@ func toPerFilterConfigMap(typedPerFilterConfig ir.TypedFilterConfigMap) map[stri
 }
 
 func (h *httpRouteConfigurationTranslator) runVhostPlugins(ctx context.Context, virtualHost *ir.VirtualHost, out *envoy_config_route_v3.VirtualHost,
-	typedPerFilterConfig ir.TypedFilterConfigMap) {
-	for gk, pols := range virtualHost.AttachedPolicies.Policies {
+	typedPerFilterConfig ir.TypedFilterConfigMap,
+) {
+	for _, gk := range virtualHost.AttachedPolicies.ApplyOrderedGroupKinds() {
+		pols := virtualHost.AttachedPolicies.Policies[gk]
 		pass := h.PluginPass[gk]
 		if pass == nil {
 			// TODO: user error - they attached a non http policy
@@ -261,7 +264,8 @@ func (h *httpRouteConfigurationTranslator) runRoutePlugins(
 			errs = append(errs, err)
 		}
 	}
-	for gk, pols := range attachedPolicies.Policies {
+	for _, gk := range attachedPolicies.ApplyOrderedGroupKinds() {
+		pols := attachedPolicies.Policies[gk]
 		pass := h.PluginPass[gk]
 		if pass == nil {
 			// TODO: should never happen, log error and report condition
@@ -307,7 +311,8 @@ func mergePolicies(pass *TranslationPass, policies []ir.PolicyAtt) []ir.PolicyAt
 
 func (h *httpRouteConfigurationTranslator) runBackendPolicies(ctx context.Context, in ir.HttpBackend, pCtx *ir.RouteBackendContext) error {
 	var errs []error
-	for gk, pols := range in.AttachedPolicies.Policies {
+	for _, gk := range in.AttachedPolicies.ApplyOrderedGroupKinds() {
+		pols := in.AttachedPolicies.Policies[gk]
 		pass := h.PluginPass[gk]
 		if pass == nil {
 			// TODO: should never happen, log error and report condition

--- a/pkg/plugins/gwextbase/base.go
+++ b/pkg/plugins/gwextbase/base.go
@@ -26,6 +26,7 @@ type (
 var (
 	ExtAuthzEnabledMetadataMatcher = trafficpolicy.ExtAuthzEnabledMetadataMatcher
 	EnableFilterPerRoute           = trafficpolicy.EnableFilterPerRoute
+	MergeTrafficPolicies           = trafficpolicy.MergeTrafficPolicies
 )
 
 // Create a traffic policy builder. This converts a traffic policy into its IR form.

--- a/pkg/pluginsdk/ir/gw_test.go
+++ b/pkg/pluginsdk/ir/gw_test.go
@@ -1,0 +1,53 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestPolicyApplyOrderedGroupKinds(t *testing.T) {
+	fooGK := schema.GroupKind{Group: "foo", Kind: "bar"}
+	barGK := schema.GroupKind{Group: "bar", Kind: "baz"}
+
+	tests := []struct {
+		name     string
+		policies map[schema.GroupKind][]PolicyAtt
+		assertFn func(*assert.Assertions, []schema.GroupKind)
+	}{
+		{
+			name:     "1",
+			policies: map[schema.GroupKind][]PolicyAtt{VirtualBuiltInGK: {}, fooGK: {}, barGK: {}},
+			assertFn: func(a *assert.Assertions, got []schema.GroupKind) {
+				a.Len(got, 3)
+				a.Equal(got[2], VirtualBuiltInGK, "VirtualBuiltInGK should be last in the list")
+			},
+		},
+		{
+			name:     "2",
+			policies: map[schema.GroupKind][]PolicyAtt{fooGK: {}, barGK: {}},
+			assertFn: func(a *assert.Assertions, got []schema.GroupKind) {
+				a.Len(got, 2)
+				// either fooGK or barGK can be last as map's key iteration order is not deterministic
+			},
+		},
+		{
+			name:     "3",
+			policies: map[schema.GroupKind][]PolicyAtt{barGK: {}, VirtualBuiltInGK: {}, fooGK: {}},
+			assertFn: func(a *assert.Assertions, got []schema.GroupKind) {
+				a.Len(got, 3)
+				a.Equal(got[2], VirtualBuiltInGK, "VirtualBuiltInGK should be last in the list")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			ap := AttachedPolicies{Policies: tt.policies}
+			got := ap.ApplyOrderedGroupKinds()
+			tt.assertFn(a, got)
+		})
+	}
+}


### PR DESCRIPTION
# Description
- Exports MergeTrafficPolicies to make it possible to be consumed outside the pkg.

- Orders policy application such that built-in policies are applied last so that they can override other forms of attachments. Builtin policies are policies inlined within the targeted object's spec.

- Makes policy application consistent by merging policies by GroupKind (in order) before calling the Apply funcs on the TranslationPass. Not merging them can result in semantic differences when plugins support MergePolicies for a given GroupKind.

- Refactors the translator test to make it importable.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
```
/kind cleanup
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

