### PR TITLE
internal: bump Go, fix port check, and remove unused param

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kgateway-dev/kgateway/v2
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/avast/retry-go v2.4.3+incompatible

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
@@ -130,7 +130,7 @@ func PreprocessAIBackend(ctx context.Context, aiBackend *v1alpha1.AIBackend, ir 
 
 	// We only want to add the transformation filter if we have a single AI backend
 	// Otherwise we already have the transformation filter added by the weighted destination.
-	transformation := createTransformationTemplate(ctx, aiBackend)
+	transformation := createTransformationTemplate(aiBackend)
 	routeTransformation := &envoytransformation.RouteTransformations_RouteTransformation{
 		Match: &envoytransformation.RouteTransformations_RouteTransformation_RequestMatch_{
 			RequestMatch: &envoytransformation.RouteTransformations_RouteTransformation_RequestMatch{

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_model_cluster.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_model_cluster.go
@@ -1,7 +1,6 @@
 package ai
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 
@@ -40,12 +39,12 @@ func tlsMatch(matchStr string) *structpb.Struct {
 	}
 }
 
-func ProcessAIBackend(ctx context.Context, in *v1alpha1.AIBackend, aiSecret *ir.Secret, multiSecrets map[string]*ir.Secret, out *envoy_config_cluster_v3.Cluster) error {
+func ProcessAIBackend(in *v1alpha1.AIBackend, aiSecret *ir.Secret, multiSecrets map[string]*ir.Secret, out *envoy_config_cluster_v3.Cluster) error {
 	if in == nil {
 		return nil
 	}
 
-	if err := buildModelCluster(ctx, in, aiSecret, multiSecrets, out); err != nil {
+	if err := buildModelCluster(in, aiSecret, multiSecrets, out); err != nil {
 		return err
 	}
 
@@ -56,7 +55,7 @@ func ProcessAIBackend(ctx context.Context, in *v1alpha1.AIBackend, aiSecret *ir.
 // This function is used by the `ProcessBackend` function to build the cluster for the AI backend.
 // It is ALSO used by `ProcessRoute` to create the cluster in the event of backup models being used
 // and fallbacks being required.
-func buildModelCluster(ctx context.Context, aiUs *v1alpha1.AIBackend, aiSecret *ir.Secret, multiSecrets map[string]*ir.Secret, out *envoy_config_cluster_v3.Cluster) error {
+func buildModelCluster(aiUs *v1alpha1.AIBackend, aiSecret *ir.Secret, multiSecrets map[string]*ir.Secret, out *envoy_config_cluster_v3.Cluster) error {
 	// set the type to strict dns to support mutli pool backends
 	out.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_STRICT_DNS,
@@ -112,7 +111,7 @@ func buildModelCluster(ctx context.Context, aiUs *v1alpha1.AIBackend, aiSecret *
 						secretRef := ep.Provider.VertexAI.AuthToken.SecretRef
 						secretForMultiPool = multiSecrets[GetMultiPoolSecretKey(idx, jdx, secretRef.Name)]
 					}
-					result, err = buildVertexAIEndpoint(ctx, ep.Provider.VertexAI, ep.HostOverride, secretForMultiPool)
+					result, err = buildVertexAIEndpoint(ep.Provider.VertexAI, ep.HostOverride, secretForMultiPool)
 				}
 				if err != nil {
 					return err
@@ -129,7 +128,7 @@ func buildModelCluster(ctx context.Context, aiUs *v1alpha1.AIBackend, aiSecret *
 			return eris.Errorf("multi backend pools must all be of the same type, got %v", epByType)
 		}
 	} else if aiUs.LLM != nil {
-		prioritized, err = buildLLMEndpoint(ctx, aiUs, aiSecret)
+		prioritized, err = buildLLMEndpoint(aiUs, aiSecret)
 		if err != nil {
 			return err
 		}
@@ -217,7 +216,7 @@ func buildModelCluster(ctx context.Context, aiUs *v1alpha1.AIBackend, aiSecret *
 	return nil
 }
 
-func buildLLMEndpoint(ctx context.Context, aiUs *v1alpha1.AIBackend, aiSecrets *ir.Secret) ([]*envoy_config_endpoint_v3.LocalityLbEndpoints, error) {
+func buildLLMEndpoint(aiUs *v1alpha1.AIBackend, aiSecrets *ir.Secret) ([]*envoy_config_endpoint_v3.LocalityLbEndpoints, error) {
 	var prioritized []*envoy_config_endpoint_v3.LocalityLbEndpoints
 	provider := aiUs.LLM.Provider
 	if provider.OpenAI != nil {
@@ -253,7 +252,7 @@ func buildLLMEndpoint(ctx context.Context, aiUs *v1alpha1.AIBackend, aiSecrets *
 			{LbEndpoints: []*envoy_config_endpoint_v3.LbEndpoint{host}},
 		}
 	} else if provider.VertexAI != nil {
-		host, err := buildVertexAIEndpoint(ctx, provider.VertexAI, aiUs.LLM.HostOverride, aiSecrets)
+		host, err := buildVertexAIEndpoint(provider.VertexAI, aiUs.LLM.HostOverride, aiSecrets)
 		if err != nil {
 			return nil, err
 		}
@@ -280,6 +279,7 @@ func buildOpenAIEndpoint(data *v1alpha1.OpenAIConfig, hostOverride *v1alpha1.Hos
 		buildEndpointMeta(token, model, nil),
 	), nil
 }
+
 func buildAnthropicEndpoint(data *v1alpha1.AnthropicConfig, hostOverride *v1alpha1.Host, aiSecrets *ir.Secret) (*envoy_config_endpoint_v3.LbEndpoint, error) {
 	token, err := aiutils.GetAuthToken(data.AuthToken, aiSecrets)
 	if err != nil {
@@ -296,6 +296,7 @@ func buildAnthropicEndpoint(data *v1alpha1.AnthropicConfig, hostOverride *v1alph
 		buildEndpointMeta(token, model, nil),
 	), nil
 }
+
 func buildAzureOpenAIEndpoint(data *v1alpha1.AzureOpenAIConfig, hostOverride *v1alpha1.Host, aiSecrets *ir.Secret) (*envoy_config_endpoint_v3.LbEndpoint, error) {
 	token, err := aiutils.GetAuthToken(data.AuthToken, aiSecrets)
 	if err != nil {
@@ -308,6 +309,7 @@ func buildAzureOpenAIEndpoint(data *v1alpha1.AzureOpenAIConfig, hostOverride *v1
 		buildEndpointMeta(token, data.DeploymentName, map[string]string{"api_version": data.ApiVersion}),
 	), nil
 }
+
 func buildGeminiEndpoint(data *v1alpha1.GeminiConfig, hostOverride *v1alpha1.Host, aiSecrets *ir.Secret) (*envoy_config_endpoint_v3.LbEndpoint, error) {
 	token, err := aiutils.GetAuthToken(data.AuthToken, aiSecrets)
 	if err != nil {
@@ -320,7 +322,8 @@ func buildGeminiEndpoint(data *v1alpha1.GeminiConfig, hostOverride *v1alpha1.Hos
 		buildEndpointMeta(token, data.Model, map[string]string{"api_version": data.ApiVersion}),
 	), nil
 }
-func buildVertexAIEndpoint(ctx context.Context, data *v1alpha1.VertexAIConfig, hostOverride *v1alpha1.Host, aiSecrets *ir.Secret) (*envoy_config_endpoint_v3.LbEndpoint, error) {
+
+func buildVertexAIEndpoint(data *v1alpha1.VertexAIConfig, hostOverride *v1alpha1.Host, aiSecrets *ir.Secret) (*envoy_config_endpoint_v3.LbEndpoint, error) {
 	token, err := aiutils.GetAuthToken(data.AuthToken, aiSecrets)
 	if err != nil {
 		return nil, err
@@ -420,7 +423,7 @@ func buildEndpointMeta(token, model string, additionalFields map[string]string) 
 	}
 }
 
-func createTransformationTemplate(ctx context.Context, aiBackend *v1alpha1.AIBackend) *envoytransformation.TransformationTemplate {
+func createTransformationTemplate(aiBackend *v1alpha1.AIBackend) *envoytransformation.TransformationTemplate {
 	// Setup initial transformation template. This may be modified by further
 	transformationTemplate := &envoytransformation.TransformationTemplate{
 		// We will add the auth token later
@@ -430,11 +433,11 @@ func createTransformationTemplate(ctx context.Context, aiBackend *v1alpha1.AIBac
 	var headerName, prefix, path string
 	var bodyTransformation *envoytransformation.TransformationTemplate_MergeJsonKeys
 	if aiBackend.LLM != nil {
-		headerName, prefix, path, bodyTransformation = getTransformation(ctx, aiBackend.LLM)
+		headerName, prefix, path, bodyTransformation = getTransformation(aiBackend.LLM)
 	} else if aiBackend.MultiPool != nil {
 		// We already know that all the backends are the same type so we can just take the first one
 		llmMultiPool := aiBackend.MultiPool.Priorities[0].Pool[0]
-		headerName, prefix, path, bodyTransformation = getTransformation(ctx, &llmMultiPool)
+		headerName, prefix, path, bodyTransformation = getTransformation(&llmMultiPool)
 	}
 	transformationTemplate.GetHeaders()[headerName] = &envoytransformation.InjaTemplate{
 		Text: prefix + `{% if host_metadata("auth_token") != "" %}{{host_metadata("auth_token")}}{% else %}{{dynamic_metadata("auth_token","ai.kgateway.io")}}{% endif %}`,
@@ -446,7 +449,7 @@ func createTransformationTemplate(ctx context.Context, aiBackend *v1alpha1.AIBac
 	return transformationTemplate
 }
 
-func getTransformation(ctx context.Context, llm *v1alpha1.LLMProvider) (string, string, string, *envoytransformation.TransformationTemplate_MergeJsonKeys) {
+func getTransformation(llm *v1alpha1.LLMProvider) (string, string, string, *envoytransformation.TransformationTemplate_MergeJsonKeys) {
 	headerName := "Authorization"
 	var prefix, path string
 	var bodyTransformation *envoytransformation.TransformationTemplate_MergeJsonKeys

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_model_cluster_test.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_model_cluster_test.go
@@ -1,7 +1,6 @@
 package ai
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -15,12 +14,11 @@ import (
 )
 
 func TestProcessAIBackend_Empty(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "test-cluster",
 	}
 
-	err := ProcessAIBackend(ctx, nil, nil, nil, cluster)
+	err := ProcessAIBackend(nil, nil, nil, cluster)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "test-cluster", cluster.Name)
@@ -28,7 +26,6 @@ func TestProcessAIBackend_Empty(t *testing.T) {
 }
 
 func TestProcessAIBackend_OpenAI(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "openai-cluster",
 	}
@@ -51,7 +48,7 @@ func TestProcessAIBackend_OpenAI(t *testing.T) {
 	secrets := &ir.Secret{}
 	multiSecrets := map[string]*ir.Secret{}
 
-	err := ProcessAIBackend(ctx, aiBackend, secrets, multiSecrets, cluster)
+	err := ProcessAIBackend(aiBackend, secrets, multiSecrets, cluster)
 
 	require.NoError(t, err)
 
@@ -97,7 +94,6 @@ func TestProcessAIBackend_OpenAI(t *testing.T) {
 }
 
 func TestProcessAIBackend_Anthropic(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "anthropic-cluster",
 	}
@@ -120,7 +116,7 @@ func TestProcessAIBackend_Anthropic(t *testing.T) {
 	secrets := &ir.Secret{}
 	multiSecrets := map[string]*ir.Secret{}
 
-	err := ProcessAIBackend(ctx, aiBackend, secrets, multiSecrets, cluster)
+	err := ProcessAIBackend(aiBackend, secrets, multiSecrets, cluster)
 
 	require.NoError(t, err)
 
@@ -147,7 +143,6 @@ func TestProcessAIBackend_Anthropic(t *testing.T) {
 }
 
 func TestProcessAIBackend_AzureOpenAI(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "azure-openai-cluster",
 	}
@@ -171,7 +166,7 @@ func TestProcessAIBackend_AzureOpenAI(t *testing.T) {
 	secrets := &ir.Secret{}
 	multiSecrets := map[string]*ir.Secret{}
 
-	err := ProcessAIBackend(ctx, aiBackend, secrets, multiSecrets, cluster)
+	err := ProcessAIBackend(aiBackend, secrets, multiSecrets, cluster)
 
 	require.NoError(t, err)
 
@@ -199,7 +194,6 @@ func TestProcessAIBackend_AzureOpenAI(t *testing.T) {
 }
 
 func TestProcessAIBackend_Gemini(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "gemini-cluster",
 	}
@@ -222,7 +216,7 @@ func TestProcessAIBackend_Gemini(t *testing.T) {
 	secrets := &ir.Secret{}
 	multiSecrets := map[string]*ir.Secret{}
 
-	err := ProcessAIBackend(ctx, aiBackend, secrets, multiSecrets, cluster)
+	err := ProcessAIBackend(aiBackend, secrets, multiSecrets, cluster)
 
 	require.NoError(t, err)
 
@@ -250,7 +244,6 @@ func TestProcessAIBackend_Gemini(t *testing.T) {
 }
 
 func TestProcessAIBackend_VertexAI(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "vertex-ai-cluster",
 	}
@@ -276,7 +269,7 @@ func TestProcessAIBackend_VertexAI(t *testing.T) {
 	secrets := &ir.Secret{}
 	multiSecrets := map[string]*ir.Secret{}
 
-	err := ProcessAIBackend(ctx, aiBackend, secrets, multiSecrets, cluster)
+	err := ProcessAIBackend(aiBackend, secrets, multiSecrets, cluster)
 
 	require.NoError(t, err)
 
@@ -307,7 +300,6 @@ func TestProcessAIBackend_VertexAI(t *testing.T) {
 }
 
 func TestProcessAIBackend_CustomURL(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "custom-host-cluster",
 	}
@@ -342,7 +334,7 @@ func TestProcessAIBackend_CustomURL(t *testing.T) {
 	secrets := &ir.Secret{}
 	multiSecrets := map[string]*ir.Secret{}
 
-	err := ProcessAIBackend(ctx, aiBackend, secrets, multiSecrets, cluster)
+	err := ProcessAIBackend(aiBackend, secrets, multiSecrets, cluster)
 
 	require.NoError(t, err)
 
@@ -362,7 +354,6 @@ func TestProcessAIBackend_CustomURL(t *testing.T) {
 }
 
 func TestProcessAIBackend_MultiPool(t *testing.T) {
-	ctx := context.Background()
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name: "multi-pool-cluster",
 	}
@@ -411,7 +402,7 @@ func TestProcessAIBackend_MultiPool(t *testing.T) {
 	secrets := &ir.Secret{}
 	multiSecrets := map[string]*ir.Secret{}
 
-	err := ProcessAIBackend(ctx, aiBackend, secrets, multiSecrets, cluster)
+	err := ProcessAIBackend(aiBackend, secrets, multiSecrets, cluster)
 
 	require.NoError(t, err)
 

--- a/internal/kgateway/extensions2/plugins/backend/aws.go
+++ b/internal/kgateway/extensions2/plugins/backend/aws.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -81,7 +80,7 @@ func (u *AwsIr) Equals(other any) bool {
 }
 
 // processAws processes an AWS backend and returns an envoy cluster.
-func processAws(ctx context.Context, in *v1alpha1.AwsBackend, ir *AwsIr, out *envoy_config_cluster_v3.Cluster) error {
+func processAws(ir *AwsIr, out *envoy_config_cluster_v3.Cluster) error {
 	// defensive check; this should never happen with union types
 	if ir == nil {
 		return fmt.Errorf("aws ir is nil")

--- a/internal/kgateway/extensions2/plugins/backend/dfp.go
+++ b/internal/kgateway/extensions2/plugins/backend/dfp.go
@@ -1,8 +1,6 @@
 package backend
 
 import (
-	"context"
-
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_dfp_cluster "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/dynamic_forward_proxy/v3"
@@ -17,15 +15,13 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils"
 )
 
-var (
-	dfpFilterConfig = &envoydfp.FilterConfig{
-		ImplementationSpecifier: &envoydfp.FilterConfig_SubClusterConfig{
-			SubClusterConfig: &envoydfp.SubClusterConfig{},
-		},
-	}
-)
+var dfpFilterConfig = &envoydfp.FilterConfig{
+	ImplementationSpecifier: &envoydfp.FilterConfig_SubClusterConfig{
+		SubClusterConfig: &envoydfp.SubClusterConfig{},
+	},
+}
 
-func processDynamicForwardProxy(ctx context.Context, in *v1alpha1.DynamicForwardProxyBackend, out *envoy_config_cluster_v3.Cluster) error {
+func processDynamicForwardProxy(in *v1alpha1.DynamicForwardProxyBackend, out *envoy_config_cluster_v3.Cluster) error {
 	out.LbPolicy = envoy_config_cluster_v3.Cluster_CLUSTER_PROVIDED
 	c := &envoy_dfp_cluster.ClusterConfig{
 		ClusterImplementationSpecifier: &envoy_dfp_cluster.ClusterConfig_SubClustersConfig{

--- a/internal/kgateway/extensions2/plugins/backend/plugin.go
+++ b/internal/kgateway/extensions2/plugins/backend/plugin.go
@@ -268,15 +268,15 @@ func processBackend(ctx context.Context, in ir.BackendObjectIR, out *envoy_confi
 	spec := be.Spec
 	switch spec.Type {
 	case v1alpha1.BackendTypeStatic:
-		if err := processStatic(ctx, spec.Static, out); err != nil {
+		if err := processStatic(spec.Static, out); err != nil {
 			logger.Error("failed to process static backend", "error", err)
 		}
 	case v1alpha1.BackendTypeAWS:
-		if err := processAws(ctx, spec.Aws, ir.AwsIr, out); err != nil {
+		if err := processAws(ir.AwsIr, out); err != nil {
 			logger.Error("failed to process aws backend", "error", err)
 		}
 	case v1alpha1.BackendTypeAI:
-		err := ai.ProcessAIBackend(ctx, spec.AI, ir.AIIr.AISecret, ir.AIIr.AIMultiSecret, out)
+		err := ai.ProcessAIBackend(spec.AI, ir.AIIr.AISecret, ir.AIIr.AIMultiSecret, out)
 		if err != nil {
 			logger.Error("failed to process ai backend", "error", err)
 		}
@@ -285,7 +285,7 @@ func processBackend(ctx context.Context, in ir.BackendObjectIR, out *envoy_confi
 			logger.Error("failed to add upstream cluster http filters", "error", err)
 		}
 	case v1alpha1.BackendTypeDynamicForwardProxy:
-		if err := processDynamicForwardProxy(ctx, spec.DynamicForwardProxy, out); err != nil {
+		if err := processDynamicForwardProxy(spec.DynamicForwardProxy, out); err != nil {
 			logger.Error("failed to process dynamic forward proxy backend", "error", err)
 		}
 	}

--- a/internal/kgateway/extensions2/plugins/backend/static.go
+++ b/internal/kgateway/extensions2/plugins/backend/static.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"context"
 	"fmt"
 	"net/netip"
 
@@ -13,7 +12,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 )
 
-func processStatic(ctx context.Context, in *v1alpha1.StaticBackend, out *envoy_config_cluster_v3.Cluster) error {
+func processStatic(in *v1alpha1.StaticBackend, out *envoy_config_cluster_v3.Cluster) error {
 	var hostname string
 	out.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_STATIC,
@@ -76,13 +75,13 @@ func processStatic(ctx context.Context, in *v1alpha1.StaticBackend, out *envoy_c
 			Type: envoy_config_cluster_v3.Cluster_STRICT_DNS,
 		}
 
-		//do we still need this?
+		// do we still need this?
 		//		// fix issue where ipv6 addr cannot bind
 		//		out.DnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
 	}
 	return nil
 }
 
-func processEndpointsStatic(in *v1alpha1.StaticBackend) *ir.EndpointsForBackend {
+func processEndpointsStatic(_ *v1alpha1.StaticBackend) *ir.EndpointsForBackend {
 	return nil
 }

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -468,7 +468,8 @@ func (h *headerModifierIr) applyToBackend(pCtx *ir.RouteBackendContext) {
 		pCtx.ResponseHeadersToRemove = h.Remove
 	}
 }
-func convertHeaderModifierIR(kctx krt.HandlerContext, f *gwv1.HTTPHeaderFilter, isRequest bool) *headerModifierIr {
+
+func convertHeaderModifierIR(_ krt.HandlerContext, f *gwv1.HTTPHeaderFilter, isRequest bool) *headerModifierIr {
 	if f == nil {
 		return nil
 	}
@@ -724,7 +725,7 @@ func (r *requestRedirectIr) apply(outputRoute *envoy_config_route_v3.Route) {
 	}
 }
 
-func convertRequestRedirectIR(kctx krt.HandlerContext, config *gwv1.HTTPRequestRedirectFilter) *requestRedirectIr {
+func convertRequestRedirectIR(_ krt.HandlerContext, config *gwv1.HTTPRequestRedirectFilter) *requestRedirectIr {
 	if config == nil {
 		return nil
 	}
@@ -784,7 +785,7 @@ func (u *urlRewriteIr) apply(outputRoute *envoy_config_route_v3.Route) {
 	}
 }
 
-func convertURLRewriteIR(kctx krt.HandlerContext, config *gwv1.HTTPURLRewriteFilter) *urlRewriteIr {
+func convertURLRewriteIR(_ krt.HandlerContext, config *gwv1.HTTPURLRewriteFilter) *urlRewriteIr {
 	if config == nil {
 		return nil
 	}
@@ -827,6 +828,7 @@ func (c *corsIr) apply(outputRoute *envoy_config_route_v3.Route) {
 	}
 	outputRoute.GetTypedPerFilterConfig()[envoy_wellknown.CORS] = c.Cors
 }
+
 func (c *corsIr) applyToBackend(pCtx *ir.RouteBackendContext) {
 	if c.Cors == nil {
 		return

--- a/internal/kgateway/krtcollections/endpoints.go
+++ b/internal/kgateway/krtcollections/endpoints.go
@@ -84,10 +84,10 @@ func NewGlooK8sEndpointInputs(
 }
 
 func NewK8sEndpoints(ctx context.Context, inputs EndpointsInputs) krt.Collection[ir.EndpointsForBackend] {
-	return krt.NewCollection(inputs.Backends, transformK8sEndpoints(ctx, inputs), inputs.KrtOpts.ToOptions("K8sEndpoints")...)
+	return krt.NewCollection(inputs.Backends, transformK8sEndpoints(inputs), inputs.KrtOpts.ToOptions("K8sEndpoints")...)
 }
 
-func transformK8sEndpoints(ctx context.Context, inputs EndpointsInputs) func(kctx krt.HandlerContext, backend ir.BackendObjectIR) *ir.EndpointsForBackend {
+func transformK8sEndpoints(inputs EndpointsInputs) func(kctx krt.HandlerContext, backend ir.BackendObjectIR) *ir.EndpointsForBackend {
 	augmentedPods := inputs.Pods
 
 	return func(kctx krt.HandlerContext, backend ir.BackendObjectIR) *ir.EndpointsForBackend {
@@ -285,13 +285,10 @@ func findPortInEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, singlePor
 		}
 		// If the endpoint port is not named, it implies that
 		// the kube service only has a single unnamed port as well.
-		switch {
-		case singlePortService:
-			port = uint32(*p.Port)
-		case p.Name != nil && *p.Name == kubeServicePort.Name:
-			port = uint32(*p.Port)
-			break
+		if singlePortService || (p.Name != nil && *p.Name == kubeServicePort.Name) {
+			return uint32(*p.Port)
 		}
 	}
+
 	return port
 }

--- a/internal/kgateway/krtcollections/endpoints_test.go
+++ b/internal/kgateway/krtcollections/endpoints_test.go
@@ -1116,8 +1116,7 @@ func TestEndpoints(t *testing.T) {
 				Pods:                    pods,
 				EndpointsSettings:       endpointSettings,
 			}
-			ctx := context.Background()
-			builder := transformK8sEndpoints(ctx, ei)
+			builder := transformK8sEndpoints(ei)
 
 			eps := builder(krt.TestingDummyContext{}, tc.upstream)
 			res := tc.result(tc.upstream)

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -364,7 +364,7 @@ func NewGatewayIndex(
 				})
 			}
 
-			allowedNs, err := allowedListenerSet(i, ls, namespaces)
+			allowedNs, err := allowedListenerSet(i, namespaces)
 			if err != nil {
 				out.DeniedListenerSets = append(out.DeniedListenerSets, lsIR)
 				continue
@@ -386,7 +386,7 @@ func NewGatewayIndex(
 	return h
 }
 
-func allowedListenerSet(gw *gwv1.Gateway, listenerSet *gwxv1a1.XListenerSet, namespaces krt.Collection[NamespaceMetadata]) (func(kctx krt.HandlerContext, namespace string) bool, error) {
+func allowedListenerSet(gw *gwv1.Gateway, namespaces krt.Collection[NamespaceMetadata]) (func(kctx krt.HandlerContext, namespace string) bool, error) {
 	// Default to None. Ref: https://gateway-api.sigs.k8s.io/geps/gep-1713/#gateway-listenerset-handshake
 	allowedNs := NoNamespace()
 
@@ -1110,7 +1110,7 @@ func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext g
 		}
 		policy := h.policies.fetchPolicy(kctx, key)
 		if policy == nil {
-			return schema.GroupKind{}, nil, []error{ErrPolicyNotFound}
+			return schema.GroupKind{}, nil, []error{fmt.Errorf("%s: %w", key, ErrPolicyNotFound)}
 		}
 
 		gk := schema.GroupKind{

--- a/internal/kgateway/krtcollections/setup.go
+++ b/internal/kgateway/krtcollections/setup.go
@@ -27,7 +27,7 @@ import (
 
 // registertypes for common collections
 
-func registerTypes(ourCli versioned.Interface) {
+func registerTypes(_ versioned.Interface) {
 	kubeclient.Register[*gwv1.HTTPRoute](
 		gvr.HTTPRoute_v1,
 		gvk.HTTPRoute_v1.Kubernetes(),


### PR DESCRIPTION
# Description
- Bumps Go to 1.24.2
- Fixes port lookup function. `break` was misused.
- Removes unused params

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```
