### PR TITLE
status: use Accepted=False,Reason=RouteRuleDropped for replaced rule

### DIFF
--- a/internal/kgateway/query/httproute.go
+++ b/internal/kgateway/query/httproute.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -304,7 +303,7 @@ func (r *gatewayQueries) fetchRoutesByRef(
 			// Lookup a specific child route by its name
 			route := r.collections.Routes.FetchHttp(kctx, delegatedNs, string(backendRef.Name))
 			if route == nil {
-				return nil, errors.New("not found")
+				return nil, ErrUnresolvedReference
 			}
 			refChildren = append(refChildren, *route)
 		}

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -267,15 +267,15 @@ var _ = DescribeTable("Basic",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(strings.Count(partiallyInvalid.Message, `field invalid_object contains invalid JSON string: "model":"gpt-4"}`)).To(Equal(2),
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(strings.Count(acceptedCond.Message, `field invalid_object contains invalid JSON string: "model":"gpt-4"}`)).To(Equal(2),
 					"Expected 'invalid_object' message to appear exactly twice")
-				Expect(strings.Count(partiallyInvalid.Message, `field invalid_slices contains invalid JSON string: [1,2,3`)).To(Equal(2),
+				Expect(strings.Count(acceptedCond.Message, `field invalid_slices contains invalid JSON string: [1,2,3`)).To(Equal(2),
 					"Expected 'invalid_slices' message to appear exactly twice")
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(0)))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		}),
 	Entry(
@@ -342,6 +342,16 @@ var _ = DescribeTable("Basic",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
 				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				expectedPolicies := []reports.PolicyKey{
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "infra", Name: "extauth-for-gateway-section-name"},
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "infra", Name: "extauth-for-gateway"},
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "infra", Name: "extauth-for-http-route"},
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "infra", Name: "extauth-for-extension-ref"},
+					{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy", Namespace: "infra", Name: "extauth-for-route-section-name"},
+				}
+				assertAcceptedPolicyStatus(reportsMap, expectedPolicies)
 			},
 		}),
 	Entry(
@@ -717,12 +727,12 @@ var _ = DescribeTable("Basic",
 			Expect(resolvedRefs.Status).To(Equal(metav1.ConditionTrue))
 			Expect(resolvedRefs.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
 
-			// Check if there's a PartiallyInvalid condition that reports the missing DirectResponse
-			partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-			Expect(partiallyInvalid).NotTo(BeNil())
-			Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-			Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule"))
-			Expect(partiallyInvalid.Message).To(ContainSubstring("no action specified"))
+			// Assert Accepted=False reports the missing DirectResponse
+			acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+			Expect(acceptedCond).NotTo(BeNil())
+			Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule"))
+			Expect(acceptedCond.Message).To(ContainSubstring("no action specified"))
 		},
 	}),
 	Entry("DirectResponse with overlapping filters reports correctly", translatorTestCase{
@@ -743,12 +753,12 @@ var _ = DescribeTable("Basic",
 			Expect(routeStatus).NotTo(BeNil())
 			Expect(routeStatus.Parents).To(HaveLen(1))
 
-			// Check for PartiallyInvalid condition due to overlapping filters
-			partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-			Expect(partiallyInvalid).NotTo(BeNil())
-			Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-			Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-			Expect(partiallyInvalid.Message).To(ContainSubstring("cannot be applied to route with existing action"))
+			// Check for Accepted condition due to overlapping filters
+			acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+			Expect(acceptedCond).NotTo(BeNil())
+			Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+			Expect(acceptedCond.Message).To(ContainSubstring("cannot be applied to route with existing action"))
 		},
 	}),
 	Entry("DirectResponse with invalid backendRef filter reports correctly", translatorTestCase{
@@ -999,13 +1009,13 @@ var _ = DescribeTable("Route Replacement",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("the rewrite /new//../path is invalid"))
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(1)))
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("the rewrite /new//../path is invalid"))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(1)))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1031,14 +1041,14 @@ var _ = DescribeTable("Route Replacement",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("failed to create rate limit actions"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("header entry requires Header field to be set"))
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(0)))
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("failed to create rate limit actions"))
+				Expect(acceptedCond.Message).To(ContainSubstring("header entry requires Header field to be set"))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1073,9 +1083,10 @@ var _ = DescribeTable("Route Replacement",
 				Expect(accepted.Message).To(Equal("Route is accepted"))
 				Expect(accepted.ObservedGeneration).To(Equal(int64(0)))
 
-				// Expect no PartiallyInvalid condition since template validation is skipped in standard mode
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).To(BeNil())
+				// Expect Accepted=True condition since template validation is skipped in standard mode
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).ToNot(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionTrue))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1110,9 +1121,10 @@ var _ = DescribeTable("Route Replacement",
 				Expect(accepted.Message).To(Equal("Route is accepted"))
 				Expect(accepted.ObservedGeneration).To(Equal(int64(0)))
 
-				// Expect no PartiallyInvalid condition since template validation is skipped in standard mode
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).To(BeNil())
+				// Expect Accepted=True condition since template validation is skipped in standard mode
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).ToNot(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionTrue))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1146,9 +1158,10 @@ var _ = DescribeTable("Route Replacement",
 				Expect(accepted.Message).To(Equal("Route is accepted"))
 				Expect(accepted.ObservedGeneration).To(Equal(int64(0)))
 
-				// Expect no PartiallyInvalid condition since template validation is skipped in standard mode
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).To(BeNil())
+				// Expect no Accepted=False condition since template validation is skipped in standard mode
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).ToNot(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionTrue))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1173,13 +1186,13 @@ var _ = DescribeTable("Route Replacement",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("invalid xds configuration"))
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(0)))
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("invalid xds configuration"))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1204,13 +1217,13 @@ var _ = DescribeTable("Route Replacement",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("extauthz: extension not found"))
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(0)))
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("extauthz: extension not found"))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1235,13 +1248,13 @@ var _ = DescribeTable("Route Replacement",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("invalid xds configuration"))
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(0)))
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("invalid xds configuration"))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1266,13 +1279,13 @@ var _ = DescribeTable("Route Replacement",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("invalid xds configuration"))
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(0)))
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("invalid xds configuration"))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1297,13 +1310,13 @@ var _ = DescribeTable("Route Replacement",
 				Expect(routeStatus).NotTo(BeNil())
 				Expect(routeStatus.Parents).To(HaveLen(1))
 
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).NotTo(BeNil())
-				Expect(partiallyInvalid.Status).To(Equal(metav1.ConditionTrue))
-				Expect(partiallyInvalid.Reason).To(Equal(string(gwv1.RouteReasonUnsupportedValue)))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(partiallyInvalid.Message).To(ContainSubstring("invalid xds configuration"))
-				Expect(partiallyInvalid.ObservedGeneration).To(Equal(int64(0)))
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("invalid xds configuration"))
+				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		},
 		func(s *settings.Settings) {
@@ -1330,15 +1343,12 @@ var _ = DescribeTable("Route Replacement",
 
 				accepted := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
 				Expect(accepted).NotTo(BeNil())
+				// Template is structurally valid (passes xDS validation) but would fail at runtime
+				// Accepted=true condition should be set since it passes validation
 				Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
 				Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
 				Expect(accepted.Message).To(Equal("Route is accepted"))
 				Expect(accepted.ObservedGeneration).To(Equal(int64(0)))
-
-				// Template is structurally valid (passes xDS validation) but would fail at runtime
-				// No PartiallyInvalid condition should be set since it passes validation
-				partiallyInvalid := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionPartiallyInvalid))
-				Expect(partiallyInvalid).To(BeNil())
 			},
 		},
 		func(s *settings.Settings) {
@@ -1347,6 +1357,7 @@ var _ = DescribeTable("Route Replacement",
 )
 
 var _ = DescribeTable("Route Delegation",
+	// wantStatusErrors is an optional list of route,policy errors in that order
 	func(inputFile string, wantHTTPRouteErrors map[types.NamespacedName]string) {
 		dir := fsutils.MustGetThisDir()
 		test(
@@ -1361,8 +1372,8 @@ var _ = DescribeTable("Route Delegation",
 			},
 			func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
 				if wantHTTPRouteErrors == nil {
-					Expect(translatortest.AreReportsSuccess(gwNN, reportsMap)).NotTo(HaveOccurred())
-					return
+					// validate status on all routes
+					Expect(translatortest.GetHTTPRouteStatusError(reportsMap, nil)).NotTo(HaveOccurred())
 				}
 				for route, err := range wantHTTPRouteErrors {
 					Expect(translatortest.GetHTTPRouteStatusError(reportsMap, &route)).To(MatchError(ContainSubstring(err)))

--- a/internal/kgateway/translator/httproute/gateway_http_route_translator.go
+++ b/internal/kgateway/translator/httproute/gateway_http_route_translator.go
@@ -209,7 +209,7 @@ func setRouteAction(
 			)
 			if err != nil {
 				query.ProcessBackendError(err, reporter)
-				outputRoute.Error = err
+				outputRoute.RouteReplacementError = err
 			}
 			continue
 		}

--- a/pkg/pluginsdk/ir/gw2.go
+++ b/pkg/pluginsdk/ir/gw2.go
@@ -44,8 +44,12 @@ type HttpRouteRuleMatchIR struct {
 	// Higher weight means higher priority, and are evaluated before routes with lower weight
 	PrecedenceWeight int32
 
-	// Error encountered during translation
-	Error error
+	// RouteReplacementError is an error that results in the route being replaced
+	RouteReplacementError error
+
+	// RouteAcceptanceError is an error that results in the route being replaced and a status
+	// condition with Accepted=false,Reason=RouteRuleDropped
+	RouteAcceptanceError error
 }
 
 type ListenerIR struct {

--- a/pkg/pluginsdk/reporter/types.go
+++ b/pkg/pluginsdk/reporter/types.go
@@ -18,6 +18,9 @@ const (
 	PolicyMergedMsg = "Merged with other policies in target(s) and attached"
 
 	PolicyOverriddenMsg = "Overridden due to conflict with higher priority policy in target(s)"
+
+	// RouteRuleDroppedReason is used with the Accepted=False condition when the route rule is dropped
+	RouteRuleDroppedReason = "RouteRuleDropped"
 )
 
 // PolicyAttachmentState represents the state of a policy attachment

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 
@@ -353,11 +354,19 @@ func GetHTTPRouteStatusError(
 	reportsMap reports.ReportMap,
 	route *types.NamespacedName,
 ) error {
-	for nns, routeReport := range reportsMap.HTTPRoutes {
+	for nns := range reportsMap.HTTPRoutes {
 		if route != nil && nns != *route {
 			continue
 		}
-		for ref, parentRefReport := range routeReport.Parents {
+		r := gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nns.Name,
+				Namespace: nns.Namespace,
+			},
+		}
+		status := reportsMap.BuildRouteStatus(context.Background(), &r, wellknown.DefaultGatewayClassName)
+
+		for ref, parentRefReport := range status.Parents {
 			for _, c := range parentRefReport.Conditions {
 				// most route conditions true is good, except RouteConditionPartiallyInvalid
 				if c.Type == string(gwv1.RouteConditionPartiallyInvalid) && c.Status != metav1.ConditionFalse {
@@ -375,14 +384,15 @@ func GetPolicyStatusError(
 	reportsMap reports.ReportMap,
 	policy *reporter.PolicyKey,
 ) error {
-	for key, policyReport := range reportsMap.Policies {
+	for key := range reportsMap.Policies {
 		if policy != nil && *policy != key {
 			continue
 		}
-		for ancestor, report := range policyReport.Ancestors {
+		status := reportsMap.BuildPolicyStatus(context.Background(), key, wellknown.DefaultGatewayControllerName, gwv1a2.PolicyStatus{})
+		for ancestor, report := range status.Ancestors {
 			for _, c := range report.Conditions {
 				if c.Status != metav1.ConditionTrue {
-					return fmt.Errorf("condition error for policy: %v, ancestor ref: %v, condition: %v", policy, ancestor, c)
+					return fmt.Errorf("condition error for policy: %v, ancestor ref: %v, condition: %v", key, ancestor, c)
 				}
 			}
 		}
@@ -396,8 +406,16 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 		return err
 	}
 
-	for nns, routeReport := range reportsMap.TCPRoutes {
-		for ref, parentRefReport := range routeReport.Parents {
+	for nns := range reportsMap.TCPRoutes {
+		r := gwv1a2.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nns.Name,
+				Namespace: nns.Namespace,
+			},
+		}
+		status := reportsMap.BuildRouteStatus(context.Background(), &r, wellknown.DefaultGatewayClassName)
+
+		for ref, parentRefReport := range status.Parents {
 			for _, c := range parentRefReport.Conditions {
 				// most route conditions true is good, except RouteConditionPartiallyInvalid
 				if c.Type == string(gwv1.RouteConditionPartiallyInvalid) && c.Status != metav1.ConditionFalse {
@@ -409,8 +427,16 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 		}
 	}
 
-	for nns, routeReport := range reportsMap.TLSRoutes {
-		for ref, parentRefReport := range routeReport.Parents {
+	for nns := range reportsMap.TLSRoutes {
+		r := gwv1a2.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nns.Name,
+				Namespace: nns.Namespace,
+			},
+		}
+		status := reportsMap.BuildRouteStatus(context.Background(), &r, wellknown.DefaultGatewayClassName)
+
+		for ref, parentRefReport := range status.Parents {
 			for _, c := range parentRefReport.Conditions {
 				// most route conditions true is good, except RouteConditionPartiallyInvalid
 				if c.Type == string(gwv1.RouteConditionPartiallyInvalid) && c.Status != metav1.ConditionFalse {
@@ -422,8 +448,16 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 		}
 	}
 
-	for nns, routeReport := range reportsMap.GRPCRoutes {
-		for ref, parentRefReport := range routeReport.Parents {
+	for nns := range reportsMap.GRPCRoutes {
+		r := gwv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nns.Name,
+				Namespace: nns.Namespace,
+			},
+		}
+		status := reportsMap.BuildRouteStatus(context.Background(), &r, wellknown.DefaultGatewayClassName)
+
+		for ref, parentRefReport := range status.Parents {
 			for _, c := range parentRefReport.Conditions {
 				// most route conditions true is good, except RouteConditionPartiallyInvalid
 				if c.Type == string(gwv1.RouteConditionPartiallyInvalid) && c.Status != metav1.ConditionFalse {
@@ -435,8 +469,15 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 		}
 	}
 
-	for nns, gwReport := range reportsMap.Gateways {
-		for _, c := range gwReport.GetConditions() {
+	for nns := range reportsMap.Gateways {
+		g := gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nns.Name,
+				Namespace: nns.Namespace,
+			},
+		}
+		status := reportsMap.BuildGWStatus(context.Background(), g)
+		for _, c := range status.Conditions {
 			if c.Type == listener.AttachedListenerSetsConditionType {
 				// A gateway might or might not have AttachedListenerSets so skip this condition
 				continue


### PR DESCRIPTION
# Description
PartiallyInvalid condition has several problems:
1. It must be set only when PartiallyInvalid=True. This requires extra logic to invalidate an existing condition when there should be no PartiallyInvalid condition on an updated route status.
2. PartiallyInvalid must only be set when the route is partially invalid and not fully invalid. This requires post processing as translation merges routes with the same hostname and tracking whether a route is only partially invalid needs to group translated route rules by their parent route and check the rules for validity.

This change drops the usage of PartiallyInvalid=True in favor of Accepted=False with Reason=RouteRuleDropped. A replaced route rule will have this condition set. A route is replaced in case there are processing errors or errors on the HTTPRouteRuleMatchIr, however the condition is only set if there are processing errors from runRoutePlugins. In the case of delegating/parent routes, it is expected for the route to not have an Action set, in this case return early as the rule simply delegates and is not relevant for the final output.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes

Resolves #11801
Resolves #11761
Resolves #11315