### PR TITLE
Adds InferencePool Readiness Trigger and Limits Recomputes

### DIFF
--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"sync/atomic"
 
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/kube/controllers"
@@ -66,6 +67,10 @@ type BackendIndex struct {
 	policies  *PolicyIndex
 	refgrants *RefGrantIndex
 	krtopts   krtutil.KrtOptions
+
+	// poolReady is used to recompute the backend index when an InferencePool is ready.
+	poolReady *krt.RecomputeTrigger
+	readyOnce atomic.Bool
 }
 
 type backendKey struct {
@@ -85,6 +90,7 @@ func NewBackendIndex(
 		aliasIndex:        map[schema.GroupKind]krt.Index[backendKey, ir.BackendObjectIR]{},
 		gkAliases:         map[schema.GroupKind][]schema.GroupKind{},
 		krtopts:           krtopts,
+		poolReady:         krt.NewRecomputeTrigger(false, krt.WithName("InferencePoolReady")),
 	}
 }
 
@@ -100,6 +106,24 @@ func (i *BackendIndex) HasSynced() bool {
 			return false
 		}
 	}
+	// If no InferencePool collection exists, unblock dependants.
+	hasPool := false
+	for gk, col := range i.availableBackends {
+		if !col.HasSynced() {
+			return false
+		}
+		hasPool = hasPool || isInfPoolGK(gk)
+	}
+
+	if !i.readyOnce.Load() {
+		if hasPool {
+			i.readyOnce.CompareAndSwap(false, true)
+		} else {
+			i.readyOnce.Store(true)
+		}
+		i.poolReady.MarkSynced()
+	}
+
 	return true
 }
 
@@ -141,6 +165,15 @@ func (i *BackendIndex) AddBackends(gk schema.GroupKind, col krt.Collection[ir.Ba
 	// when we query by the alias, also check our "actual" gk
 	for _, aliasGK := range aliasKinds {
 		i.gkAliases[aliasGK] = append(i.gkAliases[aliasGK], gk)
+	}
+
+	// Re-queue dependents only for InferencePool collections. This avoids unnecessary
+	// wake-ups when the inference extension plugin is not enabled.
+	isInfPool := isInfPoolGK(gk) || sliceHasInfPool(aliasKinds)
+	if isInfPool {
+		col.Register(func(e krt.Event[ir.BackendObjectIR]) {
+			i.poolReady.TriggerRecomputation()
+		})
 	}
 }
 
@@ -1329,6 +1362,16 @@ func (i *BackendIndex) normalizeInfPoolBackendPort(
 	srcNamespace string,
 	ref *gwv1.BackendObjectReference,
 ) error {
+	if i.poolReady != nil {
+		// Register the caller, i.e. HTTPRoute, as dependant on the all pools synced trigger.
+		i.poolReady.MarkDependant(kctx)
+	}
+
+	// If pools are still loading, defer and the route will re-run after MarkSynced()
+	if !i.readyOnce.Load() {
+		return nil
+	}
+
 	// Build an ObjectSource for the pool (ignoring any port for lookup)
 	poolSrc := toFromBackendRef(srcNamespace, *ref)
 	poolGK := poolSrc.GetGroupKind()
@@ -1378,4 +1421,19 @@ func parseRoutePrecedenceWeight(annotations map[string]string) (int32, error) {
 		return 0, fmt.Errorf("invalid value for annotation %s: %s; must be a valid integer", apiannotations.RoutePrecedenceWeight, val)
 	}
 	return int32(weight), nil
+}
+
+// isInfPoolGK returns true if the GroupKind represents an InferencePool.
+func isInfPoolGK(gk schema.GroupKind) bool {
+	return gk.Kind == wellknown.InferencePoolKind
+}
+
+// sliceHasInfPool returns true if any GroupKind in the slice is an InferencePool.
+func sliceHasInfPool(list []schema.GroupKind) bool {
+	for _, gk := range list {
+		if isInfPoolGK(gk) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -68,8 +68,9 @@ type BackendIndex struct {
 	refgrants *RefGrantIndex
 	krtopts   krtutil.KrtOptions
 
-	// poolReady is used to recompute the backend index when an InferencePool is ready.
-	poolReady *krt.RecomputeTrigger
+	// infPoolReady is used to recompute the backend index when an InferencePool is ready.
+	infPoolReady *krt.RecomputeTrigger
+	// readyOnce is used to ensure that the infPoolReady is only marked as ready once.
 	readyOnce atomic.Bool
 }
 
@@ -90,7 +91,7 @@ func NewBackendIndex(
 		aliasIndex:        map[schema.GroupKind]krt.Index[backendKey, ir.BackendObjectIR]{},
 		gkAliases:         map[schema.GroupKind][]schema.GroupKind{},
 		krtopts:           krtopts,
-		poolReady:         krt.NewRecomputeTrigger(false, krt.WithName("InferencePoolReady")),
+		infPoolReady:      krt.NewRecomputeTrigger(false, krt.WithName("InferencePoolReady")),
 	}
 }
 
@@ -106,7 +107,7 @@ func (i *BackendIndex) HasSynced() bool {
 			return false
 		}
 	}
-	// If no InferencePool collection exists, unblock dependants.
+	// If no InferencePool collection exists, unblock dependents.
 	hasPool := false
 	for gk, col := range i.availableBackends {
 		if !col.HasSynced() {
@@ -121,7 +122,7 @@ func (i *BackendIndex) HasSynced() bool {
 		} else {
 			i.readyOnce.Store(true)
 		}
-		i.poolReady.MarkSynced()
+		i.infPoolReady.MarkSynced()
 	}
 
 	return true
@@ -172,7 +173,7 @@ func (i *BackendIndex) AddBackends(gk schema.GroupKind, col krt.Collection[ir.Ba
 	isInfPool := isInfPoolGK(gk) || sliceHasInfPool(aliasKinds)
 	if isInfPool {
 		col.Register(func(e krt.Event[ir.BackendObjectIR]) {
-			i.poolReady.TriggerRecomputation()
+			i.infPoolReady.TriggerRecomputation()
 		})
 	}
 }
@@ -1362,9 +1363,9 @@ func (i *BackendIndex) normalizeInfPoolBackendPort(
 	srcNamespace string,
 	ref *gwv1.BackendObjectReference,
 ) error {
-	if i.poolReady != nil {
+	if i.infPoolReady != nil {
 		// Register the caller, i.e. HTTPRoute, as dependant on the all pools synced trigger.
-		i.poolReady.MarkDependant(kctx)
+		i.infPoolReady.MarkDependant(kctx)
 	}
 
 	// If pools are still loading, defer and the route will re-run after MarkSynced()

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -1062,7 +1062,7 @@ func TestNormalizeInfPoolBackendPortHandlesNilTrigger(t *testing.T) {
 func TestNewBackendIndexInitializesPoolReady(t *testing.T) {
 	idx := NewBackendIndex(krtutil.KrtOptions{}, nil, nil)
 	assert.NotNil(t, idx)
-	assert.NotNil(t, idx.poolReady, "poolReady should be pre-initialized")
+	assert.NotNil(t, idx.infPoolReady, "poolReady should be pre-initialized")
 }
 
 func TestIsAndSliceHasInfPool(t *testing.T) {

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	extensionsplug "github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/settings"
+	intir "github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
@@ -699,6 +701,11 @@ func preRouteIndex(t test.Failer, inputs []any) *RoutesIndex {
 	pools := krttest.GetMockCollection[*infextv1a2.InferencePool](mock)
 	upstreams.AddBackends(infPoolGk, infPoolUpstreams(pools))
 
+	// Wait until the backend index synced before proceeding
+	for !upstreams.HasSynced() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	httproutes := krttest.GetMockCollection[*gwv1.HTTPRoute](mock)
 	tcpproutes := krttest.GetMockCollection[*gwv1a2.TCPRoute](mock)
 	tlsroutes := krttest.GetMockCollection[*gwv1a2.TLSRoute](mock)
@@ -1001,4 +1008,70 @@ func TestParseRoutePrecedenceWeight(t *testing.T) {
 			a.Equal(tt.expected, weight)
 		})
 	}
+}
+
+// backendCountingCollection is a wrapper that counts Register() calls for
+// BackendObjectIR collections.
+type backendCountingCollection struct {
+	*krt.StaticCollection[intir.BackendObjectIR]
+	cnt *atomic.Int32
+}
+
+func (c *backendCountingCollection) Register(f func(krt.Event[intir.BackendObjectIR])) krt.Syncer {
+	c.cnt.Add(1)
+	return c.StaticCollection.Register(f)
+}
+
+func newCountingCollection(counter *atomic.Int32) *backendCountingCollection {
+	sc := krt.NewStaticCollection[intir.BackendObjectIR](nil)
+	return &backendCountingCollection{
+		StaticCollection: &sc,
+		cnt:              counter,
+	}
+}
+
+func TestAddBackendsRegistersTriggerOnlyForPools(t *testing.T) {
+	var svcCnt, poolCnt atomic.Int32
+
+	svcCol := newCountingCollection(&svcCnt)
+	poolCol := newCountingCollection(&poolCnt)
+
+	bi := NewBackendIndex(krtutil.KrtOptions{}, &PolicyIndex{}, &RefGrantIndex{})
+
+	bi.AddBackends(svcGk, svcCol)
+	require.Equal(t, int32(0), svcCnt.Load(),
+		"adding Service backends must NOT register poolReady")
+
+	bi.AddBackends(infPoolGk, poolCol)
+	require.Equal(t, int32(1), poolCnt.Load(),
+		"adding InferencePool backends must register poolReady once")
+}
+
+func TestNormalizeInfPoolBackendPortHandlesNilTrigger(t *testing.T) {
+	idx := &BackendIndex{}
+	ctx := krt.TestingDummyContext{}
+	// Minimal fake inputs
+	ns := "default"
+	ref := &gwv1.BackendObjectReference{Name: "foo"}
+	// The function should no longer panic
+	assert.NotPanics(t, func() {
+		_ = idx.normalizeInfPoolBackendPort(ctx, ns, ref)
+	})
+}
+
+func TestNewBackendIndexInitializesPoolReady(t *testing.T) {
+	idx := NewBackendIndex(krtutil.KrtOptions{}, nil, nil)
+	assert.NotNil(t, idx)
+	assert.NotNil(t, idx.poolReady, "poolReady should be pre-initialized")
+}
+
+func TestIsAndSliceHasInfPool(t *testing.T) {
+	ipGK := schema.GroupKind{Group: infextv1a2.GroupVersion.Group, Kind: wellknown.InferencePoolKind}
+	othGK := schema.GroupKind{Group: "", Kind: "Service"}
+
+	require.True(t, isInfPoolGK(ipGK))
+	require.False(t, isInfPoolGK(othGK))
+
+	require.True(t, sliceHasInfPool([]schema.GroupKind{othGK, ipGK}))
+	require.False(t, sliceHasInfPool([]schema.GroupKind{othGK}))
 }


### PR DESCRIPTION
# Description

* Introduces the `poolReady` RecomputeTrigger in BackendIndex.
* Marks the trigger `synced` only when at least one InferencePool collection exists or none are registered, avoiding indefinite wait when inference extension is not enabled.
* Registers the trigger on add/update/delete events only for InferencePool collections to limit unnecessary wake-ups.
* Updates `normalizeInfPoolBackendPort()` to declare a dependency on `poolReady` and exits early until InferencePools are ready, preventing black-hole clusters.

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
Ensure HTTPRoutes wait for InferencePool data only when the Inference EndpointPicker extension is active, preventing premature “black-hole” clusters and unnecessary recomputations.
```

# Additional Notes

xref #11498
