### PR TITLE
Inference Plugin: Adds status trigger based on route krt collection

### DIFF
--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/status.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -28,15 +29,54 @@ func buildRegisterCallback(
 	commonCol *common.CommonCollections,
 	bcol krt.Collection[ir.BackendObjectIR],
 ) func() {
+	var (
+		once   sync.Once
+		byPool krt.Index[types.NamespacedName, ir.HttpRouteIR]
+	)
+
 	return func() {
 		bcol.Register(func(o krt.Event[ir.BackendObjectIR]) {
+			// Bail out until Routes exist.
+			if commonCol.Routes == nil {
+				return
+			}
+
 			if o.Event == controllers.EventDelete {
 				return
 			}
 
 			in := o.Latest()
-			ir, ok := in.ObjIr.(*inferencePool)
+			irPool, ok := in.ObjIr.(*inferencePool)
 			if !ok {
+				return
+			}
+
+			// Build the index only once since routes
+			once.Do(func() {
+				byPool = krt.NewIndex(
+					commonCol.Routes.HTTPRoutes(),
+					func(rt ir.HttpRouteIR) []types.NamespacedName {
+						// Collect every ns/name of pools referenced by the route
+						var keys []types.NamespacedName
+						for _, rule := range rt.Rules {
+							for _, be := range rule.Backends {
+								if be.Backend != nil &&
+									be.Backend.BackendObject != nil &&
+									be.Backend.BackendObject.Group == infextv1a2.GroupVersion.Group &&
+									be.Backend.BackendObject.Kind == wellknown.InferencePoolKind {
+									keys = append(keys, types.NamespacedName{
+										Namespace: be.Backend.BackendObject.Namespace,
+										Name:      be.Backend.BackendObject.Name,
+									})
+								}
+							}
+						}
+						return keys
+					})
+			})
+
+			if byPool == nil {
+				// Still uninitialized, so wait for the next event
 				return
 			}
 
@@ -54,12 +94,11 @@ func buildRegisterCallback(
 						return err
 					}
 
-					irRoutes := commonCol.Routes.ListHTTPRoutesInNamespace(poolNsName.Namespace)
-
-					// Check if any HTTPRoute references this InferencePool.
-					gtwName := ir.referencedGateway(ctx, commonCol, irRoutes, poolNsName)
+					// Only fetch routes that reference this pool
+					irRoutes := krtcollections.Lookup(byPool, poolNsName)
+					gtwName := irPool.referencedGateway(ctx, commonCol, irRoutes, poolNsName)
 					if gtwName == "" {
-						// If needed, remove the Kgateway-managed gateway from the InferencePool status.
+						// No route references this pool anymore, so clean up.
 						if err := removeGatewayParentRef(ctx, cli, pool, commonCol.GatewayIndex); err != nil {
 							return err
 						}
@@ -103,7 +142,7 @@ func buildRegisterCallback(
 					}
 
 					// Build the InferencePool ResolvedRefs status condition.
-					newRRCond := buildResolvedRefsCondition(pool.Generation, ir.errors)
+					newRRCond := buildResolvedRefsCondition(pool.Generation, irPool.errors)
 
 					// Check if the Accepted condition already exists and is up-to-date.
 					existingRRCond := meta.FindStatusCondition(pool.Status.Parents[pIdx].Conditions, string(infextv1a2.InferencePoolConditionResolvedRefs))

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -963,6 +963,11 @@ func NewRoutesIndex(
 	return h
 }
 
+// HTTPRoutes returns the underlying krt collection of HTTPRoute IRs.
+func (h *RoutesIndex) HTTPRoutes() krt.Collection[ir.HttpRouteIR] {
+	return h.httpRoutes
+}
+
 func (h *RoutesIndex) FetchHTTPRoutesBySelector(kctx krt.HandlerContext, selector HTTPRouteSelector) []ir.HttpRouteIR {
 	return krt.Fetch(kctx, h.httpRoutes, krt.FilterIndex(h.httpBySelector, selector))
 }
@@ -998,17 +1003,6 @@ func (h *RoutesIndex) FetchHttp(kctx krt.HandlerContext, ns, n string) *ir.HttpR
 	}
 	route := krt.FetchOne(kctx, h.httpRoutes, krt.FilterKey(src.ResourceName()))
 	return route
-}
-
-// ListHTTPRoutesInNamespace returns all HTTPRouteIRs in the given namespace.
-func (h *RoutesIndex) ListHTTPRoutesInNamespace(ns string) []ir.HttpRouteIR {
-	var out []ir.HttpRouteIR
-	for _, rt := range h.httpRoutes.List() {
-		if rt.GetNamespace() == ns {
-			out = append(out, rt)
-		}
-	}
-	return out
 }
 
 func (h *RoutesIndex) Fetch(kctx krt.HandlerContext, gk schema.GroupKind, ns, n string) *RouteWrapper {
@@ -1388,4 +1382,11 @@ func parseRoutePrecedenceWeight(annotations map[string]string) (int32, error) {
 		return 0, fmt.Errorf("invalid value for annotation %s: %s; must be a valid integer", apiannotations.RoutePrecedenceWeight, val)
 	}
 	return int32(weight), nil
+}
+
+// Lookup returns all objects stored under key k without registering any
+// dependency in krt’s DAG. It's meant for status-update side paths where we
+// only need a snapshot.
+func Lookup[K comparable, V any](idx krt.Index[K, V], k K) []V {
+	return idx.Lookup(k)
 }

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool-out.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool-out.yaml
@@ -1,0 +1,233 @@
+clusters:
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker-2.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool-2_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool-2_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9090
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker-2_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9090
+  type: EDS
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: inferencepool.backend.transformation.kgateway.io
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            grpcService:
+              envoyGrpc:
+                authority: placeholder-service.placeholder-namespace.svc:9002
+                clusterName: endpointpicker_placeholder-pool_placeholder-namespace_ext_proc
+            messageTimeout: 5s
+            processingMode:
+              requestBodyMode: FULL_DUPLEX_STREAMED
+              requestHeaderMode: SEND
+              requestTrailerMode: SEND
+              responseBodyMode: FULL_DUPLEX_STREAMED
+              responseHeaderMode: SEND
+              responseTrailerMode: SEND
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-gateway-route-gwtest-0-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+              timeout: 10s
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct-2
+        prefix: /
+      name: listener~8080~www_example_com-route-1-httproute-gateway-route-2-gwtest-0-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool-2_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker-2.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+              timeout: 10s

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-multi-route-single-pool.yaml
@@ -1,0 +1,132 @@
+# One Gateway with two HTTPRoutes each referencing one InferencePool
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: gateway-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: gateway-route-2
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool-2
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct-2
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker-2
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool-2
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker-2
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool-out.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool-out.yaml
@@ -1,0 +1,233 @@
+clusters:
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker-2.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool-2_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool-2_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9090
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker-2_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9090
+  type: EDS
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: inferencepool.backend.transformation.kgateway.io
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            grpcService:
+              envoyGrpc:
+                authority: placeholder-service.placeholder-namespace.svc:9002
+                clusterName: endpointpicker_placeholder-pool_placeholder-namespace_ext_proc
+            messageTimeout: 5s
+            processingMode:
+              requestBodyMode: FULL_DUPLEX_STREAMED
+              requestHeaderMode: SEND
+              requestTrailerMode: SEND
+              responseBodyMode: FULL_DUPLEX_STREAMED
+              responseHeaderMode: SEND
+              responseTrailerMode: SEND
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-gateway-route-gwtest-0-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+              timeout: 10s
+    - match:
+        headers:
+        - name: x-model-name
+          stringMatch:
+            exact: facebook/llama3-8b-instruct-2
+        prefix: /
+      name: listener~8080~www_example_com-route-1-httproute-gateway-route-gwtest-1-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool-2_gwtest_original_dst
+        timeout: 300s
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker-2.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool-2_gwtest_ext_proc
+              timeout: 10s

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-single-route-multi-pool.yaml
@@ -1,0 +1,120 @@
+# One Gateway with one HTTPRoute referencing two InferencePools
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: gateway-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+  - backendRefs:
+    - group: inference.networking.x-k8s.io
+      kind: InferencePool
+      name: gateway-pool-2
+    matches:
+    - headers:
+      - name: x-model-name
+        type: Exact
+        value: facebook/llama3-8b-instruct-2
+      path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 300s
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker-2
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool-2
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker-2
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-with-port-override-out.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-with-port-override-out.yaml
@@ -1,0 +1,157 @@
+clusters:
+- connectTimeout: 10s
+  lbPolicy: LEAST_REQUEST
+  loadAssignment:
+    clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: gateway-pool-endpoint-picker.gwtest.svc
+              portValue: 9002
+        healthStatus: HEALTHY
+  name: endpointpicker_gateway-pool_gwtest_ext_proc
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        validationContext: {}
+  type: STRICT_DNS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- circuitBreakers:
+    thresholds:
+    - maxConnections: 40000
+      maxPendingRequests: 40000
+      maxRequests: 40000
+  connectTimeout: 1000s
+  lbPolicy: CLUSTER_PROVIDED
+  metadata: {}
+  name: endpointpicker_gateway-pool_gwtest_original_dst
+  originalDstLbConfig:
+    httpHeaderName: x-gateway-destination-endpoint
+    useHttpHeader: true
+  type: ORIGINAL_DST
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-2-endpoint-picker_9090
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9002
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_gateway-pool-endpoint-picker_9090
+  type: EDS
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: inferencepool.backend.transformation.kgateway.io
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            grpcService:
+              envoyGrpc:
+                authority: placeholder-service.placeholder-namespace.svc:9002
+                clusterName: endpointpicker_placeholder-pool_placeholder-namespace_ext_proc
+            messageTimeout: 5s
+            processingMode:
+              requestBodyMode: FULL_DUPLEX_STREAMED
+              requestHeaderMode: SEND
+              requestTrailerMode: SEND
+              responseBodyMode: FULL_DUPLEX_STREAMED
+              responseHeaderMode: SEND
+              responseTrailerMode: SEND
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-gateway-route-gwtest-0-0-matcher-0
+      route:
+        cluster: endpointpicker_gateway-pool_gwtest_original_dst
+      typedPerFilterConfig:
+        inferencepool.backend.transformation.kgateway.io:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides:
+            grpcService:
+              envoyGrpc:
+                authority: gateway-pool-endpoint-picker.gwtest.svc:9002
+                clusterName: endpointpicker_gateway-pool_gwtest_ext_proc
+              timeout: 10s

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-with-port-override.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-with-port-override.yaml
@@ -1,0 +1,66 @@
+# One Gateway with one HTTPRoute referencing one InferencePool with differing target ports
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: gateway-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: gateway-pool
+          kind: InferencePool
+          group: inference.networking.x-k8s.io
+          weight: 1
+          port: 8009 # Port should be overridden by InferencePool targetPortNumber
+---
+# This service is auto created by the inference extension deployer but it's created
+# here for clean-up purposes (avoid test pollution). Repeat for additional endpoint
+# picker tests or until test cases are run in parallel.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker
+  namespace: gwtest
+spec:
+  ports:
+    - name: grpc
+      port: 9002
+      targetPort: 9002
+  selector:
+    app: gateway
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferencePool
+metadata:
+  name: gateway-pool
+  namespace: gwtest
+spec:
+  extensionRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker
+    portNumber: 9002
+  selector:
+    app: gateway
+  targetPortNumber: 8080


### PR DESCRIPTION
# Description

## Motivation 

E2E tests were flaky when an HTTPRoute and its referenced InferencePool were created in the same manifest.  
If the HTTPRoute reconciled before the InferencePool, the pool never received Accepted/ResolvedRefs status conditions, preventing the route from becoming `Accepted=True`.

## What Changed

* **Bidirectional reconciliation**
  * Added a `krt.Index` that maps *Route -> InferencePool* so the plugin can look up all routes that reference a pool.
  * Registered a watcher on the `HTTPRoute` collection to re-enqueue (`reconcile`) the affected pool whenever any route is added, updated, or deleted.
* **Early status calculation**
  * The callback runs even when the `Routes` collection is not yet initialized, allowing `Accepted`/`ResolvedRefs` status conditions to be set at start-up.
* **Changed code**
  * `endpointpicker/status.go`: new reverse index and updated event handling.
  * `krtcollections/policy.go`: exposed `HTTPRoutes()` and lightweight `Lookup()` helper.
  * No change to public API; behaviour is internal to the Endpoint-Picker plugin.

## Related issues

Fixes #11516
Fixes #11379

# Change Type

```
/kind bug_fix  
/kind flake
```

# Changelog

```release-note
Inference EndpointPicker (EPP) plugin now recalculates InferencePool status whenever an HTTPRoute that references the pool is added, updated, or deleted.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
