### PR TITLE
allow setting per connection buffer limit on Gateway with annotation

### DIFF
--- a/api/annotations/gateway.go
+++ b/api/annotations/gateway.go
@@ -1,0 +1,7 @@
+package annotations
+
+// PerConnectionBufferLimit is the annotation key for the per connection buffer limit.
+// It is used to set the per connection buffer limit for the gateway.
+// The value is a string representing the limit, e.g "64Ki".
+// The limit is applied to all listeners in the gateway.
+const PerConnectionBufferLimit = "kgateway.dev/per-connection-buffer-limit"

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -9,6 +9,7 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -310,6 +311,15 @@ func NewGatewayIndex(
 			},
 			Obj:       i,
 			Listeners: make([]ir.Listener, 0, len(i.Spec.Listeners)),
+		}
+
+		if i.Annotations[apiannotations.PerConnectionBufferLimit] != "" {
+			limit, err := resource.ParseQuantity(i.Annotations[apiannotations.PerConnectionBufferLimit])
+			if err != nil {
+				logger.Error("failed to parse per connection buffer limit", "error", err)
+			} else {
+				out.PerConnectionBufferLimitBytes = k8sptr.To(uint32(limit.Value()))
+			}
 		}
 
 		// TODO: http polic

--- a/internal/kgateway/translator/gateway/gateway_translator.go
+++ b/internal/kgateway/translator/gateway/gateway_translator.go
@@ -80,10 +80,11 @@ func (t *translator) Translate(
 	)
 
 	return &ir.GatewayIR{
-		SourceObject:         gateway,
-		Listeners:            listeners,
-		AttachedPolicies:     gateway.AttachedListenerPolicies,
-		AttachedHttpPolicies: gateway.AttachedHttpPolicies,
+		SourceObject:                  gateway,
+		Listeners:                     listeners,
+		AttachedPolicies:              gateway.AttachedListenerPolicies,
+		AttachedHttpPolicies:          gateway.AttachedHttpPolicies,
+		PerConnectionBufferLimitBytes: gateway.PerConnectionBufferLimitBytes,
 	}
 }
 

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -37,6 +37,16 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 		translatortest.TestTranslation(GinkgoT(), ctx, inputFiles, expectedProxyFile, in.gwNN, in.assertReports)
 	},
 	Entry(
+		"http gateway with per connection buffer limit",
+		translatorTestCase{
+			inputFile:  "gateway-per-conn-buf-lim/gateway.yaml",
+			outputFile: "gateway-per-conn-buf-lim/proxy.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		}),
+	Entry(
 		"http gateway with basic routing",
 		translatorTestCase{
 			inputFile:  "http-routing",

--- a/internal/kgateway/translator/gateway/testutils/inputs/gateway-per-conn-buf-lim/gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/gateway-per-conn-buf-lim/gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  annotations:
+    kgateway.dev/per-connection-buffer-limit: 64Ki
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+  - name: http2
+    protocol: HTTP
+    port: 3000
+---

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
@@ -1,0 +1,62 @@
+Clusters:
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 3000
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~3000
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~3000
+  name: listener~3000
+  perConnectionBufferLimitBytes: 65536
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  name: listener~80
+  perConnectionBufferLimitBytes: 65536
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~3000
+- ignorePortInHostMatching: true
+  name: listener~80

--- a/internal/kgateway/translator/irtranslator/gateway.go
+++ b/internal/kgateway/translator/irtranslator/gateway.go
@@ -8,6 +8,7 @@ import (
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"golang.org/x/net/context"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/slices"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
@@ -90,6 +91,9 @@ func (t *Translator) ComputeListener(
 	ret := &envoy_config_listener_v3.Listener{
 		Name:    lis.Name,
 		Address: computeListenerAddress(lis.BindAddress, lis.BindPort, gwreporter),
+	}
+	if gw.PerConnectionBufferLimitBytes != nil {
+		ret.PerConnectionBufferLimitBytes = &wrapperspb.UInt32Value{Value: *gw.PerConnectionBufferLimitBytes}
 	}
 	t.runListenerPlugins(ctx, pass, gw, lis, ret)
 

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -271,6 +271,8 @@ type Gateway struct {
 
 	AttachedListenerPolicies AttachedPolicies
 	AttachedHttpPolicies     AttachedPolicies
+
+	PerConnectionBufferLimitBytes *uint32
 }
 
 func (c Gateway) ResourceName() string {

--- a/pkg/pluginsdk/ir/gw2.go
+++ b/pkg/pluginsdk/ir/gw2.go
@@ -114,4 +114,8 @@ type GatewayIR struct {
 
 	AttachedPolicies     AttachedPolicies
 	AttachedHttpPolicies AttachedPolicies
+
+	// PerConnectionBufferLimitBytes is the listener-level per connection buffer limit.
+	// Applied to all listeners in the gateway.
+	PerConnectionBufferLimitBytes *uint32
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

https://github.com/kgateway-dev/kgateway/issues/11387

Allow setting listener-level perConnectionBufferLimitBytes. 

# Change Type

/kind new_feature

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Allow setting listener-level perConnectionBufferLimitBytes by setting the `kgateway.dev/per-connection-buffer-limit` annotation on the gateway. 
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

We discussed several options for setting perConnectionBufferLimitBytes.
- Creating new policy for listener options
  -  decided against this since it was overkill to create a new policy for one field, and we're unlikely to have other listener level fields even in future
- adding this option to GatewayParameters
  - while this makes sense, it will require a lot of up front work to refactor it out of deployer and into krt collections
  
We decided using an annotation on the gateway made sense and was straightforward to implement.