### PR TITLE
Add e2e testing for HTTPRoute path matching and simple prefix rewrites

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -27,45 +27,45 @@ jobs:
         # If tests are exceeding the 30-minute limit, please see:
         # /test/kubernetes/e2e/load_balancing_tests.md
         #
-        # Above each test below, we document the latest date/time for the GitHub action job to run
-        # NOTE: We use the GitHub action job time (as opposed to the `go test` time or GitHub action step time), because the slowest job is the bottleneck
+        # Above each test below, we document the latest date/time for the GitHub action step `Run /./.github/actions/kubernetes-e2e-tests` to run
+        # NOTE: We use the GitHub action step time (as opposed to the `go test` time or the GitHub action job time), because it is easier to capture and fairly consistent
         test:
-        # July 8, 2025: ~23 minutes
+        # July 8, 2025: ~10 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^PathMatching$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$|^TestKgateway$$/^GRPCRouteServices$$|^TestListenerSet$$'
           localstack: 'false'
-        # July 8, 2025: ~26 minutes
+        # July 8, 2025: ~13 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgatewayWaypoint$$'
           localstack: 'false'
-        # July 8, 2025: ~25 minutes
+        # July 8, 2025: ~11 minutes
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^DynamicForwardProxy$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^AccessLog$$|^TestKgateway$$/^LocalRateLimit$$|^TestKgateway$$/^Cors$$|^TestKgateway$$/^BackendConfigPolicy$$|^TestKgateway$$/^Metrics$$|^TestKgateway$$/^HttpListenerPolicy$$|^TestKgateway$$/^Tracing$$'
           localstack: 'true'
-        # July 8, 2025: ~22 minutes
+        # July 8, 2025: ~9 minutes
         - cluster-name: 'cluster-four'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^ExtProc$$|^TestKgateway$$/^ExtAuth$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^PolicySelector$$|^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$|^TestKgateway$$/^CSRF$$|^TestInferenceExtension$$'
           localstack: 'false'
-        # July 8, 2025: ~21 minutes
+        # July 8, 2025: ~7 minutes
         - cluster-name: 'cluster-ai'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestAIExtension'
           localstack: 'false'
-        # July 8, 2025: ~16 minutes
+        # July 8, 2025: ~4 minutes
         - cluster-name: 'cluster-multi-install'
           go-test-args: '-v -timeout=5m'
           go-test-run-regex: '^TestMultipleInstalls'
           localstack: 'false'
-        # July 8, 2025: ~16 minutes
+        # July 8, 2025: ~4 minutes
         - cluster-name: 'agent-gateway-cluster'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestAgentGatewayIntegration'
           agentgateway: 'true'
-        # July 8, 2025: ~16 minutes
+        # July 8, 2025: ~3 minutes
         - cluster-name: 'api-validation'
           go-test-args: '-v -timeout=10m'
           go-test-run-regex: '^TestAPIValidation'

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -27,43 +27,45 @@ jobs:
         # If tests are exceeding the 30-minute limit, please see:
         # /test/kubernetes/e2e/load_balancing_tests.md
         #
-        # Above each test below, we document the latest date/time for the GitHub action step to run
-        # NOTE: We use the GitHub action step time (as opposed to the `go test` time), because it is easier to capture
+        # Above each test below, we document the latest date/time for the GitHub action job to run
+        # NOTE: We use the GitHub action job time (as opposed to the `go test` time or GitHub action step time), because the slowest job is the bottleneck
         test:
-        # May 19, 2025: ~19 minutes
+        # July 8, 2025: ~23 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$|^TestKgateway$$/^GRPCRouteServices$$|^TestListenerSet$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^PathMatching$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$|^TestKgateway$$/^GRPCRouteServices$$|^TestListenerSet$$'
           localstack: 'false'
-        # May 19, 2025: ~25 minutes
+        # July 8, 2025: ~26 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$|^TestKgatewayWaypoint$$'
+          go-test-run-regex: '^TestKgatewayWaypoint$$'
           localstack: 'false'
-        # June 23, 2025: ~20 minutes
+        # July 8, 2025: ~25 minutes
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestKgateway$$/^DynamicForwardProxy$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^RouteDelegation$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^AccessLog$$|^TestKgateway$$/^LocalRateLimit$$|^TestKgateway$$/^Cors$$|^TestKgateway$$/^BackendConfigPolicy$$|^TestKgateway$$/^Metrics$$|^TestKgateway$$/^HttpListenerPolicy$$|^TestKgateway$$/^Tracing$$'
           localstack: 'true'
-        # May 19, 2025: ~20 minutes
+        # July 8, 2025: ~22 minutes
         - cluster-name: 'cluster-four'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^ExtProc$$|^TestKgateway$$/^ExtAuth$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^PolicySelector$$|^TestInferenceExtension$$|^TestKgateway$$/^CSRF$$'
+          go-test-run-regex: '^TestKgateway$$/^ExtProc$$|^TestKgateway$$/^ExtAuth$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^PolicySelector$$|^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$|^TestKgateway$$/^CSRF$$|^TestInferenceExtension$$'
           localstack: 'false'
-        # May 19, 2025: ~20 minutes
+        # July 8, 2025: ~21 minutes
         - cluster-name: 'cluster-ai'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestAIExtension'
           localstack: 'false'
+        # July 8, 2025: ~16 minutes
         - cluster-name: 'cluster-multi-install'
           go-test-args: '-v -timeout=5m'
           go-test-run-regex: '^TestMultipleInstalls'
           localstack: 'false'
-        # May 19, 2025: ~10 minutes
+        # July 8, 2025: ~16 minutes
         - cluster-name: 'agent-gateway-cluster'
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestAgentGatewayIntegration'
           agentgateway: 'true'
+        # July 8, 2025: ~16 minutes
         - cluster-name: 'api-validation'
           go-test-args: '-v -timeout=10m'
           go-test-run-regex: '^TestAPIValidation'

--- a/test/kubernetes/e2e/features/path_matching/suite.go
+++ b/test/kubernetes/e2e/features/path_matching/suite.go
@@ -2,16 +2,18 @@ package path_matching
 
 import (
 	"context"
+	"net/http"
+
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
-	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/test/kubernetes/e2e/features/path_matching/suite.go
+++ b/test/kubernetes/e2e/features/path_matching/suite.go
@@ -1,0 +1,165 @@
+package path_matching
+
+import (
+	"context"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+type testingSuite struct {
+	*base.BaseTestingSuite
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+	}
+}
+
+// BeforeTest runs before each test in the suite
+func (s *testingSuite) BeforeTest(suiteName, testName string) {
+	s.BaseTestingSuite.BeforeTest(suiteName, testName)
+
+	s.TestInstallation.Assertions.EventuallyHTTPRouteCondition(s.Ctx, "httpbin", "httpbin", gwv1.RouteConditionAccepted, metav1.ConditionTrue)
+}
+
+// TestExactMatch tests an HTTPRoute with a path match of type Exact
+func (s *testingSuite) TestExactMatch() {
+	// expected path works
+	s.assertStatus("anything/justme", http.StatusOK)
+
+	// all other paths do not
+	s.assertStatus("anything/nope", http.StatusNotFound)
+
+	s.assertStatus("anything/justmea", http.StatusNotFound)
+	s.assertStatus("anything/justm", http.StatusNotFound)
+	s.assertStatus("anything/justma", http.StatusNotFound)
+	s.assertStatus("anything/ajustme", http.StatusNotFound)
+	s.assertStatus("anything/ustme", http.StatusNotFound)
+	s.assertStatus("anything/austme", http.StatusNotFound)
+
+	s.assertStatus("anything/justme/", http.StatusNotFound)
+	s.assertStatus("anything/justme/nope", http.StatusNotFound)
+	s.assertStatus("anything/nope/justme", http.StatusNotFound)
+}
+
+// TestPrefixMatch tests an HTTPRoute with a path match of type PathPrefix
+func (s *testingSuite) TestPrefixMatch() {
+	// prefix path works
+	s.assertStatus("anything/pre", http.StatusOK)
+
+	// additional characters including or after a slash work
+	s.assertStatus("anything/pre/", http.StatusOK)
+	s.assertStatus("anything/pre/plus", http.StatusOK)
+	s.assertStatus("anything/pre/plus/more", http.StatusOK)
+
+	// all other paths do not
+	s.assertStatus("anything/nope", http.StatusNotFound)
+
+	s.assertStatus("anything/prea", http.StatusNotFound)
+	s.assertStatus("anything/pr", http.StatusNotFound)
+	s.assertStatus("anything/pra", http.StatusNotFound)
+	s.assertStatus("anything/apre", http.StatusNotFound)
+	s.assertStatus("anything/re", http.StatusNotFound)
+	s.assertStatus("anything/are", http.StatusNotFound)
+
+	s.assertStatus("anything/nope/pre", http.StatusNotFound)
+}
+
+// TestRegexMatch tests an HTTPRoute with a path match of type RegularExpression
+// regex: /anything/plus/(this|that)/[^/]+?/\d[.]/(1.)/(.+)/end
+func (s *testingSuite) TestRegexMatch() {
+	// paths matching regex work
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/end", http.StatusOK)
+	s.assertStatus("anything/plus/that/what3v3r/4./1a/stuff/end", http.StatusOK)
+	s.assertStatus("anything/plus/this/!@$*&().a-b_c~'+4,;0=:sdf/4./1a/stuff/end", http.StatusOK) // unusual chars
+	s.assertStatus("anything/plus/this/what3v3r/0./1a/stuff/end", http.StatusOK)
+	s.assertStatus("anything/plus/this/what3v3r/4./15/stuff/end", http.StatusOK)
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/plus/more/stuff/end", http.StatusOK) // additional path elements where permitted
+
+	// all other paths do not
+	s.assertStatus("anything/this/what3v3r/4./1a/stuff/end", http.StatusNotFound)     // missing early path element
+	s.assertStatus("anything/plus/this/what3v3r4./1a/stuff/end", http.StatusNotFound) // merging path elements
+	s.assertStatus("anything/plus/this/what3v3r/4.1a/stuff/end", http.StatusNotFound) // merging path elements
+	s.assertStatus("anything/plus/this/what3v3r/4./1astuff/end", http.StatusNotFound) // merging path elements
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuffend", http.StatusNotFound) // merging path elements
+
+	s.assertStatus("anything/plus/thus/what3v3r/4./1a/stuff/end", http.StatusNotFound)        // not this or that
+	s.assertStatus("anything/plus/this|that/what3v3r/4./1a/stuff/end", http.StatusNotFound)   // literal this or that
+	s.assertStatus("anything/plus/(this|that)/what3v3r/4./1a/stuff/end", http.StatusNotFound) // literal this or that
+	s.assertStatus("anything/plus//what3v3r/4./1a/stuff/end", http.StatusNotFound)            // missing this or that
+	s.assertStatus("anything/plus/what3v3r/4./1a/stuff/end", http.StatusNotFound)             // missing this or that
+
+	s.assertStatus("anything/plus/this/what/3v3r/4./1a/stuff/end", http.StatusNotFound) // 2 path elements where 1 is expected
+	s.assertStatus("anything/plus/this//4./1a/stuff/end", http.StatusNotFound)          // 0 path elements where 1 is expected
+	s.assertStatus("anything/plus/this/4./1a/stuff/end", http.StatusNotFound)           // 0 path elements where 1 is expected
+
+	s.assertStatus("anything/plus/this/what3v3r/12./1a/stuff/end", http.StatusNotFound) // 2 digits where 1 is expected
+	s.assertStatus("anything/plus/this/what3v3r/./1a/stuff/end", http.StatusNotFound)   // 0 digits where 1 is expected
+	s.assertStatus("anything/plus/this/what3v3r/a./1a/stuff/end", http.StatusNotFound)  // letter where digit is expected
+	s.assertStatus("anything/plus/this/what3v3r/4../1a/stuff/end", http.StatusNotFound) // 2 dots where 1 is expected
+	s.assertStatus("anything/plus/this/what3v3r/4/1a/stuff/end", http.StatusNotFound)   // 0 dots where 1 is expected
+	s.assertStatus("anything/plus/this/what3v3r/4a/1a/stuff/end", http.StatusNotFound)  // letter where dot is expected
+	s.assertStatus("anything/plus/this/what3v3r/a4./1a/stuff/end", http.StatusNotFound) // extra char
+	s.assertStatus("anything/plus/this/what3v3r/4.a/1a/stuff/end", http.StatusNotFound) // extra char
+
+	s.assertStatus("anything/plus/this/what3v3r/4./11a/stuff/end", http.StatusNotFound) // 2 '1's where 1 is expected
+	s.assertStatus("anything/plus/this/what3v3r/4./a/stuff/end", http.StatusNotFound)   // 0 '1's where 1 is expected
+	s.assertStatus("anything/plus/this/what3v3r/4./0a/stuff/end", http.StatusNotFound)  // 0 where '1' is expected
+	s.assertStatus("anything/plus/this/what3v3r/4./1/stuff/end", http.StatusNotFound)   // missing char
+	s.assertStatus("anything/plus/this/what3v3r/4./1ab/stuff/end", http.StatusNotFound) // extra char
+
+	s.assertStatus("anything/plus/this/what3v3r/4./1a//end", http.StatusNotFound) // missing path element content where expected
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/end", http.StatusNotFound)  // missing path element where expected
+
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/en", http.StatusNotFound)       // missing char
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/nd", http.StatusNotFound)       // missing char
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/ends", http.StatusNotFound)     // extra char
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/end/", http.StatusNotFound)     // extra slash
+	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/end/more", http.StatusNotFound) // extra path element
+
+}
+
+// TestPrefixRewrite tests an HTTPRoute with a path match of type PathPrefix
+// which also uses the URLRewrite filter to drop that prefix
+func (s *testingSuite) TestPrefixRewrite() {
+	// paths matching prefix drop it and work
+	s.assertStatus("el360/bi/v1/anything", http.StatusOK)
+	s.assertStatus("el360/bi/v1/status/200", http.StatusOK)
+	s.assertStatus("el360/bi/v1/status/418", http.StatusTeapot)
+
+	// all other paths do not work
+	s.assertStatus("el360/bi/v1anything/whatever", http.StatusNotFound)
+	s.assertStatus("el360/bi/anything/whatever", http.StatusNotFound)
+	s.assertStatus("l360/bi/v1/anything/whatever", http.StatusNotFound)
+	s.assertStatus("bi/v1/anything/whatever", http.StatusNotFound)
+	s.assertStatus("anything/whatever", http.StatusNotFound)
+	s.assertStatus("status/200", http.StatusNotFound)
+	s.assertStatus("anything/el360/bi/v1/anything/whatever", http.StatusNotFound)
+}
+
+func (s *testingSuite) assertStatus(path string, status int) {
+	s.TestInstallation.Assertions.AssertEventualCurlResponse(
+		s.Ctx,
+		defaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(gatewayService.ObjectMeta)),
+			curl.WithHostHeader("www.example.com"),
+			curl.WithPort(8080),
+			curl.WithPath(path),
+		},
+		&matchers.HttpResponse{
+			StatusCode: status,
+		},
+	)
+}

--- a/test/kubernetes/e2e/features/path_matching/suite.go
+++ b/test/kubernetes/e2e/features/path_matching/suite.go
@@ -129,7 +129,6 @@ func (s *testingSuite) TestRegexMatch() {
 	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/ends", http.StatusNotFound)     // extra char
 	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/end/", http.StatusNotFound)     // extra slash
 	s.assertStatus("anything/plus/this/what3v3r/4./1a/stuff/end/more", http.StatusNotFound) // extra path element
-
 }
 
 // TestPrefixRewrite tests an HTTPRoute with a path match of type PathPrefix

--- a/test/kubernetes/e2e/features/path_matching/testdata/exact.yaml
+++ b/test/kubernetes/e2e/features/path_matching/testdata/exact.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    example: httpbin-route
+spec:
+  parentRefs:
+    - name: gw
+      namespace: default
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: httpbin
+          port: 8000
+      matches:
+        - path:
+            type: Exact
+            value: /anything/justme

--- a/test/kubernetes/e2e/features/path_matching/testdata/prefix-rewrite.yaml
+++ b/test/kubernetes/e2e/features/path_matching/testdata/prefix-rewrite.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    example: httpbin-route
+spec:
+  parentRefs:
+    - name: gw
+      namespace: default
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: httpbin
+          port: 8000
+      matches:
+        - path:
+            type: PathPrefix
+            value: /el360/bi/v1/
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /

--- a/test/kubernetes/e2e/features/path_matching/testdata/prefix.yaml
+++ b/test/kubernetes/e2e/features/path_matching/testdata/prefix.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    example: httpbin-route
+spec:
+  parentRefs:
+    - name: gw
+      namespace: default
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: httpbin
+          port: 8000
+      matches:
+        - path:
+            type: PathPrefix
+            value: /anything/pre

--- a/test/kubernetes/e2e/features/path_matching/testdata/regex.yaml
+++ b/test/kubernetes/e2e/features/path_matching/testdata/regex.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    example: httpbin-route
+spec:
+  parentRefs:
+    - name: gw
+      namespace: default
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: httpbin
+          port: 8000
+      matches:
+        - path:
+            type: RegularExpression
+            value: /anything/plus/(this|that)/[^/]+?/\d[.]/(1.)/(.+)/end

--- a/test/kubernetes/e2e/features/path_matching/testdata/setup.yaml
+++ b/test/kubernetes/e2e/features/path_matching/testdata/setup.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: httpbin
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+  namespace: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    app: httpbin
+    service: httpbin
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080
+    - name: tcp
+      port: 9000
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      serviceAccountName: httpbin
+      containers:
+        - image: docker.io/mccutchen/go-httpbin:v2.6.0
+          imagePullPolicy: IfNotPresent
+          name: httpbin
+          command: [ go-httpbin ]
+          args:
+            - "-port"
+            - "8080"
+            - "-max-duration"
+            - "600s" # override default 10s
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: "100m"
+            limits:
+              cpu: "200m"
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: gw
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/test/kubernetes/e2e/features/path_matching/types.go
+++ b/test/kubernetes/e2e/features/path_matching/types.go
@@ -1,16 +1,16 @@
 package path_matching
 
 import (
-	e2edefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 	"path/filepath"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	e2edefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
 )
 

--- a/test/kubernetes/e2e/features/path_matching/types.go
+++ b/test/kubernetes/e2e/features/path_matching/types.go
@@ -1,0 +1,78 @@
+package path_matching
+
+import (
+	e2edefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
+	"path/filepath"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
+)
+
+var (
+	// manifests
+	setupManifest         = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	exactManifest         = filepath.Join(fsutils.MustGetThisDir(), "testdata", "exact.yaml")
+	prefixManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "prefix.yaml")
+	regexManifest         = filepath.Join(fsutils.MustGetThisDir(), "testdata", "regex.yaml")
+	prefixRewriteManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "prefix-rewrite.yaml")
+
+	// Core infrastructure objects that we need to track
+	gatewayObjectMeta = metav1.ObjectMeta{
+		Name:      "gw",
+		Namespace: "default",
+	}
+	gatewayService    = &corev1.Service{ObjectMeta: gatewayObjectMeta}
+	gatewayDeployment = &appsv1.Deployment{ObjectMeta: gatewayObjectMeta}
+
+	httpbinObjectMeta = metav1.ObjectMeta{
+		Name:      "httpbin",
+		Namespace: "httpbin",
+	}
+	httpbinDeployment = &appsv1.Deployment{ObjectMeta: httpbinObjectMeta}
+
+	route = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httpbin",
+			Namespace: "httpbin",
+		},
+	}
+
+	setup = base.SimpleTestCase{
+		Manifests: []string{e2edefaults.CurlPodManifest, setupManifest},
+		Resources: []client.Object{e2edefaults.CurlPod, httpbinDeployment, gatewayService, gatewayDeployment},
+	}
+
+	// test cases
+	testCases = map[string]*base.TestCase{
+		"TestExactMatch": {
+			SimpleTestCase: base.SimpleTestCase{
+				Manifests: []string{exactManifest},
+				Resources: []client.Object{route},
+			},
+		},
+		"TestPrefixMatch": {
+			SimpleTestCase: base.SimpleTestCase{
+				Manifests: []string{prefixManifest},
+				Resources: []client.Object{route},
+			},
+		},
+		"TestRegexMatch": {
+			SimpleTestCase: base.SimpleTestCase{
+				Manifests: []string{regexManifest},
+				Resources: []client.Object{route},
+			},
+		},
+		"TestPrefixRewrite": {
+			SimpleTestCase: base.SimpleTestCase{
+				Manifests: []string{prefixRewriteManifest},
+				Resources: []client.Object{route},
+			},
+		},
+	}
+)

--- a/test/kubernetes/e2e/tests/kgateway_tests.go
+++ b/test/kubernetes/e2e/tests/kgateway_tests.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/lambda"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/local_rate_limit"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/metrics"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/path_matching"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/policyselector"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/rate_limit"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/route_delegation"
@@ -64,6 +65,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("Metrics", metrics.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("CSRF", csrf.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("Tracing", tracing.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("PathMatching", path_matching.NewTestingSuite)
 
 	// kubeGatewaySuiteRunner.Register("HttpListenerOptions", http_listener_options.NewTestingSuite)
 	// kubeGatewaySuiteRunner.Register("ListenerOptions", listener_options.NewTestingSuite)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

This PR adds e2e testing for HTTPRoute path matching using the `spec.rules.matches.path` field.
It also includes testing for simple prefix rewrites, trimming a prefix using the `PathPrefix` match type alongside setting `spec.rules.filters.urlRewrite.path.replacePrefixMatch` to `/`

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
