### PR TITLE
plugins/tp: Rename TrafficPolicyBuilder to TrafficPolicyConstructor

### DIFF
--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
@@ -102,8 +102,8 @@ func (a *aiPolicyIR) Validate() error {
 	return nil
 }
 
-// applyAI processes the AI policy specification and sets the corresponding IR in the output spec
-func applyAI(
+// constructAI processes the AI policy specification and sets the corresponding IR in the output spec
+func constructAI(
 	krtctx krt.HandlerContext,
 	policyCR *v1alpha1.TrafficPolicy,
 	secrets *krtcollections.SecretIndex,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
@@ -102,7 +102,7 @@ func (a *aiPolicyIR) Validate() error {
 	return nil
 }
 
-// constructAI processes the AI policy specification and sets the corresponding IR in the output spec
+// constructAI constructs the AI policy IR from the policy specification.
 func constructAI(
 	krtctx krt.HandlerContext,
 	policyCR *v1alpha1.TrafficPolicy,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/auto_host_rewrite.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/auto_host_rewrite.go
@@ -31,8 +31,8 @@ func (a *autoHostRewriteIR) Equals(other PolicySubIR) bool {
 // needed as it's a single bool field.
 func (a *autoHostRewriteIR) Validate() error { return nil }
 
-// applyAutoHostRewrite translates the auto host rewrite spec into an envoy auto host rewrite policy and stores it in the traffic policy IR
-func applyAutoHostRewrite(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) {
+// constructAutoHostRewrite translates the auto host rewrite spec into an envoy auto host rewrite policy and stores it in the traffic policy IR
+func constructAutoHostRewrite(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) {
 	if spec.AutoHostRewrite == nil {
 		return
 	}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/auto_host_rewrite.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/auto_host_rewrite.go
@@ -31,7 +31,7 @@ func (a *autoHostRewriteIR) Equals(other PolicySubIR) bool {
 // needed as it's a single bool field.
 func (a *autoHostRewriteIR) Validate() error { return nil }
 
-// constructAutoHostRewrite translates the auto host rewrite spec into an envoy auto host rewrite policy and stores it in the traffic policy IR
+// constructAutoHostRewrite constructs the auto host rewrite policy IR from the policy specification.
 func constructAutoHostRewrite(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) {
 	if spec.AutoHostRewrite == nil {
 		return

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/buffer.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/buffer.go
@@ -36,8 +36,8 @@ func (b *bufferIR) Equals(other PolicySubIR) bool {
 // Note: buffer validation is not needed as it's a single uint32 field
 func (b *bufferIR) Validate() error { return nil }
 
-// applyBuffer translates the buffer spec into an envoy buffer policy and stores it in the traffic policy IR.
-func applyBuffer(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) {
+// constructBuffer translates the buffer spec into an envoy buffer policy and stores it in the traffic policy IR.
+func constructBuffer(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) {
 	if spec.Buffer == nil {
 		return
 	}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/buffer.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/buffer.go
@@ -36,7 +36,7 @@ func (b *bufferIR) Equals(other PolicySubIR) bool {
 // Note: buffer validation is not needed as it's a single uint32 field
 func (b *bufferIR) Validate() error { return nil }
 
-// constructBuffer translates the buffer spec into an envoy buffer policy and stores it in the traffic policy IR.
+// constructBuffer constructs the buffer policy IR from the policy specification.
 func constructBuffer(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) {
 	if spec.Buffer == nil {
 		return

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
@@ -37,7 +37,7 @@ func TestBufferForSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := &trafficPolicySpecIr{}
-			applyBuffer(tt.spec, out)
+			constructBuffer(tt.spec, out)
 
 			if tt.expected == nil {
 				assert.Nil(t, out.buffer)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/constructor.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/constructor.go
@@ -93,7 +93,7 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 	constructBuffer(policyCR.Spec, &outSpec)
 
 	for _, err := range errors {
-		logger.Error("error constructing gateway extension IR", "namespace", policyCR.GetNamespace(), "name", policyCR.GetName(), "error", err)
+		logger.Error("error translating gateway extension", "namespace", policyCR.GetNamespace(), "name", policyCR.GetName(), "error", err)
 	}
 	policyIr.spec = outSpec
 

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/constructor.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/constructor.go
@@ -16,29 +16,29 @@ import (
 // FetchGatewayExtensionFunc defines the signature for fetching gateway extensions
 type FetchGatewayExtensionFunc func(krtctx krt.HandlerContext, extensionRef *corev1.LocalObjectReference, ns string) (*TrafficPolicyGatewayExtensionIR, error)
 
-type TrafficPolicyBuilder struct {
+type TrafficPolicyConstructor struct {
 	commoncol         *common.CommonCollections
 	gatewayExtensions krt.Collection[TrafficPolicyGatewayExtensionIR]
 	extBuilder        func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR
 }
 
-func NewTrafficPolicyBuilder(
+func NewTrafficPolicyConstructor(
 	ctx context.Context,
 	commoncol *common.CommonCollections,
-) *TrafficPolicyBuilder {
+) *TrafficPolicyConstructor {
 	extBuilder := TranslateGatewayExtensionBuilder(commoncol)
 	defaultExtBuilder := func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {
 		return extBuilder(krtctx, gExt)
 	}
 	gatewayExtensions := krt.NewCollection(commoncol.GatewayExtensions, defaultExtBuilder)
-	return &TrafficPolicyBuilder{
+	return &TrafficPolicyConstructor{
 		commoncol:         commoncol,
 		gatewayExtensions: gatewayExtensions,
 		extBuilder:        extBuilder,
 	}
 }
 
-func (b *TrafficPolicyBuilder) Translate(
+func (c *TrafficPolicyConstructor) ConstructIR(
 	krtctx krt.HandlerContext,
 	policyCR *v1alpha1.TrafficPolicy,
 ) (*TrafficPolicy, []error) {
@@ -48,63 +48,63 @@ func (b *TrafficPolicyBuilder) Translate(
 	outSpec := trafficPolicySpecIr{}
 
 	var errors []error
-	// Apply AI specific translation
-	if err := applyAI(krtctx, policyCR, b.commoncol.Secrets, &outSpec); err != nil {
+	// Construct AI specific IR
+	if err := constructAI(krtctx, policyCR, c.commoncol.Secrets, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply transformation specific translation
-	if err := applyTransformation(policyCR, &outSpec); err != nil {
+	// Construct transformation specific IR
+	if err := constructTransformation(policyCR, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply rustformation specific translation
-	if err := applyRustformation(policyCR, &outSpec); err != nil {
+	// Construct rustformation specific IR
+	if err := constructRustformation(policyCR, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply extproc specific translation
-	if err := applyExtProc(krtctx, policyCR, b.FetchGatewayExtension, &outSpec); err != nil {
+	// Construct extproc specific IR
+	if err := constructExtProc(krtctx, policyCR, c.FetchGatewayExtension, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply extauth specific translation
-	if err := applyExtAuth(krtctx, policyCR, b.FetchGatewayExtension, &outSpec); err != nil {
+	// Construct extauth specific IR
+	if err := constructExtAuth(krtctx, policyCR, c.FetchGatewayExtension, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply local rate limit specific translation
-	if err := applyLocalRateLimit(policyCR, &outSpec); err != nil {
+	// Construct local rate limit specific IR
+	if err := constructLocalRateLimit(policyCR, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply global rate limit specific translation
-	if err := applyGlobalRateLimit(krtctx, policyCR, b.FetchGatewayExtension, &outSpec); err != nil {
+	// Construct global rate limit specific IR
+	if err := constructGlobalRateLimit(krtctx, policyCR, c.FetchGatewayExtension, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply cors specific translation
-	if err := applyCORS(policyCR, &outSpec); err != nil {
+	// Construct cors specific IR
+	if err := constructCORS(policyCR, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
-	// Apply csrf specific translation
-	if err := applyCSRF(policyCR.Spec, &outSpec); err != nil {
+	// Construct csrf specific IR
+	if err := constructCSRF(policyCR.Spec, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
 
-	// Apply hash policy specific translation
-	applyHashPolicy(policyCR.Spec, &outSpec)
-	// Apply auto host rewrite specific translation
-	applyAutoHostRewrite(policyCR.Spec, &outSpec)
-	// Apply buffer specific translation
-	applyBuffer(policyCR.Spec, &outSpec)
+	// Construct hash policy specific IR
+	constructHashPolicy(policyCR.Spec, &outSpec)
+	// Construct auto host rewrite specific IR
+	constructAutoHostRewrite(policyCR.Spec, &outSpec)
+	// Construct buffer specific IR
+	constructBuffer(policyCR.Spec, &outSpec)
 
 	for _, err := range errors {
-		logger.Error("error translating gateway extension", "namespace", policyCR.GetNamespace(), "name", policyCR.GetName(), "error", err)
+		logger.Error("error constructing gateway extension IR", "namespace", policyCR.GetNamespace(), "name", policyCR.GetName(), "error", err)
 	}
 	policyIr.spec = outSpec
 
 	return &policyIr, errors
 }
 
-func (b *TrafficPolicyBuilder) FetchGatewayExtension(krtctx krt.HandlerContext, extensionRef *corev1.LocalObjectReference, ns string) (*TrafficPolicyGatewayExtensionIR, error) {
+func (c *TrafficPolicyConstructor) FetchGatewayExtension(krtctx krt.HandlerContext, extensionRef *corev1.LocalObjectReference, ns string) (*TrafficPolicyGatewayExtensionIR, error) {
 	var gatewayExtension *TrafficPolicyGatewayExtensionIR
 	if extensionRef != nil {
 		gwExtName := types.NamespacedName{Name: extensionRef.Name, Namespace: ns}
-		gatewayExtension = krt.FetchOne(krtctx, b.gatewayExtensions, krt.FilterObjectName(gwExtName))
+		gatewayExtension = krt.FetchOne(krtctx, c.gatewayExtensions, krt.FilterObjectName(gwExtName))
 	}
 	if gatewayExtension == nil {
 		return nil, fmt.Errorf("extension not found")
@@ -115,6 +115,6 @@ func (b *TrafficPolicyBuilder) FetchGatewayExtension(krtctx krt.HandlerContext, 
 	return gatewayExtension, nil
 }
 
-func (b *TrafficPolicyBuilder) HasSynced() bool {
-	return b.gatewayExtensions.HasSynced()
+func (c *TrafficPolicyConstructor) HasSynced() bool {
+	return c.gatewayExtensions.HasSynced()
 }

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/cors_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/cors_policy.go
@@ -38,7 +38,7 @@ func (c *corsIR) Validate() error {
 	return c.policy.Validate()
 }
 
-// constructCORS translates the cors spec into an envoy cors policy and stores it in the traffic policy IR.
+// constructCORS constructs the CORS policy IR from the policy specification.
 func constructCORS(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.Cors == nil {
 		return nil

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/cors_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/cors_policy.go
@@ -38,8 +38,8 @@ func (c *corsIR) Validate() error {
 	return c.policy.Validate()
 }
 
-// applyCORS translates the cors spec into an envoy cors policy and stores it in the traffic policy IR.
-func applyCORS(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
+// constructCORS translates the cors spec into an envoy cors policy and stores it in the traffic policy IR.
+func constructCORS(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.Cors == nil {
 		return nil
 	}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/csrf_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/csrf_policy.go
@@ -62,8 +62,8 @@ func (p *trafficPolicyPluginGwPass) handleCsrf(fcn string, typedFilterConfig *ir
 	}
 }
 
-// applyCSRF translates the CSRF spec into and onto the IR policy.
-func applyCSRF(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) error {
+// constructCSRF translates the CSRF spec into and onto the IR policy.
+func constructCSRF(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) error {
 	if spec.Csrf == nil {
 		return nil
 	}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/csrf_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/csrf_policy.go
@@ -62,7 +62,7 @@ func (p *trafficPolicyPluginGwPass) handleCsrf(fcn string, typedFilterConfig *ir
 	}
 }
 
-// constructCSRF translates the CSRF spec into and onto the IR policy.
+// constructCSRF constructs the CSRF policy IR from the policy specification.
 func constructCSRF(spec v1alpha1.TrafficPolicySpec, out *trafficPolicySpecIr) error {
 	if spec.Csrf == nil {
 		return nil

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
@@ -98,8 +98,8 @@ func (e *extAuthIR) Validate() error {
 	return nil
 }
 
-// applyExtAuth converts the extauth policy spec to the IR.
-func applyExtAuth(
+// constructExtAuth converts the extauth policy spec to the IR.
+func constructExtAuth(
 	krtctx krt.HandlerContext,
 	in *v1alpha1.TrafficPolicy,
 	fetchGatewayExtension FetchGatewayExtensionFunc,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
@@ -98,7 +98,7 @@ func (e *extAuthIR) Validate() error {
 	return nil
 }
 
-// constructExtAuth converts the extauth policy spec to the IR.
+// constructExtAuth constructs the external authentication policy IR from the policy specification.
 func constructExtAuth(
 	krtctx krt.HandlerContext,
 	in *v1alpha1.TrafficPolicy,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extproc_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extproc_policy.go
@@ -59,8 +59,8 @@ func (e *extprocIR) Validate() error {
 	return nil
 }
 
-// applyExtProc converts the extproc policy spec to the IR.
-func applyExtProc(
+// constructExtProc converts the extproc policy spec to the IR.
+func constructExtProc(
 	krtctx krt.HandlerContext,
 	in *v1alpha1.TrafficPolicy,
 	fetchGatewayExtension FetchGatewayExtensionFunc,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extproc_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extproc_policy.go
@@ -59,7 +59,7 @@ func (e *extprocIR) Validate() error {
 	return nil
 }
 
-// constructExtProc converts the extproc policy spec to the IR.
+// constructExtProc constructs the external processing policy IR from the policy specification.
 func constructExtProc(
 	krtctx krt.HandlerContext,
 	in *v1alpha1.TrafficPolicy,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
@@ -77,8 +77,8 @@ func (r *globalRateLimitIR) Validate() error {
 	return nil
 }
 
-// applyGlobalRateLimit translates the global rate limit spec into and onto the IR policy.
-func applyGlobalRateLimit(
+// constructGlobalRateLimit translates the global rate limit spec into and onto the IR policy.
+func constructGlobalRateLimit(
 	krtctx krt.HandlerContext,
 	in *v1alpha1.TrafficPolicy,
 	fetchGatewayExtension FetchGatewayExtensionFunc,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
@@ -77,7 +77,7 @@ func (r *globalRateLimitIR) Validate() error {
 	return nil
 }
 
-// constructGlobalRateLimit translates the global rate limit spec into and onto the IR policy.
+// constructGlobalRateLimit constructs the global rate limit policy IR from the policy specification.
 func constructGlobalRateLimit(
 	krtctx krt.HandlerContext,
 	in *v1alpha1.TrafficPolicy,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/hash_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/hash_policy.go
@@ -51,8 +51,8 @@ func (h *hashPolicyIR) Validate() error {
 	return nil
 }
 
-// applyHashPolicy converts the hash policy spec to the IR.
-func applyHashPolicy(spec v1alpha1.TrafficPolicySpec, outSpec *trafficPolicySpecIr) {
+// constructHashPolicy converts the hash policy spec to the IR.
+func constructHashPolicy(spec v1alpha1.TrafficPolicySpec, outSpec *trafficPolicySpecIr) {
 	if len(spec.HashPolicies) == 0 {
 		return
 	}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/hash_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/hash_policy.go
@@ -51,7 +51,7 @@ func (h *hashPolicyIR) Validate() error {
 	return nil
 }
 
-// constructHashPolicy converts the hash policy spec to the IR.
+// constructHashPolicy constructs the hash policy IR from the policy specification.
 func constructHashPolicy(spec v1alpha1.TrafficPolicySpec, outSpec *trafficPolicySpecIr) {
 	if len(spec.HashPolicies) == 0 {
 		return

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/hash_policy_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/hash_policy_test.go
@@ -345,7 +345,7 @@ func TestHashPolicyForSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			outSpec := &trafficPolicySpecIr{}
-			applyHashPolicy(tt.spec, outSpec)
+			constructHashPolicy(tt.spec, outSpec)
 
 			var actual []*envoyroutev3.RouteAction_HashPolicy
 			if outSpec.hashPolicies != nil {

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/local_rate_limit_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/local_rate_limit_plugin.go
@@ -45,7 +45,7 @@ func (l *localRateLimitIR) Validate() error {
 	return l.config.ValidateAll()
 }
 
-// constructLocalRateLimit converts the local rate limit policy spec to the IR.
+// constructLocalRateLimit constructs the local rate limit policy IR from the policy specification.
 func constructLocalRateLimit(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.RateLimit == nil || in.Spec.RateLimit.Local == nil {
 		return nil

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/local_rate_limit_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/local_rate_limit_plugin.go
@@ -45,8 +45,8 @@ func (l *localRateLimitIR) Validate() error {
 	return l.config.ValidateAll()
 }
 
-// applyLocalRateLimit converts the local rate limit policy spec to the IR.
-func applyLocalRateLimit(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
+// constructLocalRateLimit converts the local rate limit policy spec to the IR.
+func constructLocalRateLimit(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.RateLimit == nil || in.Spec.RateLimit.Local == nil {
 		return nil
 	}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -220,7 +220,7 @@ func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensi
 	), commoncol.KrtOpts.ToOptions("TrafficPolicy")...)
 	gk := wellknown.TrafficPolicyGVK.GroupKind()
 
-	translator := NewTrafficPolicyBuilder(ctx, commoncol)
+	translator := NewTrafficPolicyConstructor(ctx, commoncol)
 	v := validator.New()
 
 	// TrafficPolicy IR will have TypedConfig -> implement backendroute method to add prompt guard, etc.
@@ -232,7 +232,7 @@ func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensi
 			Name:      policyCR.Name,
 		}
 
-		policyIR, errors := translator.Translate(krtctx, policyCR)
+		policyIR, errors := translator.ConstructIR(krtctx, policyCR)
 		if err := validateWithRouteReplacementMode(ctx, policyIR, v, commoncol.Settings.RouteReplacementMode); err != nil {
 			logger.Error("validation failed", "policy", policyCR.Name, "error", err)
 			errors = append(errors, err)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
@@ -42,7 +42,7 @@ func (t *transformationIR) Validate() error {
 	return t.config.ValidateAll()
 }
 
-// constructTransformation converts the transformation policy spec to the IR.
+// constructTransformation constructs the transformation policy IR from the policy specification.
 func constructTransformation(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.Transformation == nil && !useRustformations {
 		return nil
@@ -195,6 +195,7 @@ func (r *rustformationIR) Validate() error {
 	return r.config.ValidateAll()
 }
 
+// constructRustformation constructs the rustformation policy IR from the policy specification.
 func constructRustformation(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.Transformation == nil || !useRustformations {
 		return nil

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
@@ -42,8 +42,8 @@ func (t *transformationIR) Validate() error {
 	return t.config.ValidateAll()
 }
 
-// applyTransformation converts the transformation policy spec to the IR.
-func applyTransformation(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
+// constructTransformation converts the transformation policy spec to the IR.
+func constructTransformation(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.Transformation == nil && !useRustformations {
 		return nil
 	}
@@ -195,7 +195,7 @@ func (r *rustformationIR) Validate() error {
 	return r.config.ValidateAll()
 }
 
-func applyRustformation(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
+func constructRustformation(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr) error {
 	if in.Spec.Transformation == nil || !useRustformations {
 		return nil
 	}

--- a/pkg/plugins/gwextbase/base.go
+++ b/pkg/plugins/gwextbase/base.go
@@ -18,7 +18,7 @@ import (
 
 type (
 	TrafficPolicy                   = trafficpolicy.TrafficPolicy
-	TrafficPolicyBuilder            = trafficpolicy.TrafficPolicyBuilder
+	TrafficPolicyConstructor        = trafficpolicy.TrafficPolicyConstructor
 	ProviderNeededMap               = trafficpolicy.ProviderNeededMap
 	TrafficPolicyGatewayExtensionIR = trafficpolicy.TrafficPolicyGatewayExtensionIR
 )
@@ -29,12 +29,12 @@ var (
 	MergeTrafficPolicies           = trafficpolicy.MergeTrafficPolicies
 )
 
-// Create a traffic policy builder. This converts a traffic policy into its IR form.
-func NewTrafficPolicyBuilder(
+// Create a traffic policy constructor. This converts a traffic policy into its IR form.
+func NewTrafficPolicyConstructor(
 	ctx context.Context,
 	commoncol *common.CommonCollections,
-) *trafficpolicy.TrafficPolicyBuilder {
-	return trafficpolicy.NewTrafficPolicyBuilder(ctx, commoncol)
+) *trafficpolicy.TrafficPolicyConstructor {
+	return trafficpolicy.NewTrafficPolicyConstructor(ctx, commoncol)
 }
 
 func NewGatewayTranslationPass(ctx context.Context, tctx ir.GwTranslationCtx, reporter reports.Reporter) ir.ProxyTranslationPass {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The current TrafficPolicy implementation has a naming conflict between two distinct
phases in the plugin lifecycle that both use "apply" terminology:

- Phase 1: Spec -> IR conversion. Currently implemented via applyX() functions
- Phase 2: IR -> xDS application. There's are the existing ApplyForX() methods

The current naming created confusion since both phases used "apply"
terminology, and "builder" didn't match the actual construction pattern.

This commit refactors the builder.go file, renames it to constructor.go,
updates the type and the Translate method naming to better reflect the
responsibility for this type, etc. Additionally, it makes a breaking
changes to the pkg/ public surface for the alias'd type.

This change provides better semantic clarity consumption while avoiding conflicts
with existing "translation" terminology used for the overall k8s resource -> xDS
process.

Phases After This Change:

| Phase | Responsibility | Key Files / Methods | Terminology |
|-------|----------------|---------------------|-------------|
| 1 | Convert Kubernetes **Spec → IR** | `constructor.go`, `Constructor.ConstructX()` | **Construction** |
| 2 | Materialize **IR → Envoy xDS** and push | existing `ApplyForX()` helpers | **Application** |

Fixes #11432.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
