### PR TITLE
.github: Refresh issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-ISSUE.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Create a report to help us improve
 labels: ["Type: Bug"]
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -10,8 +11,8 @@ body:
     id: version
     attributes:
       label: kgateway version
-      description: What version of your product are you using? Please specify a specific patch version
-      placeholder: eg v1.14.2
+      description: What version of kgateway are you using? Please specify a specific patch version
+      placeholder: eg v2.0.2
     validations:
       required: true
   - type: input
@@ -37,7 +38,7 @@ body:
       label: Expected Behavior
       description: A clear and concise description of what is expected to happen
       placeholder: |
-        Resource x should be accepted. 
+        Resource x should be accepted.
         Or, if "bar" is not a valid possible value for field "foo", then an error message should say so.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-ISSUE.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest an idea for this project
 labels: ["Type: Enhancement"]
+type: Feature
 body:
   - type: markdown
     attributes:
@@ -11,7 +12,7 @@ body:
     attributes:
       label: kgateway version
       description: What version of kgateway are you using? Please specify a specific patch version
-      placeholder: eg v1.14.2
+      placeholder: eg v2.0.2
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Refresh the bug and feature issue templates:

- Remove product vs. project mentions. This is now cruft with the 2.x cadence and post migration to CNCF
- Add the 'type' field for both templates. This was introduced ~year ago

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
