### PR TITLE
feat: Add helmPath configuration to Client for customizable helm executable path

### DIFF
--- a/pkg/utils/helmutils/client.go
+++ b/pkg/utils/helmutils/client.go
@@ -13,12 +13,14 @@ type Client struct {
 	receiver io.Writer
 
 	namespace string
+	helmPath  string
 }
 
 // NewClient returns an implementation of the helmutils.Client
 func NewClient() *Client {
 	return &Client{
 		receiver: io.Discard,
+		helmPath: "helm",
 	}
 }
 
@@ -32,6 +34,12 @@ func (c *Client) WithReceiver(receiver io.Writer) *Client {
 // WithNamespace sets the namespace that all commands will be invoked against
 func (c *Client) WithNamespace(ns string) *Client {
 	c.namespace = ns
+	return c
+}
+
+// WithHelmPath sets the path to the helm executable
+func (c *Client) WithHelmPath(path string) *Client {
+	c.helmPath = path
 	return c
 }
 

--- a/pkg/utils/helmutils/client.go
+++ b/pkg/utils/helmutils/client.go
@@ -50,7 +50,7 @@ func (c *Client) Command(ctx context.Context, args ...string) cmdutils.Cmd {
 		args = append([]string{"--namespace", c.namespace}, args...)
 	}
 
-	return cmdutils.Command(ctx, "helm", args...).
+	return cmdutils.Command(ctx, c.helmPath, args...).
 		// For convenience, we set the stdout and stderr to the receiver
 		// This can still be overwritten by consumers who use the commands
 		WithStdout(c.receiver).


### PR DESCRIPTION
<!--  
Thanks for opening a PR! Please delete any sections that don’t apply.  
-->

# Description

<!--  
A concise explanation of the change. You may include:  
- **Motivation:** why this change is needed  
- **What changed:** key implementation details  
- **Related issues:** e.g., `Fixes #123`  
-->

Related issues: Fixes #11658


**What changed:**

* Added a `helmPath` field to `helmutils.Client` to store the path to the helm executable.
* Introduced a `WithHelmPath` method to allow consumers to configure the executable path.


# Change Type

<!--  
Select one or more of the following by including the corresponding slash-command:  
```
/kind bug_fix
/kind cleanup
```
-->

/kind cleanup

```release-note
NONE
```


