### PR TITLE
fix: set UpstreamProtocolOptions whenever CommonHttpProtocolOptions are specified

### DIFF
--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
@@ -201,6 +201,14 @@ func processBackend(_ context.Context, polir ir.PolicyIR, _ ir.BackendObjectIR, 
 	if pol.commonHttpProtocolOptions != nil {
 		if err := translatorutils.MutateHttpOptions(out, func(opts *envoy_upstreams_v3.HttpProtocolOptions) {
 			opts.CommonHttpProtocolOptions = pol.commonHttpProtocolOptions
+			if opts.UpstreamProtocolOptions == nil {
+				// Envoy requires UpstreamProtocolOptions if CommonHttpProtocolOptions is set.
+				opts.UpstreamProtocolOptions = &envoy_upstreams_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+					ExplicitHttpConfig: &envoy_upstreams_v3.HttpProtocolOptions_ExplicitHttpConfig{
+						ProtocolConfig: &envoy_upstreams_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+					},
+				}
+			}
 		}); err != nil {
 			logger.Error("failed to apply common http protocol options", "error", err)
 		}

--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
@@ -115,6 +115,11 @@ func TestBackendConfigPolicyFlow(t *testing.T) {
 						CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
 							MaxRequestsPerConnection: &wrapperspb.UInt32Value{Value: 50},
 						},
+						UpstreamProtocolOptions: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+							ExplicitHttpConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+								ProtocolConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+							},
+						},
 					}),
 				},
 			},


### PR DESCRIPTION
Signed-off-by: omar <omar.hammami@solo.io>

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note

```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
