### PR TITLE
Inference Extension: Use a Single Shared ExtProc Filter for all InferencePools

### DIFF
--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-basic-out.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-basic-out.yaml
@@ -78,12 +78,12 @@ listeners:
       typedConfig:
         '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         httpFilters:
-        - name: inferencepool.backend.transformation.kgateway.io_gwtest_gateway-pool
+        - name: inferencepool.backend.transformation.kgateway.io
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
             grpcService:
               envoyGrpc:
-                authority: gateway-pool-endpoint-picker.gwtest:9002
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
                 clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
             messageTimeout: 5s
             processingMode:

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-basic.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-basic.yaml
@@ -1,3 +1,5 @@
+# One Gateway with one HTTPRoute referencing one InferencePool
+---
 kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1
 metadata:

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool-out.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool-out.yaml
@@ -1,0 +1,227 @@
+clusters:
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker-2.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool-2_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool-2_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9090
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker-2_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9090
+  type: EDS
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: inferencepool.backend.transformation.kgateway.io
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+            messageTimeout: 5s
+            processingMode:
+              requestBodyMode: FULL_DUPLEX_STREAMED
+              requestHeaderMode: SEND
+              requestTrailerMode: SEND
+              responseBodyMode: FULL_DUPLEX_STREAMED
+              responseHeaderMode: SEND
+              responseTrailerMode: SEND
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-gateway-route-gwtest-0-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+              timeout: 10s
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct-2
+        prefix: /
+      name: listener~8080~www_example_com-route-1-httproute-gateway-route-2-gwtest-0-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool-2_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker-2.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+              timeout: 10s

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool.yaml
@@ -1,0 +1,132 @@
+# One Gateway with two HTTPRoutes each referencing one InferencePool
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: gateway-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: gateway-route-2
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool-2
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct-2
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker-2
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool-2
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker-2
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool-out.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool-out.yaml
@@ -1,0 +1,227 @@
+clusters:
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker-2.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool-2_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool-2_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9090
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker-2_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9090
+  type: EDS
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: inferencepool.backend.transformation.kgateway.io
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+            messageTimeout: 5s
+            processingMode:
+              requestBodyMode: FULL_DUPLEX_STREAMED
+              requestHeaderMode: SEND
+              requestTrailerMode: SEND
+              responseBodyMode: FULL_DUPLEX_STREAMED
+              responseHeaderMode: SEND
+              responseTrailerMode: SEND
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-gateway-route-gwtest-0-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+              timeout: 10s
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct-2
+        prefix: /
+      name: listener~8080~www_example_com-route-1-httproute-gateway-route-gwtest-1-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool-2_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker-2.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+              timeout: 10s

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool.yaml
@@ -1,0 +1,120 @@
+# One Gateway with one HTTPRoute referencing two InferencePools
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: gateway-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool-2
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct-2
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker-2
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool-2
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker-2
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080


### PR DESCRIPTION
# Description

Modifies `HttpFilters()` to register one well-known ext-proc filter regardless of InferencePool count and rely on the `typed_per_filter_config` overrides added in `ApplyForBackend()` to direct each request to the appropriate EPP cluster.

# Change Type

```
/kind bug_fix
```

Fixes #11389 

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

- xref llm-d issue for add'l context: https://github.com/llm-d/llm-d-inference-scheduler/issues/158#issuecomment-2961262227
- https://github.com/kgateway-dev/kgateway/pull/11412 adds e2e test coverage for this change. 