### PR TITLE
test(settings): improve error handling and assertions in TestSettings

### DIFF
--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -2,13 +2,23 @@ package settings_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 )
+
+func cleanupEnvVars(t *testing.T, envVars map[string]string) {
+	t.Helper()
+	for k := range envVars {
+		if err := os.Unsetenv(k); err != nil {
+			t.Errorf("Failed to unset environment variable %s: %v", k, err)
+		}
+	}
+}
 
 func TestSettings(t *testing.T) {
 	testCases := []struct {
@@ -138,35 +148,45 @@ func TestSettings(t *testing.T) {
 				DefaultImageTag:             "",
 				DefaultImagePullPolicy:      "IfNotPresent",
 				WaypointLocalBinding:        false,
+				IngressUseWaypoints:         false,
 				LogLevel:                    "info",
 				DiscoveryNamespaceSelectors: "[]",
 				EnableAgentGateway:          false,
+				WeightedRoutePrecedence:     false,
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
-
 			t.Cleanup(func() {
-				for k := range tc.envVars {
-					err := os.Unsetenv(k)
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-				}
+				cleanupEnvVars(t, tc.envVars)
 			})
 
 			for k, v := range tc.envVars {
-				err := os.Setenv(k, v)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
+				if err := os.Setenv(k, v); err != nil {
+					t.Fatalf("Failed to set environment variable %s=%s: %v", k, v, err)
+				}
 			}
+
 			s, err := settings.BuildSettings()
+
 			if tc.expectedErrorStr != "" {
-				g.Expect(err).To(gomega.HaveOccurred())
-				g.Expect(err.Error()).To(gomega.ContainSubstring(tc.expectedErrorStr))
-			} else {
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(s).To(gomega.Equal(tc.expectedSettings))
+				if err == nil {
+					t.Fatalf("Expected error containing %q, but got no error", tc.expectedErrorStr)
+				}
+				if !strings.Contains(err.Error(), tc.expectedErrorStr) {
+					t.Fatalf("Expected error to contain %q, but got: %v", tc.expectedErrorStr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedSettings, s); diff != "" {
+				t.Errorf("Settings do not match expected values (-expected +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request refactors the `pkg/settings/settings_test.go` file to improve test readability, enhance error handling, and replace the testing library used for assertions. The most significant changes include introducing a helper function for environment variable cleanup, replacing `gomega` with native Go assertions, and adding new configuration fields to the test cases.

### Test improvements:

* Introduced the `cleanupEnvVars` helper function to simplify and centralize the cleanup of environment variables during tests. This replaces repetitive code blocks with a reusable function.
* Replaced `gomega` assertions with native Go testing assertions (`t.Fatalf`, `t.Errorf`, etc.) to reduce dependencies and improve maintainability.

### Configuration updates:

* Added new configuration fields (`IngressUseWaypoints` and `WeightedRoutePrecedence`) to the test cases to ensure coverage of recently introduced settings.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
Refactored settings test suites to use consistent standard library testing patterns
```