### PR TITLE
Inference: Replace Deprecated AddToScheme() with Install()

### DIFF
--- a/internal/kgateway/controller/controller_suite_test.go
+++ b/internal/kgateway/controller/controller_suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	// Create a scheme and add both Gateway and InferencePool types.
 	scheme = schemes.GatewayScheme()
-	err := infextv1a2.AddToScheme(scheme)
+	err := infextv1a2.Install(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	// Required to deploy endpoint picker RBAC resources.
 	err = rbacv1.AddToScheme(scheme)

--- a/internal/kgateway/deployer/gateway_parameters_test.go
+++ b/internal/kgateway/deployer/gateway_parameters_test.go
@@ -208,7 +208,7 @@ func newFakeClientWithObjs(objs ...client.Object) client.Client {
 	for _, obj := range objs {
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		if gvk.Kind == wellknown.InferencePoolKind {
-			if err := infextv1a2.AddToScheme(scheme); err != nil {
+			if err := infextv1a2.Install(scheme); err != nil {
 				panic(fmt.Sprintf("failed to add InferenceExtension scheme: %v", err))
 			}
 			break

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2386,7 +2386,7 @@ func newFakeClientWithObjs(objs ...client.Object) client.Client {
 	for _, obj := range objs {
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		if gvk.Kind == wellknown.InferencePoolKind {
-			if err := infextv1a2.AddToScheme(scheme); err != nil {
+			if err := infextv1a2.Install(scheme); err != nil {
 				panic(fmt.Sprintf("failed to add InferenceExtension scheme: %v", err))
 			}
 			break

--- a/pkg/schemes/extended_scheme.go
+++ b/pkg/schemes/extended_scheme.go
@@ -45,7 +45,7 @@ func AddInferExtV1A2Scheme(restConfig *rest.Config, scheme *runtime.Scheme) (boo
 		if err := rbacv1.AddToScheme(scheme); err != nil {
 			return false, fmt.Errorf("error adding RBAC v1 to scheme: %w", err)
 		}
-		if err := infextv1a2.AddToScheme(scheme); err != nil {
+		if err := infextv1a2.Install(scheme); err != nil {
 			return false, fmt.Errorf("error adding Gateway API Inference Extension v1alpha1 to scheme: %w", err)
 		}
 	}


### PR DESCRIPTION
# Description

Replaces the deprecated `AddToScheme()` with `Install()` to install the Inference Extension v1alpha2 scheme.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
Inference: Replaces deprecated AddToScheme() with Install() to install the Inference Extension v1alpha2 scheme.
```

# Additional Notes

See https://github.com/solo-io/gloo-gateway/pull/449#event-18709492492 and https://github.com/solo-io/gloo-gateway/actions/runs/16395469284/job/46327182858?pr=449 where this issue surfaces.
