### PR TITLE
use correct commit for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ on:
       - main
 
 env:
-  # this is uses the `github.repository_owner` to support releases from forks (useful for testing).
+  # this uses the `github.repository_owner` to support releases from forks (useful for testing).
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   VANITY_REGISTRY: cr.kgateway.dev/kgateway-dev
   MAIN_VERSION: v2.1.0-main
@@ -65,9 +65,6 @@ jobs:
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             VERSION="v0.0.0-manual-${GIT_SHA}"
             echo "goreleaser_args=--clean --skip=validate" >> $GITHUB_OUTPUT
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-            echo "goreleaser_args=--clean" >> $GITHUB_OUTPUT
           elif [[ $GITHUB_REF == refs/heads/main ]]; then
             VERSION="${MAIN_VERSION}"
             echo "goreleaser_args=--clean --skip=validate" >> $GITHUB_OUTPUT

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -177,6 +177,7 @@ release:
   prerelease: "auto"
   mode: "replace"
   replace_existing_artifacts: true
+  target_commitish: "{{ .FullCommit }}"
   header: |
     {{ if eq .Env.VERSION "v2.1.0-main" }}
     🚀 Rolling main build of kgateway!


### PR DESCRIPTION
# Description

Correct set the commit that will be used for releases.
This should not have a direct impact on releases from `main` but it is explicitly correct and prepares us for the next 2.1.x branch cut.

Forward port of https://github.com/kgateway-dev/kgateway/pull/11201

Fixes https://github.com/kgateway-dev/kgateway/issues/11176

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```