### PR TITLE
.github/workflows: Simplify job names in unit test workflow

### DIFF
--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -11,10 +11,9 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
-  # Runs the unit tests for `internal/kgateway`
-  kube_gateway_project:
-    # TODO(tim): rename this job or consolidate with the other workflows.
-    name: projects/gateway2
+  # Runs the unit tests for Go packages
+  go:
+    name: Go Unit Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
@@ -38,8 +37,8 @@ jobs:
       # We intentionally ignore the errors while we build out our test coverage, to establish a good baseline
       # However, we should strive to establish a baseline, and then make it required on PRs
       run: make --always-make --ignore-errors validate-test-coverage
-  # Runs the units tests for `python`
-  python_unit_tests:
+  # Runs the units tests for Python
+  python:
     timeout-minutes: 60
     name: Python Unit Tests
     env:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Simplified job IDs in pr-unit-tests.yaml workflow from verbose names to concise language identifiers:

- kube_gateway_project -> go
- python_unit_tests -> python

The display names (Go Unit Tests, Python Unit Tests) remain unchanged. This change removes legacy naming artifacts from the 1.x project organization while keeping the workflow's functionality identical.


# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

Required changes to branch protection rules. Fixes https://github.com/kgateway-dev/kgateway/issues/10603.