### PR TITLE
Adds Support for Gateway API Inference Extension Conformance

### DIFF
--- a/.github/actions/kube-inference-extension-conformance-tests/action.yaml
+++ b/.github/actions/kube-inference-extension-conformance-tests/action.yaml
@@ -1,8 +1,8 @@
-name: Gateway API Conformance Tests
-description: run kubernetes gateway api conformance tests
+name: Gateway API Inference Extension Conformance Tests
+description: run kubernetes gateway api inference extension conformance tests
 inputs:
   api-version:
-    description: "Override of the sig Gateway API to test against."
+    description: "Override of the sig Gateway API inference extension to test against."
     required: false
 runs:
   using: "composite"
@@ -26,7 +26,6 @@ runs:
         echo "VERSION=${{ matrix.version }}" >> $GITHUB_ENV
         echo "SKIP_DOCKER=true" >> $GITHUB_ENV
       fi
-      echo "CONFORMANCE_VERSION=${{ inputs.API_VERSION }}" >> $GITHUB_ENV
 
   - name: Setup test env
     shell: bash
@@ -42,25 +41,30 @@ runs:
       if [[ -z "${{ matrix.version }}" ]]; then
         # If matrix.version is empty, use the local chart path specified in the Makefile.
           helm upgrade -i -n kgateway-system kgateway-crds ./install/helm/kgateway-crds/ \
-          --create-namespace
+          --create-namespace \
+          --set inferenceExtension.enabled=true
         helm upgrade -i -n kgateway-system kgateway ./install/helm/kgateway/ \
           --create-namespace \
-          --set image.tag=${VERSION} --set image.registry=ghcr.io/kgateway-dev
+          --set image.tag=${VERSION} \
+          --set image.registry=ghcr.io/kgateway-dev \
+          --set inferenceExtension.enabled=true
       else
         # TODO(tim): this will require changes once the new helm chart is integrated
         # and published with the release pipeline.
         # Else, use the provided version to install Gloo from the helm repository.
         helm upgrade -i -n kgateway-system kgateway-crds oci://${{ env.IMAGE_REGISTRY }}/charts/kgateway-crds \
           --version ${VERSION} \
-          --create-namespace
+          --create-namespace \
+          --set inferenceExtension.enabled=true
         helm upgrade -i -n kgateway-system kgateway oci://${{ env.IMAGE_REGISTRY }}/charts/kgateway \
           --version ${VERSION} \
           --create-namespace \
-          --set image.tag=${VERSION}
+          --set image.tag=${VERSION} \
+          --set inferenceExtension.enabled=true
       fi
-  - name: Run the kubernetes gateway API conformance tests
+  - name: Run the kubernetes gateway API inference extension conformance tests
     shell: bash
-    run: make conformance
+    run: make gie-conformance
   - name: Capture debug information when tests fail
     if: ${{ failure() }}
     shell: bash
@@ -71,8 +75,6 @@ runs:
       echo
       kubectl -n gateway-conformance-app-backend get events --sort-by='{.lastTimestamp}'
       echo
-      kubectl -n gateway-conformance-web-backend get events --sort-by='{.lastTimestamp}'
-      echo
       kubectl -n kgateway-system logs deploy/kgateway
   - name: Upload reports
     if: ${{ failure() }}
@@ -80,5 +82,5 @@ runs:
     with:
       # Name of the path to upload. The VERSION variable refers to the Makefile
       # VERSION variable.
-      name: conformance-kgateway-gateway-report@k8s${{ matrix.kube-version.kubectl }}
-      path: _test/conformance/${{ env.VERSION }}-report.yaml
+      name: conformance-kgateway-gateway-inference-extension-report@k8s${{ matrix.kube-version.kubectl }}
+      path: _test/conformance/${{ env.VERSION }}-inference-extension-report.yaml

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -29,3 +29,19 @@ jobs:
     - uses: actions/checkout@v4
     - id: run-tests
       uses: ./.github/actions/kube-gateway-api-conformance-tests
+
+  kube_inference_extension_conformance_tests:
+    name: kubernetes gateway api inference extension conformance tests (${{matrix.image-variant}})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-version: [ { node: 'v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f', kubectl: 'v1.33.2', kind: 'v0.29.0' } ]
+        image-variant:
+          - standard
+    steps:
+    - uses: actions/checkout@v4
+    - id: run-tests
+      uses: ./.github/actions/kube-inference-extension-conformance-tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,14 +170,15 @@ jobs:
             oci://${{ env.IMAGE_REGISTRY }}/charts/kgateway \
             --set image.registry=${{ env.IMAGE_REGISTRY }} \
             --version ${{ needs.setup.outputs.version }} \
+            --set inferenceExtension.enabled=true \
             --wait --timeout 5m
 
       - name: Wait for the kgateway deployment to be ready
         run: |
           kubectl wait --for=condition=available --timeout=5m deployment/kgateway -n kgateway-system
 
-      - name: Run Conformance Tests
-        run: make conformance
+      - name: Run Gateway API and Inference Extension Conformance Tests
+        run: make all-conformance
         shell: bash
         env:
           VERSION: ${{ needs.setup.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -492,6 +492,10 @@ CONFORMANCE_VERSION ?= v1.3.0
 gw-api-crds: ## Install the Gateway API CRDs
 	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/$(CONFORMANCE_CHANNEL)?ref=$(CONFORMANCE_VERSION)"
 
+.PHONY: gie-crds
+gie-crds: gw-api-crds ## Install the Gateway API Inference Extension CRDs
+	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd/"
+
 .PHONY: kind-metallb
 metallb: ## Install the MetalLB load balancer
 	./hack/kind/setup-metalllb-on-kind.sh
@@ -500,7 +504,7 @@ metallb: ## Install the MetalLB load balancer
 deploy-kgateway: package-kgateway-charts deploy-kgateway-crd-chart deploy-kgateway-chart ## Deploy the kgateway chart and CRDs
 
 .PHONY: setup
-setup: kind-create kind-build-and-load gw-api-crds metallb package-kgateway-charts ## Set up basic infrastructure (kind cluster, images, CRDs, MetalLB)
+setup: kind-create kind-build-and-load gw-api-crds gie-crds metallb package-kgateway-charts ## Set up basic infrastructure (kind cluster, images, CRDs, MetalLB)
 
 .PHONY: run
 run: setup deploy-kgateway  ## Set up complete development environment
@@ -598,6 +602,39 @@ conformance: $(TEST_ASSET_DIR)/conformance/conformance_test.go
 conformance-%: $(TEST_ASSET_DIR)/conformance/conformance_test.go
 	go test -mod=mod -ldflags='$(LDFLAGS)' -tags conformance -test.v $(TEST_ASSET_DIR)/conformance/... -args $(CONFORMANCE_ARGS) \
 	-run-test=$*
+
+#----------------------------------------------------------------------------------
+# Targets for running Gateway API Inference Extension conformance tests
+#----------------------------------------------------------------------------------
+
+# Where the inference extension module is checked out in our Go module cache.
+INFERENCE_CONFORMANCE_DIR := $(shell go list -m -f '{{.Dir}}' sigs.k8s.io/gateway-api-inference-extension)/conformance
+# Allow skipping known‐failing tests.
+INFERENCE_SKIP_TESTS ?= -skip-tests EppUnAvailableFailOpen
+# The Gateway API Inference Extension conformance suite requires a GatewayClass to be specified.
+GIE_CONFORMANCE_ARGS := -gateway-class=$(CONFORMANCE_GATEWAY_CLASS)
+
+.PHONY: gie-conformance
+gie-conformance: gie-crds ## Run the Gateway API Inference Extension conformance suite
+	go test -mod=mod -ldflags='$(LDFLAGS)' \
+	    -tags conformance \
+	    -timeout=25m \
+	    -v $(INFERENCE_CONFORMANCE_DIR) \
+	    -args $(GIE_CONFORMANCE_ARGS) $(INFERENCE_SKIP_TESTS)
+
+.PHONY: gie-conformance-%
+gie-conformance-%: gie-crds ## Run only the specified Gateway API Inference Extension conformance test by ShortName
+	go test -mod=mod -ldflags='$(LDFLAGS)' \
+	    -tags conformance \
+	    -timeout=25m \
+	    -v $(INFERENCE_CONFORMANCE_DIR) \
+	    -args $(CONFORMANCE_ARGS) $(INFERENCE_SKIP_TESTS) \
+	    -run-test=$*
+
+# An alias to run both Gateway API and Inference Extension conformance tests.
+.PHONY: all-conformance
+all-conformance: conformance gie-conformance ## Run both Gateway API and Inference Extension conformance
+	@echo "All conformance suites have completed."
 
 #----------------------------------------------------------------------------------
 # Printing makefile variables utility

--- a/hack/kind/setup-kind.sh
+++ b/hack/kind/setup-kind.sh
@@ -88,14 +88,17 @@ fi
 # the CRDs yet, or won't be for the foreseeable future.
 kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api/config/crd/$CONFORMANCE_CHANNEL?ref=$CONFORMANCE_VERSION"
 
-# 7. Conformance test setup
+# 7. Apply the Kubernetes Gateway API Inference Extension CRDs
+kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd/"
+
+# 8. Conformance test setup
 if [[ $CONFORMANCE == "true" ]]; then
   echo "Running conformance test setup"
 
   . $SCRIPT_DIR/setup-metalllb-on-kind.sh
 fi
 
-# 7. Setup localstack
+# 9. Setup localstack
 if [[ $LOCALSTACK == "true" ]]; then
   echo "Setting up localstack"
   . $SCRIPT_DIR/setup-localstack.sh


### PR DESCRIPTION
# Description

Updates CI and Make workflows to support running the Gateway API Inference Extension conformance tests.

# Change Type

```
/kind new_feature
```

# Changelog

```release-note
CI: Adds support for running Gateway API Inference Extension conformance tests.
```


# Additional Notes

Only review commit 824967d7018e5af35488b3838cefdf431a46d8ef since this PR requires commit f73fe0dce7b3c0d13b48949d2ad6ecfeebb0a319 from #11621 to pass CI.
