### PR TITLE
Docs: Added link to Inference Extension documentation

### DIFF
--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -77,6 +77,7 @@ image:
   pullPolicy: IfNotPresent
 
 # -- Configure the integration with the Gateway API Inference Extension project, which lets you use kgateway to route to AI inference workloads like LLMs that run locally in your Kubernetes cluster.
+# -- Documentation on Inference Extension can be found here: https://kgateway.dev/docs/integrations/inference-extension/
 inferenceExtension:
   # -- Enable Inference Extension.
   enabled: false


### PR DESCRIPTION
Signed-off-by: Hanh Vu <hanh@solo.io>


# Description

- **Motivation:** why this change is needed
- **What changed:** 1 new comment line with link to Inference Extension documentation
- **Related issues:** Fixes https://github.com/kgateway-dev/kgateway/issues/11332

# Change Type
/kind documentation


# Changelog

```release-note
NONE
```