### PR TITLE
Makefile: Fix the run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,8 @@ deploy-kgateway-crd-chart: ## Deploy the kgateway crd chart
 deploy-kgateway-chart: ## Deploy the kgateway chart
 	$(HELM) upgrade --install kgateway $(TEST_ASSET_DIR)/kgateway-$(VERSION).tgz \
 	--namespace kgateway-system --create-namespace \
-	--set image.registry=ghcr.io/kgateway-dev \
+	--set image.registry=$(IMAGE_REGISTRY) \
+	--set image.tag=$(VERSION)
 
 .PHONY: lint-kgateway-charts
 lint-kgateway-charts: ## Lint the kgateway charts
@@ -670,7 +671,7 @@ kind-create: ## Create a KinD cluster
 CONFORMANCE_CHANNEL ?= experimental
 CONFORMANCE_VERSION ?= v1.3.0
 .PHONY: gw-api-crds
-gw-api-crds:
+gw-api-crds: ## Install the Gateway API CRDs
 	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/$(CONFORMANCE_CHANNEL)?ref=$(CONFORMANCE_VERSION)"
 
 .PHONY: kind-metallb

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ help: ## Output the self-documenting make targets
 ROOTDIR := $(shell pwd)
 OUTPUT_DIR ?= $(ROOTDIR)/_output
 
-# TODO: fix this
 export IMAGE_REGISTRY ?= ghcr.io/kgateway-dev
 
 # Kind of a hack to make sure _output exists
@@ -546,7 +545,9 @@ deploy-kgateway-crd-chart: ## Deploy the kgateway crd chart
 
 .PHONY: deploy-kgateway-chart
 deploy-kgateway-chart: ## Deploy the kgateway chart
-	$(HELM) upgrade --install kgateway $(TEST_ASSET_DIR)/kgateway-$(VERSION).tgz --namespace kgateway-system --create-namespace
+	$(HELM) upgrade --install kgateway $(TEST_ASSET_DIR)/kgateway-$(VERSION).tgz \
+	--namespace kgateway-system --create-namespace \
+	--set image.registry=ghcr.io/kgateway-dev \
 
 .PHONY: lint-kgateway-charts
 lint-kgateway-charts: ## Lint the kgateway charts
@@ -666,6 +667,12 @@ INSTALL_NAMESPACE ?= kgateway-system
 kind-create: ## Create a KinD cluster
 	$(KIND) get clusters | grep $(CLUSTER_NAME) || $(KIND) create cluster --name $(CLUSTER_NAME)
 
+CONFORMANCE_CHANNEL ?= experimental
+CONFORMANCE_VERSION ?= v1.3.0
+.PHONY: gw-api-crds
+gw-api-crds:
+	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/$(CONFORMANCE_CHANNEL)?ref=$(CONFORMANCE_VERSION)"
+
 .PHONY: kind-metallb
 metallb: ## Install the MetalLB load balancer
 	./hack/kind/setup-metalllb-on-kind.sh
@@ -674,7 +681,7 @@ metallb: ## Install the MetalLB load balancer
 deploy-kgateway: package-kgateway-charts deploy-kgateway-crd-chart deploy-kgateway-chart ## Deploy the kgateway chart and CRDs
 
 .PHONY: run
-run: kind-create kind-build-and-load-standard metallb deploy-kgateway  ## Set up complete development environment
+run: kind-create kind-build-and-load-standard gw-api-crds metallb deploy-kgateway  ## Set up complete development environment
 
 #----------------------------------------------------------------------------------
 # Build assets for kubernetes e2e tests


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The run Makefile target was introduced recently in an effort to automate dev environments without having to run the setup-kind.sh script, install the helm charts, etc.

Previously, this target was broken as it failed to install the GW API CRDs and used the vanity registry for deployment, which led to ImagePullBackOff in environments bootstrapped by this target.

This PR updates the target to install everything. There's some additional work that needs to be done to integrate it with CI that'll likely require some refactoring in how we manage these deployment and test related targets.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
