### PR TITLE
Fix ServiceEntry key returned as first alias

### DIFF
--- a/internal/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
+++ b/internal/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
@@ -45,7 +45,20 @@ type Service struct {
 // including those from aliases.
 // Specifically returns the aliases _first_.
 func (s Service) Keys() []ir.ObjectSource {
-	return append(s.Aliases, ir.ObjectSource{
+	aliases := s.Aliases
+
+	// Check if the first alias is a ServiceEntry's own ObjectSource
+	if len(aliases) > 0 && aliases[0].Equals(ir.ObjectSource{
+		Name:      s.GetName(),
+		Namespace: s.GetNamespace(),
+		Group:     wellknown.ServiceEntryGVK.Group,
+		Kind:      wellknown.ServiceEntryGVK.Kind,
+	}) {
+		// ServiceEntry has self as the first one (see BuildServiceEntryBackendObjectIR).
+		// We want to return the aliases _after_ the self.
+		aliases = aliases[1:]
+	}
+	return append(aliases, ir.ObjectSource{
 		Name:      s.GetName(),
 		Namespace: s.GetNamespace(),
 		Group:     s.GroupKind.Group,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

A small fix for the ServiceEntry's Key returning the SE itself as the first key instead of its actual aliases first.
ServiceEntry self key is being added here https://github.com/kgateway-dev/kgateway/blob/main/internal/kgateway/extensions2/plugins/serviceentry/backends.go#L126.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
