### PR TITLE
Inference: Bumps CRDs

### DIFF
--- a/internal/kgateway/crds/inferencemodels.yaml
+++ b/internal/kgateway/crds/inferencemodels.yaml
@@ -89,7 +89,7 @@ spec:
                   ModelNames must be unique for a referencing InferencePool
                   (names can be reused for a different pool in the same cluster).
                   The modelName with the oldest creation timestamp is retained, and the incoming
-                  InferenceModel is sets the Ready status to false with a corresponding reason.
+                  InferenceModel's Ready status is set to false with a corresponding reason.
                   In the rare case of a race condition, one Model will be selected randomly to be considered valid, and the other rejected.
                   Names can be reserved without an underlying model configured in the pool.
                   This can be done by specifying a target model and setting the weight to zero,

--- a/internal/kgateway/crds/inferencepools.yaml
+++ b/internal/kgateway/crds/inferencepools.yaml
@@ -135,16 +135,32 @@ spec:
             - targetPortNumber
             type: object
           status:
-            description: InferencePoolStatus defines the observed state of InferencePool
+            default:
+              parent:
+              - conditions:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                parentRef:
+                  kind: Status
+                  name: default
+            description: Status defines the observed state of InferencePool.
             properties:
               parent:
                 description: |-
                   Parents is a list of parent resources (usually Gateways) that are
-                  associated with the route, and the status of the InferencePool with respect to
+                  associated with the InferencePool, and the status of the InferencePool with respect to
                   each parent.
 
-                  A maximum of 32 Gateways will be represented in this list. An empty list
-                  means the route has not been attached to any Gateway.
+                  A maximum of 32 Gateways will be represented in this list. When the list contains
+                  `kind: Status, name: default`, it indicates that the InferencePool is not
+                  associated with any Gateway and a controller must perform the following:
+
+                   - Remove the parent when setting the "Accepted" condition.
+                   - Add the parent when the controller will no longer manage the InferencePool
+                     and no other parents exist.
                 items:
                   description: PoolStatus defines the observed state of InferencePool
                     from a Gateway.


### PR DESCRIPTION
Bumps the InferencePool and InferenceModel CRDs to consume recent upstream changes.

# Description

Needed to pass inference extension conformance tests.

# Change Type

```
/kind cleanup
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Bumps the inference extension CRDs to sync with upstream commit 842603b.
```

# Additional Notes

Fixes #11531
