### PR TITLE
make: dynamically set Kubernetes and Gateway API versions for tests

### DIFF
--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -28,6 +28,8 @@ jobs:
         go-version-file: go.mod
     - name: Install dependencies
       run: make mod-download
+    - name: Install setup-envtest
+      run: go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
     - name: Build kgateway
       run: go build -v ./internal/kgateway/...
     - name: Run Tests

--- a/Makefile
+++ b/Makefile
@@ -204,9 +204,11 @@ run-e2e-tests: test
 # Env test
 #----------------------------------------------------------------------------------
 
-# client-go version v0.X.Y corresponds to Kubernetes version 1.X
-ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{.Version}}" k8s.io/client-go | sed 's/v0\.\([0-9]*\)\..*/1.\1/')
-ENVTEST ?= go tool setup-envtest
+
+# client-go version v0.X.Y corresponds to Kubernetes version 1.X.0
+ENVTEST_K8S_VERSION = $(shell go list -m -f "{{.Version}}" k8s.io/client-go | sed 's/v0\.\([0-9]*\)\..*/1.\1.0/')
+
+ENVTEST ?= $(shell go env GOPATH)/bin/setup-envtest
 
 .PHONY: envtest-path
 envtest-path: ## Set the envtest path

--- a/Makefile
+++ b/Makefile
@@ -204,9 +204,8 @@ run-e2e-tests: test
 # Env test
 #----------------------------------------------------------------------------------
 
-
 # client-go version v0.X.Y corresponds to Kubernetes version 1.X
-ENVTEST_K8S_VERSION = $(shell go list -m k8s.io/client-go | awk '{print $$2}' | sed 's/v0\.\([0-9]*\)\..*/1.\1/')
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{.Version}}" k8s.io/client-go | sed 's/v0\.\([0-9]*\)\..*/1.\1/')
 ENVTEST ?= go tool setup-envtest
 
 .PHONY: envtest-path
@@ -508,7 +507,7 @@ kind-create: ## Create a KinD cluster
 CONFORMANCE_CHANNEL ?= experimental
 # Dynamically determine the Gateway API version for conformance tests from go.mod
 # This ensures conformance tests stay in sync with the actual Gateway API dependency
-CONFORMANCE_VERSION ?= $(shell go list -m sigs.k8s.io/gateway-api | awk '{print $$2}')
+CONFORMANCE_VERSION ?= $(shell go list -m -f "{{.Version}}" sigs.k8s.io/gateway-api)
 .PHONY: gw-api-crds
 gw-api-crds: ## Install the Gateway API CRDs
 	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/$(CONFORMANCE_CHANNEL)?ref=$(CONFORMANCE_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,9 @@ run-e2e-tests: test
 # Env test
 #----------------------------------------------------------------------------------
 
-ENVTEST_K8S_VERSION = 1.23
+
+# client-go version v0.X.Y corresponds to Kubernetes version 1.X
+ENVTEST_K8S_VERSION = $(shell go list -m k8s.io/client-go | awk '{print $$2}' | sed 's/v0\.\([0-9]*\)\..*/1.\1/')
 ENVTEST ?= go tool setup-envtest
 
 .PHONY: envtest-path
@@ -504,7 +506,9 @@ kind-create: ## Create a KinD cluster
 	$(KIND) get clusters | grep $(CLUSTER_NAME) || $(KIND) create cluster --name $(CLUSTER_NAME)
 
 CONFORMANCE_CHANNEL ?= experimental
-CONFORMANCE_VERSION ?= v1.3.0
+# Dynamically determine the Gateway API version for conformance tests from go.mod
+# This ensures conformance tests stay in sync with the actual Gateway API dependency
+CONFORMANCE_VERSION ?= $(shell go list -m sigs.k8s.io/gateway-api | awk '{print $$2}')
 .PHONY: gw-api-crds
 gw-api-crds: ## Install the Gateway API CRDs
 	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/$(CONFORMANCE_CHANNEL)?ref=$(CONFORMANCE_VERSION)"


### PR DESCRIPTION
This pull request introduces changes to improve dependency management and ensure dynamic synchronization with external dependencies in the project's workflows and Makefile. The most important changes focus on automating version detection for tools and dependencies, enhancing maintainability, and reducing manual updates.

### Dependency Management Improvements:

* [`.github/workflows/pr-unit-tests.yaml`](diffhunk://#diff-9194fb37e86951b33beec8d32f871a78c0c7bcdf0e70e5176fcaf9bf0ad92619R31-R32): Added a step to install `setup-envtest` in the unit test workflow, ensuring the necessary tool is available for testing Kubernetes environments.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L207-R211): Updated `ENVTEST_K8S_VERSION` to dynamically determine the Kubernetes version based on the `client-go` dependency, and modified the `ENVTEST` variable to reference the installed `setup-envtest` binary path. This eliminates hardcoded versions and ensures compatibility with the project's dependencies.

### Synchronization with External Dependencies:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L507-R512): Updated `CONFORMANCE_VERSION` to dynamically determine the Gateway API version from `go.mod`. This ensures that conformance tests automatically stay in sync with the project's Gateway API dependency, reducing the need for manual updates.


# Change Type
```
/kind  feature
```

# Changelog
```release-note
NONE
```

closed #11500 