### PR TITLE
fix: ensure HTTPListenerPolicy is accepted before running tests

### DIFF
--- a/test/kubernetes/e2e/features/accesslog/suite.go
+++ b/test/kubernetes/e2e/features/accesslog/suite.go
@@ -38,6 +38,12 @@ func (s *testingSuite) SetupSuite() {
 	s.TestInstallation.Assertions.EventuallyHTTPRouteCondition(s.Ctx, "httpbin", "httpbin", gwv1.RouteConditionAccepted, metav1.ConditionTrue)
 }
 
+func (s *testingSuite) BeforeTest(suiteName, testName string) {
+	s.BaseTestingSuite.BeforeTest(suiteName, testName)
+
+	s.TestInstallation.Assertions.EventuallyHTTPListenerPolicyCondition(s.Ctx, "access-logs", "default", gwv1.GatewayConditionAccepted, metav1.ConditionTrue)
+}
+
 // TestAccessLogWithFileSink tests access log with file sink
 func (s *testingSuite) TestAccessLogWithFileSink() {
 	pods := s.getPods(fmt.Sprintf("app.kubernetes.io/name=%s", gatewayObjectMeta.GetName()))

--- a/test/kubernetes/e2e/features/accesslog/testdata/otel.yaml
+++ b/test/kubernetes/e2e/features/accesslog/testdata/otel.yaml
@@ -92,7 +92,8 @@ spec:
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: HTTPListenerPolicy
 metadata:
-  name: tracing-policy
+  name: access-logs
+  namespace: default
 spec:
   targetRefs:
   - group: gateway.networking.k8s.io

--- a/test/kubernetes/e2e/features/tracing/suite.go
+++ b/test/kubernetes/e2e/features/tracing/suite.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
@@ -41,6 +43,8 @@ func (s *testingSuite) TestOTelTracingSecure() {
 // testOTelTracing makes a request to the httpbin service
 // and checks if the collector pod logs contain the expected lines
 func (s *testingSuite) testOTelTracing() {
+	s.TestInstallation.Assertions.EventuallyHTTPListenerPolicyCondition(s.Ctx, "tracing-policy", "default", gwv1.GatewayConditionAccepted, metav1.ConditionTrue)
+
 	// The headerValue passed is used to differentiate between multiple calls by identifying a unique trace per call
 	headerValue := fmt.Sprintf("%v", rand.Intn(10000))
 	s.TestInstallation.Assertions.Gomega.Eventually(func(g gomega.Gomega) {

--- a/test/kubernetes/e2e/features/tracing/testdata/tracing-policy.yaml
+++ b/test/kubernetes/e2e/features/tracing/testdata/tracing-policy.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.kgateway.dev/v1alpha1
 kind: HTTPListenerPolicy
 metadata:
   name: tracing-policy
+  namespace: default
 spec:
   targetRefs:
   - group: gateway.networking.k8s.io

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -15,6 +15,7 @@ import (
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/v2/test/helpers"
 )
@@ -421,4 +422,33 @@ func getListener(listeners []gwxv1a1.ListenerEntryStatus, name string) *gwxv1a1.
 		}
 	}
 	return nil
+}
+
+// EventuallyHTTPListenerPolicyCondition checks that provided HTTPListenerPolicy condition is set to expect.
+func (p *Provider) EventuallyHTTPListenerPolicyCondition(
+	ctx context.Context,
+	name string,
+	namespace string,
+	cond gwv1.GatewayConditionType,
+	expect metav1.ConditionStatus,
+	timeout ...time.Duration,
+) {
+	ginkgo.GinkgoHelper()
+	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+	p.Gomega.Eventually(func(g gomega.Gomega) {
+		hlp := &v1alpha1.HTTPListenerPolicy{}
+		err := p.clusterContext.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, hlp)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get HTTPListenerPolicy %s/%s", namespace, name)
+
+		var conditionFound bool
+		for _, parentStatus := range hlp.Status.Ancestors {
+			condition := getConditionByType(parentStatus.Conditions, string(cond))
+			if condition != nil && condition.Status == expect {
+				conditionFound = true
+				break
+			}
+		}
+		g.Expect(conditionFound).To(gomega.BeTrue(), fmt.Sprintf("%v condition is not %v for any parent of HTTPListenerPolicy %s/%s",
+			cond, expect, namespace, name))
+	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Fix a flake caused by the test running before the HTTPListenerPolicy is accepted
Ref: https://github.com/kgateway-dev/kgateway/actions/runs/16053044429/job/45300367457?pr=11483

# Change Type

```
/kind flake
```


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```
