### PR TITLE
fix TrafficPolicy plugin name to match the resource name

### DIFF
--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -494,7 +494,7 @@ func NewGatewayTranslationPass(ctx context.Context, tctx ir.GwTranslationCtx, re
 }
 
 func (p *TrafficPolicy) Name() string {
-	return "routepolicies" // TODO: rename to trafficpolicies
+	return "trafficpolicies"
 }
 
 func (p *trafficPolicyPluginGwPass) ApplyRouteConfigPlugin(ctx context.Context, pCtx *ir.RouteConfigContext, out *routev3.RouteConfiguration) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Updates TrafficPolicy plugin name to "trafficpolicies", which now matches corresponding resource name.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind cleanup
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog
<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Updated TrafficPolicy plugin name to "trafficpolicies" to match resource kind.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
