### PR TITLE
Switch to exposing usedonly stats in StatsConfig

### DIFF
--- a/install/test/fixtures.go
+++ b/install/test/fixtures.go
@@ -54,7 +54,7 @@ static_resources:
                   - name: ":method"
                     exact_match: GET
                 route:
-                  prefix_rewrite: "/stats/prometheus"
+                  prefix_rewrite: "/stats/prometheus?usedonly"
                   cluster: admin_port_cluster
           http_filters:
           - name: envoy.filters.http.router # if $spec.tracing # if $statsConfig.enabled # if $spec.readConfig
@@ -302,7 +302,7 @@ static_resources:
                   prefix: /metrics
                 route:
                   cluster: admin_port_cluster
-                  prefix_rewrite: /stats/prometheus
+                  prefix_rewrite: /stats/prometheus?usedonly
           stat_prefix: prometheus
         name: envoy.filters.network.http_connection_manager
     name: prometheus_listener
@@ -459,7 +459,7 @@ static_resources:
                   prefix: /metrics
                 route:
                   cluster: admin_port_cluster
-                  prefix_rewrite: /stats/prometheus
+                  prefix_rewrite: /stats/prometheus?usedonly
           stat_prefix: prometheus
         name: envoy.filters.network.http_connection_manager
     name: prometheus_listener
@@ -602,7 +602,7 @@ static_resources:
                   prefix: /metrics
                 route:
                   cluster: admin_port_cluster
-                  prefix_rewrite: /stats/prometheus
+                  prefix_rewrite: /stats/prometheus?usedonly
           stat_prefix: prometheus
         name: envoy.filters.network.http_connection_manager
     name: prometheus_listener
@@ -809,7 +809,7 @@ static_resources:
                   prefix: /metrics
                 route:
                   cluster: admin_port_cluster
-                  prefix_rewrite: /stats/prometheus
+                  prefix_rewrite: /stats/prometheus?usedonly
           stat_prefix: prometheus
         name: envoy.filters.network.http_connection_manager
     name: prometheus_listener

--- a/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
+++ b/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
@@ -49,7 +49,7 @@ static_resources:
                   - name: ":method"
                     exact_match: GET
                 route:
-                  prefix_rewrite: /stats/prometheus
+                  prefix_rewrite: /stats/prometheus?usedonly
                   cluster: admin_port_cluster
           http_filters:
           - name: envoy.filters.http.router

--- a/install/test/fixtures/envoy_config/custom_static_bootstrap.yaml
+++ b/install/test/fixtures/envoy_config/custom_static_bootstrap.yaml
@@ -51,7 +51,7 @@ static_resources:
                               - name: ":method"
                                 exact_match: GET
                           route:
-                            prefix_rewrite: /stats/prometheus
+                            prefix_rewrite: /stats/prometheus?usedonly
                             cluster: admin_port_cluster
                 http_filters:
                   - name: envoy.filters.http.router

--- a/install/test/fixtures/envoy_config/overload_manager.yaml
+++ b/install/test/fixtures/envoy_config/overload_manager.yaml
@@ -49,7 +49,7 @@ static_resources:
                   - name: ":method"
                     exact_match: GET
                 route:
-                  prefix_rewrite: /stats/prometheus
+                  prefix_rewrite: /stats/prometheus?usedonly
                   cluster: admin_port_cluster
           http_filters:
           - name: envoy.filters.http.router

--- a/install/test/fixtures/envoy_config/static_clusters.yaml
+++ b/install/test/fixtures/envoy_config/static_clusters.yaml
@@ -49,7 +49,7 @@ static_resources:
                   - name: ":method"
                     exact_match: GET
                 route:
-                  prefix_rewrite: /stats/prometheus
+                  prefix_rewrite: /stats/prometheus?usedonly
                   cluster: admin_port_cluster
           http_filters:
           - name: envoy.filters.http.router

--- a/install/test/fixtures/envoy_config/tcp_keepalive.yaml
+++ b/install/test/fixtures/envoy_config/tcp_keepalive.yaml
@@ -49,7 +49,7 @@ static_resources:
                               - name: ":method"
                                 exact_match: GET
                           route:
-                            prefix_rewrite: /stats/prometheus
+                            prefix_rewrite: /stats/prometheus?usedonly
                             cluster: admin_port_cluster
                 http_filters:
                   - name: envoy.filters.http.router

--- a/install/test/k8sgateway_test.go
+++ b/install/test/k8sgateway_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 				Expect(gwpKube.GetServiceAccount()).To(BeNil())
 
 				Expect(*gwpKube.GetStats().GetEnabled()).To(BeTrue())
-				Expect(*gwpKube.GetStats().GetRoutePrefixRewrite()).To(Equal("/stats/prometheus"))
+				Expect(*gwpKube.GetStats().GetRoutePrefixRewrite()).To(Equal("/stats/prometheus?usedonly"))
 				Expect(*gwpKube.GetStats().GetEnableStatsRoute()).To(BeTrue())
 				Expect(*gwpKube.GetStats().GetStatsRoutePrefixRewrite()).To(Equal("/stats"))
 

--- a/internal/kgateway/deployer/deployer.go
+++ b/internal/kgateway/deployer/deployer.go
@@ -812,7 +812,7 @@ func defaultGatewayParameters(imageInfo *ImageInfo) *v1alpha1.GatewayParameters 
 				},
 				Stats: &v1alpha1.StatsConfig{
 					Enabled:                 ptr.To(true),
-					RoutePrefixRewrite:      ptr.To("/stats/prometheus"),
+					RoutePrefixRewrite:      ptr.To("/stats/prometheus?usedonly"),
 					EnableStatsRoute:        ptr.To(true),
 					StatsRoutePrefixRewrite: ptr.To("/stats"),
 				},

--- a/internal/kgateway/deployer/deployer_test.go
+++ b/internal/kgateway/deployer/deployer_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Deployer", func() {
 						},
 						Stats: &gw2_v1alpha1.StatsConfig{
 							Enabled:                 ptr.To(true),
-							RoutePrefixRewrite:      ptr.To("/stats/prometheus"),
+							RoutePrefixRewrite:      ptr.To("/stats/prometheus?usedonly"),
 							EnableStatsRoute:        ptr.To(true),
 							StatsRoutePrefixRewrite: ptr.To("/stats"),
 						},


### PR DESCRIPTION
# Description

Switches to [Envoy's](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--stats?format=prometheus&usedonly) /stats/prometheus?usedonly endpoint "to only get statistics that Envoy has updated (counters incremented at least once, gauges changed at least once, and histograms added to at least once)".

This improves monitoring UX and resource usage.

# Change Type

```
/kind breaking_change
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Switching to Envoy's `/stats/prometheus?usedonly` endpoint to only get statistics that Envoy has updated (counters incremented at least once, gauges changed at least once, and histograms added to at least once).
```