### PR TITLE
policy: enable global cross-namespace targetSelector attachment

### DIFF
--- a/design/11466.md
+++ b/design/11466.md
@@ -63,7 +63,7 @@ When the feature is enabled, the route rules in the [HTTPRoutes with weights](/i
 
 ### Test Plan
 
-Unit tests and translator tests will be added to ensure correct sorting of routes based on weights and standard precedence rules.
+Translator and e2e tests are added to ensure correct sorting of routes based on weights and standard precedence rules.
 
 ## Alternatives
 

--- a/design/11584.md
+++ b/design/11584.md
@@ -1,0 +1,53 @@
+# EP-11584: Global Policy Attachment using targetSelectors
+
+
+* Issue: [#11584](https://github.com/kgateway-dev/kgateway/issues/11584)
+
+
+## Background
+
+Currently, resources (such as `HTTPRoutes`) can only attach to targeting policies defined in the same namespace. This requirement can be limiting in scenarios where policies need to be attachable across multiple application namespace.
+
+## Motivation
+
+Provide the ability to:
+1. Define policies that are meant to be applicable to multiple namespaces to be defined in a single well known namespace.
+1. Use `targetSelectors` to attach such policies to arbitrary resources defined in any namespace.
+1. Allow resources (such as `HTTPRoutes`) to attach to such policies defined in the well known namespace using labels, enabling a more centralized policy management approach.
+
+## Goals
+
+- Preserve same-namespace policy attachment as the default behavior.
+- Enable cross-namespace global policy attachment using `KGW_GLOBAL_POLICY_NAMESPACE` environment variable.
+
+## Non-Goals
+
+- Cross-namespace policy attachment with `targetRefs`.
+
+## Implementation Details
+
+### Feature Enablement
+
+This feature is disabled by default and can be enabled by setting the `KGW_GLOBAL_POLICY_NAMESPACE` environment variable to the namespace where global policies reside.
+
+### Example Behavior
+
+When the feature is enabled with `KGW_GLOBAL_POLICY_NAMESPACE=kgateway-system`, the [configuration](/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/label_based.yaml) enables the `HTTPRoute` `example-route` in the `infra` namespace to attach to the `TrafficPolicy` `global-policy` in the `kgateway-system` namespace.
+
+### Test Plan
+
+Translator and e2e tests are added to ensure cross-namespace policy attachment works with a global policy namespace.
+
+## Alternatives
+
+### 1. Implicitly enable cross-namespace policy attachment
+- **Pros**: Simpler UX.
+- **Cons**: Performance degradation at scale.
+
+### 2. Add namespace to targetSelectors
+- **Pros**: Targeting namespace is explicit.
+- **Cons**: Violates standard policy attachment API, performance degradation at scale.
+
+## Open Questions
+
+n/a

--- a/internal/kgateway/deployer/gateway_parameters_test.go
+++ b/internal/kgateway/deployer/gateway_parameters_test.go
@@ -28,6 +28,7 @@ import (
 	common "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/pkg/schemes"
+	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 )
 
 const (
@@ -72,7 +73,8 @@ func TestShouldUseExtendedGatewayParameters(t *testing.T) {
 	gwc := defaultGatewayClass()
 	gwParams := emptyGatewayParameters()
 	extraGwParams := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Namespace: defaultNamespace}}
+		ObjectMeta: metav1.ObjectMeta{Namespace: defaultNamespace},
+	}
 
 	gw := &api.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
@@ -227,7 +229,7 @@ func newCommonCols(t test.Failer, initObjs ...client.Object) *common.CommonColle
 	}
 	mock := krttest.NewMock(t, anys)
 
-	policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{})
+	policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{}, settings.Settings{})
 	kubeRawGateways := krttest.GetMockCollection[*api.Gateway](mock)
 	kubeRawListenerSets := krttest.GetMockCollection[*apixv1a1.XListenerSet](mock)
 	gatewayClasses := krttest.GetMockCollection[*api.GatewayClass](mock)

--- a/internal/kgateway/krtcollections/grpc_route_test.go
+++ b/internal/kgateway/krtcollections/grpc_route_test.go
@@ -475,7 +475,7 @@ func TestTransformGRPCRoute(t *testing.T) {
 			grpcRoutes := krttest.GetMockCollection[*gwv1.GRPCRoute](mock)
 			services := krttest.GetMockCollection[*corev1.Service](mock)
 			refgrants := krtcollections.NewRefGrantIndex(krttest.GetMockCollection[*gwv1beta1.ReferenceGrant](mock))
-			policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{})
+			policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{}, settings.Settings{})
 
 			// Set up backend index
 			backends := krtcollections.NewBackendIndex(krtutil.KrtOptions{}, policies, refgrants)

--- a/internal/kgateway/krtcollections/metrics_test.go
+++ b/internal/kgateway/krtcollections/metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
 	"github.com/kgateway-dev/kgateway/v2/pkg/metrics/metricstest"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 )
 
 func setupTest() {
@@ -284,7 +285,8 @@ func TestGatewaysCollectionMetrics(t *testing.T) {
 			mockGws := krttest.GetMockCollection[*gwv1.Gateway](mock)
 			mockLss := krttest.GetMockCollection[*gwxv1a1.XListenerSet](mock)
 
-			idx := NewGatewayIndex(krtutil.KrtOptions{}, "test", NewPolicyIndex(krtutil.KrtOptions{}, nil), mockGws, mockLss, mockGwcs, mockNs)
+			idx := NewGatewayIndex(krtutil.KrtOptions{}, "test",
+				NewPolicyIndex(krtutil.KrtOptions{}, nil, settings.Settings{}), mockGws, mockLss, mockGwcs, mockNs)
 			idx.Gateways.WaitUntilSynced(context.Background().Done())
 
 			time.Sleep(5 * time.Millisecond) // Allow some time for events to process.

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -721,7 +721,9 @@ func (p *PolicyIndex) getTargetingPoliciesMaybeForBackends(
 		policiesByLabel := p.fetchByTargetRefLabels(kctx, refIndexKeyByNamespace, onlyBackends, targetLabels)
 		policies = append(policies, policiesByLabel...)
 
-		// Check if policies defined in the global policy namespace target this ref
+		// Check if policies defined in the global policy namespace target this ref.
+		// `targetRef.Namespace != p.globalPolicyNamespace` ensures we avoid a duplicate lookup as done
+		// above when targetRef.Namespace is the same as globalPolicyNamespace
 		if p.globalPolicyNamespace != "" && targetRef.Namespace != p.globalPolicyNamespace {
 			refIndexKeyByNamespace.Namespace = p.globalPolicyNamespace
 			globalPolicies := p.fetchByTargetRefLabels(kctx, refIndexKeyByNamespace, onlyBackends, targetLabels)

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -508,7 +508,8 @@ type policyAndIndex struct {
 	forBackends         bool
 }
 type PolicyIndex struct {
-	availablePolicies map[schema.GroupKind]policyAndIndex
+	globalPolicyNamespace string
+	availablePolicies     map[schema.GroupKind]policyAndIndex
 
 	policiesFetch  map[schema.GroupKind]func(n string, ns string) ir.PolicyIR
 	globalPolicies []globalPolicy
@@ -534,8 +535,16 @@ func (h *PolicyIndex) HasSynced() bool {
 	return true
 }
 
-func NewPolicyIndex(krtopts krtutil.KrtOptions, contributesPolicies extensionsplug.ContributesPolicies) *PolicyIndex {
-	index := &PolicyIndex{policiesFetch: policyFetcherMap{}, availablePolicies: map[schema.GroupKind]policyAndIndex{}}
+func NewPolicyIndex(
+	krtopts krtutil.KrtOptions,
+	contributesPolicies extensionsplug.ContributesPolicies,
+	globalSettings settings.Settings,
+) *PolicyIndex {
+	index := &PolicyIndex{
+		globalPolicyNamespace: globalSettings.GlobalPolicyNamespace,
+		policiesFetch:         policyFetcherMap{},
+		availablePolicies:     map[schema.GroupKind]policyAndIndex{},
+	}
 
 	for gk, plugin := range contributesPolicies {
 		if plugin.Policies != nil {
@@ -711,6 +720,13 @@ func (p *PolicyIndex) getTargetingPoliciesMaybeForBackends(
 		}
 		policiesByLabel := p.fetchByTargetRefLabels(kctx, refIndexKeyByNamespace, onlyBackends, targetLabels)
 		policies = append(policies, policiesByLabel...)
+
+		// Check if policies defined in the global policy namespace target this ref
+		if p.globalPolicyNamespace != "" && targetRef.Namespace != p.globalPolicyNamespace {
+			refIndexKeyByNamespace.Namespace = p.globalPolicyNamespace
+			globalPolicies := p.fetchByTargetRefLabels(kctx, refIndexKeyByNamespace, onlyBackends, targetLabels)
+			policies = append(policies, globalPolicies...)
+		}
 	}
 
 	for _, p := range policies {

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -688,11 +688,15 @@ func preRouteIndex(t test.Failer, inputs []any) *RoutesIndex {
 	services := krttest.GetMockCollection[*corev1.Service](mock)
 	policyCol := krttest.GetMockCollection[ir.PolicyWrapper](mock)
 
-	policies := NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{
-		wellknown.TrafficPolicyGVK.GroupKind(): {
-			Policies: policyCol,
+	policies := NewPolicyIndex(
+		krtutil.KrtOptions{},
+		extensionsplug.ContributesPolicies{
+			wellknown.TrafficPolicyGVK.GroupKind(): {
+				Policies: policyCol,
+			},
 		},
-	})
+		settings.Settings{},
+	)
 	refgrants := NewRefGrantIndex(krttest.GetMockCollection[*gwv1beta1.ReferenceGrant](mock))
 	upstreams := NewBackendIndex(krtutil.KrtOptions{}, policies, refgrants)
 	upstreams.AddBackends(svcGk, k8sSvcUpstreams(services))

--- a/internal/kgateway/krtcollections/setup.go
+++ b/internal/kgateway/krtcollections/setup.go
@@ -144,7 +144,7 @@ func InitCollections(
 	gatewayClasses := krt.WrapClient(kclient.New[*gwv1.GatewayClass](istioClient), krtopts.ToOptions("KubeGatewayClasses")...)
 	namespaces, _ := NewNamespaceCollection(ctx, istioClient, krtopts)
 
-	policies := NewPolicyIndex(krtopts, plugins.ContributesPolicies)
+	policies := NewPolicyIndex(krtopts, plugins.ContributesPolicies, globalSettings)
 	backendIndex := NewBackendIndex(krtopts, policies, refgrants)
 	initBackends(plugins, backendIndex)
 	endpointIRs := initEndpoints(plugins, krtopts)

--- a/internal/kgateway/query/query_test.go
+++ b/internal/kgateway/query/query_test.go
@@ -1131,7 +1131,7 @@ func newQueries(t test.Failer, initObjs ...client.Object) query.GatewayQueries {
 	services := krttest.GetMockCollection[*corev1.Service](mock)
 	refgrants := krtcollections.NewRefGrantIndex(krttest.GetMockCollection[*gwv1beta1.ReferenceGrant](mock))
 
-	policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{})
+	policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{}, settings.Settings{})
 	upstreams := krtcollections.NewBackendIndex(krtutil.KrtOptions{}, policies, refgrants)
 	upstreams.AddBackends(SvcGk, k8sUpstreams(services))
 

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -258,6 +258,28 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			},
 		}),
 	Entry(
+		"TrafficPolicy with targetSelectors and global policy attachment",
+		translatorTestCase{
+			inputFile:  "traffic-policy/label_based.yaml",
+			outputFile: "traffic-policy/label_based_global_policy.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "infra",
+				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				expectedPolicies := []reports.PolicyKey{
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "infra", Name: "transform"},
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "infra", Name: "rate-limit"},
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "kgateway-system", Name: "global-policy"},
+				}
+				assertAcceptedPolicyStatus(reportsMap, expectedPolicies)
+			},
+		},
+		func(s *settings.Settings) {
+			s.GlobalPolicyNamespace = "kgateway-system"
+		},
+	),
+	Entry(
 		"TrafficPolicy edge cases",
 		translatorTestCase{
 			inputFile:  "traffic-policy/extauth.yaml",

--- a/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/label_based.yaml
@@ -46,6 +46,7 @@ metadata:
   namespace: infra
   labels:
     route: example
+    global-policy: cors # will be applied only when Settings.GlobalPolicyNamespace=kgateway-system
 spec:
   parentRefs:
   - name: example-gateway
@@ -120,3 +121,18 @@ spec:
     targetPort: 50051
   selector:
     app: log-test
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: global-policy
+  namespace: kgateway-system
+spec:
+  targetSelectors:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    matchLabels: 
+      global-policy: cors
+  cors:
+    allowOrigins:
+    - "https://example.com"

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -1,0 +1,127 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_infra_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_infra_log-test_50051
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        accessLog:
+        - filter:
+            headerFilter:
+              header:
+                name: x-my-cool-test-filter
+                stringMatch:
+                  exact: test
+          name: envoy.access_loggers.http_grpc
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
+            commonConfig:
+              grpcService:
+                envoyGrpc:
+                  clusterName: kube_infra_log-test_50051
+              logName: test-accesslog-service
+              transportApiVersion: V3
+        httpFilters:
+        - name: envoy.filters.http.cors
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+        - disabled: true
+          name: ratelimit/local
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            statPrefix: http_local_rate_limiter
+        - disabled: true
+          name: transformation
+          typedConfig:
+            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-infra-0-0-matcher-0
+      route:
+        cluster: kube_infra_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        envoy.filters.http.cors:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+          allowOriginStringMatch:
+          - exact: https://example.com
+        ratelimit/local:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+          filterEnabled:
+            defaultValue:
+              numerator: 100
+            runtimeKey: local_rate_limit_enabled
+          filterEnforced:
+            defaultValue:
+              numerator: 100
+            runtimeKey: local_rate_limit_enforced
+          statPrefix: http_local_rate_limiter
+          tokenBucket:
+            fillInterval: 33s
+            maxTokens: 99
+            tokensPerFill: 1
+        transformation:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
+          transformations:
+          - requestMatch:
+              responseTransformation:
+                transformationTemplate:
+                  headersToAppend:
+                  - key: abc
+                    value:
+                      text: custom-value-abc
+                  parseBodyBehavior: DontParse
+                  passthrough: {}

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/pkg/schemes"
+	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 
 	// TODO BML tests in this suite fail if this no-op import is not imported first.
 	//
@@ -567,9 +568,7 @@ var _ = Describe("Deployer", func() {
 	})
 
 	Context("special cases", func() {
-		var (
-			gwc *api.GatewayClass
-		)
+		var gwc *api.GatewayClass
 		BeforeEach(func() {
 			gwc = defaultGatewayClass()
 		})
@@ -771,9 +770,7 @@ var _ = Describe("Deployer", func() {
 			tag = "1.2.3"
 		})
 		When("a GC is created with an empty spec.parametersRef", func() {
-			var (
-				d *deployer.Deployer
-			)
+			var d *deployer.Deployer
 			It("should use the default in-memory GWP", func() {
 				var objs clientObjects
 				var err error
@@ -2099,7 +2096,7 @@ var _ = Describe("Deployer", func() {
 			Expect(pool.GetFinalizers()).To(ContainElement(wellknown.InferencePoolFinalizer))
 
 			// Get the endpoint picker objects for the InferencePool.
-			objs, err := d.GetObjsToDeploy(nil, pool)
+			objs, err := d.GetObjsToDeploy(context.Background(), pool)
 			Expect(err).NotTo(HaveOccurred())
 			objs = d.SetNamespaceAndOwner(pool, objs)
 
@@ -2167,7 +2164,6 @@ var _ = Describe("Deployer", func() {
 	})
 
 	Context("with listener sets", func() {
-
 		var (
 			listenerSetPort int32 = 4567
 			listenerPort    int32 = 1234
@@ -2505,7 +2501,7 @@ func newCommonCols(t test.Failer, initObjs ...client.Object) *common.CommonColle
 	}
 	mock := krttest.NewMock(t, anys)
 
-	policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{})
+	policies := krtcollections.NewPolicyIndex(krtutil.KrtOptions{}, extensionsplug.ContributesPolicies{}, settings.Settings{})
 	kubeRawGateways := krttest.GetMockCollection[*api.Gateway](mock)
 	kubeRawListenerSets := krttest.GetMockCollection[*apixv1a1.XListenerSet](mock)
 	gatewayClasses := krttest.GetMockCollection[*api.GatewayClass](mock)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -155,6 +155,10 @@ type Settings struct {
 	// EnableBuiltinDefaultMetrics enables the default builtin controller-runtime metrics and go runtime metrics.
 	// Since these metrics can be numerous, it is disabled by default.
 	EnableBuiltinDefaultMetrics bool `split_words:"true" default:"false"`
+
+	// GlobalPolicyNamespace is the namespace where policies that can attach to resources
+	// in any namespace are defined.
+	GlobalPolicyNamespace string `split_words:"true"`
 }
 
 // BuildSettings returns a zero-valued Settings obj if error is encountered when parsing env

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -52,6 +52,7 @@ func TestSettings(t *testing.T) {
 				WeightedRoutePrecedence:     false,
 				RouteReplacementMode:        settings.RouteReplacementStandard,
 				EnableBuiltinDefaultMetrics: false,
+				GlobalPolicyNamespace:       "",
 			},
 		},
 		{
@@ -80,6 +81,7 @@ func TestSettings(t *testing.T) {
 				"KGW_WEIGHTED_ROUTE_PRECEDENCE":      "true",
 				"KGW_ROUTE_REPLACEMENT_MODE":         string(settings.RouteReplacementStrict),
 				"KGW_ENABLE_BUILTIN_DEFAULT_METRICS": "true",
+				"KGW_GLOBAL_POLICY_NAMESPACE":        "foo",
 			},
 			expectedSettings: &settings.Settings{
 				DnsLookupFamily:             settings.DnsLookupFamilyV4Only,
@@ -104,6 +106,7 @@ func TestSettings(t *testing.T) {
 				WeightedRoutePrecedence:     true,
 				RouteReplacementMode:        settings.RouteReplacementStrict,
 				EnableBuiltinDefaultMetrics: true,
+				GlobalPolicyNamespace:       "foo",
 			},
 		},
 		{

--- a/test/kubernetes/e2e/defaults/defaults.go
+++ b/test/kubernetes/e2e/defaults/defaults.go
@@ -85,4 +85,17 @@ Commercial support is available at
 <p><em>Thank you for using nginx.</em></p>
 </body>
 </html>`
+
+	HttpbinManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "httpbin.yaml")
+
+	HttpbinLabelSelector = "app=httpbin"
+
+	HttpbinPod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httpbin",
+			Namespace: "default",
+		},
+	}
+
+	WellKnownAppLabel = "app.kubernetes.io/name"
 )

--- a/test/kubernetes/e2e/defaults/testdata/httpbin.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/httpbin.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+    service: httpbin
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080
+    - name: tcp
+      port: 9000
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      serviceAccountName: httpbin
+      containers:
+        - image: docker.io/mccutchen/go-httpbin:v2.6.0
+          imagePullPolicy: IfNotPresent
+          name: httpbin
+          command: [ go-httpbin ]
+          args:
+            - "-port"
+            - "8080"
+            - "-max-duration"
+            - "600s" # override default 10s
+          ports:
+            - containerPort: 8080
+        - name: curl
+          image: curlimages/curl:7.83.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - "tail"
+            - "-f"
+            - "/dev/null"

--- a/test/kubernetes/e2e/features/policyselector/testdata/label_selector.yaml
+++ b/test/kubernetes/e2e/features/policyselector/testdata/label_selector.yaml
@@ -43,7 +43,7 @@ spec:
           request_id: "%REQ(X-REQUEST-ID)%"
           authority: "%REQ(:AUTHORITY)%"
           backendHost: "%UPSTREAM_HOST%"
-          backendCluster: "%UPSTREAM_CLUSTER%"        
+          backendCluster: "%UPSTREAM_CLUSTER%"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -51,6 +51,7 @@ metadata:
   name: httpbin
   labels:
     route: httpbin-app
+    global-policy: cors
 spec:
   parentRefs:
   - name: http-gw
@@ -73,54 +74,25 @@ spec:
     response:
       add:
       - name: x-foo
-        value: bar        
+        value: bar
 ---
-apiVersion: v1
-kind: Service
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
 metadata:
-  name: httpbin
-  labels:
-    app: httpbin
+  name: global-cors
+  namespace: $INSTALL_NAMESPACE
 spec:
-  ports:
-  - name: http
-    port: 8000
-    targetPort: 8080
-  selector:
-    app: httpbin
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: httpbin
-spec:
-  replicas: 1
-  selector:
+  targetSelectors:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
     matchLabels:
-      app: httpbin
-      version: v1
-  template:
-    metadata:
-      labels:
-        app: httpbin
-        version: v1
-    spec:
-      containers:
-      - image: docker.io/kennethreitz/httpbin
-        imagePullPolicy: IfNotPresent
-        name: httpbin
-        command:
-        - gunicorn
-        - -b
-        - 0.0.0.0:8080
-        - httpbin:app
-        - -k
-        - gevent
-        env:
-        # Tells pipenv to use a writable directory instead of $HOME
-        - name: WORKON_HOME
-          value: /tmp
-        ports:
-        - containerPort: 8080
----
-
+      global-policy: cors
+  cors:
+    allowOrigins:
+      - https://example.com
+    allowMethods:
+      - GET
+      - POST
+      - DELETE
+    allowHeaders:
+      - x-custom-header

--- a/test/kubernetes/e2e/features/policyselector/types.go
+++ b/test/kubernetes/e2e/features/policyselector/types.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -23,20 +22,6 @@ var (
 	gateway = &gwv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "http-gw",
-			Namespace: "default",
-		},
-	}
-
-	httpbinRoute = &gwv1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "httpbin",
-			Namespace: "default",
-		},
-	}
-
-	httpbinDeployment = &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "httpbin",
 			Namespace: "default",
 		},
 	}

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -182,6 +182,7 @@ func (i *TestInstallation) InstallKgatewayCoreFromLocalChart(ctx context.Context
 			ValuesFiles:     []string{i.Metadata.ProfileValuesManifestFile, i.Metadata.ValuesManifestFile},
 			ReleaseName:     helmutils.ChartName,
 			ChartUri:        chartUri,
+			ExtraArgs:       i.Metadata.ExtraHelmArgs,
 		})
 	i.Assertions.Require.NoError(err)
 	i.Assertions.EventuallyKgatewayInstallSucceeded(ctx)

--- a/test/kubernetes/e2e/tests/kgateway_test.go
+++ b/test/kubernetes/e2e/tests/kgateway_test.go
@@ -21,6 +21,9 @@ func TestKgateway(t *testing.T) {
 			InstallNamespace:          installNs,
 			ProfileValuesManifestFile: e2e.CommonRecommendationManifest,
 			ValuesManifestFile:        e2e.EmptyValuesManifestPath,
+			ExtraHelmArgs: []string{
+				"--set", "controller.extraEnv.KGW_GLOBAL_POLICY_NAMESPACE=" + installNs,
+			},
 		},
 	)
 

--- a/test/kubernetes/testutils/install/context.go
+++ b/test/kubernetes/testutils/install/context.go
@@ -14,6 +14,9 @@ type Context struct {
 
 	// ValuesManifestFile points to the file that contains the set of Helm values that are unique to this test
 	ValuesManifestFile string
+
+	// ExtraHelmArgs are additional Helm arguments
+	ExtraHelmArgs []string
 }
 
 // ValidateInstallContext returns an error if the provided Context is invalid


### PR DESCRIPTION
#  Description
Enables the ability to define policies in a well known namespace controlled by Settings.GlobalPolicyNamespace that resources in any namespace can attach to if they match the selected labels.

Resolves #11584

# Change Type

```
/kind new_feature
```

# Changelog

```release-note
Adds the ability for resources to attach to policies defined
in the global policy namespace when using targetSelectors.
```