### PR TITLE
Remove the github.com/rotisserie/eris library

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - copyloopvar
     - forbidigo
     - ginkgolinter
+    - gomodguard
     - importas
     - ineffassign
     - misspell
@@ -29,11 +30,23 @@ linters:
     - whitespace
   settings:
     forbidigo:
+      analyze-types: true
       forbid:
         - pattern: anypb.New
           msg: use utils.MessageToAny instead
         - pattern: kclient.New$
           msg: use kclient.NewFiltered with discovery namespace ObjectFilter instead
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/rotisserie/eris:
+              recommendations:
+                - errors.Join
+              reason: Use the std-lib errors package with \\%w instead.
+          - github.com/hashicorp/go-multierror:
+              recommendations:
+                - errors.Join
+              reason: Use errors.Join (Go 1.20+) instead.
     importas:
       alias:
         - pkg: k8s.io/api/apps/v1
@@ -78,7 +91,7 @@ linters:
         - time
         - level
         - msg
-        - source     
+        - source
   exclusions:
     generated: lax
     presets:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,7 +30,6 @@ linters:
     - whitespace
   settings:
     forbidigo:
-      analyze-types: true
       forbid:
         - pattern: anypb.New
           msg: use utils.MessageToAny instead

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
-	github.com/rotisserie/eris v0.5.4
 	github.com/solo-io/envoy-gloo/go v0.0.0-20250102165327-33a74fcf9966
 	github.com/solo-io/go-list-licenses v0.1.4
 	github.com/solo-io/go-utils v0.27.3
@@ -66,6 +65,7 @@ require (
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/manuelarte/funcorder v0.2.1 // indirect
 	github.com/mikefarah/yq/v4 v4.45.4 // indirect
+	github.com/rotisserie/eris v0.5.4 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.augendre.info/fatcontext v0.8.0 // indirect
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473 // indirect

--- a/hack/utils/oss_compliance/osa_provided.md
+++ b/hack/utils/oss_compliance/osa_provided.md
@@ -22,7 +22,6 @@ Name|Version|License
 [pkg/errors](https://github.com/pkg/errors)|v0.9.1|BSD 2-clause "Simplified" License
 [prometheus/client_golang](https://github.com/prometheus/client_golang)|v1.22.0|Apache License 2.0
 [prometheus/client_model](https://github.com/prometheus/client_model)|v0.6.2|Apache License 2.0
-[rotisserie/eris](https://github.com/rotisserie/eris)|v0.5.4|MIT License
 [spf13/afero](https://github.com/spf13/afero)|v1.14.0|Apache License 2.0
 [spf13/cobra](https://github.com/spf13/cobra)|v1.9.1|Apache License 2.0
 [stretchr/testify](https://github.com/stretchr/testify)|v1.10.0|MIT License

--- a/internal/kgateway/admin/response_test.go
+++ b/internal/kgateway/admin/response_test.go
@@ -1,9 +1,10 @@
 package admin_test
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rotisserie/eris"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -26,7 +27,7 @@ var _ = Describe("SnapshotResponseData", func() {
 		Entry("errored response can be formatted as json",
 			admin.SnapshotResponseData{
 				Data:  "",
-				Error: eris.New("one error"),
+				Error: errors.New("one error"),
 			},
 			"{\"data\":\"\",\"error\":\"one error\"}"),
 		Entry("CR list can be formatted as json",

--- a/internal/kgateway/admin/xds_snapshot.go
+++ b/internal/kgateway/admin/xds_snapshot.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/rotisserie/eris"
 )
 
 // The xDS Snapshot is intended to return the full in-memory xDS cache that the Control Plane manages
@@ -37,7 +36,7 @@ func getXdsSnapshotDataFromCache(xdsCache cache.SnapshotCache) SnapshotResponseD
 func getXdsSnapshot(xdsCache cache.SnapshotCache, k string) (cache cache.ResourceSnapshot, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = eris.New(fmt.Sprintf("panic occurred while getting xds snapshot: %v", r))
+			err = fmt.Errorf("panic occurred while getting xds snapshot: %v", r)
 		}
 	}()
 	return xdsCache.GetSnapshot(k)

--- a/internal/kgateway/deployer/deployer.go
+++ b/internal/kgateway/deployer/deployer.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"path/filepath"
 	"slices"
 
-	"github.com/rotisserie/eris"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -37,13 +37,12 @@ import (
 )
 
 var (
-	GetGatewayParametersError = eris.New("could not retrieve GatewayParameters")
+	GetGatewayParametersError = errors.New("could not retrieve GatewayParameters")
 	getGatewayParametersError = func(err error, gwpNamespace, gwpName, gwNamespace, gwName, resourceType string) error {
-		wrapped := eris.Wrap(err, GetGatewayParametersError.Error())
-		return eris.Wrapf(wrapped, "(%s.%s) for %s (%s.%s)",
-			gwpNamespace, gwpName, resourceType, gwNamespace, gwName)
+		return fmt.Errorf("(%s.%s) for %s (%s.%s): %w",
+			gwpNamespace, gwpName, resourceType, gwNamespace, gwName, fmt.Errorf("%s: %w", GetGatewayParametersError.Error(), err))
 	}
-	NilDeployerInputsErr = eris.New("nil inputs to NewDeployer")
+	NilDeployerInputsErr = errors.New("nil inputs to NewDeployer")
 )
 
 // A Deployer is responsible for deploying proxies and inference extensions.
@@ -351,7 +350,7 @@ func (d *Deployer) DeployObjs(ctx context.Context, objs []client.Object) error {
 	return nil
 }
 
-// EnsureFinalizer adds the InferencePool finalizer to the given pool if it’s not already present.
+// EnsureFinalizer adds the InferencePool finalizer to the given pool if it's not already present.
 // The deployer requires InferencePools to be finalized to remove cluster-scoped resources.
 // This can be removed if the endpoint picker no longer requires cluster-scoped resources.
 // See: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/224 for details.

--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -2,9 +2,10 @@ package deployer
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 
-	"github.com/rotisserie/eris"
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	corev1 "k8s.io/api/core/v1"
@@ -157,10 +158,10 @@ func (k *kGatewayParameters) getGatewayParametersForGateway(ctx context.Context,
 
 	gwpName := gw.Spec.Infrastructure.ParametersRef.Name
 	if group := gw.Spec.Infrastructure.ParametersRef.Group; group != v1alpha1.GroupName {
-		return nil, eris.Errorf("invalid group %s for GatewayParameters", group)
+		return nil, fmt.Errorf("invalid group %s for GatewayParameters", group)
 	}
 	if kind := gw.Spec.Infrastructure.ParametersRef.Kind; kind != api.Kind(wellknown.GatewayParametersGVK.Kind) {
-		return nil, eris.Errorf("invalid kind %s for GatewayParameters", kind)
+		return nil, fmt.Errorf("invalid kind %s for GatewayParameters", kind)
 	}
 
 	// the GatewayParameters must live in the same namespace as the Gateway
@@ -203,7 +204,7 @@ func (k *kGatewayParameters) getGatewayParametersForGatewayClass(ctx context.Con
 
 	gwpName := paramRef.Name
 	if gwpName == "" {
-		err := eris.New("parametersRef.name cannot be empty when parametersRef is specified")
+		err := errors.New("parametersRef.name cannot be empty when parametersRef is specified")
 		logger.Error(err,
 			"gatewayClassName", gwc.GetName(),
 			"gatewayClassNamespace", gwc.GetNamespace(),
@@ -360,16 +361,16 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 
 func getGatewayClassFromGateway(ctx context.Context, cli client.Client, gw *api.Gateway) (*api.GatewayClass, error) {
 	if gw == nil {
-		return nil, eris.New("nil Gateway")
+		return nil, errors.New("nil Gateway")
 	}
 	if gw.Spec.GatewayClassName == "" {
-		return nil, eris.New("GatewayClassName must not be empty")
+		return nil, errors.New("GatewayClassName must not be empty")
 	}
 
 	gwc := &api.GatewayClass{}
 	err := cli.Get(ctx, client.ObjectKey{Name: string(gw.Spec.GatewayClassName)}, gwc)
 	if err != nil {
-		return nil, eris.Errorf("failed to get GatewayClass for Gateway %s/%s", gw.GetName(), gw.GetNamespace())
+		return nil, fmt.Errorf("failed to get GatewayClass for Gateway %s/%s: %w", gw.GetName(), gw.GetNamespace(), err)
 	}
 
 	return gwc, nil

--- a/internal/kgateway/deployer/values_helpers.go
+++ b/internal/kgateway/deployer/values_helpers.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/rotisserie/eris"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -22,7 +21,7 @@ import (
 // by the deployer.
 
 var ComponentLogLevelEmptyError = func(key string, value string) error {
-	return eris.Errorf("an empty key or value was provided in componentLogLevels: key=%s, value=%s", key, value)
+	return fmt.Errorf("an empty key or value was provided in componentLogLevels: key=%s, value=%s", key, value)
 }
 
 // Extract the listener ports from a Gateway and corresponding listener sets. These will be used to populate:

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
@@ -3,13 +3,13 @@ package ai
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"maps"
 	"os"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
-	"github.com/rotisserie/eris"
 	envoytransformation "github.com/solo-io/envoy-gloo/go/config/filter/http/transformation/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -119,7 +119,7 @@ func PreprocessAIBackend(ctx context.Context, aiBackend *v1alpha1.AIBackend, ir 
 	}
 
 	if len(byType) != 1 {
-		return eris.Errorf("multiple AI backend types found for single ai route %+v", byType)
+		return fmt.Errorf("multiple AI backend types found for single ai route %+v", byType)
 	}
 
 	// This is only len(1)

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_model_cluster.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_model_cluster.go
@@ -9,7 +9,6 @@ import (
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/rotisserie/eris"
 	envoytransformation "github.com/solo-io/envoy-gloo/go/config/filter/http/transformation/v2"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -125,7 +124,7 @@ func buildModelCluster(aiUs *v1alpha1.AIBackend, aiSecret *ir.Secret, multiSecre
 			})
 		}
 		if len(epByType) > 1 {
-			return eris.Errorf("multi backend pools must all be of the same type, got %v", epByType)
+			return fmt.Errorf("multi backend pools must all be of the same type, got %v", epByType)
 		}
 	} else if aiUs.LLM != nil {
 		prioritized, err = buildLLMEndpoint(aiUs, aiSecret)

--- a/internal/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
+++ b/internal/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
@@ -1,11 +1,11 @@
 package waypointquery
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/rotisserie/eris"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,7 +29,7 @@ import (
 
 // ErrUnsupportedServiceType should never occur due to unexpected input.
 // If we see this, there is a bug and we're converting a non-Service type into Service.
-var ErrUnsupportedServiceType = eris.New("unsupported service type")
+var ErrUnsupportedServiceType = errors.New("unsupported service type")
 
 // Service is a common type to use between Service and ServiceEntry
 type Service struct {
@@ -165,7 +165,7 @@ func (s Service) Provider() provider.ID {
 // ClusterIP, or ServiceEntry that don't have addresses in Spec or Status.
 // We also validate the format of these addresses are either IPs or CIDR ranges,
 // but those cases should already get rejected by Kubernetes or Istio validation.
-var ErrNoServiceVIPs = eris.New("service has no valid VIPs")
+var ErrNoServiceVIPs = errors.New("service has no valid VIPs")
 
 func (svc *Service) CidrRanges() ([]*v3.CidrRange, error) {
 	// TODO support headless by passing dest hostname on TLVs and

--- a/internal/kgateway/translator/httproute/delegation.go
+++ b/internal/kgateway/translator/httproute/delegation.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/rotisserie/eris"
-
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/query"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
@@ -40,7 +38,7 @@ func flattenDelegatedRoutes(
 ) error {
 	parentRoute, ok := parentInfo.Object.(*ir.HttpRouteIR)
 	if !ok {
-		return eris.Errorf("unsupported route type: %T", parentInfo.Object)
+		return fmt.Errorf("unsupported route type: %T", parentInfo.Object)
 	}
 	parentRef := types.NamespacedName{Namespace: parentRoute.Namespace, Name: parentRoute.Name}
 	routesVisited.Insert(parentRef)
@@ -49,7 +47,7 @@ func flattenDelegatedRoutes(
 	rawChildren, err := parentInfo.GetChildrenForRef(*backend.Delegate)
 	if len(rawChildren) == 0 || err != nil {
 		if err == nil {
-			err = eris.Errorf("unresolved reference %s", backend.Delegate.ResourceName())
+			err = fmt.Errorf("unresolved reference %s", backend.Delegate.ResourceName())
 		}
 		return err
 	}

--- a/internal/kgateway/translator/listener/gateway_listener_translator.go
+++ b/internal/kgateway/translator/listener/gateway_listener_translator.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/rotisserie/eris"
 	"istio.io/istio/pkg/kube/krt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -108,7 +107,7 @@ func (ml *MergedListeners) AppendListener(
 	case gwv1.TLSProtocolType:
 		ml.AppendTlsListener(listener, routes, reporter)
 	default:
-		return eris.Errorf("unsupported protocol: %v", listener.Protocol)
+		return fmt.Errorf("unsupported protocol: %v", listener.Protocol)
 	}
 
 	return nil

--- a/internal/kgateway/translator/sslutils/ssl_utils.go
+++ b/internal/kgateway/translator/sslutils/ssl_utils.go
@@ -2,9 +2,9 @@ package sslutils
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 
-	"github.com/rotisserie/eris"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/cert"
 )
@@ -14,7 +14,7 @@ var (
 		return fmt.Errorf("%v.%v is not a valid TLS secret: %w", ns, n, err)
 	}
 
-	NoCertificateFoundError = eris.New("no certificate information found")
+	NoCertificateFoundError = errors.New("no certificate information found")
 )
 
 // ValidateTlsSecret and return a cleaned cert

--- a/pkg/envoyinit/run.go
+++ b/pkg/envoyinit/run.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -13,7 +14,6 @@ import (
 	envoy_config_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"github.com/rotisserie/eris"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/envoyinit/pkg/downward"
 	"github.com/kgateway-dev/kgateway/v2/internal/envoyinit/pkg/utils"
@@ -53,7 +53,7 @@ func RunEnvoyValidate(ctx context.Context, envoyExecutable, bootstrapConfig stri
 			slog.Warn("unable to validate envoy configuration", "executable", envoyExecutable)
 			return nil
 		}
-		return eris.Errorf("envoy validation mode output: %v, error: %v", err.OutputString(), err.Error())
+		return fmt.Errorf("envoy validation mode output: %v, error: %w", err.OutputString(), err)
 	}
 
 	return nil

--- a/pkg/utils/controllerutils/admincli/client.go
+++ b/pkg/utils/controllerutils/admincli/client.go
@@ -3,9 +3,9 @@ package admincli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
-	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/threadsafe"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
@@ -116,9 +116,8 @@ func (c *Client) GetInputSnapshot(ctx context.Context) ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	if output.Error != "" {
-		return nil, eris.New(output.Error)
+		return nil, errors.New(output.Error)
 	}
 	return output.Data, nil
 }

--- a/pkg/utils/envoyutils/bootstrap/bootstrap.go
+++ b/pkg/utils/envoyutils/bootstrap/bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	envoy_config_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -13,7 +14,6 @@ import (
 	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/rotisserie/eris"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -25,7 +25,7 @@ var (
 	// errNoHcm represents a situation where a filter chain does not have an HttpConnectionManager.
 	// Because this could occur for valid reasons, such as a TCP proxy, we use
 	// this as a sentinel error to inform us it's ok to ignore it and continue.
-	errNoHcm = eris.New("no HttpConnectionManager found")
+	errNoHcm = errors.New("no HttpConnectionManager found")
 )
 
 func FromEnvoyResources(resources *EnvoyResources) (string, error) {
@@ -283,7 +283,7 @@ func getHcmForFilterChain(fc *envoy_config_listener_v3.FilterChain) (
 			if hcm, ok := hcmAny.(*envoy_extensions_filters_network_http_connection_manager_v3.HttpConnectionManager); ok {
 				return hcm, f, nil
 			} else {
-				return nil, nil, eris.Errorf("filter %v has hcm type url but casting to concrete failed", f.GetName())
+				return nil, nil, fmt.Errorf("filter %v has hcm type url but casting to concrete failed", f.GetName())
 			}
 		}
 	}

--- a/pkg/utils/envoyutils/validation/validation.go
+++ b/pkg/utils/envoyutils/validation/validation.go
@@ -2,10 +2,10 @@ package validation
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/rotisserie/eris"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/xds"
 	"github.com/kgateway-dev/kgateway/v2/pkg/envoyinit"
@@ -46,7 +46,7 @@ func ValidateSnapshot(
 
 	bootstrapJson, err := bootstrap.FromSnapshot(ctx, snap)
 	if err != nil {
-		err = eris.Wrap(err, "error converting xDS snapshot to static bootstrap")
+		err = fmt.Errorf("error converting xDS snapshot to static bootstrap: %w", err)
 		slog.Error("error converting xDS snapshot to static bootstrap", "error", err)
 		return err
 	}

--- a/pkg/utils/errutils/concurrent_test.go
+++ b/pkg/utils/errutils/concurrent_test.go
@@ -1,21 +1,19 @@
 package errutils
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rotisserie/eris"
 )
 
 var _ = Describe("Concurrent", func() {
-
 	Context("AggregateConcurrent", func() {
-
 		It("returns the aggregate error", func() {
 			badFns := []func() error{
-				errorFn(eris.Errorf("Erroring function. ID=%d", 1)),
-				errorFn(eris.Errorf("Erroring function. ID=%d", 2)),
+				errorFn(fmt.Errorf("Erroring function. ID=%d", 1)),
+				errorFn(fmt.Errorf("Erroring function. ID=%d", 2)),
 			}
 
 			aggregateErr := AggregateConcurrent(badFns)
@@ -36,7 +34,7 @@ var _ = Describe("Concurrent", func() {
 				goodFn(&sum),
 			}
 			badFns := []func() error{
-				errorFn(eris.Errorf("Erroring function. ID=%d", 1)),
+				errorFn(fmt.Errorf("Erroring function. ID=%d", 1)),
 			}
 
 			aggregateErr := AggregateConcurrent(append(badFns, goodFns...))

--- a/pkg/utils/kubeutils/portforward/api_forwarder.go
+++ b/pkg/utils/kubeutils/portforward/api_forwarder.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/avast/retry-go/v4"
 
-	"github.com/rotisserie/eris"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
@@ -171,9 +170,8 @@ func (f *apiPortForwarder) getPodName(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
-
 		if len(pods) == 0 {
-			return "", eris.Errorf("No pods found for deployment %s: %s", f.properties.resourceNamespace, f.properties.resourceName)
+			return "", fmt.Errorf("No pods found for deployment %s: %s", f.properties.resourceNamespace, f.properties.resourceName)
 		}
 		return pods[0], nil
 
@@ -184,9 +182,8 @@ func (f *apiPortForwarder) getPodName(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
-
 		if len(pods) == 0 {
-			return "", eris.Errorf("No pods found for service %s: %s", f.properties.resourceNamespace, f.properties.resourceName)
+			return "", fmt.Errorf("No pods found for service %s: %s", f.properties.resourceNamespace, f.properties.resourceName)
 		}
 		return pods[0], nil
 
@@ -194,7 +191,7 @@ func (f *apiPortForwarder) getPodName(ctx context.Context) (string, error) {
 		return f.properties.resourceName, nil
 	}
 
-	return "", eris.Errorf("Could not determine pod name for resourceType: %s", f.properties.resourceType)
+	return "", fmt.Errorf("Could not determine pod name for resourceType: %s", f.properties.resourceType)
 }
 
 // Fetch ClientConfig. If kubeConfigPath is not specified, retrieve the kubeconfig from environment in which this is invoked.

--- a/pkg/utils/kubeutils/portforward/cli_portforwarder.go
+++ b/pkg/utils/kubeutils/portforward/cli_portforwarder.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	errors "github.com/rotisserie/eris"
-
 	"github.com/avast/retry-go/v4"
 )
 
@@ -101,7 +99,7 @@ func (c *cliPortForwarder) startOnce(ctx context.Context) error {
 	// If we get here, we didn't get any stdout, so grab stderr and return it as error
 	stdErr := bufio.NewScanner(fwdErr)
 	stdErr.Scan()
-	return errors.Errorf("failed to start port-forward: %s", stdErr.Text())
+	return fmt.Errorf("failed to start port-forward: %s", stdErr.Text())
 }
 
 func (c *cliPortForwarder) Address() string {
@@ -133,7 +131,7 @@ func getFreePort() (int, error) {
 	defer l.Close()
 	tcpAddr, ok := l.Addr().(*net.TCPAddr)
 	if !ok {
-		return 0, errors.Errorf("Error occurred looking for an open tcp port")
+		return 0, fmt.Errorf("Error occurred looking for an open tcp port")
 	}
 	return tcpAddr.Port, nil
 }

--- a/pkg/utils/protoutils/utils.go
+++ b/pkg/utils/protoutils/utils.go
@@ -1,10 +1,10 @@
 package protoutils
 
 import (
+	"errors"
 	"io"
 
 	"github.com/ghodss/yaml"
-	"github.com/rotisserie/eris"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	structpb "google.golang.org/protobuf/types/known/structpb"
@@ -16,7 +16,7 @@ var (
 	jsonpbMarshalerIndented       = &protojson.MarshalOptions{UseProtoNames: false, Indent: "  "}
 	jsonpbUnmarshalerAllowUnknown = &protojson.UnmarshalOptions{DiscardUnknown: true}
 
-	NilStructError = eris.New("cannot unmarshal nil struct")
+	NilStructError = errors.New("cannot unmarshal nil struct")
 )
 
 // this function is designed for converting go object (that is not a proto.Message) into a

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rotisserie/eris"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
@@ -155,16 +154,16 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 		Eventually(func() (string, error) {
 			res, err := http.Get(url)
 			if err != nil {
-				return "", eris.Wrapf(err, "unable to call GET")
+				return "", fmt.Errorf("unable to call GET: %w", err)
 			}
 			if res.StatusCode != http.StatusOK {
-				return "", eris.New(fmt.Sprintf("%v is not OK", res.StatusCode))
+				return "", fmt.Errorf("%v is not OK", res.StatusCode)
 			}
 
 			defer res.Body.Close()
 			body, err := io.ReadAll(res.Body)
 			if err != nil {
-				return "", eris.Wrapf(err, "unable to read body")
+				return "", fmt.Errorf("unable to read body: %w", err)
 			}
 
 			return string(body), nil

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -17,8 +17,6 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/test/services/envoy"
 
-	errors "github.com/rotisserie/eris"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -556,7 +554,7 @@ var _ = Describe("AWS Lambda", func() {
 			}
 			if res.StatusCode != http.StatusOK {
 				res.Body.Close()
-				return errors.New(fmt.Sprintf("%v is not OK", res.StatusCode))
+				return fmt.Errorf("%v is not OK", res.StatusCode)
 			}
 
 			defer res.Body.Close()

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/test/services/envoy"
 
-	"github.com/rotisserie/eris"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -876,20 +875,20 @@ var _ = Describe("Gateway", func() {
 					// There should only be a single listener on the proxy and it should be a HybridListener
 					hybridListener := proxy.GetListeners()[0].GetHybridListener()
 					if hybridListener == nil {
-						return nil, eris.New("HybridListener is not present on Proxy")
+						return nil, errors.New("HybridListener is not present on Proxy")
 					}
 
 					matchedListeners := hybridListener.GetMatchedListeners()
 					if len(matchedListeners) != 2 {
-						return nil, eris.New("HybridListener should have 2 matched listeners")
+						return nil, errors.New("HybridListener should have 2 matched listeners")
 					}
 
 					if len(matchedListeners[0].GetHttpListener().GetVirtualHosts()) != 1 {
-						return nil, eris.New("HybridListener should have HttpListener with 1 Virtual host")
+						return nil, errors.New("HybridListener should have HttpListener with 1 Virtual host")
 					}
 
 					if matchedListeners[1].GetTcpListener() == nil {
-						return nil, eris.New("HybridListener should have non-nil TcpListener")
+						return nil, errors.New("HybridListener should have non-nil TcpListener")
 					}
 
 					// if all conditions are met, return the proxy

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	errors "github.com/rotisserie/eris"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
@@ -228,7 +227,7 @@ var _ = Describe("Happy path", func() {
 					return err
 				}
 				if res.StatusCode != http.StatusOK {
-					return errors.Errorf("bad status code: %v", res.StatusCode)
+					return fmt.Errorf("bad status code: %v", res.StatusCode)
 				}
 				return nil
 			}, time.Second*10, time.Second/2).ShouldNot(HaveOccurred())
@@ -243,7 +242,7 @@ var _ = Describe("Happy path", func() {
 					return err
 				}
 				if res.StatusCode != http.StatusServiceUnavailable {
-					return errors.Errorf("bad status code: %v", res.StatusCode)
+					return fmt.Errorf("bad status code: %v", res.StatusCode)
 				}
 				return nil
 			}, time.Second*10, time.Second/2).ShouldNot(HaveOccurred())

--- a/test/ginkgo/parallel/ports.go
+++ b/test/ginkgo/parallel/ports.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rotisserie/eris"
-
 	"github.com/avast/retry-go"
 
 	"github.com/onsi/ginkgo/v2"
@@ -94,7 +92,7 @@ func portInUseListen(proposedPort uint32) error {
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", proposedPort))
 
 	if err != nil {
-		return eris.Wrapf(err, "port %d is in use", proposedPort)
+		return fmt.Errorf("port %d is in use: %w", proposedPort, err)
 	}
 
 	// Port should available if the listener closes without an error
@@ -109,7 +107,7 @@ var denyListPorts = map[uint32]struct{}{
 
 func portInDenyList(proposedPort uint32) error {
 	if _, ok := denyListPorts[proposedPort]; ok {
-		return eris.Errorf("port %d is in deny list", proposedPort)
+		return fmt.Errorf("port %d is in deny list", proposedPort)
 	}
 	return nil
 }

--- a/test/ginkgo/parallel/ports_test.go
+++ b/test/ginkgo/parallel/ports_test.go
@@ -3,12 +3,12 @@
 package parallel_test
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/avast/retry-go"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rotisserie/eris"
 
 	"github.com/kgateway-dev/kgateway/v2/test/ginkgo/parallel"
 )
@@ -25,7 +25,7 @@ var _ = Describe("Ports", func() {
 			}
 
 			if _, ok := denyList[proposedPort]; ok {
-				return eris.Errorf("port %d is in use", proposedPort)
+				return fmt.Errorf("port %d is in use", proposedPort)
 			}
 			return nil
 		}
@@ -45,7 +45,7 @@ var _ = Describe("Ports", func() {
 			startingPort := uint32(10010)
 			selectedPort, err := parallel.AdvancePortSafe(&startingPort, func(proposedPort uint32) error {
 				// We always error here, to ensure that we continue to retry advancing the port
-				return eris.Errorf("Port invalid: %d", proposedPort)
+				return fmt.Errorf("Port invalid: %d", proposedPort)
 			}, retry.Delay(0))
 			Expect(err).To(HaveOccurred())
 			Expect(selectedPort).To(Equal(uint32(11015)), "should have exhausted 5 retries")

--- a/test/gomega/matchers/have_kubegateway_status.go
+++ b/test/gomega/matchers/have_kubegateway_status.go
@@ -1,12 +1,12 @@
 package matchers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
-	"github.com/rotisserie/eris"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -55,13 +55,13 @@ func (m *HaveKubeGatewayRouteStatusMatcher) Match(actual interface{}) (success b
 		// For example, the underlying http body matcher caches the response body, so if you are wrapping this
 		// matcher in an Eventually, you need to create a new matcher each iteration.
 		// This error is intended to help prevent developers hitting this edge case
-		return false, eris.New("using the same matcher twice can lead to inconsistent behaviors")
+		return false, errors.New("using the same matcher twice can lead to inconsistent behaviors")
 	}
 	m.evaluated = true
 
 	val, ok := actual.(gwv1.RouteStatus)
 	if !ok {
-		return false, eris.Errorf("matcher expected gwv1.RouteStatus, got %T", actual)
+		return false, fmt.Errorf("matcher expected gwv1.RouteStatus, got %T", actual)
 	}
 
 	if ok, err := m.statusMatcher.Match(val); !ok {

--- a/test/gomega/transforms/metrics.go
+++ b/test/gomega/transforms/metrics.go
@@ -3,7 +3,8 @@
 package transforms
 
 import (
-	errors "github.com/rotisserie/eris"
+	"fmt"
+
 	"go.opencensus.io/stats/view"
 )
 
@@ -17,7 +18,7 @@ func WithLastValueTransform() func(rows []*view.Row) (int, error) {
 		}
 
 		if len(rows) > 1 {
-			return 0, errors.Errorf("expected 1 row, found %d", len(rows))
+			return 0, fmt.Errorf("expected 1 row, found %d", len(rows))
 		}
 
 		return int(rows[0].Data.(*view.LastValueData).Value), nil
@@ -35,7 +36,7 @@ func WithSumValueTransform() func(rows []*view.Row) (int, error) {
 		}
 
 		if len(rows) > 1 {
-			return 0, errors.Errorf("expected 1 row, found %d", len(rows))
+			return 0, fmt.Errorf("expected 1 row, found %d", len(rows))
 		}
 
 		return int(rows[0].Data.(*view.SumData).Value), nil

--- a/test/helpers/metrics.go
+++ b/test/helpers/metrics.go
@@ -3,7 +3,8 @@
 package helpers
 
 import (
-	errors "github.com/rotisserie/eris"
+	"fmt"
+
 	"go.opencensus.io/stats/view"
 )
 
@@ -17,7 +18,7 @@ import (
 func ReadMetricByLabel(metricName string, labelKey string, labelValue string) (int, error) {
 	rows, err := view.RetrieveData(metricName)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to retrieve data for %s", metricName)
+		return 0, fmt.Errorf("failed to retrieve data for %s: %w", metricName, err)
 	}
 	for _, row := range rows {
 		for _, tag := range row.Tags {
@@ -26,5 +27,5 @@ func ReadMetricByLabel(metricName string, labelKey string, labelValue string) (i
 			}
 		}
 	}
-	return 0, errors.Errorf("%s does not have any time series with label (key=%s,value=%s)", metricName, labelKey, labelValue)
+	return 0, fmt.Errorf("%s does not have any time series with label (key=%s,value=%s)", metricName, labelKey, labelValue)
 }

--- a/test/helpers/resources.go
+++ b/test/helpers/resources.go
@@ -3,6 +3,7 @@
 package helpers
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/onsi/gomega/types"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
-	errors "github.com/rotisserie/eris"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	skerrors "github.com/solo-io/solo-kit/pkg/errors"
@@ -91,7 +91,7 @@ func EventuallyResourceStatusMatchesWithOffset(offset int, getter InputResourceG
 func getResourceStatus(getter InputResourceGetter) (core.Status, error) {
 	resource, err := getter()
 	if err != nil {
-		return core.Status{}, errors.Wrapf(err, "failed to get resource")
+		return core.Status{}, fmt.Errorf("failed to get resource: %w", err)
 	}
 
 	statusClient := statusutils.GetStatusClientFromEnvOrDefault(defaults.GlooSystem)
@@ -101,7 +101,7 @@ func getResourceStatus(getter InputResourceGetter) (core.Status, error) {
 	// As a result, a nil check isn't enough to determine that that status hasn't been reported
 	// Note: RateLimitConfig statuses can have an empty reporter
 	if status == nil {
-		return core.Status{}, errors.Wrapf(err, "waiting for %v status to be non-empty", resource.GetMetadata().GetName())
+		return core.Status{}, fmt.Errorf("waiting for %v status to be non-empty: %w", resource.GetMetadata().GetName(), err)
 	}
 
 	return *status, nil

--- a/test/kubernetes/e2e/features/helm/suite.go
+++ b/test/kubernetes/e2e/features/helm/suite.go
@@ -6,13 +6,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"slices"
 	"time"
 
-	"github.com/rotisserie/eris"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -93,7 +93,7 @@ func (s *testingSuite) TestApplyCRDs() {
 		// Parse the file, and extract the CRD- will fail for any non-yaml files or files not containing a CRD
 		crd, err := schemagen.GetCRDFromFile(crdFile)
 		if err != nil {
-			return eris.Wrap(err, "error getting CRD from "+crdFile)
+			return fmt.Errorf("error getting CRD from %s: %w", crdFile, err)
 		}
 		crdsByFileName[crdFile] = crd
 

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -9,8 +9,6 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 
-	// errors "github.com/rotisserie/eris"
-	// "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"

--- a/test/kubernetes/testutils/helper/install.go
+++ b/test/kubernetes/testutils/helper/install.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/log"
 	"helm.sh/helm/v3/pkg/repo"
 
@@ -46,9 +45,9 @@ func getChartVersion(testAssetDir string, chartName string) (string, error) {
 
 	// Read and return version from helm index file
 	if chartVersions, ok := helmIndex.Entries[chartName]; !ok {
-		return "", eris.Errorf("index file does not contain entry with key: %s", chartName)
+		return "", fmt.Errorf("index file does not contain entry with key: %s", chartName)
 	} else if len(chartVersions) == 0 || len(chartVersions) > 1 {
-		return "", eris.Errorf("expected a single entry with name [%s], found: %v", chartName, len(chartVersions))
+		return "", fmt.Errorf("expected a single entry with name [%s], found: %v", chartName, len(chartVersions))
 	} else {
 		version := chartVersions[0].Version
 		log.Printf("version of [%s] Helm chart is: %s", chartName, version)

--- a/test/kubernetes/testutils/install/context.go
+++ b/test/kubernetes/testutils/install/context.go
@@ -1,8 +1,6 @@
 package install
 
-import (
-	"github.com/rotisserie/eris"
-)
+import "fmt"
 
 // Context contains the set of properties for a given installation of kgateway
 type Context struct {
@@ -25,18 +23,18 @@ func ValidateInstallContext(context *Context) error {
 
 func validateValuesManifest(name string, file string) error {
 	if file == "" {
-		return eris.Errorf("%s must be provided in install.Context", name)
+		return fmt.Errorf("%s must be provided in install.Context", name)
 	}
 
 	/*
 		// TODO consider adding back helm value validation https://github.com/kgateway-dev/kgateway/issues/10483#issuecomment-2651621134
 		values, err := testutils.BuildHelmValues(testutils.HelmValues{ValuesFile: file})
 		if err != nil {
-			return eris.Wrapf(err, "failed to build helm values for %s", name)
+			return fmt.Errorf("failed to build helm values for %s: %w", name, err)
 		}
 		err = testutils.ValidateHelmValues(values)
 		if err != nil {
-			return eris.Wrapf(err, "failed to validate helm values for %s", name)
+			return fmt.Errorf("failed to validate helm values for %s: %w", name, err)
 		}
 	*/
 	return nil

--- a/test/kubernetes/testutils/resources/generate_resources.go
+++ b/test/kubernetes/testutils/resources/generate_resources.go
@@ -6,10 +6,10 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 
-	errors "github.com/rotisserie/eris"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -35,7 +35,7 @@ func WriteResourcesToFile(resources []client.Object, fileName string) error {
 	for _, resource := range resources {
 		yamlData, err := objectToYaml(resource)
 		if err != nil {
-			return errors.Wrap(err, "can marshal resources to YAML")
+			return fmt.Errorf("can marshal resources to YAML: %w", err)
 		}
 
 		outputResourceManifest.Write(yamlData)
@@ -47,13 +47,13 @@ func WriteResourcesToFile(resources []client.Object, fileName string) error {
 	// Write YAML data to file
 	manifestFile, err := os.Create(fileName)
 	if err != nil {
-		return errors.Wrap(err, "can create generated file")
+		return fmt.Errorf("can create generated file: %w", err)
 	}
 	defer manifestFile.Close()
 
 	_, err = manifestFile.Write(outputResourceManifest.Bytes())
 	if err != nil {
-		return errors.Wrap(err, "can write resources to file")
+		return fmt.Errorf("can write resources to file: %w", err)
 	}
 	return nil
 }
@@ -61,12 +61,12 @@ func WriteResourcesToFile(resources []client.Object, fileName string) error {
 func objectToYaml(obj client.Object) ([]byte, error) {
 	jsonBytes, err := json.Marshal(obj)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal resource to JSON")
+		return nil, fmt.Errorf("failed to marshal resource to JSON: %w", err)
 	}
 
 	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert resource JSON to YAML")
+		return nil, fmt.Errorf("failed to convert resource JSON to YAML: %w", err)
 	}
 
 	return cleanUp(yamlBytes), nil

--- a/test/services/envoy/factory.go
+++ b/test/services/envoy/factory.go
@@ -4,6 +4,7 @@ package envoy
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -20,7 +21,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/gloo/pkg/defaults"
 
 	"github.com/onsi/ginkgo/v2"
-	errors "github.com/rotisserie/eris"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
 	"github.com/kgateway-dev/kgateway/v2/test/services/utils"
@@ -112,7 +112,7 @@ func mustGetEnvoyGlooTag() string {
 	makefile := filepath.Join(fsutils.GetModuleRoot(), "Makefile")
 	inFile, err := os.Open(makefile)
 	if err != nil {
-		ginkgo.Fail(errors.Wrapf(err, "failed to open Makefile").Error())
+		ginkgo.Fail(fmt.Errorf("failed to open Makefile: %w", err).Error())
 	}
 
 	defer inFile.Close()
@@ -143,7 +143,7 @@ func mustGetEnvoyWrapperTag() string {
 
 	latestPatchVersion, err := version.GetLastReleaseOfCurrentBranch()
 	if err != nil {
-		ginkgo.Fail(errors.Wrap(err, "Failed to extract the latest release of current minor").Error())
+		ginkgo.Fail(fmt.Errorf("Failed to extract the latest release of current minor: %w", err).Error())
 	}
 
 	return strings.TrimPrefix(latestPatchVersion.String(), "v")
@@ -178,7 +178,7 @@ func (f *factoryImpl) Clean() {
 func (f *factoryImpl) NewInstance() *Instance {
 	instance, err := f.newInstanceOrError()
 	if err != nil {
-		ginkgo.Fail(errors.Wrap(err, "failed to create envoy instance").Error())
+		ginkgo.Fail(fmt.Errorf("failed to create envoy instance: %w", err).Error())
 	}
 	return instance
 }

--- a/test/services/envoy/instance.go
+++ b/test/services/envoy/instance.go
@@ -24,8 +24,6 @@ import (
 	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 
 	"github.com/onsi/ginkgo/v2"
-
-	errors "github.com/rotisserie/eris"
 )
 
 const (
@@ -264,7 +262,7 @@ func (ei *Instance) runContainer(ctx context.Context) error {
 	cmd.Stdout = ginkgo.GinkgoWriter
 	cmd.Stderr = ginkgo.GinkgoWriter
 	if err := cmd.Start(); err != nil {
-		return errors.Wrap(err, "Unable to start envoy container")
+		return fmt.Errorf("Unable to start envoy container: %w", err)
 	}
 
 	// cmd.Run() is entering an infinite loop here (not sure why).
@@ -283,7 +281,7 @@ func (ei *Instance) waitForEnvoyToBeRunning() error {
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Errorf("timed out waiting for envoy on %s", pingEndpoint)
+			return fmt.Errorf("timed out waiting for envoy on %s", pingEndpoint)
 
 		case <-pingInterval:
 			conn, _ := net.Dial("tcp", pingEndpoint)
@@ -302,7 +300,7 @@ func (ei *Instance) Logs() (string, error) {
 		cmd := exec.Command("docker", logsArgs...)
 		byt, err := cmd.CombinedOutput()
 		if err != nil {
-			return "", errors.Wrap(err, "Unable to fetch logs from envoy container")
+			return "", fmt.Errorf("Unable to fetch logs from envoy container: %w", err)
 		}
 		return string(byt), nil
 	}

--- a/test/services/logging.go
+++ b/test/services/logging.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/onsi/gomega"
-	errors "github.com/rotisserie/eris"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -139,7 +138,7 @@ func (l *logProvider) ReloadFromString(userDefinedLogLevel string) {
 		// We intentionally error loudly here
 		// This will occur if the user passes an invalid log level string
 		if err != nil {
-			panic(errors.Wrapf(err, "invalid log level string: %s", logLevelStr))
+			panic(fmt.Errorf("invalid log level string: %s: %w", logLevelStr, err))
 		}
 
 		// This whole function operates with a lock, so we can modify the map directly

--- a/test/services/vault.go
+++ b/test/services/vault.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	errors "github.com/rotisserie/eris"
-
 	"github.com/onsi/gomega"
 	"github.com/solo-io/solo-kit/pkg/utils/protoutils"
 
@@ -154,7 +152,7 @@ func (i *VaultInstance) waitForVaultToBeRunning() error {
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Errorf("timed out waiting for vault on %s", pingEndpoint)
+			return fmt.Errorf("timed out waiting for vault on %s", pingEndpoint)
 
 		case <-pingInterval:
 			conn, _ := net.Dial("tcp", pingEndpoint)

--- a/test/translator/file_loader.go
+++ b/test/translator/file_loader.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/rotisserie/eris"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
@@ -149,12 +149,12 @@ func truncateString(str string, num int) string {
 func ReadProxyFromFile(filename string) (*irtranslator.TranslationResult, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, eris.Wrapf(err, "reading proxy file")
+		return nil, fmt.Errorf("reading proxy file: %w", err)
 	}
 	var proxy irtranslator.TranslationResult
 
 	if err := UnmarshalAnyYaml(data, &proxy); err != nil {
-		return nil, eris.Wrapf(err, "parsing proxy from file")
+		return nil, fmt.Errorf("parsing proxy from file: %w", err)
 	}
 	return &proxy, nil
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Fixes the #11472 issue and removes any imports to the github.com/rotisserie/eris library. Additionally, introduces the gomodguard linter to enforce that the eris and multi-errors package (originally removed in https://github.com/kgateway-dev/kgateway/pull/11158/) are no longer importable going forward.

Note, I tried enforcing this via the forbidigo linter, but that linter is more scoped towards identifier vs. enforcing imports, and there was an open question on whether gomodguard replaces the depguard linter going forward when I was researching it earlier today.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
