### PR TITLE
fix Equals for PolicyAtt and PolicyWrapper

### DIFF
--- a/internal/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -55,7 +55,7 @@ func (e TrafficPolicyGatewayExtensionIR) Equals(other TrafficPolicyGatewayExtens
 	if e.Err != nil && other.Err == nil {
 		return false
 	}
-	if e.Err.Error() != other.Err.Error() {
+	if (e.Err != nil && other.Err != nil) && e.Err.Error() != other.Err.Error() {
 		return false
 	}
 

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -49,15 +49,17 @@ func (e TrafficPolicyGatewayExtensionIR) Equals(other TrafficPolicyGatewayExtens
 		return false
 	}
 
-	// Compare providers
-	if e.Err == nil && other.Err == nil {
-		return true
+	if e.Err == nil && other.Err != nil {
+		return false
 	}
-	if e.Err == nil || other.Err == nil {
+	if e.Err != nil && other.Err == nil {
+		return false
+	}
+	if e.Err.Error() != other.Err.Error() {
 		return false
 	}
 
-	return e.Err.Error() == other.Err.Error()
+	return true
 }
 
 func TranslateGatewayExtensionBuilder(commoncol *common.CommonCollections) func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -105,6 +105,12 @@ func (c PolicyAtt) TargetRef() *AttachedPolicyRef {
 }
 
 func (c PolicyAtt) Equals(in PolicyAtt) bool {
+	if !slices.EqualFunc(c.Errors, in.Errors, func(e1, e2 error) bool {
+		return e1.Error() == e2.Error()
+	}) {
+		return false
+	}
+
 	return c.GroupKind == in.GroupKind && ptrEquals(c.PolicyRef, in.PolicyRef) && c.PolicyIr.Equals(in.PolicyIr)
 }
 

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -106,7 +106,17 @@ func (c PolicyAtt) TargetRef() *AttachedPolicyRef {
 
 func (c PolicyAtt) Equals(in PolicyAtt) bool {
 	if !slices.EqualFunc(c.Errors, in.Errors, func(e1, e2 error) bool {
-		return e1.Error() == e2.Error()
+		if e1 == nil && e2 != nil {
+			return false
+		}
+		if e1 != nil && e2 == nil {
+			return false
+		}
+		if (e1 != nil && e2 != nil) && e1.Error() != e2.Error() {
+			return false
+		}
+
+		return true
 	}) {
 		return false
 	}

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -275,7 +275,17 @@ func (c PolicyWrapper) Equals(in PolicyWrapper) bool {
 	}
 
 	if !slices.EqualFunc(c.Errors, in.Errors, func(e1, e2 error) bool {
-		return e1.Error() == e2.Error()
+		if e1 == nil && e2 != nil {
+			return false
+		}
+		if e1 != nil && e2 == nil {
+			return false
+		}
+		if (e1 != nil && e2 != nil) && e1.Error() != e2.Error() {
+			return false
+		}
+
+		return true
 	}) {
 		return false
 	}

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -3,6 +3,7 @@ package ir
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -270,6 +271,12 @@ func versionEquals(a, b metav1.Object) bool {
 
 func (c PolicyWrapper) Equals(in PolicyWrapper) bool {
 	if c.ObjectSource != in.ObjectSource {
+		return false
+	}
+
+	if !slices.EqualFunc(c.Errors, in.Errors, func(e1, e2 error) bool {
+		return e1.Error() == e2.Error()
+	}) {
 		return false
 	}
 


### PR DESCRIPTION
# Description

`PolicyAtt` and `PolicyWrapper` types did not consider their errors in their `Equals` impl

# Change Type
```
/kind bug_fix
```

# Changelog
```release-note
Correctly report status for attached policies and gatewayExtensions when only errors change
```