### PR TITLE
ir: fix Equals for HttpRouteIr and PolicyAtt

### DIFF
--- a/devel/contributing/conventions.md
+++ b/devel/contributing/conventions.md
@@ -1,4 +1,5 @@
 # Contribution Conventions
+
 ## Coding Conventions
 - Bash
     - [Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
@@ -10,6 +11,10 @@
     - Errors:
         - Error variables with a fixed string should start with `Err` - [Examples from `io/fs`](https://pkg.go.dev/io/fs#pkg-variables)
         - Error types should be descriptive and end with `Error` - [PathError example from `io/fs`](https://pkg.go.dev/io/fs#PathError)
+
+### IR Conventions
+- IRs that are outputs of a KRT collection must implement the `Equals` method.
+- Generally, all fields in the IR must be compared in the `Equals` method. If a field is explicitly omitted, it must have the `+noKrtEquals` marker in the last line of its leading comments. Currently, `+noKrtEquals` is only used for documentation but may be used by a tool in the future to detect fields unintentionally omitted in the `Equals` method.
 
 ## Testing conventions
 See [writing tests](/devel/testing/writing-tests.md) for more details about writing tests.

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/backendref"
 	tmetrics "github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/metrics"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/utils"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/delegation"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
@@ -1155,7 +1156,8 @@ func (h *RoutesIndex) transformHttpRoute(kctx krt.HandlerContext, i *gwv1.HTTPRo
 			h.policies.getTargetingPolicies(kctx, extensionsplug.RouteAttachmentPoint, src, "", i.GetLabels()),
 			ir.WithInheritedPolicyPriority(inheritedPolicyPriority),
 		),
-		PrecedenceWeight: precedenceWeight,
+		PrecedenceWeight:               precedenceWeight,
+		DelegationInheritParentMatcher: delegation.ShouldInheritParentMatcher(i.GetAnnotations()),
 	}
 }
 

--- a/internal/kgateway/translator/httproute/delegation_helpers.go
+++ b/internal/kgateway/translator/httproute/delegation_helpers.go
@@ -56,7 +56,7 @@ func filterDelegatedChildren(
 		child.Rules = make([]ir.HttpRouteRuleIR, len(origChild.Rules))
 		copy(child.Rules, origChild.Rules)
 
-		inheritMatcher := delegationutils.ShouldInheritParentMatcher(child.SourceObject.GetAnnotations())
+		inheritMatcher := child.DelegationInheritParentMatcher
 
 		// We use validRules to store the rules in the child route that are valid
 		// (matches in the rule match the parent route matcher). If a specific rule

--- a/pkg/pluginsdk/ir/gw_test.go
+++ b/pkg/pluginsdk/ir/gw_test.go
@@ -2,9 +2,12 @@ package ir
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
 )
 
 func TestPolicyApplyOrderedGroupKinds(t *testing.T) {
@@ -48,6 +51,163 @@ func TestPolicyApplyOrderedGroupKinds(t *testing.T) {
 			ap := AttachedPolicies{Policies: tt.policies}
 			got := ap.ApplyOrderedGroupKinds()
 			tt.assertFn(a, got)
+		})
+	}
+}
+
+// Mock PolicyIR implementation for testing
+type mockPolicyIR struct {
+	time   time.Time
+	equals bool
+}
+
+func (m mockPolicyIR) CreationTime() time.Time {
+	return m.time
+}
+
+func (m mockPolicyIR) Equals(other any) bool {
+	return m.equals
+}
+
+func TestPolicyAttEquals(t *testing.T) {
+	equalIR := mockPolicyIR{
+		equals: true,
+	}
+	unequalIR := mockPolicyIR{
+		equals: false,
+	}
+
+	testCases := []struct {
+		name string
+		a, b PolicyAtt
+		want bool
+	}{
+		{
+			name: "identical",
+			a: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			b: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			want: true,
+		},
+		{
+			name: "different GroupKind",
+			a: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test1", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			b: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test2", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			want: false,
+		},
+		{
+			name: "different Generation",
+			a: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			b: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              2,
+				PolicyIr:                equalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			want: false,
+		},
+		{
+			name: "different PolicyIr",
+			a: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                unequalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			b: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               nil,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			want: false,
+		},
+		{
+			name: "different PolicyRef",
+			a: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               &AttachedPolicyRef{Group: "test", Kind: "Policy", Name: "policy1"},
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			b: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				PolicyRef:               &AttachedPolicyRef{Group: "test", Kind: "Policy", Name: "policy2"},
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			want: false,
+		},
+		{
+			name: "different InheritedPolicyPriority",
+			a: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				InheritedPolicyPriority: "",
+				Errors:                  nil,
+			},
+			b: PolicyAtt{
+				GroupKind:               schema.GroupKind{Group: "test", Kind: "Policy"},
+				Generation:              1,
+				PolicyIr:                equalIR,
+				InheritedPolicyPriority: apiannotations.ShallowMergePreferParent,
+				Errors:                  nil,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+
+			got := tc.a.Equals(tc.b)
+			a.Equal(tc.want, got)
 		})
 	}
 }

--- a/pkg/pluginsdk/ir/routes.go
+++ b/pkg/pluginsdk/ir/routes.go
@@ -33,6 +33,10 @@ type HttpRouteIR struct {
 	// PrecedenceWeight specifies the weight of this route relative to other route.
 	// Higher weight means higher priority, and are evaluated before routes with lower weight
 	PrecedenceWeight int32
+
+	// DelegationInheritParentMatcher indicates if the route should inherit the parent matcher
+	// from the parent route delegating to it
+	DelegationInheritParentMatcher bool
 }
 
 func (c *HttpRouteIR) GetParentRefs() []gwv1.ParentReference {
@@ -61,11 +65,15 @@ var (
 )
 
 func (c HttpRouteIR) Equals(in HttpRouteIR) bool {
-	// TODO: equals should take the attached policies to account too!
 	// as backends resolution may change when they are added/remove we need to check equality for them as well
 	// we don't need to check the whole backend, just the cluster name (that may swap in and out of black-hole)
 	// note - if we stop setting cluster to black whole here (and always set it to the expect cluster name) we can remove the backend equality check.
-	return c.ObjectSource == in.ObjectSource && versionEquals(c.SourceObject, in.SourceObject) && c.AttachedPolicies.Equals(in.AttachedPolicies) && c.rulesEqual(in)
+	return c.ObjectSource == in.ObjectSource &&
+		versionEquals(c.SourceObject, in.SourceObject) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		c.rulesEqual(in) &&
+		c.PrecedenceWeight == in.PrecedenceWeight &&
+		c.DelegationInheritParentMatcher == in.DelegationInheritParentMatcher
 }
 
 func (c HttpRouteIR) rulesEqual(in HttpRouteIR) bool {


### PR DESCRIPTION
#  Description
Fixes Equals check so that configuration derived
from annotations are reconciled on updates.

- HTTPRoutes with relevant annotation updates were not triggering translation. PrecedenceWeight changes and DelegationInheritParentMatcher are considered in the Equals check now. Both these fields are derived from annotations on the HTTPRoute.

- PolicyAtt.Equals needs to consider InheritedPolicyPriority to update the policies when a route's inherited policy priority is updated using the corresponding annotation.

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
NONE
```

# Additional Notes
Resolves #11789