### PR TITLE
trafficpolicy: Preserve policy errors during route translation

### DIFF
--- a/internal/kgateway/extensions2/plugins/trafficpolicy/merge_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/merge_test.go
@@ -1,0 +1,38 @@
+package trafficpolicy
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergePoliciesPreservesErrors(t *testing.T) {
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+
+	gk := schema.GroupKind{Group: "test", Kind: "TrafficPolicy"}
+
+	p1 := ir.PolicyAtt{
+		GroupKind: gk,
+		PolicyRef: &ir.AttachedPolicyRef{Name: "p1"},
+		PolicyIr:  &TrafficPolicy{ct: time.Now()},
+		Errors:    []error{err1},
+	}
+	p2 := ir.PolicyAtt{
+		GroupKind: gk,
+		PolicyRef: &ir.AttachedPolicyRef{Name: "p2"},
+		PolicyIr:  &TrafficPolicy{ct: time.Now().Add(time.Minute)},
+		Errors:    []error{err2},
+	}
+
+	merged := mergePolicies([]ir.PolicyAtt{p1, p2})
+	require.Len(t, merged.Errors, 2)
+	assert.Contains(t, merged.Errors, err1)
+	assert.Contains(t, merged.Errors, err2)
+}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/merge_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/merge_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMergePoliciesPreservesErrors(t *testing.T) {

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -574,12 +574,19 @@ func mergePolicies(policies []ir.PolicyAtt) ir.PolicyAtt {
 		return out
 	}
 
+	// collect all errors from the policies being merged
+	var allErrors []error
+	for _, p := range policies {
+		allErrors = append(allErrors, p.Errors...)
+	}
+
 	// base policy to merge into has an empty PolicyIr so it can always be merged into
 	out = ir.PolicyAtt{
 		GroupKind:    policies[0].GroupKind,
 		PolicyRef:    policies[0].PolicyRef,
 		MergeOrigins: map[string]*ir.AttachedPolicyRef{},
 		PolicyIr:     &TrafficPolicy{},
+		Errors:       allErrors,
 	}
 	merged := out.PolicyIr.(*TrafficPolicy)
 

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -574,19 +574,12 @@ func mergePolicies(policies []ir.PolicyAtt) ir.PolicyAtt {
 		return out
 	}
 
-	// collect all errors from the policies being merged
-	var allErrors []error
-	for _, p := range policies {
-		allErrors = append(allErrors, p.Errors...)
-	}
-
 	// base policy to merge into has an empty PolicyIr so it can always be merged into
 	out = ir.PolicyAtt{
 		GroupKind:    policies[0].GroupKind,
 		PolicyRef:    policies[0].PolicyRef,
 		MergeOrigins: map[string]*ir.AttachedPolicyRef{},
 		PolicyIr:     &TrafficPolicy{},
-		Errors:       allErrors,
 	}
 	merged := out.PolicyIr.(*TrafficPolicy)
 
@@ -611,6 +604,7 @@ func mergePolicies(policies []ir.PolicyAtt) ir.PolicyAtt {
 		mergeOrigins := MergeTrafficPolicies(merged, p2, p2Ref, mergeOpts)
 		maps.Copy(out.MergeOrigins, mergeOrigins)
 		out.HierarchicalPriority = policies[i].HierarchicalPriority
+		out.Errors = append(out.Errors, policies[i].Errors...)
 	}
 
 	return out


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Previously, any errors in individual TrafficPolicy IR types were lost during
route translation due to the mergePolicies function not collecting errors from
individual policies. The function would create a new PolicyAtt with an empty
Errors slice, discarding all validation errors from the input policies.

This caused route.go line 310-311 to result in zero errors for attached
policies post-merge, even when individual policies had validation errors.
Invalid TrafficPolicy configurations would appear to be accepted during route
processing when they should have been rejected with appropriate error messages.

This change adds error aggregation to the mergePolicies function by iterating
through each policy and appending their Errors field to a combined slice in
the final merged result. Policy validation errors are now properly surfaced
during route translation and reported back to users.

Fixes issue where invalid TrafficPolicy configurations would appear to be
accepted during route processing when they should have been rejected with
appropriate error messages.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
