### PR TITLE
api: Remove unused Extended enum value from GatewayExtensionType

### DIFF
--- a/api/v1alpha1/gateway_extensions_types.go
+++ b/api/v1alpha1/gateway_extensions_types.go
@@ -95,7 +95,7 @@ type RateLimitProvider struct {
 type GatewayExtensionSpec struct {
 	// Type indicates the type of the GatewayExtension to be used.
 	// +unionDiscriminator
-	// +kubebuilder:validation:Enum=ExtAuth;ExtProc;RateLimit;Extended
+	// +kubebuilder:validation:Enum=ExtAuth;ExtProc;RateLimit
 	// +required
 	Type GatewayExtensionType `json:"type"`
 

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
@@ -211,7 +211,6 @@ spec:
                 - ExtAuth
                 - ExtProc
                 - RateLimit
-                - Extended
                 type: string
             required:
             - type


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

- Remove 'Extended' from GatewayExtensionType enum validation as it was never implemented
- Only ExtAuth, ExtProc, and RateLimit are actually supported types
- No corresponding provider struct or validation rules exist for Extended type

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

Noticed this locally while looking into an unrelated issue.