### PR TITLE
fix(api): Add validation to prevent int32 overflow for CORS maxAge

### DIFF
--- a/api/v1alpha1/traffic_policy_types.go
+++ b/api/v1alpha1/traffic_policy_types.go
@@ -355,6 +355,7 @@ type RateLimitDescriptorEntryGeneric struct {
 
 type CorsPolicy struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:XValidation:rule="!has(self.maxAge) || self.maxAge <= 2147483647", message="maxAge must be less than or equal to 2147483647"
 	*gwv1.HTTPCORSFilter `json:",inline"`
 }
 

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
@@ -353,6 +353,9 @@ spec:
                     type: integer
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+                x-kubernetes-validations:
+                - message: maxAge must be less than or equal to 2147483647
+                  rule: '!has(self.maxAge) || self.maxAge <= 2147483647'
               csrf:
                 properties:
                   additionalOrigins:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Fixes #11555

1. The maxAge field in the CorsPolicy is defined as an int32 but lacked CRD validation to enforce this limit. 
2. This change adds a CEL validation rule to the CorsPolicy definition to ensure the provided maxAge is within the valid int32 range.


<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

```
/kind bug_fix
```


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
