### PR TITLE
fix: output per route config for SessionPersistence on RouteRules

### DIFF
--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -329,7 +329,12 @@ func convertSessionPersistence(sessionPersistence *gwv1.SessionPersistence) *any
 			TypedConfig: sessionStateAny,
 		},
 	}
-	typedConfig, err := utils.MessageToAny(statefulSession)
+	perRoute := &stateful_sessionv3.StatefulSessionPerRoute{
+		Override: &stateful_sessionv3.StatefulSessionPerRoute_StatefulSession{
+			StatefulSession: statefulSession,
+		},
+	}
+	typedConfig, err := utils.MessageToAny(perRoute)
 	if err != nil {
 		logger.Error("failed to create session state: %v", "error", err)
 		return nil

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -59,14 +59,15 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.stateful_session:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
-          sessionState:
-            name: envoy.http.stateful_session.cookie
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
-              cookie:
-                name: Session-A
-                ttl: 10s
+          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+          statefulSession:
+            sessionState:
+              name: envoy.http.stateful_session.cookie
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                cookie:
+                  name: Session-A
+                  ttl: 10s
     - match:
         safeRegex:
           googleRe2: {}
@@ -77,14 +78,15 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.stateful_session:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
-          sessionState:
-            name: envoy.http.stateful_session.cookie
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
-              cookie:
-                name: Session-B
-                ttl: 31536000s
+          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+          statefulSession:
+            sessionState:
+              name: envoy.http.stateful_session.cookie
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                cookie:
+                  name: Session-B
+                  ttl: 31536000s
     - match:
         safeRegex:
           googleRe2: {}
@@ -95,13 +97,14 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.stateful_session:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
-          sessionState:
-            name: envoy.http.stateful_session.cookie
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
-              cookie:
-                name: Session-B
+          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+          statefulSession:
+            sessionState:
+              name: envoy.http.stateful_session.cookie
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                cookie:
+                  name: Session-B
     - match:
         pathSeparatedPrefix: /c1
       name: listener~80~*-route-3-httproute-example-route-default-0-0-matcher-0
@@ -110,14 +113,15 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.stateful_session:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
-          sessionState:
-            name: envoy.http.stateful_session.cookie
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
-              cookie:
-                name: Session-A
-                ttl: 10s
+          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+          statefulSession:
+            sessionState:
+              name: envoy.http.stateful_session.cookie
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                cookie:
+                  name: Session-A
+                  ttl: 10s
     - match:
         pathSeparatedPrefix: /c2
       name: listener~80~*-route-4-httproute-example-route-default-1-0-matcher-0
@@ -126,14 +130,15 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.stateful_session:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
-          sessionState:
-            name: envoy.http.stateful_session.cookie
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
-              cookie:
-                name: Session-B
-                ttl: 31536000s
+          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+          statefulSession:
+            sessionState:
+              name: envoy.http.stateful_session.cookie
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                cookie:
+                  name: Session-B
+                  ttl: 31536000s
     - match:
         pathSeparatedPrefix: /c3
       name: listener~80~*-route-5-httproute-example-route-default-2-0-matcher-0
@@ -142,10 +147,11 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.stateful_session:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
-          sessionState:
-            name: envoy.http.stateful_session.cookie
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
-              cookie:
-                name: Session-B
+          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+          statefulSession:
+            sessionState:
+              name: envoy.http.stateful_session.cookie
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
+                cookie:
+                  name: Session-B

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
@@ -57,9 +57,10 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.stateful_session:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession
-          sessionState:
-            name: envoy.http.stateful_session.header
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.http.stateful_session.header.v3.HeaderBasedSessionState
-              name: Session-A
+          '@type': type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSessionPerRoute
+          statefulSession:
+            sessionState:
+              name: envoy.http.stateful_session.header
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.http.stateful_session.header.v3.HeaderBasedSessionState
+                name: Session-A


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

While working on implementing session persistence via BackendTrafficPolicies for https://github.com/kgateway-dev/kgateway/issues/11162 on a local kind cluster I ran into some issues when testing the existing  HTTPRoute implementation where it appeared session persistence was not working.

Envoy’s log repeatedly showed:

```
gRPC config … rejected: Unable to unpack as … StatefulSessionPerRoute:
[type.googleapis.com/envoy.extensions.filters.http.stateful_session.v3.StatefulSession] { … }
```

for an HTTPRoute that looks like:
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"gateway.networking.k8s.io/v1","kind":"HTTPRoute","metadata":{"annotations":{},"name":"echo","namespace":"default"},"spec":{"hostnames":["echo.local"],"parentRefs":[{"name":"test-gw"}],"rules":[{"backendRefs":[{"name":"echo","port":80}]}]}}
  creationTimestamp: "2025-07-07T20:51:57Z"
  generation: 2
  name: echo
  namespace: default
  resourceVersion: "7925"
  uid: 5802ddfc-5d12-440a-9a51-9c0c2f89b60c
spec:
  hostnames:
  - echo.local
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: test-gw
  rules:
  - backendRefs:
    - group: ""
      kind: Service
      name: echo
      port: 80
      weight: 1
    matches:
    - path:
        type: PathPrefix
        value: /
    sessionPersistence:
      absoluteTimeout: 1h
      cookieConfig:
        lifetimeType: Permanent
      sessionName: session
      type: Cookie
status:
  parents:
  - conditions:
    - lastTransitionTime: "2025-07-07T20:51:57Z"
      message: ""
      observedGeneration: 2
      reason: Accepted
      status: "True"
      type: Accepted
    - lastTransitionTime: "2025-07-07T20:51:57Z"
      message: ""
      observedGeneration: 2
      reason: ResolvedRefs
      status: "True"
      type: ResolvedRefs
    controllerName: kgateway.dev/kgateway
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: test-gw
```

After applying this fix session persistence worked as I expected.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->


```release-note
Fix HTTPRoute session persistence: marshal `StatefulSessionPerRoute` per‐route config instead of `StatefulSession`
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
