### PR TITLE
docs: single-line Helm descriptions

### DIFF
--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -1,16 +1,10 @@
 # -- Set a list of image pull secrets for Kubernetes to use when pulling container images from your own private registry instead of the default kgateway registry.
 imagePullSecrets: []
 
-# -- Add a name to the Helm base release.
-# -- The default name is 'kgateway'.
-# -- If you set 'nameOverride: "foo", the name of the resources that the Helm release creates become 'kgateway-foo',
-# -- such as the deployment, service, and service account for the kgateway control plane in the kgateway-system namespace.
+# -- Add a name to the default Helm base release, which is 'kgateway'. If you set 'nameOverride: "foo", the name of the resources that the Helm release creates become 'kgateway-foo', such as the deployment, service, and service account for the kgateway control plane in the kgateway-system namespace.
 nameOverride: ""
 
-# -- Override the full name of resources created by the Helm chart.
-# -- The default full name is 'kgateway'.
-# -- If you set 'fullnameOverride: "foo", the full name of the resources that the Helm release creates become 'foo',
-# -- such as the deployment, service, and service account for the kgateway control plane in the kgateway-system namespace.
+# -- Override the full name of resources created by the Helm chart, which is 'kgateway'. If you set 'fullnameOverride: "foo", the full name of the resources that the Helm release creates become 'foo', such as the deployment, service, and service account for the kgateway control plane in the kgateway-system namespace.
 fullnameOverride: ""
 
 # -- Configure the service account for the deployment.
@@ -19,8 +13,7 @@ serviceAccount:
   create: true
   # -- Add annotations to the service account.
   annotations: {}
-  # -- Set the name of the service account to use.
-  # -- If not set and create is true, a name is generated using the fullname template.
+  # -- Set the name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   name: ""
 
 # -- Add annotations to the kgateway deployment.
@@ -29,8 +22,7 @@ deploymentAnnotations: {}
 # -- Add annotations to the kgateway pods.
 podAnnotations: {}
 
-# -- Set the pod-level security context.
-# -- For example, 'fsGroup: 2000' sets the filesystem group to 2000.
+# -- Set the pod-level security context. For example, 'fsGroup: 2000' sets the filesystem group to 2000.
 podSecurityContext: {}
 
 # -- Set the container-level security context, such as 'runAsNonRoot: true'.
@@ -75,9 +67,7 @@ controller:
   # -- Add extra environment variables to the controller container.
   extraEnv: {}
 
-# -- Configure the default container image for the components that Helm deploys.
-# -- You can override these settings for each particular component in that component's section, such as 'controller.image' for the kgateway control plane.
-# -- If you use your own private registry, make sure to include the imagePullSecrets.
+# -- Configure the default container image for the components that Helm deploys. You can override these settings for each particular component in that component's section, such as 'controller.image' for the kgateway control plane. If you use your own private registry, make sure to include the imagePullSecrets.
 image:
   # -- Set the default image registry. 
   registry: cr.kgateway.dev/kgateway-dev
@@ -86,36 +76,16 @@ image:
   # -- Set the default image pull policy.
   pullPolicy: IfNotPresent
 
-# -- Configure the integration with the Gateway API Inference Extension project.
-# -- With Inference Extension, you can use kgateway to route to AI inference workloads like LLMs that run locally in your Kubernetes cluster.
+# -- Configure the integration with the Gateway API Inference Extension project, which lets you use kgateway to route to AI inference workloads like LLMs that run locally in your Kubernetes cluster.
 inferenceExtension:
   # -- Enable Inference Extension.
   enabled: false
   # -- Enable automatic provisioning for Inference Extension.
   autoProvision: false
 
-# -- Set namespace selectors for config discovery.
-# -- Elements in the list are disjunctive (OR semantics).
-# -- This means that a namespace is selected if it matches any selector.
-# -- For each element in the list, the result of matchLabels and matchExpressions are conjunctive (AND semantics).
-# --
-# --The following selects namespaces if either of the following is true:
-# -- - the namespace has the label prod=enabled AND version=v2, OR
-# -- - the namespace has the label version=v3
-# -- 
-# -- discoveryNamespaceSelectors:
-# -- - matchExpressions:
-# --   - key: environment
-# --     operator: In
-# --     values:
-# --     - prod
-# --   matchLabels:
-# --     version: v2
-# -- - matchLabels:
-# --     version: v3
+# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Kgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/operations/install/#namespace-discovery
 discoveryNamespaceSelectors: []
 
-# -- Enable the integration with Agent Gateway.
-# -- Agent Gateway lets you use kgateway to help manage agent connectivity across MCP servers, A2A agents, and REST APIs.
+# -- Enable the integration with Agent Gateway, which lets you use kgateway to help manage agent connectivity across MCP servers, A2A agents, and REST APIs.
 agentGateway:
   enabled: false

--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -83,7 +83,7 @@ inferenceExtension:
   # -- Enable automatic provisioning for Inference Extension.
   autoProvision: false
 
-# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Kgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/operations/install/#namespace-discovery
+# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Kgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/operations/install/#namespace-discovery.
 discoveryNamespaceSelectors: []
 
 # -- Enable the integration with Agent Gateway, which lets you use kgateway to help manage agent connectivity across MCP servers, A2A agents, and REST APIs.


### PR DESCRIPTION
# Description

- **Motivation:** the helm-docs tool that generates the markdown can only take in a single line. As such, multi-line descriptions only included the last line
- **What changed:** changed descriptions to single line
- **Related issues:** followup to https://github.com/kgateway-dev/kgateway/pull/11350

# Change Type

```
/kind documentation
```

# Changelog

```release-note
NONE
```

# Additional Notes

Since the discovery namespace selector example was too long, I added it to the docs in this commit and just linked out to that: https://github.com/kgateway-dev/kgateway.dev/pull/234/commits/615e4cb238b04c542ac975a79d6923a2d70a7074