### PR TITLE
ai mock: fix gemini endpoint

### DIFF
--- a/test/mocks/mock-ai-provider-server/main.go
+++ b/test/mocks/mock-ai-provider-server/main.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -190,7 +191,7 @@ func main() {
 	})
 
 	// Gemini endpoints
-	r.POST("/v1beta/models/gemini-1.5-flash-001:action", func(c *gin.Context) {
+	r.POST("/v1beta/models/:modelaction", func(c *gin.Context) {
 		var requestData map[string]interface{}
 		if err := c.BindJSON(&requestData); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -203,10 +204,15 @@ func main() {
 			return
 		}
 
-		action := c.Param("action")
-		if action == ":generateContent" {
+		modelaction := c.Param("modelaction")
+		_, action, ok := strings.Cut(modelaction, ":")
+		if !ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Invalid action"})
+			return
+		}
+		if action == "generateContent" {
 			handleModelResponse(c, requestData, "gemini", false)
-		} else if action == ":streamGenerateContent" {
+		} else if action == "streamGenerateContent" {
 			handleModelResponse(c, requestData, "gemini", true)
 		} else {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Invalid action"})


### PR DESCRIPTION

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Gin will not accept the `:param` in the middle of the path, and gemini has a weird api like `/gemini-1.5:generate`.


# Change Type

/kind cleanup


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
