### PR TITLE
remove erroring extauth test

### DIFF
--- a/test/kubernetes/e2e/features/extauth/suite.go
+++ b/test/kubernetes/e2e/features/extauth/suite.go
@@ -95,7 +95,7 @@ func (s *testingSuite) TearDownSuite() {
 }
 
 // TestExtAuthPolicy tests the basic ExtAuth functionality with header-based allow/deny
-// Checks for gateay level auth with route level opt out
+// Checks for gateway level auth with route level opt out
 func (s *testingSuite) TestExtAuthPolicy() {
 	manifests := []string{
 		securedGatewayPolicyManifest,
@@ -191,13 +191,11 @@ func (s *testingSuite) TestExtAuthPolicy() {
 func (s *testingSuite) TestRouteTargetedExtAuthPolicy() {
 	manifests := []string{
 		securedRouteManifest,
-		secureAndDisableAllManifest,
 		insecureRouteManifest,
 	}
 
 	resources := []client.Object{
 		secureRoute, secureTrafficPolicy,
-		disableAllRoute, insecureTrafficPolicy2, secureTrafficPolicy2,
 		insecureRoute, insecureTrafficPolicy,
 	}
 	s.T().Cleanup(func() {
@@ -233,11 +231,6 @@ func (s *testingSuite) TestRouteTargetedExtAuthPolicy() {
 		{
 			name:           "request allowed on insecure route",
 			hostname:       "insecureroute.com",
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "request allowed on reinsecured route",
-			hostname:       "disableall.com",
 			expectedStatus: http.StatusOK,
 		},
 		{

--- a/test/kubernetes/e2e/features/extauth/types.go
+++ b/test/kubernetes/e2e/features/extauth/types.go
@@ -97,12 +97,6 @@ var (
 			Namespace: "kgateway-test",
 		},
 	}
-	insecureTrafficPolicy2 = &v1alpha1.TrafficPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "insecure-route-policy2",
-			Namespace: "kgateway-test",
-		},
-	}
 	secureRoute = &gwv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "route-example-secure",
@@ -115,18 +109,6 @@ var (
 			Namespace: "kgateway-test",
 		},
 	}
-	secureTrafficPolicy2 = &v1alpha1.TrafficPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secure-route-policy2",
-			Namespace: "kgateway-test",
-		},
-	}
-	disableAllRoute = &gwv1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "route-example-disableall",
-			Namespace: "kgateway-test",
-		},
-	}
 
 	// Manifest files
 	gatewayWithRouteManifest     = getTestFile("common.yaml")
@@ -134,7 +116,6 @@ var (
 	extAuthManifest              = getTestFile("ext-authz-server.yaml")
 	securedGatewayPolicyManifest = getTestFile("secured-gateway-policy.yaml")
 	securedRouteManifest         = getTestFile("secured-route.yaml")
-	secureAndDisableAllManifest  = getTestFile("secure-and-disable-all.yaml")
 	insecureRouteManifest        = getTestFile("insecure-route.yaml")
 )
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

The e2e test `TestKgateway/ExtAuth/TestRouteTargetedExtAuthPolicy/request_allowed_on_reinsecured_route` was flaking a lot because it had 2 conflicting TrafficPolicies (one with extauth, one disabling extauth) targeting the same HTTPRoute. In the case of 2 policies of the same type targeting the same route, the policy merging works by taking the policy with the oldest timestamp. However since these resources are created at the same time and have the same timestamp, the order was not well-defined, resulting in sometimes the extauth policy winning, and sometimes the disabled extauth policy winning. This is not really a supported use case, so have deleted this test.

We have other e2e tests that cover both secure and insecure routes (`TestKgateway/ExtAuth/TestRouteTargetedExtAuthPolicy/request_allowed_on_insecure_route` specifically covers the DisableAll case)

Fixes https://github.com/kgateway-dev/kgateway/issues/11180

# Change Type

/kind flake

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
