### PR TITLE
backendconfigpolicy: added a required label

### DIFF
--- a/api/v1alpha1/backend_config_policy_types.go
+++ b/api/v1alpha1/backend_config_policy_types.go
@@ -12,7 +12,7 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway}
+// +kubebuilder:metadata:labels={app=kgateway,app.kubernetes.io/name=kgateway,gateway.networking.k8s.io/policy=Direct}
 // +kubebuilder:resource:categories=kgateway
 // +kubebuilder:subresource:status
 type BackendConfigPolicy struct {

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: kgateway
     app.kubernetes.io/name: kgateway
+    gateway.networking.k8s.io/policy: Direct
   name: backendconfigpolicies.gateway.kgateway.dev
 spec:
   group: gateway.kgateway.dev


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
The CRD related to network traffic routing must have a label attached to it, as specified in https://gateway-api.sigs.k8s.io/geps/gep-713/#standard-label-on-crd-objects
BackendConfigPolicy was missing this label so added: 
```
gateway.networking.k8s.io/policy: Direct
```
at label field.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

```
/kind bug_fix

```


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
