### PR TITLE
BackendConfigPolicy:  Add integer validation for BackendConfigPolicy window sizes

### DIFF
--- a/api/v1alpha1/backend_config_policy_types.go
+++ b/api/v1alpha1/backend_config_policy_types.go
@@ -155,14 +155,14 @@ type Http2ProtocolOptions struct {
 	// Defaults to 268435456 (256 * 1024 * 1024).
 	// Values can be specified with units like "64Ki".
 	// +optional
-	// +kubebuilder:validation:XValidation:message="InitialStreamWindowSize must be between 65535 and 2147483647 bytes (inclusive)",rule="quantity(self).isGreaterThan(quantity('65534')) && quantity(self).isLessThan(quantity('2147483648'))"
+	// +kubebuilder:validation:XValidation:message="InitialStreamWindowSize must be between 65535 and 2147483647 bytes (inclusive)",rule="(type(self) == int && int(self) >= 65535 && int(self) <= 2147483647) || (type(self) == string && quantity(self).isGreaterThan(quantity('65534')) && quantity(self).isLessThan(quantity('2147483648')))"
 	InitialStreamWindowSize *resource.Quantity `json:"initialStreamWindowSize,omitempty"`
 
 	// InitialConnectionWindowSize is similar to InitialStreamWindowSize, but for the connection level.
 	// Same range and default value as InitialStreamWindowSize.
 	// Values can be specified with units like "64Ki".
 	// +optional
-	// +kubebuilder:validation:XValidation:message="InitialConnectionWindowSize must be between 65535 and 2147483647 bytes (inclusive)",rule="quantity(self).isGreaterThan(quantity('65534')) && quantity(self).isLessThan(quantity('2147483648'))"
+	// +kubebuilder:validation:XValidation:message="InitialConnectionWindowSize must be between 65535 and 2147483647 bytes (inclusive)",rule="(type(self) == int && int(self) >= 65535 && int(self) <= 2147483647) || (type(self) == string && quantity(self).isGreaterThan(quantity('65534')) && quantity(self).isLessThan(quantity('2147483648')))"
 	InitialConnectionWindowSize *resource.Quantity `json:"initialConnectionWindowSize,omitempty"`
 
 	// The maximum number of concurrent streams that the connection can have.

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
@@ -138,7 +138,9 @@ spec:
                     x-kubernetes-validations:
                     - message: InitialConnectionWindowSize must be between 65535 and
                         2147483647 bytes (inclusive)
-                      rule: quantity(self).isGreaterThan(quantity('65534')) && quantity(self).isLessThan(quantity('2147483648'))
+                      rule: (type(self) == int && int(self) >= 65535 && int(self)
+                        <= 2147483647) || (type(self) == string && quantity(self).isGreaterThan(quantity('65534'))
+                        && quantity(self).isLessThan(quantity('2147483648')))
                   initialStreamWindowSize:
                     anyOf:
                     - type: integer
@@ -148,7 +150,9 @@ spec:
                     x-kubernetes-validations:
                     - message: InitialStreamWindowSize must be between 65535 and 2147483647
                         bytes (inclusive)
-                      rule: quantity(self).isGreaterThan(quantity('65534')) && quantity(self).isLessThan(quantity('2147483648'))
+                      rule: (type(self) == int && int(self) >= 65535 && int(self)
+                        <= 2147483647) || (type(self) == string && quantity(self).isGreaterThan(quantity('65534'))
+                        && quantity(self).isLessThan(quantity('2147483648')))
                   maxConcurrentStreams:
                     type: integer
                   overrideStreamErrorOnInvalidHttpMessage:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
This PR enhances the BackendConfigPolicy CRD by adding validation for integer types to the initialStreamWindowSize and initialConnectionWindowSize fields.

Previously, the validation rules for these fields only supported string quantities (e.g., "64Ki"), and would not correctl validate raw integer values. This change updates the CEL validation rules in both the Go API types and the corresponding Helm CRD template to accept either an integer within the valid range (65535-2147483647) or a string quantity.

Example:
 Before this change, only this was valid:
 1 initialStreamWindowSize: "131070"
After this change, both of the following are valid:
1 initialStreamWindowSize: "131070"
 2 initialStreamWindowSize: 131070

Fixes #11611 

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

```
/kind bug_fix

```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
