### PR TITLE
Port-mapping Security Context fix

### DIFF
--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -272,6 +272,10 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 		return vals, nil
 	}
 
+	// The security contexts may need to be updated if floating user ID is set or if privileged ports are used
+	// This may affect both the PodSecurityContext and the SecurityContexts for the containers defined in gwParam
+	deployer.UpdateSecurityContexts(gwParam.Spec.Kube, vals.Gateway.Ports)
+
 	// extract all the custom values from the GatewayParameters
 	// (note: if we add new fields to GatewayParameters, they will
 	// need to be plumbed through here as well)
@@ -303,9 +307,6 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 	gateway.ExtraPodLabels = podConfig.GetExtraLabels()
 	gateway.ImagePullSecrets = podConfig.GetImagePullSecrets()
 	gateway.PodSecurityContext = podConfig.GetSecurityContext()
-	// The security contexts may need to be updated if floating user ID is set or if privileged ports are used
-	// This may affect both the PodSecurityContext and the SecurityContexts for the containers defined in gwParam
-	deployer.UpdateSecurityContexts(gwParam.Spec.Kube, vals.Gateway.Ports)
 	gateway.NodeSelector = podConfig.GetNodeSelector()
 	gateway.Affinity = podConfig.GetAffinity()
 	gateway.Tolerations = podConfig.GetTolerations()

--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -274,6 +274,8 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 
 	// The security contexts may need to be updated if floating user ID is set or if privileged ports are used
 	// This may affect both the PodSecurityContext and the SecurityContexts for the containers defined in gwParam
+	// Note: this call may populate the PodSecurityContext and SecurityContext fields in the HelmConfig if they are null,
+	// so this needs to happen before those kubeProxyConfig fields are extracted to local variables.
 	deployer.UpdateSecurityContexts(gwParam.Spec.Kube, vals.Gateway.Ports)
 
 	// extract all the custom values from the GatewayParameters

--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -274,7 +274,7 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 
 	// The security contexts may need to be updated if floating user ID is set or if privileged ports are used
 	// This may affect both the PodSecurityContext and the SecurityContexts for the containers defined in gwParam
-	// Note: this call may populate the PodSecurityContext and SecurityContext fields in the HelmConfig if they are null,
+	// Note: this call may populate the PodSecurityContext and SecurityContext fields in the gateway parameters if they are null,
 	// so this needs to happen before those kubeProxyConfig fields are extracted to local variables.
 	deployer.UpdateSecurityContexts(gwParam.Spec.Kube, vals.Gateway.Ports)
 


### PR DESCRIPTION
# Description
Part of https://github.com/kgateway-dev/kgateway/issues/11650, introduced by https://github.com/kgateway-dev/kgateway/pull/11508

UpdateSecurityContexts was introduced to add 
```
    sysctls:
    - name: net.ipv4.ip_unprivileged_port_start
      value: "0"
```

To the `PodSecurityContext` in the `PodTemplate`. However, in the original PR, the [PodTemplate was assigned to a local var ](https://github.com/sheidkamp/kgateway/blob/main/internal/kgateway/deployer/gateway_parameters.go#L281) before the UpdateSecurityContexts was called.

In the case that the `PodTemplate` is null, a function called UpdateSecurityContexts [creates a PodTemplate](https://github.com/kgateway-dev/kgateway/blob/main/pkg/deployer/gateway_parameters.go#L59-L61) in order to have a place to set `PodSecurityContext` values. When this happens, the local variable created no longer points to the PodTemplate being updated, and the values are not propagated.

This fix changes the order in which these operations occur, so the `PodTemplate` (if needed) is created before the assignment. 


# Change Type

```
/kind bug_fix
```


# Changelog


```release-note
NONE
```

# Additional Notes
This PR does not address updating the `TestKgateway/BasicRouting/TestGatewayWithRoute` test which was failing locally and should have failed in CI. The bug issue will be left open until that is resolved.

The bug fix itself can go in ahead of this to fix the nightly builds/main branch.

Reviewers, please validate by running that test against the main branch and then again against this branch. 