### PR TITLE
pkg/validator: Add functional options for envoy configuration

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	envoyPath = "/usr/local/bin/envoy"
+	defaultEnvoyPath = "/usr/local/bin/envoy"
 	// TODO(tim): avoid hardcoding the envoy image version in multiple places.
-	envoyImage = "quay.io/solo-io/envoy-gloo:1.34.1-patch3"
+	defaultEnvoyImage = "quay.io/solo-io/envoy-gloo:1.34.1-patch3"
 )
 
 // ErrInvalidXDS is returned when Envoy rejects the supplied YAML.
@@ -49,11 +49,11 @@ func New(o ...Option) Validator {
 	// use defaults if not set by options
 	binaryPath := c.binaryPath
 	if binaryPath == "" {
-		binaryPath = envoyPath
+		binaryPath = defaultEnvoyPath
 	}
 	dockerImage := c.dockerImage
 	if dockerImage == "" {
-		dockerImage = envoyImage
+		dockerImage = defaultEnvoyImage
 	}
 	// check if envoy is in the path
 	if _, err := exec.LookPath(binaryPath); err == nil {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -25,14 +25,42 @@ type Validator interface {
 	Validate(context.Context, string) error
 }
 
+// Option is a functional option for New.
+type Option func(*config)
+
+// WithBinaryPath overrides the Envoy binary path.
+func WithBinaryPath(p string) Option { return func(c *config) { c.binaryPath = p } }
+
+// WithDockerImage overrides the Docker image used for validation.
+func WithDockerImage(img string) Option { return func(c *config) { c.dockerImage = img } }
+
+// config stores the validator configuration.
+type config struct {
+	binaryPath  string
+	dockerImage string
+}
+
 // New chooses the best validator available.
-func New() Validator {
+func New(o ...Option) Validator {
+	c := &config{}
+	for _, opt := range o {
+		opt(c)
+	}
+	// use defaults if not set by options
+	binaryPath := c.binaryPath
+	if binaryPath == "" {
+		binaryPath = envoyPath
+	}
+	dockerImage := c.dockerImage
+	if dockerImage == "" {
+		dockerImage = envoyImage
+	}
 	// check if envoy is in the path
-	if _, err := exec.LookPath(envoyPath); err == nil {
-		return &binaryValidator{path: envoyPath}
+	if _, err := exec.LookPath(binaryPath); err == nil {
+		return &binaryValidator{path: binaryPath}
 	}
 	// otherwise, fallback to docker
-	return &dockerValidator{img: envoyImage}
+	return &dockerValidator{img: dockerImage}
 }
 
 // binaryValidator validates envoy using the binary.

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -13,39 +13,103 @@ import (
 
 func TestNew(t *testing.T) {
 	tests := []struct {
-		name          string
-		setupEnvoy    bool
-		expectedType  string
-		cleanupEnvoy  bool
-		tempEnvoyPath string
+		name         string
+		options      []Option
+		setupEnvoy   bool
+		expectedType string
+		expectedPath string
+		expectedImg  string
 	}{
 		{
-			name:         "returns binary validator when envoy exists",
+			name:         "default - returns binary validator when envoy executable exists",
+			options:      nil,
 			setupEnvoy:   true,
 			expectedType: "*validator.binaryValidator",
 		},
 		{
-			name:         "returns docker validator when envoy not in path",
+			name:         "default - returns docker validator when envoy not in path",
+			options:      nil,
 			setupEnvoy:   false,
 			expectedType: "*validator.dockerValidator",
+		},
+		{
+			name:         "custom binary path - overrides binary validator when exists",
+			options:      nil,
+			setupEnvoy:   true,
+			expectedType: "*validator.binaryValidator",
+		},
+		{
+			name: "custom docker image - override default envoy image",
+			options: []Option{
+				WithDockerImage("envoyproxy/envoy:v1.28.0"),
+			},
+			setupEnvoy:   false,
+			expectedType: "*validator.dockerValidator",
+			expectedImg:  "envoyproxy/envoy:v1.28.0",
+		},
+		{
+			name: "custom both - binary takes precedence when exists",
+			options: []Option{
+				WithBinaryPath("/path/to/envoy"),
+				WithDockerImage("custom/envoy:latest"),
+			},
+			setupEnvoy:   true,
+			expectedType: "*validator.binaryValidator",
+		},
+		{
+			name: "custom both - docker fallback when binary not found and docker image is set",
+			options: []Option{
+				WithBinaryPath("/nonexistent/envoy"),
+				WithDockerImage("custom/envoy:latest"),
+			},
+			setupEnvoy:   false,
+			expectedType: "*validator.dockerValidator",
+			expectedImg:  "custom/envoy:latest",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var tmpFile *os.File
 			if tt.setupEnvoy {
-				tmpFile, err := os.CreateTemp("", "envoy")
+				var err error
+				tmpFile, err = os.CreateTemp("", "envoy")
 				require.NoError(t, err)
 				defer os.Remove(tmpFile.Name())
 				require.NoError(t, os.Chmod(tmpFile.Name(), 0755))
 
-				origEnvoyPath := envoyPath
-				envoyPath = tmpFile.Name()
-				defer func() { envoyPath = origEnvoyPath }()
+				// Set up custom binary path options for relevant tests
+				if tt.name == "custom binary path - binary validator" {
+					tt.options = []Option{WithBinaryPath(tmpFile.Name())}
+					tt.expectedPath = tmpFile.Name()
+				} else if tt.name == "custom both - binary takes precedence when exists" {
+					tt.options = []Option{
+						WithBinaryPath(tmpFile.Name()),
+						WithDockerImage("custom/envoy:latest"),
+					}
+					tt.expectedPath = tmpFile.Name()
+				} else if tt.options == nil {
+					// For default tests, modify global envoyPath temporarily
+					origEnvoyPath := envoyPath
+					envoyPath = tmpFile.Name()
+					defer func() { envoyPath = origEnvoyPath }()
+				}
 			}
 
-			validator := New()
+			validator := New(tt.options...)
 			assert.Equal(t, tt.expectedType, fmt.Sprintf("%T", validator))
+
+			// Verify the internal configuration
+			switch v := validator.(type) {
+			case *binaryValidator:
+				if tt.expectedPath != "" {
+					assert.Equal(t, tt.expectedPath, v.path)
+				}
+			case *dockerValidator:
+				if tt.expectedImg != "" {
+					assert.Equal(t, tt.expectedImg, v.img)
+				}
+			}
 		})
 	}
 }

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -89,10 +89,10 @@ func TestNew(t *testing.T) {
 					}
 					tt.expectedPath = tmpFile.Name()
 				} else if tt.options == nil {
-					// For default tests, modify global envoyPath temporarily
-					origEnvoyPath := envoyPath
-					envoyPath = tmpFile.Name()
-					defer func() { envoyPath = origEnvoyPath }()
+					// For default tests, modify global defaultEnvoyPath temporarily
+					origEnvoyPath := defaultEnvoyPath
+					defaultEnvoyPath = tmpFile.Name()
+					defer func() { defaultEnvoyPath = origEnvoyPath }()
 				}
 			}
 
@@ -306,7 +306,7 @@ static_resources:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validator := &dockerValidator{img: envoyImage}
+			validator := &dockerValidator{img: defaultEnvoyImage}
 			err := validator.Validate(context.Background(), tt.yaml)
 
 			if tt.expectError {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Avoid hardcoding the envoy docker image and executable path with functional options. The primary benefit with this change is being able to perform xDS validation using the upstream Envoy image until we're able to migrate off the envoy-gloo dependency later in the 2.1 cycle, in 2.2, etc.

One of the follow-up(s) to the https://github.com/kgateway-dev/kgateway/issues/11535 PR.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
