### PR TITLE
refactor: Update GetLocalChartPath to accept optional assetDir parameter

### DIFF
--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -153,7 +153,7 @@ func (i *TestInstallation) InstallKgatewayCRDsFromLocalChart(ctx context.Context
 	}
 
 	// install the CRD chart first
-	crdChartURI, err := helper.GetLocalChartPath(helmutils.CRDChartName)
+	crdChartURI, err := helper.GetLocalChartPath(helmutils.CRDChartName, "")
 	i.Assertions.Require.NoError(err)
 	err = i.Actions.Helm().WithReceiver(os.Stdout).Upgrade(
 		ctx,
@@ -172,7 +172,7 @@ func (i *TestInstallation) InstallKgatewayCoreFromLocalChart(ctx context.Context
 	}
 
 	// and then install the main chart
-	chartUri, err := helper.GetLocalChartPath(helmutils.ChartName)
+	chartUri, err := helper.GetLocalChartPath(helmutils.ChartName, "")
 	i.Assertions.Require.NoError(err)
 	err = i.Actions.Helm().WithReceiver(os.Stdout).Upgrade(
 		ctx,

--- a/test/kubernetes/testutils/helper/install.go
+++ b/test/kubernetes/testutils/helper/install.go
@@ -12,15 +12,19 @@ import (
 )
 
 const (
-	TestAssetDir          = "_test"
+	defaultTestAssetDir   = "_test"
 	HelmRepoIndexFileName = "index.yaml"
 )
 
 // Gets the absolute path to a locally-built helm chart. This assumes that the helm index has a reference
-// to exactly one version of the helm chart.
-func GetLocalChartPath(chartName string) (string, error) {
+// to exactly one version of the helm chart. If assetDir is an empty string, it will default to "_test".
+func GetLocalChartPath(chartName string, assetDir string) (string, error) {
+	dir := assetDir
+	if dir == "" {
+		dir = defaultTestAssetDir
+	}
 	rootDir := testutils.GitRootDirectory()
-	testAssetDir := filepath.Join(rootDir, TestAssetDir)
+	testAssetDir := filepath.Join(rootDir, dir)
 	if !fsutils.IsDirectory(testAssetDir) {
 		return "", fmt.Errorf("%s does not exist or is not a directory", testAssetDir)
 	}


### PR DESCRIPTION

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

**Motivation:** 
The test helper function `GetLocalChartPath` previously hardcoded the test asset directory (_test), making it difficult to override the asset location in different environments (e.g., when using a custom Makefile variable). This limited test flexibility and maintainability.

**What changed:**
- Refactored `GetLocalChartPath` to accept an optional `assetDir` parameter (variadic), allowing the test asset directory to be injected.
- If `assetDir` is not provided, the function defaults to using "_test" for backward compatibility.

**Related issues:**
Fixes: #11655 

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
NONE