### PR TITLE
Add session persistence e2e tests

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         # July 8, 2025: ~10 minutes
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^PathMatching$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$|^TestKgateway$$/^GRPCRouteServices$$|^TestListenerSet$$'
+          go-test-run-regex: '^TestKgateway$$/^BasicRouting$$|^TestKgateway$$/^PathMatching$$|^TestKgateway$$/^HTTPRouteServices$$|^TestKgateway$$/^TLSRouteServices$$|^TestKgateway$$/^GRPCRouteServices$$|^TestListenerSet$$|^TestKgateway$$/^SessionPersistence$$'
           localstack: 'false'
         # July 8, 2025: ~13 minutes
         - cluster-name: 'cluster-two'

--- a/internal/kgateway/translator/gateway/testutils/inputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/session-persistence/cookie.yaml
@@ -54,6 +54,7 @@ spec:
       sessionPersistence:
         sessionName: Session-B
         type: Cookie
+        absoluteTimeout: 8760h
         cookieConfig:
           lifetimeType: Permanent 
     - matches:
@@ -102,6 +103,7 @@ spec:
       sessionPersistence:
         sessionName: Session-B
         type: Cookie
+        absoluteTimeout: 8760h
         cookieConfig:
           lifetimeType: Permanent 
     - matches:

--- a/test/kubernetes/e2e/features/session_persistence/suite.go
+++ b/test/kubernetes/e2e/features/session_persistence/suite.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
-	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 )
 
 type testingSuite struct {
@@ -20,6 +20,7 @@ type testingSuite struct {
 	ctx context.Context
 
 	testInstallation *e2e.TestInstallation
+	manifests        map[string][]string
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
@@ -29,72 +30,107 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	}
 }
 
-func (s *testingSuite) TestCookieSessionPersistence() {
-	s.T().Cleanup(func() {
-		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, cookieSessionPersistenceManifest)
-		s.NoError(err, "can delete cookie session persistence manifest")
-		s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, echoService, echoDeployment, cookieGateway, cookieHTTPRoute)
+func (s *testingSuite) SetupSuite() {
+	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, testdefaults.CurlPodManifest)
+	s.NoError(err, "can apply curl pod manifest")
+
+	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, testdefaults.CurlPod)
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, testdefaults.CurlPod.GetNamespace(), metav1.ListOptions{
+		LabelSelector: testdefaults.CurlPodLabelSelector,
 	})
 
-	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, cookieSessionPersistenceManifest)
-	s.Assert().NoError(err, "can apply cookie session persistence manifest")
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, echoServiceManifest)
+	s.NoError(err, "can apply echo service manifest")
 
-	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, echoService, echoDeployment, cookieGateway, cookieHTTPRoute)
+	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, echoService, echoDeployment)
 	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, echoDeployment.GetNamespace(), metav1.ListOptions{
 		LabelSelector: "app=echo",
 	})
-	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, cookieGateway.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=gw-cookie",
-	})
 
+	s.manifests = map[string][]string{
+		"TestCookieSessionPersistence": {cookieSessionPersistenceManifest},
+		"TestHeaderSessionPersistence": {headerSessionPersistenceManifest},
+	}
+}
+
+func (s *testingSuite) TearDownSuite() {
+	err := s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, testdefaults.CurlPodManifest)
+	s.NoError(err, "can delete curl pod manifest")
+
+	err = s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, echoServiceManifest)
+	s.NoError(err, "can delete echo service manifest")
+}
+
+func (s *testingSuite) BeforeTest(suiteName, testName string) {
+	manifests, ok := s.manifests[testName]
+	if !ok {
+		s.FailNow("no manifests found for %s, manifest map contents: %v", testName, s.manifests)
+	}
+
+	for _, manifest := range manifests {
+		err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, manifest)
+		s.Require().NoError(err, "can apply manifest "+manifest)
+	}
+
+	switch testName {
+	case "TestCookieSessionPersistence":
+		s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, cookieGateway, cookieHTTPRoute)
+		s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, cookieGateway.GetNamespace(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", cookieGateway.Name),
+		})
+	case "TestHeaderSessionPersistence":
+		s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, headerGateway, headerHTTPRoute)
+		s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, headerGateway.GetNamespace(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", headerGateway.Name),
+		})
+	}
+}
+
+func (s *testingSuite) AfterTest(suiteName, testName string) {
+	manifests, ok := s.manifests[testName]
+	if !ok {
+		s.FailNow("no manifests found for %s, manifest map contents: %v", testName, s.manifests)
+	}
+
+	// Clean up test-specific manifests
+	for _, manifest := range manifests {
+		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, manifest, "--grace-period", "0")
+		s.NoError(err, "can delete manifest "+manifest)
+	}
+}
+
+func (s *testingSuite) TestCookieSessionPersistence() {
 	s.assertSessionPersistence("cookie")
 }
 
 func (s *testingSuite) TestHeaderSessionPersistence() {
-	s.T().Cleanup(func() {
-		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, headerSessionPersistenceManifest)
-		s.NoError(err, "can delete header session persistence manifest")
-		s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, echoService, echoDeployment, headerGateway, headerHTTPRoute)
-	})
-
-	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, headerSessionPersistenceManifest)
-	s.Assert().NoError(err, "can apply header session persistence manifest")
-
-	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, echoService, echoDeployment, headerGateway, headerHTTPRoute)
-	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, echoDeployment.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app=echo",
-	})
-	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, headerGateway.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=gw-header",
-	})
-
 	s.assertSessionPersistence("header")
 }
 
 // assertSessionPersistence makes multiple requests and verifies they go to the same backend pod
 func (s *testingSuite) assertSessionPersistence(persistenceType string) {
 	var (
-		gatewayService *metav1.ObjectMeta
+		gatewayService metav1.ObjectMeta
 		sessionHeader  string
 	)
 
 	switch persistenceType {
 	case "cookie":
-		gatewayService = &cookieGateway.ObjectMeta
+		gatewayService = cookieGateway.ObjectMeta
 	case "header":
-		gatewayService = &headerGateway.ObjectMeta
+		gatewayService = headerGateway.ObjectMeta
 		sessionHeader = "session-a"
 	}
 
 	firstCurlOpts := []curl.Option{
-		curl.WithHost(kubeutils.ServiceFQDN(*gatewayService)),
+		curl.WithHost(kubeutils.ServiceFQDN(gatewayService)),
 		curl.WithHostHeader("echo.local"),
 		curl.WithPort(8080),
 		curl.Silent(),
 		curl.WithArgs([]string{"-i"}),
 	}
 
-	firstResp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, defaults.CurlPodExecOpt, firstCurlOpts...)
+	firstResp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, testdefaults.CurlPodExecOpt, firstCurlOpts...)
 	s.Assert().NoError(err, "first request should succeed")
 
 	firstPodName := s.extractPodNameFromResponse(firstResp.StdOut)
@@ -105,7 +141,7 @@ func (s *testingSuite) assertSessionPersistence(persistenceType string) {
 		cookie := s.extractSessionCookieFromResponse(firstResp.StdOut)
 		s.Assert().NotEmpty(cookie, "should have received a session cookie")
 		subsequentCurlOpts = []curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(*gatewayService)),
+			curl.WithHost(kubeutils.ServiceFQDN(gatewayService)),
 			curl.WithHostHeader("echo.local"),
 			curl.WithPort(8080),
 			curl.Silent(),
@@ -115,7 +151,7 @@ func (s *testingSuite) assertSessionPersistence(persistenceType string) {
 		headerValue := s.extractSessionHeaderFromResponse(firstResp.StdOut)
 		s.Assert().NotEmpty(headerValue, "should have received a session header")
 		subsequentCurlOpts = []curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(*gatewayService)),
+			curl.WithHost(kubeutils.ServiceFQDN(gatewayService)),
 			curl.WithHostHeader("echo.local"),
 			curl.WithPort(8080),
 			curl.Silent(),
@@ -124,7 +160,7 @@ func (s *testingSuite) assertSessionPersistence(persistenceType string) {
 	}
 
 	for i := 0; i < 10; i++ {
-		resp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, defaults.CurlPodExecOpt, subsequentCurlOpts...)
+		resp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, testdefaults.CurlPodExecOpt, subsequentCurlOpts...)
 		s.Assert().NoError(err, fmt.Sprintf("request %d should succeed", i+2))
 
 		podName := s.extractPodNameFromResponse(resp.StdOut)

--- a/test/kubernetes/e2e/features/session_persistence/suite.go
+++ b/test/kubernetes/e2e/features/session_persistence/suite.go
@@ -1,0 +1,186 @@
+package session_persistence
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
+)
+
+type testingSuite struct {
+	suite.Suite
+
+	ctx context.Context
+
+	testInstallation *e2e.TestInstallation
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		ctx:              ctx,
+		testInstallation: testInst,
+	}
+}
+
+func (s *testingSuite) TestCookieSessionPersistence() {
+	s.T().Cleanup(func() {
+		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, cookieSessionPersistenceManifest)
+		s.NoError(err, "can delete cookie session persistence manifest")
+		s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, echoService, echoDeployment, cookieGateway, cookieHTTPRoute)
+	})
+
+	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, cookieSessionPersistenceManifest)
+	s.Assert().NoError(err, "can apply cookie session persistence manifest")
+
+	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, echoService, echoDeployment, cookieGateway, cookieHTTPRoute)
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, echoDeployment.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app=echo",
+	})
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, cookieGateway.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=gw-cookie",
+	})
+
+	s.assertSessionPersistence("cookie")
+}
+
+func (s *testingSuite) TestHeaderSessionPersistence() {
+	s.T().Cleanup(func() {
+		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, headerSessionPersistenceManifest)
+		s.NoError(err, "can delete header session persistence manifest")
+		s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, echoService, echoDeployment, headerGateway, headerHTTPRoute)
+	})
+
+	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, headerSessionPersistenceManifest)
+	s.Assert().NoError(err, "can apply header session persistence manifest")
+
+	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, echoService, echoDeployment, headerGateway, headerHTTPRoute)
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, echoDeployment.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app=echo",
+	})
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, headerGateway.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=gw-header",
+	})
+
+	s.assertSessionPersistence("header")
+}
+
+// assertSessionPersistence makes multiple requests and verifies they go to the same backend pod
+func (s *testingSuite) assertSessionPersistence(persistenceType string) {
+	var (
+		gatewayService *metav1.ObjectMeta
+		sessionHeader  string
+	)
+
+	switch persistenceType {
+	case "cookie":
+		gatewayService = &cookieGateway.ObjectMeta
+	case "header":
+		gatewayService = &headerGateway.ObjectMeta
+		sessionHeader = "session-a"
+	}
+
+	firstCurlOpts := []curl.Option{
+		curl.WithHost(kubeutils.ServiceFQDN(*gatewayService)),
+		curl.WithHostHeader("echo.local"),
+		curl.WithPort(8080),
+		curl.Silent(),
+		curl.WithArgs([]string{"-i"}),
+	}
+
+	firstResp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, defaults.CurlPodExecOpt, firstCurlOpts...)
+	s.Assert().NoError(err, "first request should succeed")
+
+	firstPodName := s.extractPodNameFromResponse(firstResp.StdOut)
+	s.Assert().NotEmpty(firstPodName, "should be able to extract pod name from first response")
+
+	var subsequentCurlOpts []curl.Option
+	if persistenceType == "cookie" {
+		cookie := s.extractSessionCookieFromResponse(firstResp.StdOut)
+		s.Assert().NotEmpty(cookie, "should have received a session cookie")
+		subsequentCurlOpts = []curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(*gatewayService)),
+			curl.WithHostHeader("echo.local"),
+			curl.WithPort(8080),
+			curl.Silent(),
+			curl.WithHeader("Cookie", cookie),
+		}
+	} else {
+		headerValue := s.extractSessionHeaderFromResponse(firstResp.StdOut)
+		s.Assert().NotEmpty(headerValue, "should have received a session header")
+		subsequentCurlOpts = []curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(*gatewayService)),
+			curl.WithHostHeader("echo.local"),
+			curl.WithPort(8080),
+			curl.Silent(),
+			curl.WithHeader(sessionHeader, headerValue),
+		}
+	}
+
+	for i := 0; i < 10; i++ {
+		resp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, defaults.CurlPodExecOpt, subsequentCurlOpts...)
+		s.Assert().NoError(err, fmt.Sprintf("request %d should succeed", i+2))
+
+		podName := s.extractPodNameFromResponse(resp.StdOut)
+		s.Assert().Equal(firstPodName, podName, fmt.Sprintf("request %d should go to the same pod due to session persistence", i+2))
+	}
+}
+
+// extractPodNameFromResponse extracts the pod name from the echo service response
+func (s *testingSuite) extractPodNameFromResponse(response string) string {
+	// The echo service returns something like "pod=echo-abc123-xyz"
+	lines := strings.Split(response, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "pod=") {
+			parts := strings.Split(line, "pod=")
+			if len(parts) > 1 {
+				return strings.TrimSpace(parts[1])
+			}
+		}
+	}
+	return ""
+}
+
+// extractSessionCookieFromResponse extracts the session cookie from the curl response
+func (s *testingSuite) extractSessionCookieFromResponse(response string) string {
+	lines := strings.Split(response, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "set-cookie:") && strings.Contains(line, "Session-A") {
+			// Extract cookie value from "Set-Cookie: Session-A=value; ..."
+			parts := strings.Split(line, "set-cookie:")
+			if len(parts) > 1 {
+				cookiePart := strings.TrimSpace(parts[1])
+				// Take only the cookie name=value part (before any semicolon)
+				if idx := strings.Index(cookiePart, ";"); idx != -1 {
+					cookiePart = cookiePart[:idx]
+				}
+				return strings.TrimSpace(cookiePart)
+			}
+		}
+	}
+	return ""
+}
+
+// extractSessionHeaderFromResponse extracts the session header from the curl response
+func (s *testingSuite) extractSessionHeaderFromResponse(response string) string {
+	lines := strings.Split(response, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "session-a:") {
+			parts := strings.Split(line, "session-a:")
+			if len(parts) > 1 {
+				cookiePart := strings.TrimSpace(parts[1])
+				if idx := strings.Index(cookiePart, ";"); idx != -1 {
+					cookiePart = cookiePart[:idx]
+				}
+				return strings.TrimSpace(cookiePart)
+			}
+		}
+	}
+	return ""
+}

--- a/test/kubernetes/e2e/features/session_persistence/testdata/cookie-session-persistence.yaml
+++ b/test/kubernetes/e2e/features/session_persistence/testdata/cookie-session-persistence.yaml
@@ -1,43 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: echo
-  namespace: default
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: echo
-  template:
-    metadata:
-      labels:
-        app: echo
-    spec:
-      containers:
-      - name: echo
-        image: hashicorp/http-echo
-        args:
-          - "-text=pod=$(POD_NAME)"
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        ports:
-        - containerPort: 5678
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: echo
-  namespace: default
-spec:
-  selector:
-    app: echo
-  ports:
-  - port: 80
-    targetPort: 5678
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -65,33 +25,10 @@ spec:
   rules:
   - backendRefs:
     - name: echo
-      port: 80
+      port: 8080
     sessionPersistence:
       sessionName: Session-A
       type: Cookie
       absoluteTimeout: 1h
       cookieConfig:
-        lifetimeType: Permanent
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: curl
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: curl
-  namespace: curl
-  labels:
-    app: curl
-    version: v1
-spec:
-  containers:
-    - name: curl
-      image: curlimages/curl:7.83.1
-      imagePullPolicy: IfNotPresent
-      command:
-        - "tail"
-        - "-f"
-        - "/dev/null" 
+        lifetimeType: Permanent 

--- a/test/kubernetes/e2e/features/session_persistence/testdata/cookie-session-persistence.yaml
+++ b/test/kubernetes/e2e/features/session_persistence/testdata/cookie-session-persistence.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+      - name: echo
+        image: hashicorp/http-echo
+        args:
+          - "-text=pod=$(POD_NAME)"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - containerPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: default
+spec:
+  selector:
+    app: echo
+  ports:
+  - port: 80
+    targetPort: 5678
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-cookie
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-cookie
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-cookie
+  hostnames: ["echo.local"]
+  rules:
+  - backendRefs:
+    - name: echo
+      port: 80
+    sessionPersistence:
+      sessionName: Session-A
+      type: Cookie
+      absoluteTimeout: 1h
+      cookieConfig:
+        lifetimeType: Permanent
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: curl
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl
+  namespace: curl
+  labels:
+    app: curl
+    version: v1
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:7.83.1
+      imagePullPolicy: IfNotPresent
+      command:
+        - "tail"
+        - "-f"
+        - "/dev/null" 

--- a/test/kubernetes/e2e/features/session_persistence/testdata/echo-service.yaml
+++ b/test/kubernetes/e2e/features/session_persistence/testdata/echo-service.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: default
+spec:
+  selector:
+    app: echo
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+      - name: echo
+        image: hashicorp/http-echo:latest
+        args:
+          - -listen=:8080
+          - -text=pod=$(HOSTNAME)
+        ports:
+        - containerPort: 8080
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "64Mi"
+          limits:
+            cpu: "200m"
+            memory: "128Mi" 

--- a/test/kubernetes/e2e/features/session_persistence/testdata/header-session-persistence.yaml
+++ b/test/kubernetes/e2e/features/session_persistence/testdata/header-session-persistence.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+      - name: echo
+        image: hashicorp/http-echo
+        args:
+          - "-text=pod=$(POD_NAME)"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - containerPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: default
+spec:
+  selector:
+    app: echo
+  ports:
+  - port: 80
+    targetPort: 5678
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-header
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-header
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-header
+  hostnames: ["echo.local"]
+  rules:
+  - backendRefs:
+    - name: echo
+      port: 80
+    sessionPersistence:
+      sessionName: Session-A
+      type: Header
+      absoluteTimeout: 100s
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: curl
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl
+  namespace: curl
+  labels:
+    app: curl
+    version: v1
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:7.83.1
+      imagePullPolicy: IfNotPresent
+      command:
+        - "tail"
+        - "-f"
+        - "/dev/null" 

--- a/test/kubernetes/e2e/features/session_persistence/testdata/header-session-persistence.yaml
+++ b/test/kubernetes/e2e/features/session_persistence/testdata/header-session-persistence.yaml
@@ -1,43 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: echo
-  namespace: default
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: echo
-  template:
-    metadata:
-      labels:
-        app: echo
-    spec:
-      containers:
-      - name: echo
-        image: hashicorp/http-echo
-        args:
-          - "-text=pod=$(POD_NAME)"
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        ports:
-        - containerPort: 5678
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: echo
-  namespace: default
-spec:
-  selector:
-    app: echo
-  ports:
-  - port: 80
-    targetPort: 5678
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -65,31 +25,8 @@ spec:
   rules:
   - backendRefs:
     - name: echo
-      port: 80
+      port: 8080
     sessionPersistence:
       sessionName: Session-A
       type: Header
-      absoluteTimeout: 100s
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: curl
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: curl
-  namespace: curl
-  labels:
-    app: curl
-    version: v1
-spec:
-  containers:
-    - name: curl
-      image: curlimages/curl:7.83.1
-      imagePullPolicy: IfNotPresent
-      command:
-        - "tail"
-        - "-f"
-        - "/dev/null" 
+      absoluteTimeout: 100s 

--- a/test/kubernetes/e2e/features/session_persistence/types.go
+++ b/test/kubernetes/e2e/features/session_persistence/types.go
@@ -1,0 +1,92 @@
+package session_persistence
+
+import (
+	"path/filepath"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+)
+
+var (
+	// Manifest paths
+	cookieSessionPersistenceManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "cookie-session-persistence.yaml")
+	headerSessionPersistenceManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "header-session-persistence.yaml")
+)
+
+var (
+	// Common echo service used by both tests
+	echoService = &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "echo",
+			Namespace: "default",
+		},
+	}
+
+	// Echo deployment with multiple replicas for testing session persistence
+	echoDeployment = &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "echo",
+			Namespace: "default",
+		},
+	}
+
+	// Cookie-based session persistence Gateway
+	cookieGateway = &gwv1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Gateway",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-cookie",
+			Namespace: "default",
+		},
+	}
+
+	// Cookie-based session persistence HTTPRoute
+	cookieHTTPRoute = &gwv1.HTTPRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HTTPRoute",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "echo-cookie",
+			Namespace: "default",
+		},
+	}
+
+	// Header-based session persistence Gateway
+	headerGateway = &gwv1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Gateway",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-header",
+			Namespace: "default",
+		},
+	}
+
+	// Header-based session persistence HTTPRoute
+	headerHTTPRoute = &gwv1.HTTPRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HTTPRoute",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "echo-header",
+			Namespace: "default",
+		},
+	}
+)

--- a/test/kubernetes/e2e/features/session_persistence/types.go
+++ b/test/kubernetes/e2e/features/session_persistence/types.go
@@ -15,6 +15,7 @@ var (
 	// Manifest paths
 	cookieSessionPersistenceManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "cookie-session-persistence.yaml")
 	headerSessionPersistenceManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "header-session-persistence.yaml")
+	echoServiceManifest              = filepath.Join(fsutils.MustGetThisDir(), "testdata", "echo-service.yaml")
 )
 
 var (

--- a/test/kubernetes/e2e/tests/kgateway_tests.go
+++ b/test/kubernetes/e2e/tests/kgateway_tests.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/httproute"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/tcproute"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/tlsroute"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/session_persistence"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/tracing"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/transformation"
 	// "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/admin_server"
@@ -52,6 +53,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("HttpListenerPolicy", http_listener_policy.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("Lambda", lambda.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("RouteDelegation", route_delegation.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("SessionPersistence", session_persistence.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TCPRouteServices", tcproute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TLSRouteServices", tlsroute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("GRPCRouteServices", grpcroute.NewTestingSuite)


### PR DESCRIPTION
# Description

The session persistence feature was missing e2e testing and had some translator test inputs that were failing CEL validation when applied directly. I've added a basic e2e test suite that validates both cookie-based and header-based session persistence functionality on httproutes. The tests create echo services with multiple replicas and verify that requests with the same session consistently hit the same backend pod.

I also fixed the CEL validation issues in the translator test inputs by adding the missing `absoluteTimeout` fields that are required when `lifetimeType` is set to `Permanent`.

fixes :
- https://github.com/kgateway-dev/kgateway/issues/11620
- https://github.com/kgateway-dev/kgateway/issues/11622

# Change Type

/kind cleanup

# Changelog
```release-note
NONE
```

# Additional Notes