### PR TITLE
policy: propagate ExtensionRef errors to PolicyAtt and fix reporting

### DIFF
--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -53,8 +53,8 @@ func (h *httpRouteConfigurationTranslator) ComputeRouteConfiguration(ctx context
 			// TODO: user error - they attached a non http policy
 			continue
 		}
+		reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 		for _, pol := range mergePolicies(pass, pols) {
-			reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 			pass.ApplyRouteConfigPlugin(ctx, &ir.RouteConfigContext{
 				FilterChainName:   h.fc.FilterChainName,
 				TypedFilterConfig: typedPerFilterConfigRoute,
@@ -213,8 +213,8 @@ func (h *httpRouteConfigurationTranslator) runVhostPlugins(ctx context.Context, 
 			// TODO: user error - they attached a non http policy
 			continue
 		}
+		reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 		for _, pol := range mergePolicies(pass, pols) {
-			reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 			pctx := &ir.VirtualHostContext{
 				Policy:            pol.PolicyIr,
 				TypedFilterConfig: typedPerFilterConfig,
@@ -318,8 +318,8 @@ func (h *httpRouteConfigurationTranslator) runBackendPolicies(ctx context.Contex
 			// TODO: should never happen, log error and report condition
 			continue
 		}
+		reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 		for _, pol := range mergePolicies(pass, pols) {
-			reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pol)
 			// Policy on extension ref
 			err := pass.ApplyForRouteBackend(ctx, pol.PolicyIr, pCtx)
 			if err != nil {


### PR DESCRIPTION
# Description
- Fixes a bug with ExtensionRef IR errors not being propagated to PolicyAtt.

- Fixes a regression introduced by 65aa25533 where the reporting must happen on indidual policies and not on the merged policy.


# Change Type

```
/kind cleanup
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```
