### PR TITLE
test: log apply output when unexpected error occurs in APIValidation

### DIFF
--- a/test/kubernetes/e2e/tests/api_validation_test.go
+++ b/test/kubernetes/e2e/tests/api_validation_test.go
@@ -434,6 +434,9 @@ spec:
 					r.Contains(out.String(), wantErr)
 				}
 			} else {
+				if err != nil {
+					t.Errorf("kubectl apply failed with output: %s", out.String())
+				}
 				r.NoError(err)
 			}
 		})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
**Motivation:**  
When an API validation test case does not expect an error (`wantErrors` is empty or nil) but the apiserver rejects the configuration, the test fails with a generic `exit status 1`. This makes it difficult to debug why the resource was rejected.

**What changed:**  
This change improves test feedback by logging the full output of `kubectl apply` (i.e., `out.String()`) when an unexpected error occurs. This provides better visibility into the underlying validation failure.

**Related issues:**  
Fixes #11751
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind bug_fix
/kind cleanup
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
API validation tests now log the output from `kubectl apply` when an unexpected error occurs, making it easier to debug failing test cases.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
