### PR TITLE
Do not ignore 'not found errors' from Deployer

### DIFF
--- a/internal/kgateway/controller/controller_suite_test.go
+++ b/internal/kgateway/controller/controller_suite_test.go
@@ -218,15 +218,18 @@ func createManager(
 		cancel()
 		return nil, err
 	}
-	mgr.GetClient().Create(ctx, &v1alpha1.GatewayParameters{
+	if err := mgr.GetClient().Create(ctx, &v1alpha1.GatewayParameters{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      selfManagedGatewayClassName,
-			Namespace: "kgateway-system",
+			Namespace: "default",
 		},
 		Spec: v1alpha1.GatewayParametersSpec{
 			SelfManaged: &v1alpha1.SelfManagedGateway{},
 		},
-	})
+	}); client.IgnoreAlreadyExists(err) != nil {
+		cancel()
+		return nil, err
+	}
 
 	// Use the default & alt GCs when no class configs are provided.
 	if classConfigs == nil {
@@ -240,9 +243,10 @@ func createManager(
 		classConfigs[selfManagedGatewayClassName] = &controller.ClassInfo{
 			Description: "self managed gw",
 			ParametersRef: &apiv1.ParametersReference{
-				Group: apiv1.Group(wellknown.GatewayParametersGVK.Group),
-				Kind:  apiv1.Kind(wellknown.GatewayParametersGVK.Kind),
-				Name:  selfManagedGatewayClassName,
+				Group:     apiv1.Group(wellknown.GatewayParametersGVK.Group),
+				Kind:      apiv1.Kind(wellknown.GatewayParametersGVK.Kind),
+				Name:      selfManagedGatewayClassName,
+				Namespace: ptr.To(apiv1.Namespace("default")),
 			},
 		}
 	}

--- a/internal/kgateway/controller/gw_controller.go
+++ b/internal/kgateway/controller/gw_controller.go
@@ -82,7 +82,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	log.Info("reconciling gateway")
 	objs, err := r.deployer.GetObjsToDeploy(ctx, &gw)
-	if client.IgnoreNotFound(err) != nil {
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 	objs = r.deployer.SetNamespaceAndOwner(&gw, objs)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
- **Motivation:** I noticed that gw_controller ignores "Not Found" errors returned when deployer attempts to render gw chart. These can happen when kube client fails to fetch GatewayClass or GatewayParameter resources (for w/e reason) and result in chart not being rendered (an empty list of objects to sync to cluster).  There's no error recorded, and the only symptom is a missing gateway pod. The same issue doesn't exist in the inference extension controller.
- **What changed:** "Not Found" returned when the deployer renders the gateway chart are no longer ignored. 
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind bug_fix
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog
<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
