### PR TITLE
api: Replace CEL validation with AtMostOneOf marker for HTTP protocol options

### DIFF
--- a/api/v1alpha1/backend_config_policy_types.go
+++ b/api/v1alpha1/backend_config_policy_types.go
@@ -29,8 +29,11 @@ type BackendConfigPolicyList struct {
 	Items           []BackendConfigPolicy `json:"items"`
 }
 
-// +kubebuilder:validation:XValidation:rule="!has(self.http1ProtocolOptions) || !has(self.http2ProtocolOptions)",message="Http1ProtocolOptions and Http2ProtocolOptions cannot both be set"
+// BackendConfigPolicySpec defines the desired state of BackendConfigPolicy.
+// +kubebuilder:validation:AtMostOneOf=http1ProtocolOptions;http2ProtocolOptions
 type BackendConfigPolicySpec struct {
+	// TargetRefs specifies the target references to attach the policy to.
+	// +optional
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
 	TargetRefs []LocalPolicyTargetReference `json:"targetRefs,omitempty"`

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
@@ -370,9 +370,10 @@ spec:
                     == 1'
             type: object
             x-kubernetes-validations:
-            - message: Http1ProtocolOptions and Http2ProtocolOptions cannot both be
-                set
-              rule: '!has(self.http1ProtocolOptions) || !has(self.http2ProtocolOptions)'
+            - message: at most one of the fields in [http1ProtocolOptions http2ProtocolOptions]
+                may be set
+              rule: '[has(self.http1ProtocolOptions),has(self.http2ProtocolOptions)].filter(x,x==true).size()
+                <= 1'
           status:
             properties:
               ancestors:

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1344,11 +1344,13 @@ func schema_kgateway_v2_api_v1alpha1_BackendConfigPolicySpec(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "BackendConfigPolicySpec defines the desired state of BackendConfigPolicy.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"targetRefs": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "TargetRefs specifies the target references to attach the policy to.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{

--- a/test/kubernetes/e2e/tests/api_validation_test.go
+++ b/test/kubernetes/e2e/tests/api_validation_test.go
@@ -44,6 +44,27 @@ spec:
 `,
 			wantError: "exactly one of the fields in [ai aws static dynamicForwardProxy] must be set",
 		},
+		{
+			name: "BackendConfigPolicy: enforce AtMostOneOf for HTTP protocol options",
+			input: `---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: BackendConfigPolicy
+metadata:
+  name: backend-config-both-http-options
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: test-service
+  http1ProtocolOptions:
+    enableTrailers: true
+    headerFormat: ProperCaseHeaderKeyFormat
+  http2ProtocolOptions:
+    maxConcurrentStreams: 100
+    overrideStreamErrorOnInvalidHttpMessage: true
+`,
+			wantError: "at most one of the fields in [http1ProtocolOptions http2ProtocolOptions] may be set",
+		},
 	}
 
 	t.Cleanup(func() {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

This is a follow-up to the https://github.com/kgateway-dev/kgateway/pull/11455/ PR which introduced support for HTTP2 protocol options on the BCP API.

Update the CEL validation used to enforce that http1 & http2 protocol options cannot be defined together via the new AtMostOneOf marker.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
