### PR TITLE
.github/workflows: Automate issue assignment

### DIFF
--- a/.github/workflows/assign-issue.yaml
+++ b/.github/workflows/assign-issue.yaml
@@ -1,0 +1,80 @@
+name: Auto-assign Issues
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign-issue:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null && contains(github.event.comment.body, '/assign')
+
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Check if comment contains /assign
+        id: check_assign
+        run: |
+          COMMENT_BODY="${{ github.event.comment.body }}"
+          if [[ "$COMMENT_BODY" =~ ^[[:space:]]*\/assign[[:space:]]*$ ]]; then
+            echo "should_assign=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_assign=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Assign issue
+        if: steps.check_assign.outputs.should_assign == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const assignee = context.payload.comment.user.login;
+
+            try {
+              // Check if the issue is already assigned
+              const { data: issue } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number
+              });
+
+              if (issue.assignees && issue.assignees.length > 0) {
+                // Issue is already assigned
+                const currentAssignees = issue.assignees.map(a => a.login).join(', ');
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: `❌ This issue is already assigned to: ${currentAssignees}`
+                });
+                return;
+              }
+
+              // Assign the issue
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number,
+                assignees: [assignee]
+              });
+
+              // Add a confirmation comment
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: `✅ Issue assigned to @${assignee}. Thanks for contributing!`
+              });
+
+            } catch (error) {
+              console.error('Error assigning issue:', error);
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: `❌ Failed to assign issue. Error: ${error.message}`
+              });
+            }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Add workflow to handle /assign comments on issues to streamline this process better:

- Consistent with [k/k](https://www.kubernetes.dev/docs/guide/first-contribution/#issue-assignment-in-github)
- Automatically assign issues to commenter when /assign is used
- Prevent assignment if issue is already assigned
- Provide feedback comments for success/failure cases
- Only trigger on issue comments, not PR comments

Manually tested this workflow in my fork: https://github.com/timflannagan/kgateway/issues/22

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
