### PR TITLE
go.mod: use patched controller-tools to avoid flakes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -613,6 +613,9 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.5.0 // indirect
 )
 
+// Remove once https://github.com/kubernetes-sigs/controller-tools/pull/1224 merges
+replace sigs.k8s.io/controller-tools => github.com/shashankram/controller-tools v0.0.0-20250626172831-f7be064a9132
+
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
 // Use a patched version of gengo to produce consistent zz_generated.openapi.go

--- a/go.sum
+++ b/go.sum
@@ -1597,6 +1597,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/shashankram/controller-tools v0.0.0-20250626172831-f7be064a9132 h1:3CGPS0J9yy6qL+IcJ893z5gPnNRdNgjSRsm0EAPzl7E=
+github.com/shashankram/controller-tools v0.0.0-20250626172831-f7be064a9132/go.mod h1:y7H2qZn9nI2dCNXzfLab/sk4wi6q2xJOcsvEspVK2VY=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
@@ -2623,8 +2625,6 @@ sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231019135941-15d792835235 h1:GRdpo0LC7QBPh9HefY30G1xmap2Q5U/KCBqeIZymDMo=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231019135941-15d792835235/go.mod h1:TF/lVLWS+JNNaVqJuDDictY2hZSXSsIHCx4FClMvqFg=
-sigs.k8s.io/controller-tools v0.18.1-0.20250625175829-8d11ce77f347 h1:O1LuoJz9cCmzsO0x+VcP/E8adUmQGrPwU+/Amw3OiKk=
-sigs.k8s.io/controller-tools v0.18.1-0.20250625175829-8d11ce77f347/go.mod h1:y7H2qZn9nI2dCNXzfLab/sk4wi6q2xJOcsvEspVK2VY=
 sigs.k8s.io/gateway-api v1.3.0 h1:q6okN+/UKDATola4JY7zXzx40WO4VISk7i9DIfOvr9M=
 sigs.k8s.io/gateway-api v1.3.0/go.mod h1:d8NV8nJbaRbEKem+5IuxkL8gJGOZ+FJ+NvOIltV8gDk=
 sigs.k8s.io/gateway-api-inference-extension v0.2.0 h1:AqENYqi2OHjAhBhTKARNcM7G5L/gsRIxZGS4P8CNqAI=


### PR DESCRIPTION
# Description
There is a bug in controller-tools that can cause
CEL rule generation to flake. Until upstream has
a fix, use a patched version instead.

This is a follow up to 7814898 which took a dependency on a newer controller-tools.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```
