### PR TITLE
Adds Retries to Updating Gateway Status

### DIFF
--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -73,6 +73,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 	}
 
 	finalGwStatus := gwv1.GatewayStatus{}
+	finalGwStatus.Addresses = gw.Status.Addresses
 	finalGwStatus.Conditions = finalConditions
 	finalGwStatus.Listeners = finalListeners
 	return &finalGwStatus


### PR DESCRIPTION
# Description

Adds retries to gateway controller and proxy syncer when updating Gateway status.

Fixes #11696 

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
Adds retries to gateway controller and proxy syncer when updating Gateway status.
```

# Additional Notes

N/A
