### PR TITLE
EP-11387 Listener-level perConnectionBufferLimitBytes.

### DIFF
--- a/design/11387.md
+++ b/design/11387.md
@@ -4,16 +4,20 @@
 
 ## Background
 
-We want to allow users to set the [perConnectionBufferLimitBytes](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-per-connection-buffer-limit-bytes).
+We want to allow users to set the [perConnectionBufferLimitBytes](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-per-connection-buffer-limit-bytes). The listener buffer limit, defined in envoy as `per_connection_buffer_limit_bytes
+`, controls the max size of read and write buffers for new connections.
 
 ## Motivation
 
-Allow setting the perConnectionBufferLimitBytes for a Gateway
-
+When using Envoy as an edge proxy, configuring the listener buffer limit is important, since you could be dealing with untrusted downstreams. By setting the limit to a small number, such as 32KiB, you better guard against potential attacks or misconfigured downstreams that could hog the proxy's resources.
 
 ## Goals
 
+Allow setting the listener level buffer limit (perConnectionBufferLimitBytes) for a Gateway.
+
 ## Non-Goals
+
+Allow setting the perConnectionBufferLimitBytes for each individual listener on a Gateway (instead, we will apply same limit to all listeners).
 
 ## Implementation Details
 

--- a/design/11387.md
+++ b/design/11387.md
@@ -10,26 +10,8 @@ We want to allow users to set the [perConnectionBufferLimitBytes](https://www.en
 
 Allow setting the perConnectionBufferLimitBytes for a Gateway
 
-<!--
-This section is for explicitly listing the motivation, goals, and non-goals of
-this EP. Describe why the change is important and the benefits to users. The
-motivation section can optionally provide links to [experience reports] to
-demonstrate the interest in a EP within the wider Kubernetes community.
-
-[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
--->
 
 ## Goals
-
-<!--
-
-List the specific goals of the EP. What is it trying to achieve? How will we
-know that this has succeeded?
-
-Include specific, actionable outcomes. Ensure that the goals focus on the scope of
-the proposed feature.
--->
-
 
 ## Non-Goals
 

--- a/design/11387.md
+++ b/design/11387.md
@@ -1,0 +1,76 @@
+# EP-11387: Allow setting listener perConnectionBufferLimitBytes
+
+* Issue: [#11387](https://github.com/kgateway-dev/kgateway/issues/11387)
+
+## Background
+
+We want to allow users to set the [perConnectionBufferLimitBytes](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-per-connection-buffer-limit-bytes).
+
+## Motivation
+
+Allow setting the perConnectionBufferLimitBytes for a Gateway
+
+<!--
+This section is for explicitly listing the motivation, goals, and non-goals of
+this EP. Describe why the change is important and the benefits to users. The
+motivation section can optionally provide links to [experience reports] to
+demonstrate the interest in a EP within the wider Kubernetes community.
+
+[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
+-->
+
+## Goals
+
+<!--
+
+List the specific goals of the EP. What is it trying to achieve? How will we
+know that this has succeeded?
+
+Include specific, actionable outcomes. Ensure that the goals focus on the scope of
+the proposed feature.
+-->
+
+
+## Non-Goals
+
+## Implementation Details
+
+We'll check the gateway for the annotation `kgateway.dev/per-connection-buffer-limit`, which should specify a value in the [resource quantity format](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/).
+
+The perConnectionBufferLimitBytes for all listeners on the gateway will be set to this value.
+
+```
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  annotations:
+    kgateway.dev/per-connection-buffer-limit: 64Ki
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+  - name: http2
+    protocol: HTTP
+    port: 3000
+```
+
+### Test Plan
+
+unit tests
+
+## Alternatives
+
+We discussed several options for setting perConnectionBufferLimitBytes.
+- Creating new policy for listener options
+  -  decided against this since it was overkill to create a new policy for one field, and we're unlikely to have other listener level fields even in future
+- adding this option to GatewayParameters
+  - while this makes sense, it will require a lot of up front work to refactor it out of deployer and into krt collections
+  
+We decided using an annotation on the gateway made sense and was straightforward to implement.
+
+## Open Questions
+
+Need to make sure this is documented 


### PR DESCRIPTION
Design doc for https://github.com/kgateway-dev/kgateway/issues/11387 (well, part of it). Allow setting listener-level perConnectionBufferLimitBytes.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind design

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
