### PR TITLE
policy/status: disambiguate acceptance and attachment

### DIFF
--- a/api/v1alpha1/policy_types.go
+++ b/api/v1alpha1/policy_types.go
@@ -1,0 +1,58 @@
+package v1alpha1
+
+// PolicyConditionType is a type of condition for a policy. This type should be
+// used with a Policy resource Status.Conditions field.
+type PolicyConditionType string
+
+// PolicyConditionReason is a reason for a policy condition.
+type PolicyConditionReason string
+
+const (
+	// PolicyConditionAccepted indicates whether the policy has been accepted or rejected, and why.
+	//
+	// Possible reasons for this condition to be True are:
+	// * Valid
+	//
+	// Possible reasons for this condition to be False are:
+	// * Pending
+	// * Invalid
+	//
+	PolicyConditionAccepted PolicyConditionType = "Accepted"
+
+	// PolicyConditionAttached indicates whether the policy has attached to the targeted resources.
+	//
+	// Possible reasons for this condition to be True are:
+	// * Attached
+	// * Merged
+	//
+	// Possible reasons for this condition to be False are:
+	// * Pending
+	// * Discarded
+	//
+	PolicyConditionAttached PolicyConditionType = "Attached"
+
+	// PolicyReasonValid is used with the "Accepted" condition when the policy
+	// has been accepted by the system.
+	PolicyReasonValid PolicyConditionReason = "Valid"
+
+	// PolicyReasonInvalid is used with the "Accepted" or "Attached" condition when the policy
+	// is syntactically or semantically invalid.
+	PolicyReasonInvalid PolicyConditionReason = "Invalid"
+
+	// PolicyReasonAttached is used with the "Attached" condition when the
+	// policy has been successfully attached to all the targeted resources.
+	PolicyReasonAttached PolicyConditionReason = "Attached"
+
+	// PolicyReasonMerged is used with the "Attached" condition when the
+	// policy has been merged with other policies and attached to the targeted resources.
+	PolicyReasonMerged PolicyConditionReason = "Merged"
+
+	// PolicyReasonDiscarded is used with the "Attached" condition when the
+	// policy is fully discarded on any targeted resource due to a conflict
+	// with another policy of higher priority.
+	PolicyReasonDiscarded PolicyConditionReason = "Discarded"
+
+	// PolicyReasonPending is used with the "Accepted" or "Attached" condition when the policy is pending
+	// acceptance or attachment respectively.
+	PolicyReasonPending PolicyConditionReason = "Pending"
+)

--- a/api/v1alpha1/policy_types.go
+++ b/api/v1alpha1/policy_types.go
@@ -52,7 +52,6 @@ const (
 	// with another policy of higher priority.
 	PolicyReasonDiscarded PolicyConditionReason = "Discarded"
 
-	// PolicyReasonPending is used with the "Accepted" or "Attached" condition when the policy is pending
-	// acceptance or attachment respectively.
+	// PolicyReasonPending is used with the "Accepted" or "Attached" condition when the policy has been referenced but not yet fully processed by the controller.
 	PolicyReasonPending PolicyConditionReason = "Pending"
 )

--- a/design/11741.md
+++ b/design/11741.md
@@ -1,0 +1,120 @@
+# EP-11741: Policy Status and merge reporting
+
+
+* Issue: [#11741](https://github.com/kgateway-dev/kgateway/issues/11741)
+
+
+## Background
+
+Kgateway policy CRs make use of the `gwv1alpha2.PolicyStatus` API for statuses. Currently, this API is limited as it does not disambiguate policy acceptance and attachment. Policy attachment is complex because it involves applying policies by priority, or merging prioritized policies, which can result in some or all fields in a lower priority policy being discarded in the final policy attached to the targeted resource. This can lead to confusion when a policy is accepted but not attached due to conflicts with other policies.
+
+## Motivation
+
+Enhance the status API to make use of custom Conditions to report policy acceptance and attachment separately. This will provide clearer insights into the state of policies, especially in cases where a policy is accepted but not attached due to conflicts.
+
+## Goals
+
+- Report policy acceptance and attachment separately using custom Conditions.
+- Summarize attachment information using the `Attached` Condition.
+- Add `MergeOrigins` as metadata on the output Envoy config.
+
+## Non-Goals
+
+- Surfacing fine grained or high cardinality data that is not representable in the status API.
+
+## Implementation Details
+
+Refer to the [status condition types and reasons](/api/v1alpha1/policy_types.go) for the new Conditions and Reasons that will be used to report policy acceptance and attachment.
+
+The existing Policy reporter framework will be extended to track the policy attachment state per policy as an aggregate for all its targets. When building the final policy status, the `Attached` Condition will report the following:
+`
+- `status: "True", reason: Attached`: if the policy is attached to all its targets without merging with other policies.
+- `status: "True", reason: Merged`: if the policy is attached to all its targets but merged with other policies for one or more tagets.
+- `status: "False", reason: Discarded`: if the policy was discarded for one or more targets during a merge.
+
+Additionally, `MergeOrigins` will be included as metadata on the corresponding output Envoy config for diagnostic purposes. In the future, tooling could make use of this metadata to provide insights into the policy merging outcome.
+
+### Examples
+
+When a policy successfully attached to all its targets:
+```
+status:
+  ancestors:
+  - ancestorRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: test
+      namespace: default
+    conditions:
+    - lastTransitionTime: "2025-07-24T18:06:29Z"
+      message: Policy accepted
+      observedGeneration: 1
+      reason: Valid
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-24T18:06:29Z"
+      message: Attached to all targets
+      observedGeneration: 1
+      reason: Attached
+      status: "True"
+      type: Attached
+    controllerName: kgateway.dev/kgateway
+```
+
+When a policy merges with other policies but is still attached partially:
+```
+status:
+  ancestors:
+  - ancestorRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: test
+      namespace: default
+    conditions:
+    - lastTransitionTime: "2025-07-24T18:06:29Z"
+      message: Policy accepted
+      observedGeneration: 1
+      reason: Valid
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-24T18:06:29Z"
+      message: Merged with other policies in target(s) and attached
+      observedGeneration: 1
+      reason: Merged
+      status: "True"
+      type: Attached
+    controllerName: kgateway.dev/kgateway
+```
+
+When a policy is accepted but not attached:
+```
+status:
+  ancestors:
+  - ancestorRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: test
+      namespace: default
+    conditions:
+    - lastTransitionTime: "2025-07-24T18:06:29Z"
+      message: Policy accepted
+      observedGeneration: 1
+      reason: Valid
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-24T18:06:29Z"
+      message: Discarded due to conflict with higher priority policy in target(s)
+      observedGeneration: 1
+      reason: Discarded
+      status: "False"
+      type: Attached
+    controllerName: kgateway.dev/kgateway
+```
+
+### Test Plan
+
+Unit, translator, and e2e tests to verify the policy Status API.
+
+## Open Questions
+
+n/a

--- a/design/11741.md
+++ b/design/11741.md
@@ -21,6 +21,7 @@ Enhance the status API to make use of custom Conditions to report policy accepta
 ## Non-Goals
 
 - Surfacing fine grained or high cardinality data that is not representable in the status API.
+- Report status for unresolved `targetRefs` on the policy CR.
 
 ## Implementation Details
 

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/merge.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/merge.go
@@ -10,6 +10,7 @@ import (
 func mergePolicies(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	mergeOpts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -17,7 +18,7 @@ func mergePolicies(
 		return
 	}
 
-	mergeFuncs := []func(*httpListenerPolicy, *httpListenerPolicy, *ir.AttachedPolicyRef, policy.MergeOptions, ir.MergeOrigins){
+	mergeFuncs := []func(*httpListenerPolicy, *httpListenerPolicy, *ir.AttachedPolicyRef, ir.MergeOrigins, policy.MergeOptions, ir.MergeOrigins){
 		mergeAccessLog,
 		mergeTracing,
 		mergeUpgradeConfigs,
@@ -29,13 +30,14 @@ func mergePolicies(
 	}
 
 	for _, mergeFunc := range mergeFuncs {
-		mergeFunc(p1, p2, p2Ref, mergeOpts, mergeOrigins)
+		mergeFunc(p1, p2, p2Ref, p2MergeOrigins, mergeOpts, mergeOrigins)
 	}
 }
 
 func mergeAccessLog(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -44,12 +46,13 @@ func mergeAccessLog(
 	}
 
 	p1.accessLog = slices.Clone(p2.accessLog)
-	mergeOrigins.SetOne("accessLog", p2Ref)
+	mergeOrigins.SetOne("accessLog", p2Ref, p2MergeOrigins)
 }
 
 func mergeTracing(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -58,12 +61,13 @@ func mergeTracing(
 	}
 
 	p1.tracing = p2.tracing
-	mergeOrigins.SetOne("tracing", p2Ref)
+	mergeOrigins.SetOne("tracing", p2Ref, p2MergeOrigins)
 }
 
 func mergeUpgradeConfigs(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -72,12 +76,13 @@ func mergeUpgradeConfigs(
 	}
 
 	p1.upgradeConfigs = slices.Clone(p2.upgradeConfigs)
-	mergeOrigins.SetOne("upgradeConfig", p2Ref)
+	mergeOrigins.SetOne("upgradeConfig", p2Ref, p2MergeOrigins)
 }
 
 func mergeUseRemoteAddress(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -86,12 +91,13 @@ func mergeUseRemoteAddress(
 	}
 
 	p1.useRemoteAddress = p2.useRemoteAddress
-	mergeOrigins.SetOne("useRemoteAddress", p2Ref)
+	mergeOrigins.SetOne("useRemoteAddress", p2Ref, p2MergeOrigins)
 }
 
 func mergeXffNumTrustedHops(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -100,12 +106,13 @@ func mergeXffNumTrustedHops(
 	}
 
 	p1.xffNumTrustedHops = p2.xffNumTrustedHops
-	mergeOrigins.SetOne("xffNumTrustedHops", p2Ref)
+	mergeOrigins.SetOne("xffNumTrustedHops", p2Ref, p2MergeOrigins)
 }
 
 func mergeServerHeaderTransformation(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -114,12 +121,13 @@ func mergeServerHeaderTransformation(
 	}
 
 	p1.serverHeaderTransformation = p2.serverHeaderTransformation
-	mergeOrigins.SetOne("serverHeaderTransformation", p2Ref)
+	mergeOrigins.SetOne("serverHeaderTransformation", p2Ref, p2MergeOrigins)
 }
 
 func mergeStreamIdleTimeout(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -128,12 +136,13 @@ func mergeStreamIdleTimeout(
 	}
 
 	p1.streamIdleTimeout = p2.streamIdleTimeout
-	mergeOrigins.SetOne("mergeStreamIdleTimeout", p2Ref)
+	mergeOrigins.SetOne("mergeStreamIdleTimeout", p2Ref, p2MergeOrigins)
 }
 
 func mergeHealthCheckPolicy(
 	p1, p2 *httpListenerPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
 ) {
@@ -142,5 +151,5 @@ func mergeHealthCheckPolicy(
 	}
 
 	p1.healthCheckPolicy = p2.healthCheckPolicy
-	mergeOrigins.SetOne("healthCheckPolicy", p2Ref)
+	mergeOrigins.SetOne("healthCheckPolicy", p2Ref, p2MergeOrigins)
 }

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/merge.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/merge.go
@@ -12,6 +12,7 @@ import (
 func mergeAI(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -28,7 +29,7 @@ func mergeAI(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.AI = p2.spec.AI
-		mergeOrigins.SetOne("ai", p2Ref)
+		mergeOrigins.SetOne("ai", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for ai policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -38,6 +39,7 @@ func mergeAI(
 func mergeExtProc(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -54,7 +56,7 @@ func mergeExtProc(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.ExtProc = p2.spec.ExtProc
-		mergeOrigins.SetOne("extProc", p2Ref)
+		mergeOrigins.SetOne("extProc", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for extProc policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -64,6 +66,7 @@ func mergeExtProc(
 func mergeTransformation(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -79,7 +82,7 @@ func mergeTransformation(
 		// Always clone so that the original policy in p2 is not modified when
 		// the merge is invoked multiple times
 		p1.spec.transform.Transformations = slices.Clone(p2.spec.transform.GetTransformations())
-		mergeOrigins.SetOne("transformation", p2Ref)
+		mergeOrigins.SetOne("transformation", p2Ref, p2MergeOrigins)
 
 	case policy.AugmentedDeepMerge:
 		if p1.spec.transform == nil {
@@ -88,7 +91,7 @@ func mergeTransformation(
 		// Always Concat so that the original policy in p1 is not modified when
 		// the merge is invoked multiple times
 		p1.spec.transform.Transformations = slices.Concat(p1.spec.transform.GetTransformations(), p2.spec.transform.GetTransformations())
-		mergeOrigins.Append("transformation", p2Ref)
+		mergeOrigins.Append("transformation", p2Ref, p2MergeOrigins)
 
 	case policy.OverridableDeepMerge:
 		if p1.spec.transform == nil {
@@ -97,7 +100,7 @@ func mergeTransformation(
 		// Always Concat so that the original policy in p1/p2 is not modified when
 		// the merge is invoked multiple times
 		p1.spec.transform.Transformations = slices.Concat(p2.spec.transform.GetTransformations(), p1.spec.transform.GetTransformations())
-		mergeOrigins.Append("transformation", p2Ref)
+		mergeOrigins.Append("transformation", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for transformation policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -107,6 +110,7 @@ func mergeTransformation(
 func mergeRustformation(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -124,7 +128,7 @@ func mergeRustformation(
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.rustformation = p2.spec.rustformation
 		p1.spec.rustformationStringToStash = p2.spec.rustformationStringToStash
-		mergeOrigins.SetOne("rustformation", p2Ref)
+		mergeOrigins.SetOne("rustformation", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for rustformation policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -134,6 +138,7 @@ func mergeRustformation(
 func mergeExtAuth(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -150,7 +155,7 @@ func mergeExtAuth(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.extAuth = p2.spec.extAuth
-		mergeOrigins.SetOne("extAuth", p2Ref)
+		mergeOrigins.SetOne("extAuth", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for extAuth policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -160,6 +165,7 @@ func mergeExtAuth(
 func mergeLocalRateLimit(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -176,7 +182,7 @@ func mergeLocalRateLimit(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.localRateLimit = p2.spec.localRateLimit
-		mergeOrigins.SetOne("rateLimit.local", p2Ref)
+		mergeOrigins.SetOne("rateLimit.local", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for localRateLimit policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -186,6 +192,7 @@ func mergeLocalRateLimit(
 func mergeGlobalRateLimit(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -202,7 +209,7 @@ func mergeGlobalRateLimit(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.rateLimit = p2.spec.rateLimit
-		mergeOrigins.SetOne("rateLimit.global", p2Ref)
+		mergeOrigins.SetOne("rateLimit.global", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for rateLimit policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -212,6 +219,7 @@ func mergeGlobalRateLimit(
 func mergeCORS(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -228,7 +236,7 @@ func mergeCORS(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.cors = p2.spec.cors
-		mergeOrigins.SetOne("cors", p2Ref)
+		mergeOrigins.SetOne("cors", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for cors policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -238,6 +246,7 @@ func mergeCORS(
 func mergeCSRF(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -254,7 +263,7 @@ func mergeCSRF(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.csrf = p2.spec.csrf
-		mergeOrigins.SetOne("csrf", p2Ref)
+		mergeOrigins.SetOne("csrf", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for csrf policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -264,6 +273,7 @@ func mergeCSRF(
 func mergeBuffer(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -280,7 +290,7 @@ func mergeBuffer(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.buffer = p2.spec.buffer
-		mergeOrigins.SetOne("buffer", p2Ref)
+		mergeOrigins.SetOne("buffer", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for buffer policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -290,6 +300,7 @@ func mergeBuffer(
 func mergeAutoHostRewrite(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -306,7 +317,7 @@ func mergeAutoHostRewrite(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.autoHostRewrite = p2.spec.autoHostRewrite
-		mergeOrigins.SetOne("autoHostRewrite", p2Ref)
+		mergeOrigins.SetOne("autoHostRewrite", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for AutoHostRewrite policy", "strategy", opts.Strategy, "policy", p2Ref)
@@ -316,6 +327,7 @@ func mergeAutoHostRewrite(
 func mergeHashPolicies(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -332,7 +344,7 @@ func mergeHashPolicies(
 
 	case policy.AugmentedShallowMerge, policy.OverridableShallowMerge:
 		p1.spec.hashPolicies = p2.spec.hashPolicies
-		mergeOrigins.SetOne("hashPolicies", p2Ref)
+		mergeOrigins.SetOne("hashPolicies", p2Ref, p2MergeOrigins)
 
 	default:
 		logger.Warn("unsupported merge strategy for hashPolicies policy", "strategy", opts.Strategy, "policy", p2Ref)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -617,6 +617,7 @@ func (p *trafficPolicyPluginGwPass) SupportsPolicyMerge() bool {
 func MergeTrafficPolicies(
 	p1, p2 *TrafficPolicy,
 	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins pluginsdkir.MergeOrigins,
 	mergeOpts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
 ) {
@@ -624,7 +625,7 @@ func MergeTrafficPolicies(
 		return
 	}
 
-	mergeFuncs := []func(*TrafficPolicy, *TrafficPolicy, *ir.AttachedPolicyRef, policy.MergeOptions, pluginsdkir.MergeOrigins){
+	mergeFuncs := []func(*TrafficPolicy, *TrafficPolicy, *ir.AttachedPolicyRef, pluginsdkir.MergeOrigins, policy.MergeOptions, pluginsdkir.MergeOrigins){
 		mergeAI,
 		mergeExtProc,
 		mergeTransformation,
@@ -640,6 +641,6 @@ func MergeTrafficPolicies(
 	}
 
 	for _, mergeFunc := range mergeFuncs {
-		mergeFunc(p1, p2, p2Ref, mergeOpts, mergeOrigins)
+		mergeFunc(p1, p2, p2Ref, p2MergeOrigins, mergeOpts, mergeOrigins)
 	}
 }

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -330,7 +330,7 @@ func NewGatewayIndex(
 			out.Listeners = append(out.Listeners, ir.Listener{
 				Listener:         l,
 				Parent:           i,
-				AttachedPolicies: toAttachedPolicies(h.policies.getTargetingPolicies(kctx, extensionsplug.RouteAttachmentPoint, out.ObjectSource, string(l.Name), i.GetLabels())),
+				AttachedPolicies: toAttachedPolicies(h.policies.getTargetingPolicies(kctx, extensionsplug.GatewayAttachmentPoint, out.ObjectSource, string(l.Name), i.GetLabels())),
 				PolicyAncestorRef: gwv1.ParentReference{
 					Group:     k8sptr.To(gwv1.Group(wellknown.GatewayGVK.Group)),
 					Kind:      k8sptr.To(gwv1.Kind(wellknown.GatewayGVK.Kind)),
@@ -376,7 +376,7 @@ func NewGatewayIndex(
 			listenerSetPolicies := h.policies.getTargetingPolicies(kctx, extensionsplug.GatewayAttachmentPoint, lsIR.ObjectSource, "", ls.GetLabels())
 
 			for _, l := range ls.Spec.Listeners {
-				listenerSpecificPolicies := h.policies.getTargetingPolicies(kctx, extensionsplug.RouteAttachmentPoint, lsIR.ObjectSource, string(l.Name), ls.GetLabels())
+				listenerSpecificPolicies := h.policies.getTargetingPolicies(kctx, extensionsplug.GatewayAttachmentPoint, lsIR.ObjectSource, string(l.Name), ls.GetLabels())
 				// The Gateway Polices applies to all listeners but we need to apply them to listeners within the LS.
 				// Since there is no LS equivalent in Envoy, apply them on each listener in the LS.
 				// Ensure the sectioned policies are first
@@ -1188,17 +1188,12 @@ func (h *RoutesIndex) getExtensionRefs(
 	}
 	for _, ext := range r {
 		// TODO: propagate error if we can't find the extension
-		gk, policy, errs := h.resolveExtension(kctx, ns, ext)
-		if policy != nil {
-			polAtt := ir.PolicyAtt{
-				// direct attachment - no target ref
-				PolicyIr: policy,
-				Errors:   errs,
-			}
+		policyAtt, errs := h.resolveExtension(kctx, ns, ext)
+		if policyAtt != nil {
 			for _, o := range opts {
-				o(&polAtt)
+				o(policyAtt)
 			}
-			ret.Policies[gk] = append(ret.Policies[gk], polAtt)
+			ret.Policies[policyAtt.GroupKind] = append(ret.Policies[policyAtt.GroupKind], *policyAtt)
 		} else if len(errs) > 0 {
 			logger.Error("unresolved HTTPRouteFilter", "error", errors.Join(errs...))
 		}
@@ -1224,11 +1219,11 @@ func (h *RoutesIndex) getBuiltInRulePolicies(
 	return ret
 }
 
-func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext gwv1.HTTPRouteFilter) (schema.GroupKind, ir.PolicyIR, []error) {
+func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext gwv1.HTTPRouteFilter) (*ir.PolicyAtt, []error) {
 	if ext.Type == gwv1.HTTPRouteFilterExtensionRef {
 		if ext.ExtensionRef == nil {
 			// TODO: report error!!
-			return schema.GroupKind{}, nil, nil
+			return nil, nil
 		}
 		ref := *ext.ExtensionRef
 		key := ir.ObjectSource{
@@ -1239,14 +1234,27 @@ func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext g
 		}
 		policy := h.policies.fetchPolicy(kctx, key)
 		if policy == nil {
-			return schema.GroupKind{}, nil, []error{fmt.Errorf("%s: %w", key, ErrPolicyNotFound)}
+			return nil, []error{fmt.Errorf("%s: %w", key, ErrPolicyNotFound)}
 		}
 
 		gk := schema.GroupKind{
 			Group: string(ref.Group),
 			Kind:  string(ref.Kind),
 		}
-		return gk, policy.PolicyIR, policy.Errors
+		policyRef := &ir.AttachedPolicyRef{
+			Group:     gk.Group,
+			Kind:      gk.Kind,
+			Name:      string(ref.Name),
+			Namespace: ns,
+		}
+		policyAtt := &ir.PolicyAtt{
+			Generation: policy.Policy.GetGeneration(),
+			GroupKind:  gk,
+			PolicyIr:   policy.PolicyIR,
+			PolicyRef:  policyRef,
+			Errors:     policy.Errors,
+		}
+		return policyAtt, policy.Errors
 	}
 
 	fromGK := schema.GroupKind{
@@ -1255,7 +1263,11 @@ func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext g
 	}
 
 	builtinIR := NewBuiltInIr(kctx, ext, fromGK, ns, h.refgrants, h.backends)
-	return pluginsdkir.VirtualBuiltInGK, builtinIR, nil
+	policyAtt := &ir.PolicyAtt{
+		GroupKind: pluginsdkir.VirtualBuiltInGK,
+		PolicyIr:  builtinIR,
+	}
+	return policyAtt, nil
 }
 
 func toFromBackendRef(fromns string, ref gwv1.BackendObjectReference) ir.ObjectSource {

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -328,9 +328,10 @@ func NewGatewayIndex(
 		out.AttachedHttpPolicies = out.AttachedListenerPolicies // see if i can find a better way to segment the listener level and http level policies
 		for _, l := range i.Spec.Listeners {
 			out.Listeners = append(out.Listeners, ir.Listener{
-				Listener:         l,
-				Parent:           i,
-				AttachedPolicies: toAttachedPolicies(h.policies.getTargetingPolicies(kctx, extensionsplug.GatewayAttachmentPoint, out.ObjectSource, string(l.Name), i.GetLabels())),
+				Listener: l,
+				Parent:   i,
+				// TODO(https://github.com/kgateway-dev/kgateway/issues/11775): is RouteAttachmentPoint correct in all scenarios?
+				AttachedPolicies: toAttachedPolicies(h.policies.getTargetingPolicies(kctx, extensionsplug.RouteAttachmentPoint, out.ObjectSource, string(l.Name), i.GetLabels())),
 				PolicyAncestorRef: gwv1.ParentReference{
 					Group:     k8sptr.To(gwv1.Group(wellknown.GatewayGVK.Group)),
 					Kind:      k8sptr.To(gwv1.Kind(wellknown.GatewayGVK.Kind)),
@@ -376,7 +377,8 @@ func NewGatewayIndex(
 			listenerSetPolicies := h.policies.getTargetingPolicies(kctx, extensionsplug.GatewayAttachmentPoint, lsIR.ObjectSource, "", ls.GetLabels())
 
 			for _, l := range ls.Spec.Listeners {
-				listenerSpecificPolicies := h.policies.getTargetingPolicies(kctx, extensionsplug.GatewayAttachmentPoint, lsIR.ObjectSource, string(l.Name), ls.GetLabels())
+				// TODO(https://github.com/kgateway-dev/kgateway/issues/11775): is RouteAttachmentPoint correct in all scenarios?
+				listenerSpecificPolicies := h.policies.getTargetingPolicies(kctx, extensionsplug.RouteAttachmentPoint, lsIR.ObjectSource, string(l.Name), ls.GetLabels())
 				// The Gateway Polices applies to all listeners but we need to apply them to listeners within the LS.
 				// Since there is no LS equivalent in Envoy, apply them on each listener in the LS.
 				// Ensure the sectioned policies are first

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -258,7 +258,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 
 	s.backendPolicyReport = krt.NewSingleton(func(kctx krt.HandlerContext) *report {
 		backends := krt.Fetch(kctx, finalBackends)
-		merged := generatePolicyReport(backends)
+		merged := generateBackendPolicyReport(backends)
 		return &report{merged}
 	}, krtopts.ToOptions("BackendsPolicyReport")...)
 

--- a/internal/kgateway/setup/setup_test.go
+++ b/internal/kgateway/setup/setup_test.go
@@ -96,7 +96,7 @@ var (
 // on each test, set the *testing.T on the writer.
 func NewTestLogger() *zap.Logger {
 	var core zapcore.Core
-	// Only log controller-runtime and gRPC logs if DEBUG_LOGS=true, otherwise they are extremely noisy
+	// Only log controller-runtime and gRPC logs if LOG_LEVEL=debug, otherwise they are extremely noisy
 	level, err := zapcore.ParseLevel(envutils.GetOrDefault("LOG_LEVEL", "error", false))
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse LOG_LEVEL: %v", err))

--- a/internal/kgateway/setup/setup_test.go
+++ b/internal/kgateway/setup/setup_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/agentgatewaysyncer"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/proxy_syncer"
 	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/v2/test/envtestutil"
 )
 
@@ -94,12 +95,18 @@ var (
 // NewTestLogger creates a zap.Logger which can be used to write to *testing.T
 // on each test, set the *testing.T on the writer.
 func NewTestLogger() *zap.Logger {
-	core := zapcore.NewCore(
+	var core zapcore.Core
+	// Only log controller-runtime and gRPC logs if DEBUG_LOGS=true, otherwise they are extremely noisy
+	level, err := zapcore.ParseLevel(envutils.GetOrDefault("LOG_LEVEL", "error", false))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse LOG_LEVEL: %v", err))
+	}
+	core = zapcore.NewCore(
 		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
 		zapcore.AddSync(writer),
 		// Adjust log level as needed
 		// if a test assertion fails and logs or too noisy, change to zapcore.FatalLevel
-		zapcore.DebugLevel,
+		level,
 	)
 
 	return zap.New(core, zap.AddCaller())
@@ -107,7 +114,10 @@ func NewTestLogger() *zap.Logger {
 
 func init() {
 	log.SetLogger(zapr.NewLogger(logger))
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(writer, writer, writer, 100))
+	// Use GRPC_GO_LOG_SEVERITY_LEVEL and GRPC_GO_LOG_VERBOSITY_LEVEL env vars to control gRPC logging
+	if logger.Level() == zapcore.DebugLevel {
+		grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(writer, writer, writer, 100))
+	}
 }
 
 func TestServiceEntry(t *testing.T) {
@@ -340,8 +350,8 @@ func setupEnvTestAndRun(t *testing.T, globalSettings *settings.Settings, run fun
 	envtestutil.RunController(t, logger, globalSettings, testEnv,
 		nil,
 		[][]string{
-			[]string{"default", "testdata/setup_yaml/setup.yaml"},
-			[]string{"gwtest", "testdata/setup_yaml/pods.yaml"},
+			{"default", "testdata/setup_yaml/setup.yaml"},
+			{"gwtest", "testdata/setup_yaml/pods.yaml"},
 		},
 		run)
 }

--- a/internal/kgateway/setup/testdata/istio_destination_rule/failover-default-diffns-out.yaml
+++ b/internal/kgateway/setup/testdata/istio_destination_rule/failover-default-diffns-out.yaml
@@ -37,6 +37,31 @@ endpoints:
     - endpoint:
         address:
           socketAddress:
+            address: 10.244.1.11
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z2s3
+      zone: r1z2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.2.14
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z2s4
+      zone: r1z2
+    priority: 1
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
             address: 10.244.3.3
             portValue: 8080
       loadBalancingWeight: 1
@@ -59,31 +84,6 @@ endpoints:
       subZone: r2z1s1
       zone: r2z1
     priority: 3
-  - lbEndpoints:
-    - endpoint:
-        address:
-          socketAddress:
-            address: 10.244.1.11
-            portValue: 8080
-      loadBalancingWeight: 1
-    loadBalancingWeight: 1
-    locality:
-      region: r1
-      subZone: r1z2s3
-      zone: r1z2
-  - lbEndpoints:
-    - endpoint:
-        address:
-          socketAddress:
-            address: 10.244.2.14
-            portValue: 8080
-      loadBalancingWeight: 1
-    loadBalancingWeight: 1
-    locality:
-      region: r1
-      subZone: r1z2s4
-      zone: r1z2
-    priority: 1
 listeners:
 - address:
     socketAddress:

--- a/internal/kgateway/setup/testdata/istio_destination_rule/failover-default-out.yaml
+++ b/internal/kgateway/setup/testdata/istio_destination_rule/failover-default-out.yaml
@@ -37,19 +37,6 @@ endpoints:
     - endpoint:
         address:
           socketAddress:
-            address: 10.244.4.4
-            portValue: 8080
-      loadBalancingWeight: 1
-    loadBalancingWeight: 1
-    locality:
-      region: r2
-      subZone: r2z1s1
-      zone: r2z1
-    priority: 3
-  - lbEndpoints:
-    - endpoint:
-        address:
-          socketAddress:
             address: 10.244.1.11
             portValue: 8080
       loadBalancingWeight: 1
@@ -84,6 +71,19 @@ endpoints:
       subZone: r1z3s4
       zone: r1z3
     priority: 2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.4.4
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r2
+      subZone: r2z1s1
+      zone: r2z1
+    priority: 3
 listeners:
 - address:
     socketAddress:

--- a/internal/kgateway/setup/testdata/serviceentry/dr/se-backendref-out.yaml
+++ b/internal/kgateway/setup/testdata/serviceentry/dr/se-backendref-out.yaml
@@ -30,6 +30,41 @@ endpoints:
     - endpoint:
         address:
           socketAddress:
+            address: 10.244.3.3
+            portValue: 80
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z3s4
+      zone: r1z3
+    priority: 2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 255.0.0.1
+            portValue: 80
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    priority: 3
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.4.4
+            portValue: 80
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r2
+      subZone: r2z1s1
+      zone: r2z1
+    priority: 3
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
             address: 10.244.1.11
             portValue: 80
       loadBalancingWeight: 1
@@ -51,41 +86,6 @@ endpoints:
       subZone: r1z2s4
       zone: r1z2
     priority: 1
-  - lbEndpoints:
-    - endpoint:
-        address:
-          socketAddress:
-            address: 10.244.3.3
-            portValue: 80
-      loadBalancingWeight: 1
-    loadBalancingWeight: 1
-    locality:
-      region: r1
-      subZone: r1z3s4
-      zone: r1z3
-    priority: 2
-  - lbEndpoints:
-    - endpoint:
-        address:
-          socketAddress:
-            address: 10.244.4.4
-            portValue: 80
-      loadBalancingWeight: 1
-    loadBalancingWeight: 1
-    locality:
-      region: r2
-      subZone: r2z1s1
-      zone: r2z1
-    priority: 3
-  - lbEndpoints:
-    - endpoint:
-        address:
-          socketAddress:
-            address: 255.0.0.1
-            portValue: 80
-      loadBalancingWeight: 1
-    loadBalancingWeight: 1
-    priority: 3
 listeners:
 - address:
     socketAddress:

--- a/internal/kgateway/setup/testdata/serviceentry/dr/se-dns-endpoints-out.yaml
+++ b/internal/kgateway/setup/testdata/serviceentry/dr/se-dns-endpoints-out.yaml
@@ -11,19 +11,6 @@ clusters:
       - endpoint:
           address:
             socketAddress:
-              address: 1.1.1.1
-              portValue: 80
-        loadBalancingWeight: 1
-      loadBalancingWeight: 1
-      locality:
-        region: r2
-        subZone: r2z1s1
-        zone: r2z1
-      priority: 3
-    - lbEndpoints:
-      - endpoint:
-          address:
-            socketAddress:
               address: foo.external.com
               portValue: 80
         loadBalancingWeight: 1
@@ -33,6 +20,19 @@ clusters:
         subZone: r1z2s4
         zone: r1z2
       priority: 1
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.1.1.1
+              portValue: 80
+        loadBalancingWeight: 1
+      loadBalancingWeight: 1
+      locality:
+        region: r2
+        subZone: r2z1s1
+        zone: r2z1
+      priority: 3
   metadata: {}
   name: istio-se_gwtest_example-se_se.example.com_80
   outlierDetection:

--- a/internal/kgateway/setup/testdata/standard/accesslog-filtercel-httplisteneropt-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/accesslog-filtercel-httplisteneropt-out.yaml
@@ -86,6 +86,11 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8080
 - address:
     socketAddress:
@@ -127,9 +132,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8081
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8081
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8080
   virtualHosts:
   - domains:
@@ -143,6 +158,11 @@ routes:
         cluster: kube_gwtest_reviews_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8081
   virtualHosts:
   - domains:

--- a/internal/kgateway/setup/testdata/standard/accesslog-filterhttp-httplisteneropt-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/accesslog-filterhttp-httplisteneropt-out.yaml
@@ -93,6 +93,11 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8080
 - address:
     socketAddress:
@@ -134,9 +139,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8081
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8081
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8080
   virtualHosts:
   - domains:
@@ -150,6 +165,11 @@ routes:
         cluster: kube_gwtest_reviews_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8081
   virtualHosts:
   - domains:

--- a/internal/kgateway/setup/testdata/standard/accesslog-httplisteneropt-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/accesslog-httplisteneropt-out.yaml
@@ -83,6 +83,11 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8080
 - address:
     socketAddress:
@@ -138,9 +143,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8081
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8081
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8080
   virtualHosts:
   - domains:
@@ -154,6 +169,11 @@ routes:
         cluster: kube_gwtest_reviews_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/gwtest/accesslog
   name: listener~8081
   virtualHosts:
   - domains:

--- a/internal/kgateway/setup/testdata/standard/ai-vertex-ai-streaming-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/ai-vertex-ai-streaming-out.yaml
@@ -158,6 +158,11 @@ routes:
     routes:
     - match:
         path: /vertexai
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            ai:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/route-test
       name: listener~8080~test-route-0-httproute-route-to-backend-gwtest-0-0-matcher-0
       route:
         autoHostRewrite: true

--- a/internal/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
@@ -81,6 +81,11 @@ routes:
     routes:
     - match:
         pathSeparatedPrefix: /headers-override
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            autoHostRewrite:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/route-auto-hostrewrite-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: backend_gwtest_httpbin-static_0
@@ -97,6 +102,11 @@ routes:
           disabled: true
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            autoHostRewrite:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/route-auto-hostrewrite-policy
       name: listener~8080~www_example_com-route-1-httproute-my-route-gwtest-1-0-matcher-0
       route:
         autoHostRewrite: true

--- a/internal/kgateway/setup/testdata/standard/cors-hr-and-tp-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/cors-hr-and-tp-out.yaml
@@ -86,6 +86,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            cors:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/cors-trafficpolicy-gw-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/cors-trafficpolicy-gw-out.yaml
@@ -56,9 +56,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        cors:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        cors:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
   name: listener~8080
   typedPerFilterConfig:
     envoy.filters.http.cors:

--- a/internal/kgateway/setup/testdata/standard/cors-trafficpolicy-route-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/cors-trafficpolicy-route-out.yaml
@@ -67,6 +67,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            cors:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/csrf-gw-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/csrf-gw-out.yaml
@@ -58,9 +58,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        csrf:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        csrf:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
   name: listener~8080
   typedPerFilterConfig:
     envoy.filters.http.csrf:

--- a/internal/kgateway/setup/testdata/standard/csrf-route-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/csrf-route-out.yaml
@@ -69,6 +69,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            csrf:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
@@ -69,6 +69,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            csrf:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
@@ -93,9 +93,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-gateway
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-gateway
   name: listener~8080
   typedPerFilterConfig:
     ext_auth/gwtest/basic-extauth:
@@ -108,6 +118,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-route
       name: listener~8080~www_example_com-route-0-httproute-happypath-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
@@ -121,9 +121,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-gateway
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-gateway
   name: listener~8080
   typedPerFilterConfig:
     ext_auth/gwtest/basic-extauth:
@@ -136,6 +146,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-route
       name: listener~8080~www_example_com-route-0-httproute-happypath-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
@@ -93,9 +93,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-gateway
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-gateway
   name: listener~8080
   typedPerFilterConfig:
     ext_auth/gwtest/basic-extauth:

--- a/internal/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
@@ -104,6 +104,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/extauth-for-route
       name: listener~8080~www_example_com-route-0-httproute-happypath-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/extproc-routerule-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extproc-routerule-out.yaml
@@ -106,6 +106,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/route-test
       name: listener~8080~example_com-route-0-httproute-route-gwtest-0-0-matcher-0
       route:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/internal/kgateway/setup/testdata/standard/extproc-targetref-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/extproc-targetref-out.yaml
@@ -97,6 +97,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/route-test
       name: listener~8080~example_com-route-0-httproute-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/local-rate-limit-extref-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/local-rate-limit-extref-out.yaml
@@ -73,6 +73,11 @@ routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example_com-route-1-httproute-my-route-gwtest-1-0-matcher-0
       route:
         cluster: kube_gwtest_reviews-v2_8080

--- a/internal/kgateway/setup/testdata/standard/local-rate-limit-route-disabled-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/local-rate-limit-route-disabled-out.yaml
@@ -77,9 +77,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        rateLimit.local:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/gw-route-rl-policy
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        rateLimit.local:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/gw-route-rl-policy
   name: listener~8080
   typedPerFilterConfig:
     ratelimit/local:
@@ -104,6 +114,11 @@ routes:
     routes:
     - match:
         pathSeparatedPrefix: /ratings
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/route-rl-policy
       name: listener~8080~www_example_com-route-0-httproute-my-ratings-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_ratings_8080

--- a/internal/kgateway/setup/testdata/standard/local-rate-limit-route-gw-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/local-rate-limit-route-gw-out.yaml
@@ -58,9 +58,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        rateLimit.local:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/gw-route-rl-policy
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        rateLimit.local:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/gw-route-rl-policy
   name: listener~8080
   typedPerFilterConfig:
     ratelimit/local:
@@ -85,6 +95,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/route-rl-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/local-rate-limit-route-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/local-rate-limit-route-out.yaml
@@ -69,6 +69,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/routeoptions-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/routeoptions-out.yaml
@@ -68,6 +68,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example2_com-route-0-httproute-my-route2-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080
@@ -97,6 +102,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/my-route-policy
       name: listener~8080~www_example_com-route-0-httproute-my-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
@@ -61,9 +61,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        transformation:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-for-gateway
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        transformation:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-for-gateway
   name: listener~8080
   typedPerFilterConfig:
     transformation:
@@ -95,6 +105,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-for-route
       name: listener~8080~www_example-route-override_com-route-0-httproute-happypath-override-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
@@ -61,9 +61,19 @@ listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        transformation:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-for-gateway
   name: listener~8080
 routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        transformation:
+        - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-for-gateway
   name: listener~8080
   typedPerFilterConfig:
     transformation:

--- a/internal/kgateway/setup/testdata/standard/transform-route-only-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/transform-route-only-out.yaml
@@ -72,6 +72,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-request-response-for-route
       name: listener~8080~www_example-request-response_com-route-0-httproute-happypath-request-response-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080
@@ -104,6 +109,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-request-for-route
       name: listener~8080~www_example-request_com-route-0-httproute-happypath-request-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080
@@ -126,6 +136,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/transform-response-for-route
       name: listener~8080~www_example-response_com-route-0-httproute-happypath-response-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_reviews_8080

--- a/internal/kgateway/setup/testdata/standard/transformation-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/transformation-out.yaml
@@ -68,6 +68,11 @@ routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/default/transformation
       name: listener~8080~www_example_com-route-0-httproute-happypath-default-0-0-matcher-0
       route:
         cluster: kube_default_reviews_8080

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -13,6 +13,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
@@ -1288,11 +1289,9 @@ var _ = DescribeTable("Route Replacement",
 )
 
 var _ = DescribeTable("Route Delegation",
-	func(inputFile string, errors map[types.NamespacedName]string) {
+	func(inputFile string, wantHTTPRouteErrors map[types.NamespacedName]string) {
 		dir := fsutils.MustGetThisDir()
-		translatortest.TestTranslation(
-			GinkgoT(),
-			context.Background(),
+		test(
 			[]string{
 				filepath.Join(dir, "testutils/inputs/delegation/common.yaml"),
 				filepath.Join(dir, "testutils/inputs/delegation", inputFile),
@@ -1303,12 +1302,12 @@ var _ = DescribeTable("Route Delegation",
 				Name:      "example-gateway",
 			},
 			func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
-				if errors == nil {
+				if wantHTTPRouteErrors == nil {
 					Expect(translatortest.AreReportsSuccess(gwNN, reportsMap)).NotTo(HaveOccurred())
-				} else {
-					for route, err := range errors {
-						Expect(translatortest.GetHTTPRouteStatusError(reportsMap, &route)).To(MatchError(ContainSubstring(err)))
-					}
+					return
+				}
+				for route, err := range wantHTTPRouteErrors {
+					Expect(translatortest.GetHTTPRouteStatusError(reportsMap, &route)).To(MatchError(ContainSubstring(err)))
 				}
 			},
 		)
@@ -1468,6 +1467,22 @@ var _ = DescribeTable("Discovery Namespace Selector",
 		"base.yaml", "base_select_infra.yaml", "condition error for httproute: infra/example-route"),
 )
 
+func test(
+	inputFiles []string,
+	outputFile string,
+	wantGateway types.NamespacedName,
+	wantReportsFn func(gwNN types.NamespacedName, reportsMap reports.ReportMap),
+) {
+	translatortest.TestTranslation(
+		GinkgoT(),
+		context.Background(),
+		inputFiles,
+		outputFile,
+		wantGateway,
+		wantReportsFn,
+	)
+}
+
 // assertPolicyStatusWithGeneration is a helper function to verify policy status conditions with a specific generation
 func assertPolicyStatusWithGeneration(reportsMap reports.ReportMap, policies []reports.PolicyKey, expectedGeneration int64) {
 	var currentStatus gwv1alpha2.PolicyStatus
@@ -1478,10 +1493,10 @@ func assertPolicyStatusWithGeneration(reportsMap reports.ReportMap, policies []r
 		Expect(status).NotTo(BeNil(), "status missing for policy %v", policy)
 		Expect(status.Ancestors).To(HaveLen(1), "ancestor missing for policy %v", policy) // 1 Gateway(ancestor)
 
-		acceptedCondition := meta.FindStatusCondition(status.Ancestors[0].Conditions, string(gwv1alpha2.PolicyConditionAccepted))
+		acceptedCondition := meta.FindStatusCondition(status.Ancestors[0].Conditions, string(v1alpha1.PolicyConditionAccepted))
 		Expect(acceptedCondition).NotTo(BeNil())
 		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
-		Expect(acceptedCondition.Reason).To(Equal(string(gwv1alpha2.PolicyReasonAccepted)))
+		Expect(acceptedCondition.Reason).To(Equal(string(v1alpha1.PolicyReasonValid)))
 		Expect(acceptedCondition.Message).To(Equal(reporter.PolicyAcceptedMsg))
 		Expect(acceptedCondition.ObservedGeneration).To(Equal(expectedGeneration))
 	}

--- a/internal/kgateway/translator/gateway/status_test.go
+++ b/internal/kgateway/translator/gateway/status_test.go
@@ -1,0 +1,252 @@
+package gateway_test
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+)
+
+var _ = DescribeTable("Statuses",
+	func(inputFile string, wantPolicyErrors map[reporter.PolicyKey]*gwv1alpha2.PolicyStatus) {
+		dir := fsutils.MustGetThisDir()
+		test(
+			[]string{
+				filepath.Join(dir, "testutils/inputs/status", inputFile),
+			},
+			filepath.Join(dir, "testutils/outputs/status", inputFile),
+			types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+			func(_ types.NamespacedName, reportsMap reports.ReportMap) {
+				for policyKey, wantStatus := range wantPolicyErrors {
+					var currentStatus gwv1alpha2.PolicyStatus
+					gotStatus := reportsMap.BuildPolicyStatus(context.Background(), policyKey, wellknown.DefaultGatewayControllerName, currentStatus)
+					diff := cmp.Diff(wantStatus, gotStatus, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"))
+					Expect(diff).To(BeEmpty(), "status mismatch for policy %v", policyKey)
+				}
+			},
+		)
+	},
+	Entry("Basic", "basic.yaml", map[reporter.PolicyKey]*gwv1alpha2.PolicyStatus{
+		{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "default", Name: "extensionref-policy"}: {
+			Ancestors: []gwv1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gwv1.ParentReference{
+						Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwv1.Kind("Gateway")),
+						Namespace: ptr.To(gwv1.Namespace("default")),
+						Name:      gwv1.ObjectName("example-gateway"),
+					},
+					ControllerName: wellknown.DefaultGatewayControllerName,
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: 1,
+							Type:               string(v1alpha1.PolicyConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonValid),
+							Message:            reporter.PolicyAcceptedMsg,
+						},
+						{
+							ObservedGeneration: 1,
+							Type:               string(v1alpha1.PolicyConditionAttached),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonMerged),
+							Message:            reporter.PolicyMergedMsg,
+						},
+					},
+				},
+			},
+		},
+		{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "default", Name: "policy-with-section-name"}: {
+			Ancestors: []gwv1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gwv1.ParentReference{
+						Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwv1.Kind("Gateway")),
+						Namespace: ptr.To(gwv1.Namespace("default")),
+						Name:      gwv1.ObjectName("example-gateway"),
+					},
+					ControllerName: wellknown.DefaultGatewayControllerName,
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: 2,
+							Type:               string(v1alpha1.PolicyConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonValid),
+							Message:            reporter.PolicyAcceptedMsg,
+						},
+						{
+							ObservedGeneration: 2,
+							Type:               string(v1alpha1.PolicyConditionAttached),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonMerged),
+							Message:            reporter.PolicyMergedMsg,
+						},
+					},
+				},
+			},
+		},
+		{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "default", Name: "policy-without-section-name"}: {
+			Ancestors: []gwv1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gwv1.ParentReference{
+						Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwv1.Kind("Gateway")),
+						Namespace: ptr.To(gwv1.Namespace("default")),
+						Name:      gwv1.ObjectName("example-gateway"),
+					},
+					ControllerName: wellknown.DefaultGatewayControllerName,
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: 3,
+							Type:               string(v1alpha1.PolicyConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonValid),
+							Message:            reporter.PolicyAcceptedMsg,
+						},
+						{
+							ObservedGeneration: 3,
+							Type:               string(v1alpha1.PolicyConditionAttached),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonMerged),
+							Message:            reporter.PolicyMergedMsg,
+						},
+					},
+				},
+			},
+		},
+		{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "default", Name: "fully-ignored"}: {
+			Ancestors: []gwv1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gwv1.ParentReference{
+						Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwv1.Kind("Gateway")),
+						Namespace: ptr.To(gwv1.Namespace("default")),
+						Name:      gwv1.ObjectName("example-gateway"),
+					},
+					ControllerName: wellknown.DefaultGatewayControllerName,
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: 4,
+							Type:               string(v1alpha1.PolicyConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonValid),
+							Message:            reporter.PolicyAcceptedMsg,
+						},
+						{
+							ObservedGeneration: 4,
+							Type:               string(v1alpha1.PolicyConditionAttached),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(v1alpha1.PolicyReasonDiscarded),
+							Message:            reporter.PolicyDiscardedMsg,
+						},
+					},
+				},
+			},
+		},
+		{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "default", Name: "policy-no-merge"}: {
+			Ancestors: []gwv1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gwv1.ParentReference{
+						Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwv1.Kind("Gateway")),
+						Namespace: ptr.To(gwv1.Namespace("default")),
+						Name:      gwv1.ObjectName("example-gateway"),
+					},
+					ControllerName: wellknown.DefaultGatewayControllerName,
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: 1,
+							Type:               string(v1alpha1.PolicyConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonValid),
+							Message:            reporter.PolicyAcceptedMsg,
+						},
+						{
+							ObservedGeneration: 1,
+							Type:               string(v1alpha1.PolicyConditionAttached),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonAttached),
+							Message:            reporter.PolicyAttachedMsg,
+						},
+					},
+				},
+			},
+		},
+		{Group: "gateway.kgateway.dev", Kind: "HTTPListenerPolicy", Namespace: "default", Name: "policy-1"}: {
+			Ancestors: []gwv1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gwv1.ParentReference{
+						Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwv1.Kind("Gateway")),
+						Namespace: ptr.To(gwv1.Namespace("default")),
+						Name:      gwv1.ObjectName("example-gateway"),
+					},
+					ControllerName: wellknown.DefaultGatewayControllerName,
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: 1,
+							Type:               string(v1alpha1.PolicyConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonValid),
+							Message:            reporter.PolicyAcceptedMsg,
+						},
+						{
+							ObservedGeneration: 1,
+							Type:               string(v1alpha1.PolicyConditionAttached),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonMerged),
+							Message:            reporter.PolicyMergedMsg,
+						},
+					},
+				},
+			},
+		},
+		{Group: "gateway.kgateway.dev", Kind: "HTTPListenerPolicy", Namespace: "default", Name: "policy-2"}: {
+			Ancestors: []gwv1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gwv1.ParentReference{
+						Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwv1.Kind("Gateway")),
+						Namespace: ptr.To(gwv1.Namespace("default")),
+						Name:      gwv1.ObjectName("example-gateway"),
+					},
+					ControllerName: wellknown.DefaultGatewayControllerName,
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: 2,
+							Type:               string(v1alpha1.PolicyConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonValid),
+							Message:            reporter.PolicyAcceptedMsg,
+						},
+						{
+							ObservedGeneration: 2,
+							Type:               string(v1alpha1.PolicyConditionAttached),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(v1alpha1.PolicyReasonMerged),
+							Message:            reporter.PolicyMergedMsg,
+						},
+					},
+				},
+			},
+		},
+	},
+	),
+)

--- a/internal/kgateway/translator/gateway/testutils/inputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/status/basic.yaml
@@ -1,0 +1,169 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-1
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - name: rule0
+    backendRefs:
+    - name: example-svc
+      port: 80
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.kgateway.dev
+        kind: TrafficPolicy
+        name: extensionref-policy
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-2
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example2.com"
+  rules:
+  - name: rule0
+    backendRefs:
+    - name: example-svc
+      port: 80
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.kgateway.dev
+        kind: TrafficPolicy
+        name: policy-no-merge        
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: extensionref-policy
+  generation: 1
+spec:
+  cors:
+    allowOrigins:
+    - "https://example.com"
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: policy-with-section-name
+  generation: 2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-1
+    sectionName: rule0
+  # cors will be ignored in favor of extensionref-policy
+  cors:
+    allowOrigins:
+    - "https://ignored.com"
+  transformation:
+    response:
+      add:
+      - name: abc
+        value: custom-value-abc
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: policy-without-section-name
+  generation: 3
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-1
+  rateLimit:
+    local:
+      tokenBucket:
+        maxTokens: 99
+        tokensPerFill: 1
+        fillInterval: 33s
+  # transformation will be ignored in favor of policy-with-section-name
+  transformation:
+    response:
+      add:
+      - name: ignored
+        value: ignored
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: fully-ignored
+  generation: 4
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-1
+  # transformation will be ignored in favor of policy-with-section-name
+  transformation:
+    response:
+      add:
+      - name: ignored
+        value: ignored       
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: policy-no-merge
+  generation: 1
+spec:
+  cors:
+    allowOrigins:
+    - "https://example.com"        
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: policy-1
+  generation: 1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  xffNumTrustedHops: 2      
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: policy-2
+  generation: 2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  streamIdleTimeout: 30s 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: test

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -69,6 +69,12 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/a/a
+            - gateway.kgateway.dev/TrafficPolicy/infra/example
       name: listener~80~example_com-route-0-httproute-a-a-0-0-rule0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -97,6 +103,11 @@ Routes:
                   passthrough: {}
     - match:
         pathSeparatedPrefix: /a/2
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example
       name: listener~80~example_com-route-1-httproute-a-a-1-0-rule1-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -120,6 +131,12 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /b/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/b/b
+            - gateway.kgateway.dev/TrafficPolicy/infra/foo
       name: listener~80~foo_com-route-0-httproute-b-b-0-0-rule0-matcher-0
       route:
         cluster: kube_b_svc-b_8080
@@ -148,6 +165,11 @@ Routes:
                   passthrough: {}
     - match:
         pathSeparatedPrefix: /b/2
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/foo
       name: listener~80~foo_com-route-1-httproute-b-b-1-0-rule1-matcher-0
       route:
         cluster: kube_b_svc-b_8080

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -69,6 +69,11 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/a/route-a-policy
       name: listener~80~example_com-route-0-httproute-route-a-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -109,6 +109,15 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/a/child-policy-filter
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/infra/parent-policy-targetref
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/parent-policy-filter
       name: listener~80~example_com-route-0-httproute-child-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -146,6 +155,13 @@ Routes:
                   passthrough: {}
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/infra/parent-policy-targetref
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/parent-policy-targetref
       name: listener~80~example_com-route-2-httproute-parent-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -69,6 +69,11 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-0-httproute-route-a-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -88,6 +93,11 @@ Routes:
                   passthrough: {}
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-2-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -69,6 +69,11 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-0-httproute-route-a-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -88,6 +93,11 @@ Routes:
                   passthrough: {}
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-2-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -74,6 +74,13 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/a/route-a-policy
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-0-httproute-route-a-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -108,6 +115,11 @@ Routes:
                   passthrough: {}
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-2-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -95,6 +95,15 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/a/route-a-policy
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/a-root/route-a-root-policy
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-1-httproute-route-a-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -132,6 +141,11 @@ Routes:
                   passthrough: {}
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-3-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -116,6 +116,15 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /mid/a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/a/a1
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/a/a1
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/a/a1
       name: listener~80~example_com-route-0-httproute-a1-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -153,6 +162,15 @@ Routes:
                   passthrough: {}
     - match:
         pathSeparatedPrefix: /mid/b/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/b/b1
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/mid/mid
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/mid/mid
       name: listener~80~example_com-route-1-httproute-b1-b-0-0-matcher-0
       route:
         cluster: kube_b_svc-b_8080
@@ -190,6 +208,13 @@ Routes:
                   passthrough: {}
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-5-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -65,6 +65,13 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /a/1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/a/route-a-policy
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-0-httproute-route-a-a-0-0-matcher-0
       route:
         cluster: kube_a_svc-a_8080
@@ -99,6 +106,11 @@ Routes:
                   passthrough: {}
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-2-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -56,9 +56,19 @@ Routes:
         status: 500
       match:
         pathSeparatedPrefix: /a
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-0-httproute-example-route-infra-1-0-matcher-0
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/example-policy
       name: listener~80~example_com-route-1-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -88,7 +88,45 @@ Listeners:
         useRemoteAddress: false
         xffNumTrustedHops: 2
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/access-log
+        healthCheckPolicy:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        mergeStreamIdleTimeout:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        serverHeaderTransformation:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        tracing:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/tracing
+        upgradeConfig:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        useRemoteAddress:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        xffNumTrustedHops:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
   name: listener~8080
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/access-log
+        healthCheckPolicy:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        mergeStreamIdleTimeout:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        serverHeaderTransformation:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        tracing:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/tracing
+        upgradeConfig:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        useRemoteAddress:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
+        xffNumTrustedHops:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
   name: listener~8080

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -46,9 +46,35 @@ Listeners:
         useRemoteAddress: true
         xffNumTrustedHops: 2
     name: listener~80
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        healthCheckPolicy:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        mergeStreamIdleTimeout:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        serverHeaderTransformation:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        useRemoteAddress:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        xffNumTrustedHops:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
   name: listener~80
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        healthCheckPolicy:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        mergeStreamIdleTimeout:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        serverHeaderTransformation:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        useRemoteAddress:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
+        xffNumTrustedHops:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
   name: listener~80
   virtualHosts:
   - domains:

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
@@ -38,9 +38,19 @@ Listeners:
         - upgradeType: websocket
         useRemoteAddress: true
     name: listener~80
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        upgradeConfig:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
   name: listener~80
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        upgradeConfig:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/upgrades
   name: listener~80
   virtualHosts:
   - domains:

--- a/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/route.yaml
@@ -64,6 +64,11 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /ringhash
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            hashPolicies:
+            - gateway.kgateway.dev/TrafficPolicy/default/header-hash-policy
       name: listener~8080~example_com-route-0-httproute-example-route-ringhash-default-0-0-matcher-0
       route:
         cluster: kube_default_httpbin-ringhash_8080
@@ -76,6 +81,11 @@ Routes:
             headerName: x-session-id
     - match:
         pathSeparatedPrefix: /maglev
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            hashPolicies:
+            - gateway.kgateway.dev/TrafficPolicy/default/cookie-sourceip-hash-policy
       name: listener~8080~example_com-route-1-httproute-example-route-maglev-default-0-0-matcher-0
       route:
         cluster: kube_default_httpbin-maglev_8080

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/transformation-template-not-validated-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/transformation-template-not-validated-out.yaml
@@ -51,6 +51,11 @@ Routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/invalid-traffic-policy
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/valid-structure-invalid-template-policy-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/valid-structure-invalid-template-policy-out.yaml
@@ -51,6 +51,11 @@ Routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/gwtest/invalid-traffic-policy
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
       route:
         cluster: kube_gwtest_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -6,7 +6,7 @@ Clusters:
       resourceApiVersion: V3
   ignoreHealthOnHostRemoval: true
   metadata: {}
-  name: kube_infra_example-svc_80
+  name: kube_default_example-svc_80
   type: EDS
 - connectTimeout: 5s
   metadata: {}
@@ -46,13 +46,49 @@ Listeners:
             resourceApiVersion: V3
           routeConfigName: listener~80
         statPrefix: http
+        streamIdleTimeout: 30s
         useRemoteAddress: true
+        xffNumTrustedHops: 2
     name: listener~80
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        mergeStreamIdleTimeout:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/policy-2
+        xffNumTrustedHops:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/policy-1
   name: listener~80
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        mergeStreamIdleTimeout:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/policy-2
+        xffNumTrustedHops:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/policy-1
   name: listener~80
   virtualHosts:
+  - domains:
+    - example2.com
+    name: listener~80~example2_com
+    routes:
+    - match:
+        prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            cors:
+            - gateway.kgateway.dev/TrafficPolicy/default/policy-no-merge
+      name: listener~80~example2_com-route-0-httproute-route-2-default-0-0-rule0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        envoy.filters.http.cors:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+          allowOriginStringMatch:
+          - exact: https://example.com
   - domains:
     - example.com
     name: listener~80~example_com
@@ -63,14 +99,14 @@ Routes:
         filterMetadata:
           merge.TrafficPolicy.gateway.kgateway.dev:
             cors:
-            - gateway.kgateway.dev/TrafficPolicy/infra/extensionref-policy
+            - gateway.kgateway.dev/TrafficPolicy/default/extensionref-policy
             rateLimit.local:
-            - gateway.kgateway.dev/TrafficPolicy/infra/policy-without-section-name
+            - gateway.kgateway.dev/TrafficPolicy/default/policy-without-section-name
             transformation:
-            - gateway.kgateway.dev/TrafficPolicy/infra/policy-with-section-name
-      name: listener~80~example_com-route-0-httproute-example-route-infra-0-0-rule0-matcher-0
+            - gateway.kgateway.dev/TrafficPolicy/default/policy-with-section-name
+      name: listener~80~example_com-route-0-httproute-route-1-default-0-0-rule0-matcher-0
       route:
-        cluster: kube_infra_example-svc_80
+        cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
       typedPerFilterConfig:
         envoy.filters.http.cors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
@@ -32,9 +32,19 @@ Listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        buffer:
+        - gateway.kgateway.dev/TrafficPolicy/default/buffer-policy
   name: listener~8080
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        buffer:
+        - gateway.kgateway.dev/TrafficPolicy/default/buffer-policy
   name: listener~8080
   typedPerFilterConfig:
     envoy.filters.http.buffer:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
@@ -86,6 +86,11 @@ Routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            buffer:
+            - gateway.kgateway.dev/TrafficPolicy/default/buffer-policy
       name: listener~8080~www_example_com-route-0-httproute-example-route-default-0-0-matcher-0
       route:
         cluster: kube_default_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
@@ -158,6 +158,11 @@ Listeners:
   - name: envoy.filters.listener.tls_inspector
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-gateway
   name: listener~443
 - address:
     socketAddress:
@@ -233,9 +238,19 @@ Listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~80
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-gateway
   name: listener~80
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-gateway
   name: listener~80
   typedPerFilterConfig:
     ext_auth/infra/basic-gw-extauth:
@@ -244,10 +259,20 @@ Routes:
   virtualHosts:
   - domains:
     - example.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          extAuth:
+          - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-gateway-section-name
     name: listener~80~example_com
     routes:
     - match:
         pathSeparatedPrefix: /example-route
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-http-route
       name: listener~80~example_com-route-0-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80
@@ -271,6 +296,11 @@ Routes:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-gateway-section-name
   name: tls1
   typedPerFilterConfig:
     ext_auth/infra/section-name-gw-extauth:
@@ -284,6 +314,11 @@ Routes:
     routes:
     - match:
         pathSeparatedPrefix: /example-route-tls-extension-ref
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-extension-ref
       name: tls1~tls_example_com-route-0-httproute-example-tls-route-extension-ref-infra-1-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80
@@ -294,6 +329,11 @@ Routes:
           config: {}
     - match:
         pathSeparatedPrefix: /example-route-tls-section-name
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-route-section-name
       name: tls1~tls_example_com-route-1-httproute-example-tls-route-extension-ref-infra-0-0-route-name-matcher-0
       route:
         cluster: kube_infra_example-svc_80
@@ -310,6 +350,11 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
     - match:
         pathSeparatedPrefix: /example-tls-route
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-http-route
       name: tls1~tls_example_com-route-3-httproute-example-tls-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80
@@ -319,6 +364,11 @@ Routes:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/infra/extauth-for-gateway
   name: tls2
   typedPerFilterConfig:
     ext_auth/infra/basic-gw-extauth:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
@@ -52,6 +52,11 @@ Routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/infra/test-policy
       name: listener~80~*-route-0-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -75,9 +75,19 @@ Listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~80
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/infra/accesslog
   name: listener~80
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/infra/accesslog
   name: listener~80
   virtualHosts:
   - domains:
@@ -86,6 +96,13 @@ Routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/infra/rate-limit
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/transform
       name: listener~80~example_com-route-0-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -78,9 +78,19 @@ Listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~80
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/infra/accesslog
   name: listener~80
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        accessLog:
+        - gateway.kgateway.dev/HTTPListenerPolicy/infra/accesslog
   name: listener~80
   virtualHosts:
   - domains:
@@ -89,6 +99,15 @@ Routes:
     routes:
     - match:
         prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            cors:
+            - gateway.kgateway.dev/TrafficPolicy/kgateway-system/global-policy
+            rateLimit.local:
+            - gateway.kgateway.dev/TrafficPolicy/infra/rate-limit
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/infra/transform
       name: listener~80~example_com-route-0-httproute-example-route-infra-0-0-matcher-0
       route:
         cluster: kube_infra_example-svc_80

--- a/internal/kgateway/translator/irtranslator/policy.go
+++ b/internal/kgateway/translator/irtranslator/policy.go
@@ -78,6 +78,7 @@ func reportPolicyAttachmentStatus(
 		if !mergeOrigins.IsSet() {
 			// Not a merged policy so this should be a direct attachment
 			r.SetAttachmentState(reporter.PolicyAttachmentStateAttached)
+			continue
 		}
 
 		switch mergeOrigins.GetRefCount(policy.PolicyRef) {

--- a/internal/kgateway/translator/irtranslator/policy.go
+++ b/internal/kgateway/translator/irtranslator/policy.go
@@ -1,16 +1,21 @@
 package irtranslator
 
 import (
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/types/known/structpb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
-	reports "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
 
+const mergeMetadataKeyPrefix = "merge."
+
 func reportPolicyAcceptanceStatus(
-	reporter reports.Reporter,
+	rp reporter.Reporter,
 	ancestorRef gwv1.ParentReference,
 	policies ...ir.PolicyAtt,
 ) {
@@ -20,32 +25,89 @@ func reportPolicyAcceptanceStatus(
 			continue
 		}
 
-		key := reports.PolicyKey{
+		key := reporter.PolicyKey{
 			Group:     policy.PolicyRef.Group,
 			Kind:      policy.PolicyRef.Kind,
 			Namespace: policy.PolicyRef.Namespace,
 			Name:      policy.PolicyRef.Name,
 		}
 		// Update the initial status
-		r := reporter.Policy(key, policy.Generation).AncestorRef(ancestorRef)
+		r := rp.Policy(key, policy.Generation).AncestorRef(ancestorRef)
 
 		if len(policy.Errors) > 0 {
-			r.SetCondition(reports.PolicyCondition{
-				Type:               gwv1alpha2.PolicyConditionAccepted,
+			r.SetCondition(reporter.PolicyCondition{
+				Type:               string(v1alpha1.PolicyConditionAccepted),
 				Status:             metav1.ConditionFalse,
-				Reason:             gwv1alpha2.PolicyReasonInvalid,
+				Reason:             string(v1alpha1.PolicyReasonInvalid),
 				Message:            policy.FormatErrors(),
 				ObservedGeneration: policy.Generation,
 			})
-			return
+			continue
 		}
 
-		r.SetCondition(reports.PolicyCondition{
-			Type:               gwv1alpha2.PolicyConditionAccepted,
+		r.SetCondition(reporter.PolicyCondition{
+			Type:               string(v1alpha1.PolicyConditionAccepted),
 			Status:             metav1.ConditionTrue,
-			Reason:             gwv1alpha2.PolicyReasonAccepted,
-			Message:            reports.PolicyAcceptedMsg,
+			Reason:             string(v1alpha1.PolicyReasonValid),
+			Message:            reporter.PolicyAcceptedMsg,
 			ObservedGeneration: policy.Generation,
 		})
 	}
+}
+
+func reportPolicyAttachmentStatus(
+	rp reporter.Reporter,
+	ancestorRef gwv1.ParentReference,
+	mergeOrigins ir.MergeOrigins,
+	policies ...ir.PolicyAtt,
+) {
+	for _, policy := range policies {
+		if policy.PolicyRef == nil {
+			// Not a policy associated with a CR, can't report status on it
+			continue
+		}
+
+		key := reporter.PolicyKey{
+			Group:     policy.PolicyRef.Group,
+			Kind:      policy.PolicyRef.Kind,
+			Namespace: policy.PolicyRef.Namespace,
+			Name:      policy.PolicyRef.Name,
+		}
+		r := rp.Policy(key, policy.Generation).AncestorRef(ancestorRef)
+
+		if !mergeOrigins.IsSet() {
+			// Not a merged policy so this should be a direct attachment
+			r.SetAttachmentState(reporter.PolicyAttachmentStateAttached)
+		}
+
+		switch mergeOrigins.GetRefCount(policy.PolicyRef) {
+		case ir.MergeOriginsRefCountNone:
+			r.SetAttachmentState(reporter.PolicyAttachmentStateDiscarded)
+
+		case ir.MergeOriginsRefCountPartial:
+			r.SetAttachmentState(reporter.PolicyAttachmentStateMerged)
+
+		case ir.MergeOriginsRefCountAll:
+			r.SetAttachmentState(reporter.PolicyAttachmentStateAttached)
+		}
+	}
+}
+
+func addMergeOriginsToFilterMetadata(
+	gk schema.GroupKind,
+	mergeOrigins ir.MergeOrigins,
+	metadata *envoycorev3.Metadata,
+) *envoycorev3.Metadata {
+	if !mergeOrigins.IsSet() {
+		return metadata
+	}
+	pb := mergeOrigins.ToProtoStruct()
+	if metadata == nil {
+		metadata = &envoycorev3.Metadata{}
+	}
+	if metadata.FilterMetadata == nil {
+		metadata.FilterMetadata = map[string]*structpb.Struct{}
+	}
+	metadata.FilterMetadata[mergeMetadataKeyPrefix+gk.String()] = pb
+	return metadata
 }

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -85,7 +85,12 @@ func (c PolicyAtt) FormatErrors() string {
 	for i, err := range c.Errors {
 		errs[i] = err.Error()
 	}
-	return strings.Join(errs, "; ")
+
+	errsStr := strings.Join(errs, "; ")
+	if c.MergeOrigins.IsSet() {
+		return "Merged policy: " + errsStr
+	}
+	return errsStr
 }
 
 type PolicyAttachmentOpts func(*PolicyAtt)
@@ -254,29 +259,4 @@ type HttpRouteRuleIR struct {
 	Backends         []HttpBackendOrDelegate
 	Matches          []gwv1.HTTPRouteMatch
 	Name             string
-}
-
-type MergeOrigins map[string][]*AttachedPolicyRef
-
-func (m MergeOrigins) Append(
-	field string,
-	policyRef *AttachedPolicyRef,
-) {
-	if _, ok := m[field]; !ok {
-		m[field] = []*AttachedPolicyRef{}
-	}
-	m[field] = append(m[field], policyRef)
-}
-
-func (m MergeOrigins) Get(
-	field string,
-) []*AttachedPolicyRef {
-	return m[field]
-}
-
-func (m MergeOrigins) SetOne(
-	field string,
-	policyRef *AttachedPolicyRef,
-) {
-	m[field] = []*AttachedPolicyRef{policyRef}
 }

--- a/pkg/pluginsdk/ir/merge.go
+++ b/pkg/pluginsdk/ir/merge.go
@@ -1,0 +1,117 @@
+package ir
+
+import (
+	"google.golang.org/protobuf/types/known/structpb"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// MergeOriginsRefCount is used to track the state of a policy ref in the MergeOrigins
+type MergeOriginsRefCount int
+
+const (
+	// MergeOriginsRefCountNone means the ref is not set for any fields in MergeOrigins
+	MergeOriginsRefCountNone MergeOriginsRefCount = iota
+
+	// MergeOriginsRefCountPartial means the ref is partially set, i.e., set for one or more fields but not all
+	MergeOriginsRefCountPartial
+
+	// MergeOriginsRefCountAll means the ref is fully set, i.e., set for all fields
+	MergeOriginsRefCountAll
+)
+
+// MergeOrigins maps policy field names to policy refs that contribute to it
+// during policy merging
+type MergeOrigins map[string]sets.Set[string]
+
+// Get returns the policy refs for the given field name
+func (m MergeOrigins) Get(
+	field string,
+) []string {
+	if _, ok := m[field]; !ok {
+		return nil
+	}
+	return m[field].UnsortedList()
+}
+
+// SetOne updates the policy refs for the field with the given ref or MergeOrigins
+// if the ref is nil
+func (m MergeOrigins) SetOne(
+	field string,
+	policyRef *AttachedPolicyRef,
+	mergeOrigins MergeOrigins,
+) {
+	if policyRef != nil {
+		m[field] = sets.New(policyRef.ID())
+		return
+	}
+	m[field] = mergeOrigins[field].Clone()
+}
+
+// Append updates the policy refs for the field by appending the given ref or
+// MergeOrigins if the ref is nil
+func (m MergeOrigins) Append(
+	field string,
+	policyRef *AttachedPolicyRef,
+	mergeOrigins MergeOrigins,
+) {
+	if _, ok := m[field]; !ok {
+		m[field] = sets.New[string]()
+	}
+	if policyRef != nil {
+		m[field].Insert(policyRef.ID())
+		return
+	}
+	m[field] = m[field].Union(mergeOrigins[field])
+}
+
+// GetRefCount returns an enum indicating the count of the given policy ref in the MergeOrigins
+func (m MergeOrigins) GetRefCount(
+	policyRef *AttachedPolicyRef,
+) MergeOriginsRefCount {
+	if policyRef == nil || !m.IsSet() {
+		return MergeOriginsRefCountNone
+	}
+
+	forRef := 0
+	for _, field := range m {
+		if field != nil && field.Has(policyRef.ID()) {
+			forRef++
+		}
+	}
+
+	switch forRef {
+	case 0:
+		return MergeOriginsRefCountNone
+	case len(m):
+		return MergeOriginsRefCountAll
+	default:
+		return MergeOriginsRefCountPartial
+	}
+}
+
+// IsSet return a boolean indicating whether MergeOrigins is set
+func (m MergeOrigins) IsSet() bool {
+	return len(m) > 0
+}
+
+func (m MergeOrigins) ToProtoStruct() *structpb.Struct {
+	if !m.IsSet() {
+		return nil
+	}
+
+	s := &structpb.Struct{
+		Fields: make(map[string]*structpb.Value),
+	}
+	for field, refs := range m {
+		// Create a ListValue for the slice of strings
+		listValues := make([]*structpb.Value, len(refs))
+		// Iterate the list in sorted order to ensure deterministic output (List vs UnsortedList)
+		for i, str := range sets.List(refs) {
+			listValues[i] = structpb.NewStringValue(str)
+		}
+		s.Fields[field] = structpb.NewListValue(&structpb.ListValue{
+			Values: listValues,
+		})
+	}
+	return s
+}

--- a/pkg/pluginsdk/ir/merge.go
+++ b/pkg/pluginsdk/ir/merge.go
@@ -34,7 +34,8 @@ func (m MergeOrigins) Get(
 }
 
 // SetOne updates the policy refs for the field with the given ref or MergeOrigins
-// if the ref is nil
+// if the ref is nil.
+// This should be used with shallow merging.
 func (m MergeOrigins) SetOne(
 	field string,
 	policyRef *AttachedPolicyRef,
@@ -48,7 +49,8 @@ func (m MergeOrigins) SetOne(
 }
 
 // Append updates the policy refs for the field by appending the given ref or
-// MergeOrigins if the ref is nil
+// MergeOrigins if the ref is nil.
+// This should be used with deep merging.
 func (m MergeOrigins) Append(
 	field string,
 	policyRef *AttachedPolicyRef,

--- a/pkg/pluginsdk/ir/merge_test.go
+++ b/pkg/pluginsdk/ir/merge_test.go
@@ -1,0 +1,343 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestMergeOrigins_Get(t *testing.T) {
+	tests := []struct {
+		name         string
+		mergeOrigins MergeOrigins
+		field        string
+		expectedRefs []string
+	}{
+		{
+			name:         "get from empty MergeOrigins",
+			mergeOrigins: MergeOrigins{},
+			field:        "field1",
+			expectedRefs: nil,
+		},
+		{
+			name: "get existing field with single ref",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+			},
+			field:        "field1",
+			expectedRefs: []string{"group1/kind1/ns1/name1"},
+		},
+		{
+			name: "get existing field with multiple refs",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1", "group2/kind2/ns2/name2"),
+			},
+			field:        "field1",
+			expectedRefs: []string{"group1/kind1/ns1/name1", "group2/kind2/ns2/name2"},
+		},
+		{
+			name: "get non-existing field",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+			},
+			field:        "field2",
+			expectedRefs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mergeOrigins.Get(tt.field)
+			if tt.expectedRefs == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.ElementsMatch(t, tt.expectedRefs, result)
+			}
+		})
+	}
+}
+
+func TestMergeOrigins_SetOne(t *testing.T) {
+	tests := []struct {
+		name                string
+		initialMergeOrigins MergeOrigins
+		field               string
+		policyRef           *AttachedPolicyRef
+		sourceMergeOrigins  MergeOrigins
+		expectedResult      MergeOrigins
+	}{
+		{
+			name:                "set with policy ref on empty MergeOrigins",
+			initialMergeOrigins: MergeOrigins{},
+			field:               "field1",
+			policyRef: &AttachedPolicyRef{
+				Group:     "group1",
+				Kind:      "kind1",
+				Namespace: "ns1",
+				Name:      "name1",
+			},
+			sourceMergeOrigins: nil,
+			expectedResult: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+			},
+		},
+		{
+			name: "set with policy ref replacing existing field",
+			initialMergeOrigins: MergeOrigins{
+				"field1": sets.New("old/ref/ns/name"),
+			},
+			field: "field1",
+			policyRef: &AttachedPolicyRef{
+				Group:     "group2",
+				Kind:      "kind2",
+				Namespace: "ns2",
+				Name:      "name2",
+			},
+			sourceMergeOrigins: nil,
+			expectedResult: MergeOrigins{
+				"field1": sets.New("group2/kind2/ns2/name2"),
+			},
+		},
+		{
+			name:                "set with nil policy ref using merge origins",
+			initialMergeOrigins: MergeOrigins{},
+			field:               "field1",
+			policyRef:           nil,
+			sourceMergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1", "group2/kind2/ns2/name2"),
+			},
+			expectedResult: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1", "group2/kind2/ns2/name2"),
+			},
+		},
+		{
+			name: "set with nil policy ref and nil merge origins",
+			initialMergeOrigins: MergeOrigins{
+				"field1": sets.New("existing/ref/ns/name"),
+			},
+			field:              "field1",
+			policyRef:          nil,
+			sourceMergeOrigins: MergeOrigins{},
+			expectedResult: MergeOrigins{
+				"field1": sets.New[string](),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initialMergeOrigins.SetOne(tt.field, tt.policyRef, tt.sourceMergeOrigins)
+			assert.Equal(t, tt.expectedResult, tt.initialMergeOrigins)
+		})
+	}
+}
+
+func TestMergeOrigins_Append(t *testing.T) {
+	tests := []struct {
+		name                string
+		initialMergeOrigins MergeOrigins
+		field               string
+		policyRef           *AttachedPolicyRef
+		sourceMergeOrigins  MergeOrigins
+		expectedResult      MergeOrigins
+	}{
+		{
+			name:                "append with policy ref on empty MergeOrigins",
+			initialMergeOrigins: MergeOrigins{},
+			field:               "field1",
+			policyRef: &AttachedPolicyRef{
+				Group:     "group1",
+				Kind:      "kind1",
+				Namespace: "ns1",
+				Name:      "name1",
+			},
+			sourceMergeOrigins: nil,
+			expectedResult: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+			},
+		},
+		{
+			name: "append with policy ref to existing field",
+			initialMergeOrigins: MergeOrigins{
+				"field1": sets.New("existing/ref/ns/name"),
+			},
+			field: "field1",
+			policyRef: &AttachedPolicyRef{
+				Group:     "group2",
+				Kind:      "kind2",
+				Namespace: "ns2",
+				Name:      "name2",
+			},
+			sourceMergeOrigins: nil,
+			expectedResult: MergeOrigins{
+				"field1": sets.New("existing/ref/ns/name", "group2/kind2/ns2/name2"),
+			},
+		},
+		{
+			name: "append with nil policy ref using merge origins",
+			initialMergeOrigins: MergeOrigins{
+				"field1": sets.New("existing/ref/ns/name"),
+			},
+			field:     "field1",
+			policyRef: nil,
+			sourceMergeOrigins: MergeOrigins{
+				"field1": sets.New("source1/ref/ns/name", "source2/ref/ns/name"),
+			},
+			expectedResult: MergeOrigins{
+				"field1": sets.New("existing/ref/ns/name", "source1/ref/ns/name", "source2/ref/ns/name"),
+			},
+		},
+		{
+			name:                "append to non-existing field",
+			initialMergeOrigins: MergeOrigins{},
+			field:               "field2",
+			policyRef: &AttachedPolicyRef{
+				Group:     "group1",
+				Kind:      "kind1",
+				Namespace: "ns1",
+				Name:      "name1",
+			},
+			sourceMergeOrigins: nil,
+			expectedResult: MergeOrigins{
+				"field2": sets.New("group1/kind1/ns1/name1"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initialMergeOrigins.Append(tt.field, tt.policyRef, tt.sourceMergeOrigins)
+			assert.Equal(t, tt.expectedResult, tt.initialMergeOrigins)
+		})
+	}
+}
+
+func TestMergeOrigins_IsSet(t *testing.T) {
+	tests := []struct {
+		name         string
+		mergeOrigins MergeOrigins
+		expected     bool
+	}{
+		{
+			name:         "empty MergeOrigins",
+			mergeOrigins: MergeOrigins{},
+			expected:     false,
+		},
+		{
+			name:         "nil MergeOrigins",
+			mergeOrigins: nil,
+			expected:     false,
+		},
+		{
+			name: "MergeOrigins with one field",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+			},
+			expected: true,
+		},
+		{
+			name: "MergeOrigins with multiple fields",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+				"field2": sets.New("group2/kind2/ns2/name2"),
+			},
+			expected: true,
+		},
+		{
+			name: "MergeOrigins with empty set",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New[string](),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mergeOrigins.IsSet()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMergeOrigins_GetRefCount(t *testing.T) {
+	policyRef1 := &AttachedPolicyRef{
+		Group:     "group1",
+		Kind:      "kind1",
+		Namespace: "ns1",
+		Name:      "name1",
+	}
+
+	tests := []struct {
+		name         string
+		mergeOrigins MergeOrigins
+		policyRef    *AttachedPolicyRef
+		expected     MergeOriginsRefCount
+	}{
+		{
+			name:         "nil policy ref",
+			mergeOrigins: MergeOrigins{"field1": sets.New("group1/kind1/ns1/name1")},
+			policyRef:    nil,
+			expected:     MergeOriginsRefCountNone,
+		},
+		{
+			name:         "empty MergeOrigins",
+			mergeOrigins: MergeOrigins{},
+			policyRef:    policyRef1,
+			expected:     MergeOriginsRefCountNone,
+		},
+		{
+			name: "ref not found in any field",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group2/kind2/ns2/name2"),
+				"field2": sets.New("group3/kind3/ns3/name3"),
+			},
+			policyRef: policyRef1,
+			expected:  MergeOriginsRefCountNone,
+		},
+		{
+			name: "ref found in some fields (partial)",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+				"field2": sets.New("group2/kind2/ns2/name2"),
+				"field3": sets.New("group1/kind1/ns1/name1"),
+			},
+			policyRef: policyRef1,
+			expected:  MergeOriginsRefCountPartial,
+		},
+		{
+			name: "ref found in all fields",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+				"field2": sets.New("group1/kind1/ns1/name1", "group2/kind2/ns2/name2"),
+			},
+			policyRef: policyRef1,
+			expected:  MergeOriginsRefCountAll,
+		},
+		{
+			name: "single field with matching ref",
+			mergeOrigins: MergeOrigins{
+				"field1": sets.New("group1/kind1/ns1/name1"),
+			},
+			policyRef: policyRef1,
+			expected:  MergeOriginsRefCountAll,
+		},
+		{
+			name: "field with nil set",
+			mergeOrigins: MergeOrigins{
+				"field1": nil,
+				"field2": sets.New("group1/kind1/ns1/name1"),
+			},
+			policyRef: policyRef1,
+			expected:  MergeOriginsRefCountPartial,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mergeOrigins.GetRefCount(tt.policyRef)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/pluginsdk/reporter/types.go
+++ b/pkg/pluginsdk/reporter/types.go
@@ -24,6 +24,7 @@ const (
 type PolicyAttachmentState int
 
 const (
+	// PolicyAttachmentStatePending indicates that the policy is pending attachment
 	PolicyAttachmentStatePending PolicyAttachmentState = iota
 
 	// PolicyAttachmentStateSucceeded indicates that the full policy was successfully attached
@@ -40,12 +41,6 @@ const (
 // Has checks if the existing state has the given state
 func (a PolicyAttachmentState) Has(b PolicyAttachmentState) bool {
 	return a&b != 0
-}
-
-type PolicyAttachmentStats struct {
-	Success    uint16
-	Invalid    uint16
-	Conflicted uint16
 }
 
 type PolicyCondition struct {

--- a/pkg/pluginsdk/reporter/types.go
+++ b/pkg/pluginsdk/reporter/types.go
@@ -3,20 +3,55 @@ package reporter
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwxv1alpha1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 )
 
 const (
 	PolicyAcceptedMsg = "Policy accepted"
 
-	PolicyAcceptedAndAttachedMsg = "Policy accepted and attached"
+	PolicyInvalidMsg = "Policy is invalid"
+
+	PolicyConflictWithHigherPriorityMsg = "Policy conflicts with higher priority policy"
+
+	PolicyAttachedMsg = "Attached to all targets"
+
+	PolicyMergedMsg = "Merged with other policies in target(s) and attached"
+
+	PolicyDiscardedMsg = "Discarded due to conflict with higher priority policy in target(s)"
 )
 
+// PolicyAttachmentState represents the state of a policy attachment
+type PolicyAttachmentState int
+
+const (
+	PolicyAttachmentStatePending PolicyAttachmentState = iota
+
+	// PolicyAttachmentStateSucceeded indicates that the full policy was successfully attached
+	PolicyAttachmentStateAttached PolicyAttachmentState = 1 << iota
+
+	// PolicyAttachmentStateMerged indicates that the policy was merged with other policies and attached
+	PolicyAttachmentStateMerged
+
+	// PolicyAttachmentStateInvalid indicates that the policy conflicts with higher priority policies
+	// and was fully discarded
+	PolicyAttachmentStateDiscarded
+)
+
+// Has checks if the existing state has the given state
+func (a PolicyAttachmentState) Has(b PolicyAttachmentState) bool {
+	return a&b != 0
+}
+
+type PolicyAttachmentStats struct {
+	Success    uint16
+	Invalid    uint16
+	Conflicted uint16
+}
+
 type PolicyCondition struct {
-	Type               gwv1alpha2.PolicyConditionType
+	Type               string
 	Status             metav1.ConditionStatus
-	Reason             gwv1alpha2.PolicyConditionReason
+	Reason             string
 	Message            string
 	ObservedGeneration int64
 }
@@ -26,6 +61,10 @@ type PolicyKey struct {
 	Kind      string
 	Namespace string
 	Name      string
+}
+
+func (p PolicyKey) DisplayString() string {
+	return p.Kind + "/" + p.Namespace + "/" + p.Name
 }
 
 type GatewayCondition struct {
@@ -51,6 +90,9 @@ type RouteCondition struct {
 
 type AncestorRefReporter interface {
 	SetCondition(condition PolicyCondition)
+	SetAttachmentState(
+		state PolicyAttachmentState,
+	)
 }
 
 type PolicyReporter interface {

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -213,8 +213,9 @@ func (r *PolicyReport) getAncestorRefOrNil(parentRef *gwv1.ParentReference) *Anc
 	return r.Ancestors[key]
 }
 
-// addMissingAncestorRefConditions initializes the AncestorRefReport with default conditions
-// for a policy's status
+// addMissingAncestorRefConditions initializes the AncestorRefReport with a default Pending
+// condition reason for the Accepted and Attached conditions.
+// Positive conditions will be added when the policy is processed and attached to targeted resources.
 func addMissingAncestorRefConditions(report *AncestorRefReport) {
 	if cond := meta.FindStatusCondition(report.Conditions, string(v1alpha1.PolicyConditionAccepted)); cond == nil {
 		meta.SetStatusCondition(&report.Conditions, metav1.Condition{

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -13,11 +13,13 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	pluginsdkreporter "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
 
 type AncestorRefReport struct {
-	Conditions []metav1.Condition
+	Conditions      []metav1.Condition
+	AttachmentState reporter.PolicyAttachmentState
 }
 
 type PolicyReport struct {
@@ -25,21 +27,27 @@ type PolicyReport struct {
 	observedGeneration int64
 }
 
-func (r *PolicyReport) AncestorRef(ref gwv1.ParentReference) pluginsdkreporter.AncestorRefReporter {
+func (r *PolicyReport) AncestorRef(ref gwv1.ParentReference) reporter.AncestorRefReporter {
 	return r.ancestorRef(ref)
 }
 
-func (prr *AncestorRefReport) SetCondition(c pluginsdkreporter.PolicyCondition) {
+func (prr *AncestorRefReport) SetCondition(c reporter.PolicyCondition) {
 	condition := metav1.Condition{
-		Type:    string(c.Type),
+		Type:    c.Type,
 		Status:  c.Status,
-		Reason:  string(c.Reason),
+		Reason:  c.Reason,
 		Message: c.Message,
 	}
 	meta.SetStatusCondition(&prr.Conditions, condition)
 }
 
-func (r *reporter) Policy(key PolicyKey, observedGeneration int64) pluginsdkreporter.PolicyReporter {
+func (prr *AncestorRefReport) SetAttachmentState(
+	state reporter.PolicyAttachmentState,
+) {
+	prr.AttachmentState |= state
+}
+
+func (r *statusReporter) Policy(key PolicyKey, observedGeneration int64) reporter.PolicyReporter {
 	pr := r.report.policy(key)
 	if pr == nil {
 		pr = r.report.newPolicyReport(key, observedGeneration)
@@ -126,8 +134,11 @@ func (r *ReportMap) BuildPolicyStatus(
 			currentParentRefConditions = currentStatus.Ancestors[currentParentRefIdx].Conditions
 		}
 
-		finalConditions := make([]metav1.Condition, 0, len(parentStatusReport.Conditions))
-		for _, pCondition := range parentStatusReport.Conditions {
+		// Build and append the Attached Condition.Type
+		existingConditions := addAttachmentCondition(parentStatusReport)
+
+		finalConditions := make([]metav1.Condition, 0, len(existingConditions))
+		for _, pCondition := range existingConditions {
 			pCondition.ObservedGeneration = report.observedGeneration
 
 			// Copy old condition to preserve LastTransitionTime, if it exists
@@ -202,15 +213,59 @@ func (r *PolicyReport) getAncestorRefOrNil(parentRef *gwv1.ParentReference) *Anc
 	return r.Ancestors[key]
 }
 
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
+// addMissingAncestorRefConditions initializes the AncestorRefReport with default conditions
+// for a policy's status
 func addMissingAncestorRefConditions(report *AncestorRefReport) {
-	if cond := meta.FindStatusCondition(report.Conditions, string(gwv1alpha2.PolicyConditionAccepted)); cond == nil {
+	if cond := meta.FindStatusCondition(report.Conditions, string(v1alpha1.PolicyConditionAccepted)); cond == nil {
 		meta.SetStatusCondition(&report.Conditions, metav1.Condition{
-			Type:   string(gwv1alpha2.PolicyConditionAccepted),
-			Status: metav1.ConditionTrue,
-			Reason: string(gwv1alpha2.PolicyReasonAccepted),
+			Type:   string(v1alpha1.PolicyConditionAccepted),
+			Status: metav1.ConditionFalse,
+			Reason: string(v1alpha1.PolicyReasonPending),
 		})
 	}
+	if cond := meta.FindStatusCondition(report.Conditions, string(v1alpha1.PolicyConditionAttached)); cond == nil {
+		meta.SetStatusCondition(&report.Conditions, metav1.Condition{
+			Type:   string(v1alpha1.PolicyConditionAttached),
+			Status: metav1.ConditionFalse,
+			Reason: string(v1alpha1.PolicyReasonPending),
+		})
+	}
+}
+
+func addAttachmentCondition(report *AncestorRefReport) []metav1.Condition {
+	if report.AttachmentState == reporter.PolicyAttachmentStatePending {
+		// no attachment state set, return the conditions as is
+		return report.Conditions
+	}
+
+	// avoid modifying the existing Conditions on the report
+	existing := slices.Clone(report.Conditions)
+
+	switch {
+	case report.AttachmentState.Has(reporter.PolicyAttachmentStateDiscarded):
+		meta.SetStatusCondition(&existing, metav1.Condition{
+			Type:    string(v1alpha1.PolicyConditionAttached),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(v1alpha1.PolicyReasonDiscarded),
+			Message: reporter.PolicyDiscardedMsg,
+		})
+
+	case report.AttachmentState.Has(reporter.PolicyAttachmentStateMerged):
+		meta.SetStatusCondition(&existing, metav1.Condition{
+			Type:    string(v1alpha1.PolicyConditionAttached),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(v1alpha1.PolicyReasonMerged),
+			Message: reporter.PolicyMergedMsg,
+		})
+
+	case report.AttachmentState.Has(reporter.PolicyAttachmentStateAttached):
+		meta.SetStatusCondition(&existing, metav1.Condition{
+			Type:    string(v1alpha1.PolicyConditionAttached),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(v1alpha1.PolicyReasonAttached),
+			Message: reporter.PolicyAttachedMsg,
+		})
+	}
+
+	return existing
 }

--- a/pkg/reports/policy_test.go
+++ b/pkg/reports/policy_test.go
@@ -298,9 +298,9 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
 								Status:             metav1.ConditionFalse,
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Reason:             string(v1alpha1.PolicyReasonInvalid),
 							},
 						},
 					},

--- a/pkg/reports/policy_test.go
+++ b/pkg/reports/policy_test.go
@@ -11,7 +11,8 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	pluginsdkreporter "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
 
 func TestPolicyStatusReport(t *testing.T) {
@@ -24,9 +25,9 @@ func TestPolicyStatusReport(t *testing.T) {
 		wantStatus      *gwv1alpha2.PolicyStatus
 	}{
 		{
-			name: "with empty status on object",
-			fakeTranslation: func(a *assert.Assertions, reporter Reporter) {
-				policyReport := reporter.Policy(PolicyKey{
+			name: "empty status on current object and no status updates during translation",
+			fakeTranslation: func(a *assert.Assertions, statusReporter Reporter) {
+				policyReport := statusReporter.Policy(PolicyKey{
 					Group:     "example.com",
 					Kind:      "Policy",
 					Namespace: "default",
@@ -68,9 +69,15 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
-								Status:             metav1.ConditionTrue,
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
+							},
+							{
+								ObservedGeneration: 1,
+								Type:               string(v1alpha1.PolicyConditionAttached),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
 							},
 						},
 					},
@@ -85,9 +92,15 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
-								Status:             metav1.ConditionTrue,
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
+							},
+							{
+								ObservedGeneration: 1,
+								Type:               string(v1alpha1.PolicyConditionAttached),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
 							},
 						},
 					},
@@ -95,36 +108,43 @@ func TestPolicyStatusReport(t *testing.T) {
 			},
 		},
 		{
-			name: "update existing status on object",
-			fakeTranslation: func(a *assert.Assertions, reporter Reporter) {
-				policyReport := reporter.Policy(PolicyKey{
+			name: "status on existing object and status updates during translation",
+			fakeTranslation: func(a *assert.Assertions, statusReporter Reporter) {
+				policyReport := statusReporter.Policy(PolicyKey{
 					Group:     "example.com",
 					Kind:      "Policy",
 					Namespace: "default",
 					Name:      "example",
 				}, 2)
 				a.NotNil(policyReport)
-				// during gw-1 translation, add PolicyReasonAccepted
+				// during gw-1 translation, add PolicyReasonValid
 				policyReport.AncestorRef(gwv1.ParentReference{
 					Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
 					Kind:      ptr.To(gwv1.Kind("Gateway")),
 					Namespace: ptr.To(gwv1.Namespace("default")),
 					Name:      gwv1.ObjectName("gw-1"),
-				}).SetCondition(pluginsdkreporter.PolicyCondition{
-					Type:   gwv1alpha2.PolicyConditionAccepted,
+				}).SetCondition(reporter.PolicyCondition{
+					Type:   string(v1alpha1.PolicyConditionAccepted),
 					Status: metav1.ConditionTrue,
-					Reason: gwv1alpha2.PolicyReasonAccepted,
+					Reason: string(v1alpha1.PolicyReasonValid),
 				})
+				// during gw-1 translation, add PolicyReasonAttached
+				policyReport.AncestorRef(gwv1.ParentReference{
+					Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+					Kind:      ptr.To(gwv1.Kind("Gateway")),
+					Namespace: ptr.To(gwv1.Namespace("default")),
+					Name:      gwv1.ObjectName("gw-1"),
+				}).SetAttachmentState(reporter.PolicyAttachmentStateAttached)
 				// during gw-2 translation, add PolicyReasonInvalid
 				policyReport.AncestorRef(gwv1.ParentReference{
 					Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
 					Kind:      ptr.To(gwv1.Kind("Gateway")),
 					Namespace: ptr.To(gwv1.Namespace("default")),
 					Name:      gwv1.ObjectName("gw-2"),
-				}).SetCondition(pluginsdkreporter.PolicyCondition{
-					Type:   gwv1alpha2.PolicyConditionAccepted,
+				}).SetCondition(reporter.PolicyCondition{
+					Type:   string(v1alpha1.PolicyConditionAccepted),
 					Status: metav1.ConditionFalse,
-					Reason: gwv1alpha2.PolicyReasonInvalid,
+					Reason: string(v1alpha1.PolicyReasonInvalid),
 				})
 			},
 			key: PolicyKey{
@@ -136,23 +156,7 @@ func TestPolicyStatusReport(t *testing.T) {
 			controller: "example-controller",
 			currentStatus: gwv1alpha2.PolicyStatus{
 				Ancestors: []gwv1alpha2.PolicyAncestorStatus{
-					{
-						AncestorRef: gwv1.ParentReference{
-							Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
-							Kind:      ptr.To(gwv1.Kind("Gateway")),
-							Namespace: ptr.To(gwv1.Namespace("default")),
-							Name:      gwv1.ObjectName("gw-1"),
-						},
-						ControllerName: "example-controller",
-						Conditions: []metav1.Condition{
-							{
-								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
-								Status:             metav1.ConditionFalse, // existing condition
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
-							},
-						},
-					},
+					// No existing status for gw-1 but test with an existing status for gw-2
 					{
 						AncestorRef: gwv1.ParentReference{
 							Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
@@ -164,9 +168,9 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
-								Status:             metav1.ConditionFalse, // existing condition
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
+								Status:             metav1.ConditionTrue,
+								Reason:             string(v1alpha1.PolicyReasonValid),
 							},
 						},
 					},
@@ -185,9 +189,16 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 2,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
 								Status:             metav1.ConditionTrue,
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Reason:             string(v1alpha1.PolicyReasonValid),
+							},
+							{
+								ObservedGeneration: 2,
+								Type:               string(v1alpha1.PolicyConditionAttached),
+								Status:             metav1.ConditionTrue,
+								Reason:             string(v1alpha1.PolicyReasonAttached),
+								Message:            reporter.PolicyAttachedMsg,
 							},
 						},
 					},
@@ -202,9 +213,15 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 2,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
 								Status:             metav1.ConditionFalse,
-								Reason:             string(gwv1alpha2.PolicyReasonInvalid),
+								Reason:             string(v1alpha1.PolicyReasonInvalid),
+							},
+							{
+								ObservedGeneration: 2,
+								Type:               string(v1alpha1.PolicyConditionAttached),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
 							},
 						},
 					},
@@ -213,24 +230,24 @@ func TestPolicyStatusReport(t *testing.T) {
 		},
 		{
 			name: "preserve ancestor status belonging to external controllers",
-			fakeTranslation: func(a *assert.Assertions, reporter Reporter) {
-				policyReport := reporter.Policy(PolicyKey{
+			fakeTranslation: func(a *assert.Assertions, statusReporter Reporter) {
+				policyReport := statusReporter.Policy(PolicyKey{
 					Group:     "example.com",
 					Kind:      "Policy",
 					Namespace: "default",
 					Name:      "example",
 				}, 2)
 				a.NotNil(policyReport)
-				// during gw-1 translation, add PolicyReasonAccepted
+				// during gw-1 translation, add PolicyReasonValid
 				policyReport.AncestorRef(gwv1.ParentReference{
 					Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
 					Kind:      ptr.To(gwv1.Kind("Gateway")),
 					Namespace: ptr.To(gwv1.Namespace("default")),
 					Name:      gwv1.ObjectName("gw-1"),
-				}).SetCondition(pluginsdkreporter.PolicyCondition{
-					Type:   gwv1alpha2.PolicyConditionAccepted,
+				}).SetCondition(reporter.PolicyCondition{
+					Type:   string(v1alpha1.PolicyConditionAccepted),
 					Status: metav1.ConditionTrue,
-					Reason: gwv1alpha2.PolicyReasonAccepted,
+					Reason: string(v1alpha1.PolicyReasonValid),
 				})
 				// during gw-2 translation, add PolicyReasonInvalid
 				policyReport.AncestorRef(gwv1.ParentReference{
@@ -238,10 +255,10 @@ func TestPolicyStatusReport(t *testing.T) {
 					Kind:      ptr.To(gwv1.Kind("Gateway")),
 					Namespace: ptr.To(gwv1.Namespace("default")),
 					Name:      gwv1.ObjectName("gw-2"),
-				}).SetCondition(pluginsdkreporter.PolicyCondition{
-					Type:   gwv1alpha2.PolicyConditionAccepted,
+				}).SetCondition(reporter.PolicyCondition{
+					Type:   string(v1alpha1.PolicyConditionAccepted),
 					Status: metav1.ConditionFalse,
-					Reason: gwv1alpha2.PolicyReasonInvalid,
+					Reason: string(v1alpha1.PolicyReasonInvalid),
 				})
 			},
 			key: PolicyKey{
@@ -264,9 +281,9 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
+								Type:               "ExternalType",
 								Status:             metav1.ConditionFalse,
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Reason:             "ExternalReason",
 							},
 						},
 					},
@@ -282,7 +299,7 @@ func TestPolicyStatusReport(t *testing.T) {
 							{
 								ObservedGeneration: 1,
 								Type:               string(gwv1alpha2.PolicyConditionAccepted),
-								Status:             metav1.ConditionFalse, // existing condition
+								Status:             metav1.ConditionFalse,
 								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
 							},
 						},
@@ -298,9 +315,9 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
-								Status:             metav1.ConditionFalse, // existing condition
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
 							},
 						},
 					},
@@ -319,9 +336,15 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 2,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
 								Status:             metav1.ConditionTrue,
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Reason:             string(v1alpha1.PolicyReasonValid),
+							},
+							{
+								ObservedGeneration: 2,
+								Type:               string(v1alpha1.PolicyConditionAttached),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
 							},
 						},
 					},
@@ -336,9 +359,15 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 2,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
+								Type:               string(v1alpha1.PolicyConditionAccepted),
 								Status:             metav1.ConditionFalse,
-								Reason:             string(gwv1alpha2.PolicyReasonInvalid),
+								Reason:             string(v1alpha1.PolicyReasonInvalid),
+							},
+							{
+								ObservedGeneration: 2,
+								Type:               string(v1alpha1.PolicyConditionAttached),
+								Status:             metav1.ConditionFalse,
+								Reason:             string(v1alpha1.PolicyReasonPending),
 							},
 						},
 					},
@@ -353,9 +382,9 @@ func TestPolicyStatusReport(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								ObservedGeneration: 1,
-								Type:               string(gwv1alpha2.PolicyConditionAccepted),
+								Type:               "ExternalType",
 								Status:             metav1.ConditionFalse,
-								Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+								Reason:             "ExternalReason",
 							},
 						},
 					},

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -270,11 +270,11 @@ func (l *ListenerReport) SetAttachedRoutes(n uint) {
 	l.Status.AttachedRoutes = int32(n)
 }
 
-type reporter struct {
+type statusReporter struct {
 	report *ReportMap
 }
 
-func (r *reporter) Gateway(gateway *gwv1.Gateway) pluginsdkreporter.GatewayReporter {
+func (r *statusReporter) Gateway(gateway *gwv1.Gateway) pluginsdkreporter.GatewayReporter {
 	gr := r.report.Gateway(gateway)
 	if gr == nil {
 		gr = r.report.newGatewayReport(gateway)
@@ -282,7 +282,7 @@ func (r *reporter) Gateway(gateway *gwv1.Gateway) pluginsdkreporter.GatewayRepor
 	return gr
 }
 
-func (r *reporter) ListenerSet(listenerSet *gwxv1alpha1.XListenerSet) pluginsdkreporter.ListenerSetReporter {
+func (r *statusReporter) ListenerSet(listenerSet *gwxv1alpha1.XListenerSet) pluginsdkreporter.ListenerSetReporter {
 	lsr := r.report.ListenerSet(listenerSet)
 	if lsr == nil {
 		lsr = r.report.newListenerSetReport(listenerSet)
@@ -290,7 +290,7 @@ func (r *reporter) ListenerSet(listenerSet *gwxv1alpha1.XListenerSet) pluginsdkr
 	return lsr
 }
 
-func (r *reporter) Route(obj metav1.Object) pluginsdkreporter.RouteReporter {
+func (r *statusReporter) Route(obj metav1.Object) pluginsdkreporter.RouteReporter {
 	rr := r.report.route(obj)
 	if rr == nil {
 		rr = r.report.newRouteReport(obj)
@@ -383,7 +383,7 @@ func (prr *ParentRefReport) SetCondition(rc pluginsdkreporter.RouteCondition) {
 }
 
 func NewReporter(reportMap *ReportMap) pluginsdkreporter.Reporter {
-	return &reporter{
+	return &statusReporter{
 		report: reportMap,
 	}
 }

--- a/test/kubernetes/e2e/features/transformation/suite.go
+++ b/test/kubernetes/e2e/features/transformation/suite.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	reports "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
@@ -94,9 +93,9 @@ func (s *testingSuite) SetupSuite() {
 	})
 
 	s.assertStatus(metav1.Condition{
-		Type:               string(gwv1alpha2.PolicyConditionAccepted),
+		Type:               string(v1alpha1.PolicyConditionAccepted),
 		Status:             metav1.ConditionTrue,
-		Reason:             string(gwv1alpha2.PolicyReasonAccepted),
+		Reason:             string(v1alpha1.PolicyReasonValid),
 		Message:            reports.PolicyAcceptedMsg,
 		ObservedGeneration: routeForHeaders.Generation,
 	})

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	common "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 	"github.com/kgateway-dev/kgateway/v2/pkg/schemes"
 	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
@@ -372,6 +373,25 @@ func GetHTTPRouteStatusError(
 	return nil
 }
 
+func GetPolicyStatusError(
+	reportsMap reports.ReportMap,
+	policy *reporter.PolicyKey,
+) error {
+	for key, policyReport := range reportsMap.Policies {
+		if policy != nil && *policy != key {
+			continue
+		}
+		for ancestor, report := range policyReport.Ancestors {
+			for _, c := range report.Conditions {
+				if c.Status != metav1.ConditionTrue {
+					return fmt.Errorf("condition error for policy: %v, ancestor ref: %v, condition: %v", policy, ancestor, c)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) error {
 	err := GetHTTPRouteStatusError(reportsMap, nil)
 	if err != nil {
@@ -427,6 +447,11 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 				return fmt.Errorf("condition not accepted for gw %v condition: %v", nns, c)
 			}
 		}
+	}
+
+	err = GetPolicyStatusError(reportsMap, nil)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
#  Description
- Updates the policy status API to make use of separate Conditions for Attached and Accepted.
- Adds MergeOrigins as metadata on the corresponding output Envoy config.

Refer to the design doc for more details.

# Change Type

```
/kind design
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes
Part of #11741