### PR TITLE
fix: handle PerConnectionBufferLimitBytes in Gateway Equals

### DIFF
--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -285,6 +285,7 @@ func (c Gateway) Equals(in Gateway) bool {
 		versionEquals(c.Obj, in.Obj) &&
 		c.AttachedListenerPolicies.Equals(in.AttachedListenerPolicies) &&
 		c.AttachedHttpPolicies.Equals(in.AttachedHttpPolicies) &&
+		c.Listeners.Equals(in.Listeners) &&
 		c.AllowedListenerSets.Equals(in.AllowedListenerSets) &&
 		c.DeniedListenerSets.Equals(in.DeniedListenerSets)
 }

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -280,7 +280,13 @@ func (c Gateway) ResourceName() string {
 }
 
 func (c Gateway) Equals(in Gateway) bool {
-	return c.ObjectSource.Equals(in.ObjectSource) && versionEquals(c.Obj, in.Obj) && c.AttachedListenerPolicies.Equals(in.AttachedListenerPolicies) && c.AttachedHttpPolicies.Equals(in.AttachedHttpPolicies) && c.AllowedListenerSets.Equals(in.AllowedListenerSets) && c.DeniedListenerSets.Equals(in.DeniedListenerSets)
+	return c.ObjectSource.Equals(in.ObjectSource) &&
+		ptrEquals(c.PerConnectionBufferLimitBytes, in.PerConnectionBufferLimitBytes) &&
+		versionEquals(c.Obj, in.Obj) &&
+		c.AttachedListenerPolicies.Equals(in.AttachedListenerPolicies) &&
+		c.AttachedHttpPolicies.Equals(in.AttachedHttpPolicies) &&
+		c.AllowedListenerSets.Equals(in.AllowedListenerSets) &&
+		c.DeniedListenerSets.Equals(in.DeniedListenerSets)
 }
 
 // Equals returns true if the two BackendRefIR instances are equal in cluster name, weight, backend object equality, and error.


### PR DESCRIPTION
# Description

Fixes https://github.com/kgateway-dev/kgateway/issues/11625

the Equals func must compare the PerConnectionBufferLimitBytes so that changing the value will update the gateway proxy.

Additionally, the Equals func was missing comparison for the Listeners, so added that

# Change Type

/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
fix: handle changing the value of the PerConnectionBufferLimitBytes annotation on the gateway
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
