### PR TITLE
route-delegation: return 500 on unresolved backendRefs

### DIFF
--- a/internal/kgateway/translator/gateway/testutils/inputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/delegation/unresolved_ref.yaml
@@ -1,0 +1,111 @@
+# This test contains 3 levels of delegation (parent -> child -> grandchild).
+#
+# Input:
+# - Parent infra/example-route:
+#   - Delegate /a to routes in "a" namespace
+#   - Delegate /b to routes in "b" namespace -> results in an unresolved reference (500 direct response)
+#   - Everything else goes to infra/example-svc
+# - Child a/route-a:
+#   - /a/1 goes to a/svc-a
+#   - Delegate /a/b to route a-b/route-a-b
+#   - Delegate /a/c to routes in a-c namespace -> results in an unresolved reference (500 direct response)
+# - Child a-b/route-a-b:
+#   - /a/b/1 goes to a-b/svc-a-b
+#
+# Expected output routes:
+# - /a/b/1 -> a-b/svc-a-b
+# - /a/1 -> a/svc-a
+# - /a/c -> 500 direct response 
+# - /b -> 500 direct response
+# - /* -> infra/example-svc
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+  # Unresolved ref
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /b
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: b
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/b
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "route-a-b"
+      namespace: a-b
+  # Unresolved ref
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/c
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: a-c
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a-b
+  namespace: a-b
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/b/1
+    backendRefs:
+    - name: svc-a-b
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a-b
+  namespace: a-b
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -63,6 +63,11 @@ Routes:
     - example.com
     name: listener~80~example_com
     routes:
+    - directResponse:
+        status: 500
+      match:
+        pathSeparatedPrefix: /a
+      name: listener~80~example_com-route-0-httproute-example-route-infra-1-0-matcher-0
     - match:
         prefix: /
       name: listener~80~example_com-route-1-httproute-example-route-infra-0-0-matcher-0

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -83,6 +83,25 @@ Routes:
       route:
         cluster: kube_a_svc-a_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - directResponse:
+        status: 500
+      match:
+        headers:
+        - name: header2
+          stringMatch:
+            exact: val2
+        - name: header3
+          stringMatch:
+            exact: val3
+        pathSeparatedPrefix: /b
+        queryParameters:
+        - name: query2
+          stringMatch:
+            exact: val2
+        - name: query3
+          stringMatch:
+            exact: val3
+      name: listener~80~example_com-route-1-httproute-example-route-infra-2-0-matcher-0
     - match:
         prefix: /
       name: listener~80~example_com-route-3-httproute-example-route-infra-0-0-matcher-0

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -69,6 +69,11 @@ Routes:
       route:
         cluster: kube_a_svc-a_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - directResponse:
+        status: 500
+      match:
+        pathSeparatedPrefix: /a/b
+      name: listener~80~example_com-route-1-httproute-route-a-a-1-0-matcher-0
     - match:
         prefix: /
       name: listener~80~example_com-route-3-httproute-example-route-infra-0-0-matcher-0

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -63,6 +63,11 @@ Routes:
     - example.com
     name: listener~80~example_com
     routes:
+    - directResponse:
+        status: 500
+      match:
+        pathSeparatedPrefix: /a/b/1
+      name: listener~80~example_com-route-0-httproute-route-a-b-a-b-0-0-matcher-0
     - match:
         pathSeparatedPrefix: /a/1
       name: listener~80~example_com-route-1-httproute-route-a-a-0-0-matcher-0

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -63,6 +63,11 @@ Routes:
     - example.com
     name: listener~80~example_com
     routes:
+    - directResponse:
+        status: 500
+      match:
+        pathSeparatedPrefix: /a
+      name: listener~80~example_com-route-0-httproute-example-route-infra-1-0-matcher-0
     - match:
         prefix: /
       name: listener~80~example_com-route-1-httproute-example-route-infra-0-0-matcher-0

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -93,3 +93,8 @@ Routes:
       route:
         cluster: kube_a_svc-a_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - directResponse:
+        status: 500
+      match:
+        pathSeparatedPrefix: /b
+      name: listener~80~foo_com-route-2-httproute-foo-route-infra-1-0-matcher-0

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
@@ -6,6 +6,15 @@ Clusters:
       resourceApiVersion: V3
   ignoreHealthOnHostRemoval: true
   metadata: {}
+  name: kube_a-b_svc-a-b_8080
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
   name: kube_a_svc-a_8080
   type: EDS
 - connectTimeout: 5s
@@ -63,14 +72,31 @@ Routes:
     - example.com
     name: listener~80~example_com
     routes:
+    - match:
+        pathSeparatedPrefix: /a/b/1
+      name: listener~80~example_com-route-0-httproute-route-a-b-a-b-0-0-matcher-0
+      route:
+        cluster: kube_a-b_svc-a-b_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /a/1
+      name: listener~80~example_com-route-1-httproute-route-a-a-0-0-matcher-0
+      route:
+        cluster: kube_a_svc-a_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
     - directResponse:
         status: 500
       match:
-        pathSeparatedPrefix: /a
-      name: listener~80~example_com-route-0-httproute-example-route-infra-1-0-matcher-0
+        pathSeparatedPrefix: /a/c
+      name: listener~80~example_com-route-3-httproute-route-a-a-2-0-matcher-0
+    - directResponse:
+        status: 500
+      match:
+        pathSeparatedPrefix: /b
+      name: listener~80~example_com-route-5-httproute-example-route-infra-2-0-matcher-0
     - match:
         prefix: /
-      name: listener~80~example_com-route-1-httproute-example-route-infra-0-0-matcher-0
+      name: listener~80~example_com-route-6-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -49,6 +49,11 @@ Routes:
     - example.com
     name: listener~80~example_com
     routes:
+    - directResponse:
+        status: 500
+      match:
+        pathSeparatedPrefix: /a
+      name: listener~80~example_com-route-0-httproute-example-route-infra-1-0-matcher-0
     - match:
         prefix: /
       name: listener~80~example_com-route-1-httproute-example-route-infra-0-0-matcher-0

--- a/internal/kgateway/translator/httproute/gateway_http_route_translator.go
+++ b/internal/kgateway/translator/httproute/gateway_http_route_translator.go
@@ -2,7 +2,6 @@ package httproute
 
 import (
 	"context"
-	"log/slog"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -11,8 +10,11 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/query"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	reports "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
+
+var logger = logging.New("translator/httproute")
 
 // TODO: Uncomment when the gateway_http_route_translator_test.go is uncommented.
 // var (
@@ -173,10 +175,6 @@ func setRouteAction(
 	routesVisited sets.Set[types.NamespacedName],
 ) {
 	backends := rule.Backends
-	// this was coming from internal/kgateway/translator/gateway/gateway_translator.go
-	// TODO: scope this to httproute?
-	logger := slog.Default()
-
 	for _, backend := range backends {
 		// If the backend is an HTTPRoute, it implies route delegation
 		// for which delegated routes are recursively flattened and translated
@@ -196,6 +194,7 @@ func setRouteAction(
 			)
 			if err != nil {
 				query.ProcessBackendError(err, reporter)
+				outputRoute.Error = err
 			}
 			continue
 		}

--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -182,13 +182,9 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 			}
 		}
 	}
-	out.RequestHeadersToAdd = append(out.GetRequestHeadersToAdd(), backendConfigCtx.RequestHeadersToAdd...)
-	out.RequestHeadersToRemove = append(out.GetRequestHeadersToRemove(), backendConfigCtx.RequestHeadersToRemove...)
-	out.ResponseHeadersToAdd = append(out.GetResponseHeadersToAdd(), backendConfigCtx.ResponseHeadersToAdd...)
-	out.ResponseHeadersToRemove = append(out.GetResponseHeadersToRemove(), backendConfigCtx.ResponseHeadersToRemove...)
 
 	if err == nil && out.GetAction() == nil {
-		if in.Delegates {
+		if in.Delegates && in.Error == nil {
 			return nil
 		} else {
 			err = errors.New("no action specified")
@@ -206,6 +202,8 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 
 		switch h.routeReplacementMode {
 		case settings.RouteReplacementStandard, settings.RouteReplacementStrict:
+			// Unset the TypedPerFilterConfig when the route is replaced with a direct response
+			out.TypedPerFilterConfig = nil
 			// Replace invalid route with a direct response
 			out.Action = &envoy_config_route_v3.Route_DirectResponse{
 				DirectResponse: &envoy_config_route_v3.DirectResponseAction{
@@ -218,6 +216,11 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 			return nil
 		}
 	}
+
+	out.RequestHeadersToAdd = append(out.GetRequestHeadersToAdd(), backendConfigCtx.RequestHeadersToAdd...)
+	out.RequestHeadersToRemove = append(out.GetRequestHeadersToRemove(), backendConfigCtx.RequestHeadersToRemove...)
+	out.ResponseHeadersToAdd = append(out.GetResponseHeadersToAdd(), backendConfigCtx.ResponseHeadersToAdd...)
+	out.ResponseHeadersToRemove = append(out.GetResponseHeadersToRemove(), backendConfigCtx.ResponseHeadersToRemove...)
 
 	return out
 }

--- a/pkg/pluginsdk/ir/gw2.go
+++ b/pkg/pluginsdk/ir/gw2.go
@@ -43,6 +43,9 @@ type HttpRouteRuleMatchIR struct {
 	// PrecedenceWeight specifies the weight of this route rule relative to other route rules.
 	// Higher weight means higher priority, and are evaluated before routes with lower weight
 	PrecedenceWeight int32
+
+	// Error encountered during translation
+	Error error
 }
 
 type ListenerIR struct {

--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -165,9 +165,9 @@ func (s *tsuite) TestCyclic() {
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
-	// Assert traffic to team2 route fails with HTTP 404 as it is a cyclic route
+	// Assert traffic to team2 route fails with HTTP 500 as it is a cyclic route
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 
 	s.ti.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"cyclic reference detected", 10*time.Second, 1*time.Second)
@@ -178,9 +178,9 @@ func (s *tsuite) TestInvalidChild() {
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
-	// Assert traffic to team2 route fails with HTTP 404 as the route is invalid due to specifying a hostname on the child route
+	// Assert traffic to team2 route fails with HTTP 500 as the route is invalid due to specifying a hostname on the child route
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 
 	s.ti.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"spec.hostnames must be unset", 10*time.Second, 1*time.Second)
@@ -197,7 +197,7 @@ func (s *tsuite) TestHeaderQueryMatch() {
 		},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
-	// Assert traffic to team2 route fails with HTTP 404 as it does not match the parent's header and query parameters
+	// Assert traffic to team2 child route fails with HTTP 404 as it does not match the parent's header and query parameters
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2),
@@ -205,6 +205,15 @@ func (s *tsuite) TestHeaderQueryMatch() {
 			curl.WithQueryParameters(map[string]string{"queryX": "valX"}),
 		},
 		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
+
+	// Assert traffic to team2 parent route fails with HTTP 500 due to unresolved child route
+	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2),
+			curl.WithHeader("header2", "val2"),
+			curl.WithQueryParameters(map[string]string{"query2": "val2"}),
+		},
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 }
 
 func (s *tsuite) TestMultipleParents() {
@@ -242,7 +251,7 @@ func (s *tsuite) TestMultipleParents() {
 			curl.WithPath(pathTeam2),
 			curl.WithHostHeader(routeParent2Host),
 		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 }
 
 func (s *tsuite) TestInvalidChildValidStandalone() {
@@ -255,14 +264,14 @@ func (s *tsuite) TestInvalidChildValidStandalone() {
 		},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
-	// Assert traffic to team2 route on parent hostname fails with HTTP 404 as the route is invalid due to specifying a hostname on the child route
+	// Assert traffic to team2 route on parent hostname fails with HTTP 500 as the route is invalid due to specifying a hostname on the child route
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyTestHostPort),
 			curl.WithPath(pathTeam2),
 			curl.WithHostHeader(routeParentHost),
 		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 
 	// Assert traffic to team2 route on standalone host succeeds
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,


### PR DESCRIPTION
# Description
When a parent route's backendRefs is unresolved, return a 500 direct response to explicitly drop the rule and prevent unintentional matches against less specific routes.

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
Parent HTTPRoutes with unresolved child routes will
return a 500 direct response.
```

# Additional Notes
Resolves #11549
