### PR TITLE
refactor: Centralize AI plugin environment variable

### DIFF
--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 // IR is the internal representation of an AI backend.
@@ -135,7 +136,7 @@ func PreprocessAIBackend(ctx context.Context, aiBackend *v1alpha1.AIBackend, ir 
 			RequestMatch: &envoytransformation.RouteTransformations_RouteTransformation_RequestMatch{
 				RequestTransformation: &envoytransformation.Transformation{
 					// Set this env var to true to log the request/response info for each transformation
-					LogRequestResponseInfo: wrapperspb.Bool(os.Getenv("AI_PLUGIN_DEBUG_TRANSFORMATIONS") == "true"),
+					LogRequestResponseInfo: wrapperspb.Bool(os.Getenv(testutils.AiDebugTransformations) == "true"),
 					TransformationType: &envoytransformation.Transformation_TransformationTemplate{
 						TransformationTemplate: transformation,
 					},

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
@@ -15,9 +15,9 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/trafficpolicy"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 // IR is the internal representation of an AI backend.
@@ -136,7 +136,7 @@ func PreprocessAIBackend(ctx context.Context, aiBackend *v1alpha1.AIBackend, ir 
 			RequestMatch: &envoytransformation.RouteTransformations_RouteTransformation_RequestMatch{
 				RequestTransformation: &envoytransformation.Transformation{
 					// Set this env var to true to log the request/response info for each transformation
-					LogRequestResponseInfo: wrapperspb.Bool(os.Getenv(testutils.AiDebugTransformations) == "true"),
+					LogRequestResponseInfo: wrapperspb.Bool(os.Getenv(trafficpolicy.AiDebugTransformations) == "true"),
 					TransformationType: &envoytransformation.Transformation_TransformationTemplate{
 						TransformationTemplate: transformation,
 					},

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_resources.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_resources.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+
 	"log/slog"
 	"os"
 	"strconv"
@@ -13,8 +14,8 @@ import (
 	envoy_upstreams_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/trafficpolicy"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils"
-	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 const (
@@ -30,7 +31,7 @@ func GetAIAdditionalResources(ctx context.Context) []*envoy_config_cluster_v3.Cl
 	// The port can be whatever you want.
 	// When running the ext-proc filter locally, you also need to set
 	// `LISTEN_ADDR` to `0.0.0.0:PORT`. Where port is the same port as above.
-	listenAddr := strings.Split(os.Getenv(testutils.AiListenAddr), ":")
+	listenAddr := strings.Split(os.Getenv(trafficpolicy.AiListenAddr), ":")
 
 	var ep *envoy_config_endpoint_v3.LbEndpoint
 	if len(listenAddr) == 2 {

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_resources.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_resources.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 const (
@@ -29,8 +30,7 @@ func GetAIAdditionalResources(ctx context.Context) []*envoy_config_cluster_v3.Cl
 	// The port can be whatever you want.
 	// When running the ext-proc filter locally, you also need to set
 	// `LISTEN_ADDR` to `0.0.0.0:PORT`. Where port is the same port as above.
-	// TODO: clean up and centralize the processing of env vars (https://github.com/kgateway-dev/kgateway/issues/10721
-	listenAddr := strings.Split(os.Getenv("AI_PLUGIN_LISTEN_ADDR"), ":")
+	listenAddr := strings.Split(os.Getenv(testutils.AiListenAddr), ":")
 
 	var ep *envoy_config_endpoint_v3.LbEndpoint
 	if len(listenAddr) == 2 {

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_env.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_env.go
@@ -1,0 +1,13 @@
+package trafficpolicy
+
+const (
+	// AiDebugTransformations Controls the debugging log behavior of the AI backend's Envoy transformation filter.
+	// When this variable is enabled, Envoy will record detailed HTTP request/response information processed by the AI Gateway.
+	// This is very helpful for understanding data flow, debugging transformation rules.
+	// Expected values: "true" to enable, any other value (or unset) to disable.
+	AiDebugTransformations = "AI_PLUGIN_DEBUG_TRANSFORMATIONS"
+
+	// AiListenAddr can be used to test the ext-proc filter locally.
+	// Expected values: A valid network address string (e.g., "127.0.0.1:9000").
+	AiListenAddr = "AI_PLUGIN_LISTEN_ADDR"
+)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 const (
@@ -99,7 +100,7 @@ func preProcessAITrafficPolicy(
 					RequestMatch: &envoytransformation.RouteTransformations_RouteTransformation_RequestMatch{
 						RequestTransformation: &envoytransformation.Transformation{
 							// Set this env var to true to log the request/response info for each transformation
-							LogRequestResponseInfo: wrapperspb.Bool(os.Getenv("AI_PLUGIN_DEBUG_TRANSFORMATIONS") == "true"),
+							LogRequestResponseInfo: wrapperspb.Bool(os.Getenv(testutils.AiDebugTransformations) == "true"),
 							TransformationType: &envoytransformation.Transformation_TransformationTemplate{
 								TransformationTemplate: transformationTemplate,
 							},

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 const (
@@ -100,7 +99,7 @@ func preProcessAITrafficPolicy(
 					RequestMatch: &envoytransformation.RouteTransformations_RouteTransformation_RequestMatch{
 						RequestTransformation: &envoytransformation.Transformation{
 							// Set this env var to true to log the request/response info for each transformation
-							LogRequestResponseInfo: wrapperspb.Bool(os.Getenv(testutils.AiDebugTransformations) == "true"),
+							LogRequestResponseInfo: wrapperspb.Bool(os.Getenv(AiDebugTransformations) == "true"),
 							TransformationType: &envoytransformation.Transformation_TransformationTemplate{
 								TransformationTemplate: transformationTemplate,
 							},

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 func TestProcessAITrafficPolicy(t *testing.T) {
@@ -76,9 +77,9 @@ func TestProcessAITrafficPolicy(t *testing.T) {
 		}
 
 		// Set env var
-		oldEnv := os.Getenv("AI_PLUGIN_DEBUG_TRANSFORMATIONS")
-		os.Setenv("AI_PLUGIN_DEBUG_TRANSFORMATIONS", "true")
-		defer os.Setenv("AI_PLUGIN_DEBUG_TRANSFORMATIONS", oldEnv)
+		oldEnv := os.Getenv(testutils.AiDebugTransformations)
+		os.Setenv(testutils.AiDebugTransformations, "true")
+		defer os.Setenv(testutils.AiDebugTransformations, oldEnv)
 
 		// Execute
 		err := preProcessAITrafficPolicy(aiConfig, aiIR)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 func TestProcessAITrafficPolicy(t *testing.T) {
@@ -77,9 +76,9 @@ func TestProcessAITrafficPolicy(t *testing.T) {
 		}
 
 		// Set env var
-		oldEnv := os.Getenv(testutils.AiDebugTransformations)
-		os.Setenv(testutils.AiDebugTransformations, "true")
-		defer os.Setenv(testutils.AiDebugTransformations, oldEnv)
+		oldEnv := os.Getenv(AiDebugTransformations)
+		os.Setenv(AiDebugTransformations, "true")
+		defer os.Setenv(AiDebugTransformations, oldEnv)
 
 		// Execute
 		err := preProcessAITrafficPolicy(aiConfig, aiIR)

--- a/test/testutils/env.go
+++ b/test/testutils/env.go
@@ -5,16 +5,6 @@ import (
 )
 
 const (
-	// AiDebugTransformations Controls the debugging log behavior of the AI backend's Envoy transformation filter.
-	// When this variable is enabled, Envoy will record detailed HTTP request/response information processed by the AI Gateway.
-	// This is very helpful for understanding data flow, debugging transformation rules.
-	// Expected values: "true" to enable, any other value (or unset) to disable.
-	AiDebugTransformations = "AI_PLUGIN_DEBUG_TRANSFORMATIONS"
-
-	// AiListenAddr can be used to test the ext-proc filter locally.
-	// Expected values: A valid network address string (e.g., "127.0.0.1:9000").
-	AiListenAddr = "AI_PLUGIN_LISTEN_ADDR"
-
 	// TearDown is used to TearDown assets after a test completes. This is used in kubernetes e2e tests to uninstall
 	// Gloo after a test suite completes
 	TearDown = "TEAR_DOWN"

--- a/test/testutils/env.go
+++ b/test/testutils/env.go
@@ -5,6 +5,16 @@ import (
 )
 
 const (
+	// AiDebugTransformations Controls the debugging log behavior of the AI backend's Envoy transformation filter.
+	// When this variable is enabled, Envoy will record detailed HTTP request/response information processed by the AI Gateway.
+	// This is very helpful for understanding data flow, debugging transformation rules.
+	// Expected values: "true" to enable, any other value (or unset) to disable.
+	AiDebugTransformations = "AI_PLUGIN_DEBUG_TRANSFORMATIONS"
+
+	// AiListenAddr can be used to test the ext-proc filter locally.
+	// Expected values: A valid network address string (e.g., "127.0.0.1:9000").
+	AiListenAddr = "AI_PLUGIN_LISTEN_ADDR"
+
 	// TearDown is used to TearDown assets after a test completes. This is used in kubernetes e2e tests to uninstall
 	// Gloo after a test suite completes
 	TearDown = "TEAR_DOWN"


### PR DESCRIPTION
# Description
Fixes #11366 

This PR centralizes the definition and documentation of AI Gateway's environment variables.
All AI-related environment variables are now defined in a single, well-documented location: `test/testutils/env.go`.

# Change Type
```
/kind cleanup
```

# Changelog
```release-note
NONE
```

# Additional Notes
