### PR TITLE
refactor: Three variables from file.go have been moved to their individual files.

### DIFF
--- a/test/kubernetes/e2e/file.go
+++ b/test/kubernetes/e2e/file.go
@@ -13,12 +13,6 @@ var (
 	// We prefer to have our tests be explicit and require defining a values file. However, some tests
 	// rely entirely on the values provided by the "profile". In those cases, the test supplies this reference
 	EmptyValuesManifestPath = ManifestPath("empty-values.yaml")
-
-	AIValuesManifestPath = ManifestPath("ai-extension-helm.yaml")
-
-	InfExtValuesManifestPath = ManifestPath("inference-extension-helm.yaml")
-
-	AgentGatewayIntegratioValuesPath = ManifestPath("agent-gateway-integration.yaml")
 )
 
 // ManifestPath returns the absolute path to a manifest file.

--- a/test/kubernetes/e2e/tests/agent_gateway_test.go
+++ b/test/kubernetes/e2e/tests/agent_gateway_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
+var AgentGatewayIntegrationValuesPath = e2e.ManifestPath("agent-gateway-integration.yaml")
+
 func TestAgentGatewayIntegration(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "agent-gateway-test")
@@ -20,7 +22,7 @@ func TestAgentGatewayIntegration(t *testing.T) {
 		&install.Context{
 			InstallNamespace:          installNs,
 			ProfileValuesManifestFile: e2e.CommonRecommendationManifest,
-			ValuesManifestFile:        e2e.AgentGatewayIntegratioValuesPath,
+			ValuesManifestFile:        AgentGatewayIntegrationValuesPath,
 		},
 	)
 

--- a/test/kubernetes/e2e/tests/agent_gateway_test.go
+++ b/test/kubernetes/e2e/tests/agent_gateway_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-var AgentGatewayIntegrationValuesPath = e2e.ManifestPath("agent-gateway-integration.yaml")
-
 func TestAgentGatewayIntegration(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "agent-gateway-test")
@@ -22,7 +20,7 @@ func TestAgentGatewayIntegration(t *testing.T) {
 		&install.Context{
 			InstallNamespace:          installNs,
 			ProfileValuesManifestFile: e2e.CommonRecommendationManifest,
-			ValuesManifestFile:        AgentGatewayIntegrationValuesPath,
+			ValuesManifestFile:        e2e.ManifestPath("agent-gateway-integration.yaml"),
 		},
 	)
 

--- a/test/kubernetes/e2e/tests/ai_extension_test.go
+++ b/test/kubernetes/e2e/tests/ai_extension_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
-var AIValuesManifestPath = e2e.ManifestPath("ai-extension-helm.yaml")
-
 // TestAIExtensions tests the AI extension functionality
 func TestAIExtensions(t *testing.T) {
 	ctx := context.Background()
@@ -30,7 +28,7 @@ func TestAIExtensions(t *testing.T) {
 		t,
 		&install.Context{
 			InstallNamespace:          installNs,
-			ProfileValuesManifestFile: AIValuesManifestPath,
+			ProfileValuesManifestFile: e2e.ManifestPath("ai-extension-helm.yaml"),
 			ValuesManifestFile:        e2e.EmptyValuesManifestPath,
 		},
 	)

--- a/test/kubernetes/e2e/tests/ai_extension_test.go
+++ b/test/kubernetes/e2e/tests/ai_extension_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
+var AIValuesManifestPath = e2e.ManifestPath("ai-extension-helm.yaml")
+
 // TestAIExtensions tests the AI extension functionality
 func TestAIExtensions(t *testing.T) {
 	ctx := context.Background()
@@ -28,7 +30,7 @@ func TestAIExtensions(t *testing.T) {
 		t,
 		&install.Context{
 			InstallNamespace:          installNs,
-			ProfileValuesManifestFile: e2e.AIValuesManifestPath,
+			ProfileValuesManifestFile: AIValuesManifestPath,
 			ValuesManifestFile:        e2e.EmptyValuesManifestPath,
 		},
 	)

--- a/test/kubernetes/e2e/tests/inference_extension_test.go
+++ b/test/kubernetes/e2e/tests/inference_extension_test.go
@@ -16,8 +16,7 @@ var (
 	poolCrdManifest  = filepath.Join(crds.AbsPathToCrd("inferencepools.yaml"))
 	modelCrdManifest = filepath.Join(crds.AbsPathToCrd("inferencemodels.yaml"))
 	// infExtNs is the namespace to install kgateway
-	infExtNs                 = "inf-ext-e2e"
-	InfExtValuesManifestPath = e2e.ManifestPath("inference-extension-helm.yaml")
+	infExtNs = "inf-ext-e2e"
 )
 
 // TestInferenceExtension tests Inference Extension functionality
@@ -27,7 +26,7 @@ func TestInferenceExtension(t *testing.T) {
 		t,
 		&install.Context{
 			InstallNamespace:          infExtNs,
-			ProfileValuesManifestFile: InfExtValuesManifestPath,
+			ProfileValuesManifestFile: e2e.ManifestPath("inference-extension-helm.yaml"),
 			ValuesManifestFile:        e2e.EmptyValuesManifestPath,
 		},
 	)

--- a/test/kubernetes/e2e/tests/inference_extension_test.go
+++ b/test/kubernetes/e2e/tests/inference_extension_test.go
@@ -16,7 +16,8 @@ var (
 	poolCrdManifest  = filepath.Join(crds.AbsPathToCrd("inferencepools.yaml"))
 	modelCrdManifest = filepath.Join(crds.AbsPathToCrd("inferencemodels.yaml"))
 	// infExtNs is the namespace to install kgateway
-	infExtNs = "inf-ext-e2e"
+	infExtNs                 = "inf-ext-e2e"
+	InfExtValuesManifestPath = e2e.ManifestPath("inference-extension-helm.yaml")
 )
 
 // TestInferenceExtension tests Inference Extension functionality
@@ -26,7 +27,7 @@ func TestInferenceExtension(t *testing.T) {
 		t,
 		&install.Context{
 			InstallNamespace:          infExtNs,
-			ProfileValuesManifestFile: e2e.InfExtValuesManifestPath,
+			ProfileValuesManifestFile: InfExtValuesManifestPath,
 			ValuesManifestFile:        e2e.EmptyValuesManifestPath,
 		},
 	)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Inside file.go, there were three variables — AIValuesManifestPath, InfExtValuesManifestPath, and AgentGatewayIntegrationValuesPath — which were only used in one test file, so I have moved them to their individual files, as suggested in Fixes #11375.

# Change Type
```
/kind cleanup
```

# Changelog
```release-note
NONE
```


