### PR TITLE
BackendConfigPolicy : dont apply http1 options to http2 backend

### DIFF
--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
@@ -28,6 +28,7 @@ func TestBackendConfigPolicyFlow(t *testing.T) {
 	tests := []struct {
 		name    string
 		policy  *v1alpha1.BackendConfigPolicy
+		cluster *clusterv3.Cluster
 		want    *clusterv3.Cluster
 		wantErr bool
 	}{
@@ -133,6 +134,43 @@ func TestBackendConfigPolicyFlow(t *testing.T) {
 			want:    &clusterv3.Cluster{},
 			wantErr: false,
 		},
+		{
+			name: "attempt to apply http1 protocol options to http2 backend should not apply",
+			policy: &v1alpha1.BackendConfigPolicy{
+				Spec: v1alpha1.BackendConfigPolicySpec{
+					Http1ProtocolOptions: &v1alpha1.Http1ProtocolOptions{
+						EnableTrailers: ptr.To(true),
+					},
+				},
+			},
+			cluster: &clusterv3.Cluster{
+				TypedExtensionProtocolOptions: map[string]*anypb.Any{
+					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustMessageToAny(t, &envoy_upstreams_http_v3.HttpProtocolOptions{
+						UpstreamProtocolOptions: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+							ExplicitHttpConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+								ProtocolConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+									Http2ProtocolOptions: &corev3.Http2ProtocolOptions{},
+								},
+							},
+						},
+					}),
+				},
+			},
+			want: &clusterv3.Cluster{
+				TypedExtensionProtocolOptions: map[string]*anypb.Any{
+					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustMessageToAny(t, &envoy_upstreams_http_v3.HttpProtocolOptions{
+						UpstreamProtocolOptions: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+							ExplicitHttpConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+								ProtocolConfig: &envoy_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+									Http2ProtocolOptions: &corev3.Http2ProtocolOptions{},
+								},
+							},
+						},
+					}),
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -146,7 +184,10 @@ func TestBackendConfigPolicyFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// Then process the backend with the translated policy
-			cluster := &clusterv3.Cluster{}
+			cluster := tt.cluster
+			if cluster == nil {
+				cluster = &clusterv3.Cluster{}
+			}
 			processBackend(context.Background(), policyIR, ir.BackendObjectIR{}, cluster)
 
 			// Compare the resulting cluster configuration

--- a/test/kubernetes/e2e/features/backendconfigpolicy/suite.go
+++ b/test/kubernetes/e2e/features/backendconfigpolicy/suite.go
@@ -105,12 +105,46 @@ func (s *testingSuite) TestBackendConfigPolicy() {
 		cfg, ok := cluster.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
 		s.Assert().True(ok)
 		s.Assert().NotNil(cfg)
+		httpProtocolOptions := &envoy_upstreams_v3.HttpProtocolOptions{}
+		err = anypb.UnmarshalTo(cfg, httpProtocolOptions, proto.UnmarshalOptions{})
+		s.Assert().NoError(err)
+		s.Assert().Equal(int64(10), httpProtocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
+		s.Assert().Equal(uint32(15), httpProtocolOptions.CommonHttpProtocolOptions.MaxHeadersCount.Value)
+		s.Assert().Equal(int64(30), httpProtocolOptions.CommonHttpProtocolOptions.MaxStreamDuration.Seconds)
+		s.Assert().Equal(uint32(100), httpProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
+
+		// check that a BackendConfigPolicy for HTTP2 backend is applied
+		// when only CommonHttpProtocolOptions is set
+		h2cCluster, ok := clusters["kube_default_httpbin-h2c_8080"]
+		s.Assert().True(ok)
+		s.Assert().NotNil(h2cCluster)
+		cfg, ok = h2cCluster.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+		s.Assert().True(ok)
+		s.Assert().NotNil(cfg)
 		http2ProtocolOptions := &envoy_upstreams_v3.HttpProtocolOptions{}
 		err = anypb.UnmarshalTo(cfg, http2ProtocolOptions, proto.UnmarshalOptions{})
 		s.Assert().NoError(err)
-		s.Assert().Equal(int64(10), http2ProtocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
-		s.Assert().Equal(uint32(15), http2ProtocolOptions.CommonHttpProtocolOptions.MaxHeadersCount.Value)
-		s.Assert().Equal(int64(30), http2ProtocolOptions.CommonHttpProtocolOptions.MaxStreamDuration.Seconds)
-		s.Assert().Equal(uint32(100), http2ProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
+		s.Assert().NotNil(http2ProtocolOptions)
+		s.Assert().Equal(int64(12), http2ProtocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
+		s.Assert().Equal(uint32(17), http2ProtocolOptions.CommonHttpProtocolOptions.MaxHeadersCount.Value)
+		s.Assert().Equal(int64(32), http2ProtocolOptions.CommonHttpProtocolOptions.MaxStreamDuration.Seconds)
+		s.Assert().Equal(uint32(102), http2ProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
+
+		// check that a BackendConfigPolicy for HTTP1 backend is applied
+		// when only CommonHttpProtocolOptions is set
+		http1Cluster, ok := clusters["kube_default_httpbin_8080"]
+		s.Assert().True(ok)
+		s.Assert().NotNil(http1Cluster)
+		cfg, ok = http1Cluster.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+		s.Assert().True(ok)
+		s.Assert().NotNil(cfg)
+		http1ProtocolOptions := &envoy_upstreams_v3.HttpProtocolOptions{}
+		err = anypb.UnmarshalTo(cfg, http1ProtocolOptions, proto.UnmarshalOptions{})
+		s.Assert().NoError(err)
+		s.Assert().NotNil(http1ProtocolOptions)
+		s.Assert().Equal(int64(11), http1ProtocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
+		s.Assert().Equal(uint32(16), http1ProtocolOptions.CommonHttpProtocolOptions.MaxHeadersCount.Value)
+		s.Assert().Equal(int64(31), http1ProtocolOptions.CommonHttpProtocolOptions.MaxStreamDuration.Seconds)
+		s.Assert().Equal(uint32(101), http1ProtocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
 	})
 }

--- a/test/kubernetes/e2e/features/backendconfigpolicy/testdata/setup.yaml
+++ b/test/kubernetes/e2e/features/backendconfigpolicy/testdata/setup.yaml
@@ -104,10 +104,10 @@ spec:
       group: ""
       kind: Service
   commonHttpProtocolOptions:
-    idleTimeout: 10s
-    maxHeadersCount: 15
-    maxStreamDuration: 30s
-    maxRequestsPerConnection: 100
+    idleTimeout: 11s
+    maxHeadersCount: 16
+    maxStreamDuration: 31s
+    maxRequestsPerConnection: 101
     headersWithUnderscoresAction: RejectRequest
 ---
 apiVersion: v1
@@ -137,8 +137,8 @@ spec:
       group: ""
       kind: Service
   commonHttpProtocolOptions:
-    idleTimeout: 10s
-    maxHeadersCount: 15
-    maxStreamDuration: 30s
-    maxRequestsPerConnection: 100
+    idleTimeout: 12s
+    maxHeadersCount: 17
+    maxStreamDuration: 32s
+    maxRequestsPerConnection: 102
     headersWithUnderscoresAction: RejectRequest


### PR DESCRIPTION
# Description

Previously, a user could specify http1 protocol options in a BackendConfigPolicy targeting an http2 backend, which would override the http2 configuration. This PR prevents this footgun.

also, follow up to https://github.com/kgateway-dev/kgateway/pull/11420 by adding additional assertions to the e2e test to ensure config is applied to envoy.

# Change Type
/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
prevent BackendConfigPolicy with http1protocoloptions set from overwriting an http2 backend
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
