### PR TITLE
deflake: try to deflake ipv6 setup tests.

### DIFF
--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Run Tests
       shell: bash
       env:
-        TEST_PKG: "./internal/kgateway/..."
+        TEST_PKG: "./internal/... ./pkg/..."
       run: make go-test-with-coverage
     - name: Validate Test Coverage
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,7 @@ GETTERCHECK ?= go tool github.com/saiskee/gettercheck
 # TODO: do we still want this?
 .PHONY: getter-check
 getter-check: ## Runs all generate directives for mockgen in the repo
-	$(GETTERCHECK) -ignoretests -ignoregenerated -write ./internal/kgateway/...
+	$(GETTERCHECK) -ignoretests -ignoregenerated -write ./internal/... ./pkg/...
 
 #----------------------------------------------------------------------------------
 # Distroless base images

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250507123352-93990c5ec02f
 	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250507123352-93990c5ec02f
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250507123352-93990c5ec02f
-	github.com/fsnotify/fsnotify v1.8.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
-github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=

--- a/hack/utils/oss_compliance/osa_provided.md
+++ b/hack/utils/oss_compliance/osa_provided.md
@@ -9,7 +9,7 @@ Name|Version|License
 [go-control-plane/contrib](https://github.com/envoyproxy/go-control-plane)|v1.32.5-0.20250507123352-93990c5ec02f|Apache License 2.0
 [go-control-plane/envoy](https://github.com/envoyproxy/go-control-plane)|v1.32.5-0.20250507123352-93990c5ec02f|Apache License 2.0
 [go-control-plane/ratelimit](https://github.com/envoyproxy/go-control-plane)|v0.1.1-0.20250507123352-93990c5ec02f|Apache License 2.0
-[fsnotify/fsnotify](https://github.com/fsnotify/fsnotify)|v1.8.0|BSD 3-clause "New" or "Revised" License
+[fsnotify/fsnotify](https://github.com/fsnotify/fsnotify)|v1.9.0|BSD 3-clause "New" or "Revised" License
 [ghodss/yaml](https://github.com/ghodss/yaml)|v1.0.1-0.20190212211648-25d852aebe32|MIT License
 [go-logr/logr](https://github.com/go-logr/logr)|v1.4.2|Apache License 2.0
 [go-logr/zapr](https://github.com/go-logr/zapr)|v1.3.0|Apache License 2.0

--- a/internal/kgateway/setup/setup_test.go
+++ b/internal/kgateway/setup/setup_test.go
@@ -163,17 +163,23 @@ func TestWithIstioAutomtlsSettings(t *testing.T) {
 }
 
 func TestWithBindIpv6(t *testing.T) {
-	st, err := settings.BuildSettings()
-	st.ListenerBindIpv6 = true
-	if err != nil {
-		t.Fatalf("can't get settings %v", err)
-	}
-	runScenario(t, "testdata/listenerbind/v6", st)
-	st.ListenerBindIpv6 = false
-	if err != nil {
-		t.Fatalf("can't get settings %v", err)
-	}
-	runScenario(t, "testdata/listenerbind/v4", st)
+	t.Run("ipv6", func(t *testing.T) {
+		st, err := settings.BuildSettings()
+		st.ListenerBindIpv6 = true
+		if err != nil {
+			t.Fatalf("can't get settings %v", err)
+		}
+		runScenario(t, "testdata/listenerbind/v6", st)
+	})
+
+	t.Run("ipv4", func(t *testing.T) {
+		st, err := settings.BuildSettings()
+		st.ListenerBindIpv6 = false
+		if err != nil {
+			t.Fatalf("can't get settings %v", err)
+		}
+		runScenario(t, "testdata/listenerbind/v4", st)
+	})
 }
 
 func TestWithAutoDns(t *testing.T) {

--- a/internal/kgateway/setup/setup_test.go
+++ b/internal/kgateway/setup/setup_test.go
@@ -163,23 +163,21 @@ func TestWithIstioAutomtlsSettings(t *testing.T) {
 }
 
 func TestWithBindIpv6(t *testing.T) {
-	t.Run("ipv6", func(t *testing.T) {
-		st, err := settings.BuildSettings()
-		st.ListenerBindIpv6 = true
-		if err != nil {
-			t.Fatalf("can't get settings %v", err)
-		}
-		runScenario(t, "testdata/listenerbind/v6", st)
-	})
+	st, err := settings.BuildSettings()
+	st.ListenerBindIpv6 = true
+	if err != nil {
+		t.Fatalf("can't get settings %v", err)
+	}
+	runScenario(t, "testdata/listenerbind/v6", st)
+}
 
-	t.Run("ipv4", func(t *testing.T) {
-		st, err := settings.BuildSettings()
-		st.ListenerBindIpv6 = false
-		if err != nil {
-			t.Fatalf("can't get settings %v", err)
-		}
-		runScenario(t, "testdata/listenerbind/v4", st)
-	})
+func TestWithBindIpv4(t *testing.T) {
+	st, err := settings.BuildSettings()
+	st.ListenerBindIpv6 = false
+	if err != nil {
+		t.Fatalf("can't get settings %v", err)
+	}
+	runScenario(t, "testdata/listenerbind/v4", st)
 }
 
 func TestWithAutoDns(t *testing.T) {

--- a/pkg/envoyinit/run.go
+++ b/pkg/envoyinit/run.go
@@ -79,7 +79,7 @@ func RunEnvoy(envoyExecutable, inputPath, outputPath string) {
 		if err != nil {
 			log.Fatalf("failed to unmarshal bootstrap config: %v", err)
 		}
-		bootstrap.StaticResources.Secrets = append(bootstrap.StaticResources.Secrets, &tlsv3.Secret{
+		bootstrap.GetStaticResources().Secrets = append(bootstrap.GetStaticResources().GetSecrets(), &tlsv3.Secret{
 			Name: utils.SystemCaSecretName,
 			Type: &tlsv3.Secret_ValidationContext{
 				ValidationContext: &tlsv3.CertificateValidationContext{

--- a/pkg/utils/cmdutils/cmd.go
+++ b/pkg/utils/cmdutils/cmd.go
@@ -34,6 +34,8 @@ type Cmd interface {
 
 	// WithStderr sets the io.Reader used for stderr
 	WithStderr(io.Writer) Cmd
+
+	PrettyCommand() string
 }
 
 // Cmder abstracts over creating commands

--- a/pkg/utils/cmdutils/local.go
+++ b/pkg/utils/cmdutils/local.go
@@ -133,3 +133,7 @@ func (cmd *LocalCmd) Wait() *RunError {
 func (cmd *LocalCmd) Output() []byte {
 	return cmd.combinedOutput.Bytes()
 }
+
+func (cmd *LocalCmd) PrettyCommand() string {
+	return PrettyCommand(cmd.Args[0], cmd.Args[1:]...)
+}

--- a/pkg/utils/controllerutils/admincli/client_test.go
+++ b/pkg/utils/controllerutils/admincli/client_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Client", func() {
 				curl.Silent(),             // new value
 			)
 
-			curlCommand := client.Command(ctx).Run().PrettyCommand()
+			curlCommand := client.Command(ctx).PrettyCommand()
 			Expect(curlCommand).To(And(
 				ContainSubstring("\"--retry\" \"1\""),
 				ContainSubstring("\"--retry-delay\" \"1\""),

--- a/test/envtestutil/util.go
+++ b/test/envtestutil/util.go
@@ -106,7 +106,7 @@ func RunController(t *testing.T, logger *zap.Logger, globalSettings *settings.Se
 		KrtDebugger:    new(krt.DebugHandler),
 		GlobalSettings: globalSettings,
 	}
-	t.Log("controller starting.xds port:", xdsPort)
+	t.Log("controller starting. xds port:", xdsPort)
 
 	// start kgateway
 	wg.Add(1)

--- a/test/envtestutil/util.go
+++ b/test/envtestutil/util.go
@@ -106,6 +106,7 @@ func RunController(t *testing.T, logger *zap.Logger, globalSettings *settings.Se
 		KrtDebugger:    new(krt.DebugHandler),
 		GlobalSettings: globalSettings,
 	}
+	t.Log("controller starting.xds port:", xdsPort)
 
 	// start kgateway
 	wg.Add(1)
@@ -118,6 +119,7 @@ func RunController(t *testing.T, logger *zap.Logger, globalSettings *settings.Se
 	// this means that it attaches the pod collection to the unique client set collection.
 	time.Sleep(time.Second)
 	run(t, ctx, setupOpts.KrtDebugger, client, xdsPort)
+	t.Log("controller done. shutting down. xds port:", xdsPort)
 }
 
 func GenerateKubeConfiguration(t *testing.T, restconfig *rest.Config) string {


### PR DESCRIPTION
i suspect the cause is not having a separate t, so cleanup is not done properly.
Also added all of `internal` and `pkg` to unit test target

fixes https://github.com/kgateway-dev/kgateway/issues/11325

# Change Type

```
/kind flake
```


# Changelog

```release-note
NONE
```