### PR TITLE
Fix e2e for empty we

### DIFF
--- a/internal/kgateway/setup/testdata/serviceentry/we/se-we-no-addr-out.yaml
+++ b/internal/kgateway/setup/testdata/serviceentry/we/se-we-no-addr-out.yaml
@@ -1,0 +1,61 @@
+clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: istio-se_gwtest_se-b_se-b.serviceentry.com_8080
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+endpoints:
+- clusterName: istio-se_gwtest_se-b_se-b.serviceentry.com_8080
+  endpoints:
+  - {}
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - se-b.serviceentry.com
+    name: listener~8080~se-b_serviceentry_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~se-b_serviceentry_com-route-0-httproute-route-to-hostname-gwtest-0-0-matcher-0
+      route:
+        cluster: istio-se_gwtest_se-b_se-b.serviceentry.com_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/internal/kgateway/setup/testdata/serviceentry/we/se-we-no-addr.yaml
+++ b/internal/kgateway/setup/testdata/serviceentry/we/se-we-no-addr.yaml
@@ -1,0 +1,62 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: route-to-hostname
+  namespace: gwtest
+spec:
+  parentRefs:
+  - name: http-gw-for-test
+  hostnames:
+  - "se-b.serviceentry.com"
+  rules:
+  - backendRefs:
+    - name: se-b.serviceentry.com
+      port: 8080
+      kind: Hostname
+      group: networking.istio.io
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se-b
+  namespace: gwtest
+spec:
+  addresses:
+  - 244.244.0.2
+  hosts:
+  - se-b.serviceentry.com
+  location: MESH_INTERNAL
+  ports:
+  - number: 8080
+    name: http
+    protocol: HTTP
+    targetPort: 5678
+  resolution: STATIC
+  workloadSelector:
+    labels:
+      app: svc-b
+---
+apiVersion: networking.istio.io/v1
+kind: WorkloadEntry
+metadata:
+  name: empty-addr-workloadentry
+  namespace: gwtest
+  labels:
+    app: svc-b
+spec:
+  network: some-external-network

--- a/test/kubernetes/e2e/features/waypoint/testdata/common/test_apps.yaml
+++ b/test/kubernetes/e2e/features/waypoint/testdata/common/test_apps.yaml
@@ -237,12 +237,13 @@ spec:
 # we just include one here and expect it to do nothing
 # this acts as an assertion that we don't push invalid envoy and cause NACKs (due to invalid LbAddr)
 ##################################################################################################
----
-apiVersion: networking.istio.io/v1beta1
-kind: WorkloadEntry
-metadata:
-  name: empty-addr-workloadentry
-  labels:
-    app: svc-b
-spec:
-  network: some-external-network
+# TODO: This is pending Istio version that included this PR: https://github.com/istio/ztunnel/pull/1570 
+# ---
+# apiVersion: networking.istio.io/v1beta1
+# kind: WorkloadEntry
+# metadata:
+#   name: empty-addr-workloadentry
+#   labels:
+#     app: svc-b
+# spec:
+#   network: some-external-network


### PR DESCRIPTION
# Description

Moved we tests from e2e to setup due pending Istio version that included this PR: https://github.com/istio/ztunnel/pull/1570 https://github…

# Change Type

/kind cleanup
/kind flake

# Changelog


```release-note
NONE

```
