### PR TITLE
envoy: bump to 1.35 and update rustformations 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ export VERSION
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
 # Note: When bumping this version, update the version in pkg/validator/validator.go as well.
-export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.34.1-patch3
+export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.35.0-patch1
 export LDFLAGS := -X 'github.com/kgateway-dev/kgateway/v2/internal/version.Version=$(VERSION)'
 export GCFLAGS ?=
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/avast/retry-go v2.4.3+incompatible
 	github.com/avast/retry-go/v4 v4.3.3
 	github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f
-	github.com/envoyproxy/go-control-plane v0.13.5-0.20250507123352-93990c5ec02f
+	github.com/envoyproxy/go-control-plane v0.13.5-0.20250722125442-5321204dac14
 	github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250507123352-93990c5ec02f
 	github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250507123352-93990c5ec02f
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250507123352-93990c5ec02f
@@ -583,8 +583,8 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/api v0.228.0 // indirect
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250507123352-93990c5ec02f h1:0SovjSoiK8Xd3WmmR0AJhCOUr9CFmHD1iurwL3/ChOY=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20250507123352-93990c5ec02f/go.mod h1:0qUBm7c5rAt4tPgVIf20MXebCvZSoir1mQZIFMzHWtU=
+github.com/envoyproxy/go-control-plane v0.13.5-0.20250722125442-5321204dac14 h1:9cAEFdenu5vOVbXrzS9W9mxPbXVcRRs31T5Azq/GFZg=
+github.com/envoyproxy/go-control-plane v0.13.5-0.20250722125442-5321204dac14/go.mod h1:whHrEUXbTAzBJlzd3Gz4us5zEFP1gL6o3LbfA+a/xbg=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250507123352-93990c5ec02f h1:8Q48+OtVytah0PvjbMgDvAeTuPiOs4+d5q4kNPbsFnw=
 github.com/envoyproxy/go-control-plane/contrib v1.32.5-0.20250507123352-93990c5ec02f/go.mod h1:f+xWFgX4KgG6AO6OYv3iH35x01oxj5nU1PSbT3Xixyo=
 github.com/envoyproxy/go-control-plane/envoy v1.32.5-0.20250507123352-93990c5ec02f h1:EkvqIU8ltMRQcOUboGq22suL1jbI4lKkX8OxOrSwmeQ=
@@ -2447,8 +2449,12 @@ google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 h1:ToEetK57OidYuqD
 google.golang.org/genproto v0.0.0-20241118233622-e639e219e697/go.mod h1:JJrvXBWRZaFMxBufik1a4RpFw4HhgVtBBWQeQgUj2cc=
 google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34 h1:0PeQib/pH3nB/5pEmFeVQJotzGohV0dq4Vcp09H5yhE=
 google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34/go.mod h1:0awUlEkap+Pb1UMeJwJQQAdJQrt3moU7J2moTy69irI=
+google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a h1:SGktgSolFCo75dnHJF2yMvnns6jCmHFJ0vE4Vn2JKvQ=
+google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a/go.mod h1:a77HrdMjoeKbnd2jmgcWdaS++ZLZAEq3orIOAEIKiVw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34 h1:h6p3mQqrmT1XkHVTfzLdNz1u7IhINeZkz67/xTbOuWs=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a h1:v2PbRU4K3llS09c7zodFpNePeamkAwG3mPrAery9VeE=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/internal/envoyinit/rustformations/Cargo.lock
+++ b/internal/envoyinit/rustformations/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "envoy-proxy-dynamic-modules-rust-sdk"
 version = "0.1.0"
-source = "git+https://github.com/envoyproxy/envoy?rev=c435eeccd4201f8d6a200922b166f5dcee08272b#c435eeccd4201f8d6a200922b166f5dcee08272b"
+source = "git+https://github.com/envoyproxy/envoy?rev=84305a6cb64bd55aaf606bdd53de7cd6080427a1#84305a6cb64bd55aaf606bdd53de7cd6080427a1"
 dependencies = [
  "bindgen",
  "mockall",

--- a/internal/envoyinit/rustformations/Cargo.toml
+++ b/internal/envoyinit/rustformations/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "c435eeccd4201f8d6a200922b166f5dcee08272b" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "84305a6cb64bd55aaf606bdd53de7cd6080427a1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.9.0"

--- a/internal/envoyinit/rustformations/src/http_simple_mutations.rs
+++ b/internal/envoyinit/rustformations/src/http_simple_mutations.rs
@@ -180,7 +180,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for Filter {
         if !self.route_specific.is_empty() {
             // check filter state for info
             let route_name_data_option =
-                envoy_filter.get_dynamic_metadata_string("kgateway", "route");
+                envoy_filter.get_metadata_string(abi::envoy_dynamic_module_type_metadata_source::Dynamic, "kgateway", "route");
             if route_name_data_option.is_some() {
                 let route_name_data = route_name_data_option.unwrap();
                 // if its there then we should be able to pull the data name
@@ -250,7 +250,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for Filter {
         if !self.route_specific.is_empty() {
             // check filter state for info
             let route_name_data_option =
-                envoy_filter.get_dynamic_metadata_string("kgateway", "route");
+                envoy_filter.get_metadata_string(abi::envoy_dynamic_module_type_metadata_source::Dynamic,"kgateway", "route");
             if route_name_data_option.is_some() {
                 let route_name_data = route_name_data_option.unwrap();
                 // if its there then we should be able to pull the data name


### PR DESCRIPTION

# What was changed
Update version of the envoy based dataplane. 

Requires rustformation updates to accept the new signatures as seen in: https://github.com/envoyproxy/envoy/commit/a37554a07d9e0dec8fce3d2d1bbbb09c4068d78c\#diff-d07ecdab42b319f3ca3d895980f1672ffb2ebe36e257d5c905351b1d379abe6d

Updates Envoy image version: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.35/v1.35.0

Updates go-control plane to https://github.com/envoyproxy/go-control-plane/commit/5321204dac14eb3ef389be392c36364d9bad4302 
This was determined based off https://github.com/envoyproxy/go-control-plane/actions/runs/16477669961/job/46583491598 which is the sync for the 1.35 commit release.
Note that 

# What was not attempted
No new features were added, for example there was no attempt to expose ext-proc per route fail mode.

# Rough summary of 1.35.0 changes in kgateway context
Envoy 1.35.0 is largely a **safe upgrade** for our control plane with minimal user impact. The changes are primarily bug fixes, internal improvements, and new features that we don't currently expose. The only user-visible change is the addition of the `x-envoy-original-host` header.
The biggest piece here is the additions that Yuval helped add to make dynamic modules closer to game time whereby we might be able to get rid of envoy-gloo.


/kind cleanup

Note https://github.com/kgateway-dev/kgateway/issues/11678 will have to consider this type of breaking changes and how we keep up to date. That being said it could be as simple as having an action like the one in go-control-plane (at least once envoy-gloo is no more)

