### PR TITLE
Agentgateway status fix

### DIFF
--- a/internal/kgateway/agentgatewaysyncer/gateway_collection.go
+++ b/internal/kgateway/agentgatewaysyncer/gateway_collection.go
@@ -15,25 +15,24 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/reports"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
 
-func toResourcepWithReports(gw types.NamespacedName, t any, reportMap reports.ReportMap) *ADPResource {
-	res := toResourceWithReports(gw, t, reportMap)
+func toResourcep(gw types.NamespacedName, t any) *ADPResource {
+	res := toResource(gw, t)
 	return &res
 }
 
-func toResourceWithReports(gw types.NamespacedName, t any, reportMap reports.ReportMap) ADPResource {
+func toResource(gw types.NamespacedName, t any) ADPResource {
 	switch tt := t.(type) {
 	case Bind:
-		return ADPResource{Resource: &api.Resource{Kind: &api.Resource_Bind{Bind: tt.Bind}}, Gateway: gw, reports: reportMap}
+		return ADPResource{Resource: &api.Resource{Kind: &api.Resource_Bind{Bind: tt.Bind}}, Gateway: gw}
 	case ADPListener:
-		return ADPResource{Resource: &api.Resource{Kind: &api.Resource_Listener{Listener: tt.Listener}}, Gateway: gw, reports: reportMap}
+		return ADPResource{Resource: &api.Resource{Kind: &api.Resource_Listener{Listener: tt.Listener}}, Gateway: gw}
 	case ADPRoute:
-		return ADPResource{Resource: &api.Resource{Kind: &api.Resource_Route{Route: tt.Route}}, Gateway: gw, reports: reportMap}
+		return ADPResource{Resource: &api.Resource{Kind: &api.Resource_Route{Route: tt.Route}}, Gateway: gw}
 	}
 	panic("unknown resource kind")
 }

--- a/internal/kgateway/agentgatewaysyncer/model.go
+++ b/internal/kgateway/agentgatewaysyncer/model.go
@@ -95,8 +95,6 @@ func (r ADPCacheAddress) Equals(in ADPCacheAddress) bool {
 type ADPResource struct {
 	Resource *api.Resource        `json:"resource"`
 	Gateway  types.NamespacedName `json:"gateway"`
-
-	reports reports.ReportMap
 }
 
 func (g ADPResource) ResourceName() string {

--- a/internal/kgateway/agentgatewaysyncer/route_collections.go
+++ b/internal/kgateway/agentgatewaysyncer/route_collections.go
@@ -34,11 +34,9 @@ func ADPRouteCollection(
 	grpcRouteCol krt.Collection[*gwv1.GRPCRoute],
 	tcpRouteCol krt.Collection[*gwv1alpha2.TCPRoute],
 	tlsRouteCol krt.Collection[*gwv1alpha2.TLSRoute],
-	gateways krt.Collection[Gateway],
 	gatewayObjs krt.Collection[*gwv1.Gateway],
 	inputs RouteContextInputs,
 	krtopts krtutil.KrtOptions,
-	rm reports.ReportMap,
 	rep reporter.Reporter,
 	plugins pluginsdk.Plugin,
 ) krt.Collection[ADPResource] {
@@ -96,7 +94,7 @@ func ADPRouteCollection(
 				_, name, _ := strings.Cut(parent.InternalName, "/")
 				inner.ListenerKey = name
 				inner.Key = inner.GetKey() + "." + string(parent.ParentSection)
-				return toResourceWithReports(gw, ADPRoute{Route: inner}, rm)
+				return toResource(gw, ADPRoute{Route: inner})
 			})...)
 		}
 		return res
@@ -145,7 +143,7 @@ func ADPRouteCollection(
 				_, name, _ := strings.Cut(parent.InternalName, "/")
 				inner.ListenerKey = name
 				inner.Key = inner.GetKey() + "." + string(parent.ParentSection)
-				return toResourceWithReports(gw, ADPRoute{Route: inner}, rm)
+				return toResource(gw, ADPRoute{Route: inner})
 			})...)
 		}
 		return res
@@ -194,7 +192,7 @@ func ADPRouteCollection(
 				_, name, _ := strings.Cut(parent.InternalName, "/")
 				inner.ListenerKey = name
 				inner.Key = inner.GetKey() + "." + string(parent.ParentSection)
-				return toResourceWithReports(gw, ADPRoute{Route: inner}, rm)
+				return toResource(gw, ADPRoute{Route: inner})
 			})...)
 		}
 		return res
@@ -243,7 +241,7 @@ func ADPRouteCollection(
 				_, name, _ := strings.Cut(parent.InternalName, "/")
 				inner.ListenerKey = name
 				inner.Key = inner.GetKey() + "." + string(parent.ParentSection)
-				return toResourceWithReports(gw, ADPRoute{Route: inner}, rm)
+				return toResource(gw, ADPRoute{Route: inner})
 			})...)
 		}
 		return res
@@ -260,7 +258,7 @@ func ADPRouteCollection(
 	routeAttachmentsIndex := krt.NewIndex(routeAttachments, func(o *RouteAttachment) []types.NamespacedName {
 		return []types.NamespacedName{o.To}
 	})
-	FinalGatewayStatusCollectionAttachedRoutes(gatewayObjs, routeAttachments, routeAttachmentsIndex, krtopts, rep)
+	finalGatewayStatusCollectionAttachedRoutes(gatewayObjs, routeAttachments, routeAttachmentsIndex, krtopts, rep)
 
 	return routes
 }
@@ -474,10 +472,10 @@ func (g gatewayStatusUpdate) Equals(other gatewayStatusUpdate) bool {
 		g.gateway.ResourceVersion == other.gateway.ResourceVersion
 }
 
-// FinalGatewayStatusCollectionAttachedRoutes finalizes a Gateway status. There is a circular logic between Gateways and Routes to determine
+// finalGatewayStatusCollectionAttachedRoutes finalizes a Gateway status. There is a circular logic between Gateways and Routes to determine
 // the attachedRoute count, so we first build a partial Gateway status, then once routes are computed we finalize it with
 // the attachedRoute count.
-func FinalGatewayStatusCollectionAttachedRoutes(
+func finalGatewayStatusCollectionAttachedRoutes(
 	gateways krt.Collection[*gwv1.Gateway],
 	routeAttachments krt.Collection[*RouteAttachment],
 	routeAttachmentsIndex krt.Index[types.NamespacedName, *RouteAttachment],

--- a/internal/kgateway/agentgatewaysyncer/route_collections_test.go
+++ b/internal/kgateway/agentgatewaysyncer/route_collections_test.go
@@ -660,7 +660,7 @@ func TestADPRouteCollection(t *testing.T) {
 			// Call ADPRouteCollection
 			rm := reports.NewReportMap()
 			rep := reports.NewReporter(&rm)
-			adpRoutes := ADPRouteCollection(httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes, gateways, gatewayObjs, routeInputs, krtopts, rm, rep, pluginsdk.Plugin{})
+			adpRoutes := ADPRouteCollection(httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes, gatewayObjs, routeInputs, krtopts, rep, pluginsdk.Plugin{})
 
 			// Wait for the collection to process
 			adpRoutes.WaitUntilSynced(context.Background().Done())
@@ -1258,7 +1258,7 @@ func TestADPRouteCollectionGRPC(t *testing.T) {
 			// Call ADPRouteCollection
 			rm := reports.NewReportMap()
 			rep := reports.NewReporter(&rm)
-			adpRoutes := ADPRouteCollection(httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes, gateways, gatewayObjs, routeInputs, krtopts, rm, rep, pluginsdk.Plugin{})
+			adpRoutes := ADPRouteCollection(httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes, gatewayObjs, routeInputs, krtopts, rep, pluginsdk.Plugin{})
 
 			// Wait for the collection to process
 			adpRoutes.WaitUntilSynced(context.Background().Done())
@@ -1554,7 +1554,7 @@ func TestADPRouteCollectionWithFilters(t *testing.T) {
 			// Call ADPRouteCollection
 			rm := reports.NewReportMap()
 			rep := reports.NewReporter(&rm)
-			adpRoutes := ADPRouteCollection(httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes, gateways, gatewayObjs, routeInputs, krtopts, rm, rep, pluginsdk.Plugin{})
+			adpRoutes := ADPRouteCollection(httpRoutes, grpcRoutes, tcpRoutes, tlsRoutes, gatewayObjs, routeInputs, krtopts, rep, pluginsdk.Plugin{})
 
 			// Wait for the collection to process
 			adpRoutes.WaitUntilSynced(context.Background().Done())

--- a/internal/kgateway/reports/reporter.go
+++ b/internal/kgateway/reports/reporter.go
@@ -277,7 +277,7 @@ func (r *reporter) Gateway(gateway *gwv1.Gateway) pluginsdkreporter.GatewayRepor
 	if gr == nil {
 		gr = r.report.newGatewayReport(gateway)
 	}
-	gr.observedGeneration = gateway.Generation
+	gr.observedGeneration = gateway.GetGeneration()
 	return gr
 }
 
@@ -286,7 +286,7 @@ func (r *reporter) ListenerSet(listenerSet *gwxv1alpha1.XListenerSet) pluginsdkr
 	if lsr == nil {
 		lsr = r.report.newListenerSetReport(listenerSet)
 	}
-	lsr.observedGeneration = listenerSet.Generation
+	lsr.observedGeneration = listenerSet.GetGeneration()
 	return lsr
 }
 
@@ -295,6 +295,7 @@ func (r *reporter) Route(obj metav1.Object) pluginsdkreporter.RouteReporter {
 	if rr == nil {
 		rr = r.report.newRouteReport(obj)
 	}
+	rr.observedGeneration = obj.GetGeneration()
 	return rr
 }
 

--- a/internal/kgateway/reports/status.go
+++ b/internal/kgateway/reports/status.go
@@ -233,8 +233,10 @@ func (r *ReportMap) BuildRouteStatus(
 		}
 
 		finalConditions := make([]metav1.Condition, 0, len(parentStatusReport.Conditions))
+		slog.Debug("parentStatusReport.Conditions", "conditions", parentStatusReport.Conditions)
 		for _, pCondition := range parentStatusReport.Conditions {
 			pCondition.ObservedGeneration = routeReport.observedGeneration
+			slog.Debug("ObservedGeneration", "ObservedGeneration", pCondition.ObservedGeneration)
 
 			// Copy old condition to preserve LastTransitionTime, if it exists
 			if cond := meta.FindStatusCondition(currentParentRefConditions, pCondition.Type); cond != nil {


### PR DESCRIPTION
# Description

Alternative approach to https://github.com/kgateway-dev/kgateway/pull/11733


# Change Type


```
/kind bug_fix
```

# Changelog

```release-note
NONE
```

# Additional Notes

- Removes reporter map from each agw resource 
- Revert equality logic to avoid syncing statuses every iteration
