### PR TITLE
changed controller tests from ginkgo to stdlib following the same tes…

### DIFF
--- a/internal/kgateway/controller/gatewayclass_provisioner_test.go
+++ b/internal/kgateway/controller/gatewayclass_provisioner_test.go
@@ -2,10 +2,9 @@ package controller_test
 
 import (
 	"context"
+	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -19,235 +18,264 @@ const (
 	interval = time.Millisecond * 250
 )
 
-var _ = Describe("GatewayClassProvisioner", func() {
-	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-	)
+func TestGatewayClassProvisioner(t *testing.T) {
+	t.Run("no GatewayClasses exist on the cluster", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer func() {
+			if cancel != nil {
+				cancel()
+			}
+			// ensure goroutines cleanup
+			time.Sleep(3 * time.Second)
+		}()
 
-	BeforeEach(func() {
-		ctx, cancel = context.WithCancel(context.Background())
+		managerCancel, err := createManager(ctx, nil, nil)
+		assertNoError(t, err)
+		defer managerCancel()
+
+		// should create the default GCs
+		assertEventually(t, func() bool {
+			gcs := &apiv1.GatewayClassList{}
+			err := k8sClient.List(ctx, gcs)
+			if err != nil {
+				return false
+			}
+			if len(gcs.Items) != gwClasses.Len() {
+				return false
+			}
+			for _, gc := range gcs.Items {
+				if !gwClasses.Has(gc.Name) {
+					return false
+				}
+			}
+			return true
+		}, timeout, interval, "expected default GatewayClasses to be created")
 	})
 
-	AfterEach(func() {
-		if cancel != nil {
-			cancel()
+	t.Run("existing GatewayClasses from other controllers exist on the cluster", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer func() {
+			if cancel != nil {
+				cancel()
+			}
+			// ensure goroutines cleanup
+			time.Sleep(3 * time.Second)
+		}()
+
+		// Create GatewayClass owned by another controller
+		otherGC := &apiv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "other-controller",
+			},
+			Spec: apiv1.GatewayClassSpec{
+				ControllerName: "other.controller/name",
+			},
 		}
-		// ensure goroutines cleanup
-		Eventually(func() bool { return true }).WithTimeout(3 * time.Second).Should(BeTrue())
-	})
+		assertNoError(t, k8sClient.Create(ctx, otherGC))
+		defer func() {
+			k8sClient.Delete(ctx, otherGC)
+		}()
 
-	When("no GatewayClasses exist on the cluster", func() {
-		BeforeEach(func() {
-			var err error
-			cancel, err = createManager(ctx, nil, nil)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		// Create our GatewayClass but with wrong controller
+		wrongControllerGC := &apiv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "wrong-controller",
+			},
+			Spec: apiv1.GatewayClassSpec{
+				ControllerName: "wrong.controller/name",
+			},
+		}
+		assertNoError(t, k8sClient.Create(ctx, wrongControllerGC))
+		defer func() {
+			k8sClient.Delete(ctx, wrongControllerGC)
+		}()
 
-		It("should create the default GCs", func() {
-			Eventually(func() bool {
-				gcs := &apiv1.GatewayClassList{}
-				err := k8sClient.List(ctx, gcs)
-				if err != nil {
+		managerCancel, err := createManager(ctx, nil, nil)
+		assertNoError(t, err)
+		defer managerCancel()
+
+		// should create our GCs and not affect others
+		// verifying our GatewayClasses are created with correct controller
+		assertEventually(t, func() bool {
+			for className := range gwClasses {
+				gc := &apiv1.GatewayClass{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: className}, gc); err != nil {
 					return false
 				}
-				if len(gcs.Items) != gwClasses.Len() {
+				if gc.Spec.ControllerName != apiv1.GatewayController(gatewayControllerName) {
 					return false
 				}
-				for _, gc := range gcs.Items {
-					if !gwClasses.Has(gc.Name) {
-						return false
-					}
-				}
-				return true
-			}, timeout, interval).Should(BeTrue())
-		})
+			}
+			return true
+		}, timeout, interval, "expected our GatewayClasses to be created with correct controller")
 	})
 
-	When("existing GatewayClasses from other controllers exist on the cluster", func() {
-		var (
-			otherGC           *apiv1.GatewayClass
-			wrongControllerGC *apiv1.GatewayClass
-		)
-		BeforeEach(func() {
-			// Create GatewayClass owned by another controller
-			otherGC = &apiv1.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "other-controller",
-				},
-				Spec: apiv1.GatewayClassSpec{
-					ControllerName: "other.controller/name",
-				},
+	t.Run("the default GCs are deleted", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer func() {
+			if cancel != nil {
+				cancel()
 			}
-			Expect(k8sClient.Create(ctx, otherGC)).To(Succeed())
+			// ensure goroutines cleanup
+			time.Sleep(3 * time.Second)
+		}()
 
-			// Create our GatewayClass but with wrong controller
-			wrongControllerGC = &apiv1.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "wrong-controller",
-				},
-				Spec: apiv1.GatewayClassSpec{
-					ControllerName: "wrong.controller/name",
-				},
+		managerCancel, err := createManager(ctx, nil, nil)
+		assertNoError(t, err)
+		defer managerCancel()
+
+		// wait for the default GCs to be created, especially needed if this is the first test to run
+		gc := &apiv1.GatewayClass{}
+		assertEventually(t, func() bool {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc) == nil
+		}, timeout, interval, "expected default GatewayClass to be created initially")
+
+		// deleting the default GCs
+		for name := range gwClasses {
+			err := k8sClient.Delete(ctx, &apiv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: name}})
+			assertNoError(t, err)
+		}
+
+		// waiting for the GCs to be recreated - should be recreated by the provisioner
+		assertEventually(t, func() bool {
+			gcs := &apiv1.GatewayClassList{}
+			err := k8sClient.List(ctx, gcs)
+			if err != nil {
+				return false
 			}
-			Expect(k8sClient.Create(ctx, wrongControllerGC)).To(Succeed())
+			return len(gcs.Items) == gwClasses.Len()
+		}, timeout, interval, "expected GatewayClasses to be recreated after deletion")
 
-			var err error
-			cancel, err = createManager(ctx, nil, nil)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			// Cleanup the test GatewayClasses
-			Expect(k8sClient.Delete(ctx, otherGC)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, wrongControllerGC)).To(Succeed())
-		})
-
-		It("should create our GCs and not affect others", func() {
-			By("verifying our GatewayClasses are created with correct controller")
-			Eventually(func() bool {
-				for className := range gwClasses {
-					gc := &apiv1.GatewayClass{}
-					if err := k8sClient.Get(ctx, types.NamespacedName{Name: className}, gc); err != nil {
-						return false
-					}
-					if gc.Spec.ControllerName != apiv1.GatewayController(gatewayControllerName) {
-						return false
-					}
-				}
-				return true
-			}, timeout, interval).Should(BeTrue())
-		})
+		// Cleanup verification
+		assertEventually(t, func() bool {
+			gcs := &apiv1.GatewayClassList{}
+			err := k8sClient.List(ctx, gcs)
+			return err == nil && len(gcs.Items) == gwClasses.Len()
+		}, timeout, interval, "expected final GatewayClass count to be correct")
 	})
 
-	When("the default GCs are deleted", func() {
-		BeforeEach(func() {
-			var err error
-			cancel, err = createManager(ctx, nil, nil)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			Eventually(func() bool {
-				gcs := &apiv1.GatewayClassList{}
-				err := k8sClient.List(ctx, gcs)
-				return err == nil && len(gcs.Items) == gwClasses.Len()
-			}, timeout, interval).Should(BeTrue())
-		})
-
-		It("should be recreated by the provisioner", func() {
-			By("deleting the default GCs")
-
-			// wait for the default GCs to be created, especially needed if this is the first test to run
-			gc := &apiv1.GatewayClass{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
-			}, timeout, interval).Should(Succeed())
-
-			for name := range gwClasses {
-				err := k8sClient.Delete(ctx, &apiv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: name}})
-				Expect(err).NotTo(HaveOccurred())
+	t.Run("a default GC is updated", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer func() {
+			if cancel != nil {
+				cancel()
 			}
-			By("waiting for the GCs to be recreated")
-			Eventually(func() bool {
-				gcs := &apiv1.GatewayClassList{}
-				err := k8sClient.List(ctx, gcs)
-				if err != nil {
-					return false
-				}
-				return len(gcs.Items) == gwClasses.Len()
-			}, timeout, interval).Should(BeTrue())
-		})
-	})
+			// ensure goroutines cleanup
+			time.Sleep(3 * time.Second)
+		}()
 
-	When("a default GC is updated", func() {
-		var (
-			description string
-		)
-		BeforeEach(func() {
-			var err error
-			cancel, err = createManager(ctx, nil, nil)
-			Expect(err).NotTo(HaveOccurred())
+		managerCancel, err := createManager(ctx, nil, nil)
+		assertNoError(t, err)
+		defer managerCancel()
 
-			By("getting the default GC")
-			gc := &apiv1.GatewayClass{}
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
-			}, timeout, interval).Should(Succeed())
+		// getting the default GC
+		gc := &apiv1.GatewayClass{}
+		assertEventually(t, func() bool {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc) == nil
+		}, timeout, interval, "expected to get default GatewayClass")
+
+		var description string
+		if gc.Spec.Description != nil {
 			description = *gc.Spec.Description
-		})
+		}
 
-		AfterEach(func() {
-			By("restoring the default GC value")
+		defer func() {
+			// restoring the default GC value
 			gc := &apiv1.GatewayClass{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
-			Expect(err).NotTo(HaveOccurred())
-			gc.Spec.Description = ptr.To(description)
-			err = k8sClient.Update(ctx, gc)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should not be overwritten by the provisioner", func() {
-			By("updating a default GC")
-			var gc *apiv1.GatewayClass
-			Eventually(func() bool {
-				gc = &apiv1.GatewayClass{}
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
-
-			By("updating the GC")
-			gc.Spec.Description = ptr.To("updated")
-			err := k8sClient.Update(ctx, gc)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("waiting for the GC to be updated")
-			Eventually(func() bool {
-				gc = &apiv1.GatewayClass{}
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
-				if err != nil {
-					return false
-				}
-				if gc.Spec.Description == nil {
-					return false
-				}
-				return *gc.Spec.Description == "updated"
-			}, timeout, interval).Should(BeTrue())
-		})
-	})
-
-	When("custom GatewayClass configurations are provided", func() {
-		var customClassConfigs map[string]*controller.ClassInfo
-
-		BeforeEach(func() {
-			customClassConfigs = map[string]*controller.ClassInfo{
-				"custom-class": {
-					Description: "custom gateway class",
-					Labels: map[string]string{
-						"custom": "true",
-					},
-					Annotations: map[string]string{
-						"custom.annotation": "value",
-					},
-				},
+			if err == nil {
+				gc.Spec.Description = ptr.To(description)
+				k8sClient.Update(ctx, gc)
 			}
+		}()
 
-			var err error
-			cancel, err = createManager(ctx, nil, customClassConfigs)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		// should not be overwritten by the provisioner
+		// updating a default GC
+		assertEventually(t, func() bool {
+			gc = &apiv1.GatewayClass{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
+			return err == nil
+		}, timeout, interval, "expected to get GatewayClass for update")
 
-		It("should create GatewayClasses with custom configurations", func() {
-			Eventually(func() bool {
-				gc := &apiv1.GatewayClass{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "custom-class"}, gc); err != nil {
-					return false
-				}
-				return gc.Spec.ControllerName == apiv1.GatewayController(gatewayControllerName) &&
-					*gc.Spec.Description == "custom gateway class" &&
-					gc.Labels["custom"] == "true" &&
-					gc.Annotations["custom.annotation"] == "value"
-			}, timeout, interval).Should(BeTrue())
-		})
+		// updating the GC
+		gc.Spec.Description = ptr.To("updated")
+		err = k8sClient.Update(ctx, gc)
+		assertNoError(t, err)
+
+		// waiting for the GC to be updated
+		assertEventually(t, func() bool {
+			gc = &apiv1.GatewayClass{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc)
+			if err != nil {
+				return false
+			}
+			if gc.Spec.Description == nil {
+				return false
+			}
+			return *gc.Spec.Description == "updated"
+		}, timeout, interval, "expected GatewayClass description to remain updated")
 	})
-})
+
+	t.Run("custom GatewayClass configurations are provided", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer func() {
+			if cancel != nil {
+				cancel()
+			}
+			// ensure goroutines cleanup
+			time.Sleep(3 * time.Second)
+		}()
+
+		customClassConfigs := map[string]*controller.ClassInfo{
+			"custom-class": {
+				Description: "custom gateway class",
+				Labels: map[string]string{
+					"custom": "true",
+				},
+				Annotations: map[string]string{
+					"custom.annotation": "value",
+				},
+			},
+		}
+
+		managerCancel, err := createManager(ctx, nil, customClassConfigs)
+		assertNoError(t, err)
+		defer managerCancel()
+
+		// should create GatewayClasses with custom configurations
+		assertEventually(t, func() bool {
+			gc := &apiv1.GatewayClass{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: "custom-class"}, gc); err != nil {
+				return false
+			}
+			return gc.Spec.ControllerName == apiv1.GatewayController(gatewayControllerName) &&
+				gc.Spec.Description != nil &&
+				*gc.Spec.Description == "custom gateway class" &&
+				gc.Labels["custom"] == "true" &&
+				gc.Annotations["custom.annotation"] == "value"
+		}, timeout, interval, "expected custom GatewayClass to be created with correct configuration")
+	})
+}
+
+// assertEventually polls a condition function until it returns true or times out
+func assertEventually(t *testing.T, condition func() bool, timeout, interval time.Duration, msgAndArgs ...interface{}) {
+	t.Helper()
+	
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(interval)
+	}
+	
+	// Build error message
+	msg := "condition was not met within timeout"
+	if len(msgAndArgs) > 0 {
+		if str, ok := msgAndArgs[0].(string); ok {
+			msg = str
+		}
+	}
+	
+	t.Fatalf("assertEventually failed: %s (timeout: %v)", msg, timeout)
+}

--- a/internal/kgateway/controller/gw_controller_test.go
+++ b/internal/kgateway/controller/gw_controller_test.go
@@ -2,10 +2,9 @@ package controller_test
 
 import (
 	"context"
+	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -13,95 +12,186 @@ import (
 	api "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-var _ = Describe("GwController", func() {
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
+// TestGwController tests the GwController functionality
+func TestGwController(t *testing.T) {
+	testCases := []struct {
+		name    string
+		gwClass string
+	}{
+		{"default gateway class", gatewayClassName},
+		{"alternative gateway class", altGatewayClassName},
+		{"self managed gateway", selfManagedGatewayClassName},
+	}
 
-	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-	)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := setupGwControllerTest(t)
+			defer teardownGwControllerTest(t, cancel)
 
-	BeforeEach(func() {
-		ctx, cancel = context.WithCancel(context.Background())
+			testShouldAddStatusToGateway(t, ctx, tc.gwClass)
+		})
+	}
+}
 
-		var err error
-		cancel, err = createManager(ctx, inferenceExt, nil)
-		Expect(err).NotTo(HaveOccurred())
-	})
+func setupGwControllerTest(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
 
-	AfterEach(func() {
-		if cancel != nil {
-			cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var err error
+	managerCancel, err := createManager(ctx, inferenceExt, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	// Return a combined cancel function
+	combinedCancel := func() {
+		if managerCancel != nil {
+			managerCancel()
 		}
-		// ensure goroutines cleanup
-		Eventually(func() bool { return true }).WithTimeout(3 * time.Second).Should(BeTrue())
-	})
+		cancel()
+	}
 
-	DescribeTable(
-		"should add status to gateway",
-		func(gwClass string) {
-			same := api.NamespacesFromSame
-			gwName := "gw-" + gwClass
-			gw := api.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      gwName,
-					Namespace: "default",
-				},
-				Spec: api.GatewaySpec{
-					Addresses: []api.GatewaySpecAddress{{
-						Type:  ptr.To(api.IPAddressType),
-						Value: "127.0.0.1",
-					}},
-					GatewayClassName: api.ObjectName(gwClass),
-					Listeners: []api.Listener{{
-						Protocol: "HTTP",
-						Port:     80,
-						AllowedRoutes: &api.AllowedRoutes{
-							Namespaces: &api.RouteNamespaces{
-								From: &same,
-							},
-						},
-						Name: "listener",
-					}},
-				},
-			}
-			err := k8sClient.Create(ctx, &gw)
-			Expect(err).NotTo(HaveOccurred())
+	return ctx, combinedCancel
+}
 
-			if gwClass != selfManagedGatewayClassName {
-				svc := waitForGatewayService(ctx, &gw)
+func teardownGwControllerTest(t *testing.T, cancel context.CancelFunc) {
+	t.Helper()
 
-				// Need to update the status of the service
-				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-					Ingress: []corev1.LoadBalancerIngress{{
-						IP: "127.0.0.1",
-					}},
-				}
-				Eventually(func() error {
-					return k8sClient.Status().Update(ctx, &svc)
-				}, timeout, interval).Should(Succeed())
-			}
+	if cancel != nil {
+		cancel()
+	}
+	// ensure goroutines cleanup
+	waitForCondition(t, func() bool { return true }, 3*time.Second, 100*time.Millisecond, "goroutines cleanup")
+}
 
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: gwName, Namespace: "default"}, &gw)
-				if err != nil {
-					return false
-				}
-				if len(gw.Status.Addresses) == 0 {
-					return false
-				}
-				return true
-			}, timeout, interval).Should(BeTrue())
-
-			Expect(gw.Status.Addresses).To(HaveLen(1))
-			Expect(*gw.Status.Addresses[0].Type).To(Equal(api.IPAddressType))
-			Expect(gw.Status.Addresses[0].Value).To(Equal("127.0.0.1"))
+func testShouldAddStatusToGateway(t *testing.T, ctx context.Context, gwClass string) {
+	same := api.NamespacesFromSame
+	gwName := "gw-" + gwClass
+	gw := api.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gwName,
+			Namespace: "default",
 		},
-		Entry("default gateway class", gatewayClassName),
-		Entry("alternative gateway class", altGatewayClassName),
-		Entry("self managed gateway", selfManagedGatewayClassName),
-	)
-})
+		Spec: api.GatewaySpec{
+			Addresses: []api.GatewaySpecAddress{{
+				Type:  ptr.To(api.IPAddressType),
+				Value: "127.0.0.1",
+			}},
+			GatewayClassName: api.ObjectName(gwClass),
+			Listeners: []api.Listener{{
+				Protocol: "HTTP",
+				Port:     80,
+				AllowedRoutes: &api.AllowedRoutes{
+					Namespaces: &api.RouteNamespaces{
+						From: &same,
+					},
+				},
+				Name: "listener",
+			}},
+		},
+	}
+
+	err := k8sClient.Create(ctx, &gw)
+	if err != nil {
+		t.Fatalf("Failed to create gateway: %v", err)
+	}
+
+	if gwClass != selfManagedGatewayClassName {
+		svc := waitForGatewayServiceSimple(t, ctx, &gw)
+
+		// Need to update the status of the service
+		svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{{
+				IP: "127.0.0.1",
+			}},
+		}
+
+		waitForConditionWithError(t, func() error {
+			return k8sClient.Status().Update(ctx, &svc)
+		}, timeout, interval, "service status update")
+	}
+
+	waitForCondition(t, func() bool {
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: gwName, Namespace: "default"}, &gw)
+		if err != nil {
+			return false
+		}
+		if len(gw.Status.Addresses) == 0 {
+			return false
+		}
+		return true
+	}, timeout, interval, "gateway status addresses update")
+
+	if len(gw.Status.Addresses) != 1 {
+		t.Errorf("Expected gateway to have 1 address, got %d", len(gw.Status.Addresses))
+	}
+
+	if gw.Status.Addresses[0].Type == nil || *gw.Status.Addresses[0].Type != api.IPAddressType {
+		t.Errorf("Expected address type %s, got %v", api.IPAddressType, gw.Status.Addresses[0].Type)
+	}
+
+	if gw.Status.Addresses[0].Value != "127.0.0.1" {
+		t.Errorf("Expected address value '127.0.0.1', got '%s'", gw.Status.Addresses[0].Value)
+	}
+}
+
+// waitForGatewayServiceSimple is a version of waitForGatewayService that matches the original signature
+func waitForGatewayServiceSimple(t *testing.T, ctx context.Context, gw *api.Gateway) corev1.Service {
+	t.Helper()
+
+	var svc corev1.Service
+
+	waitForCondition(t, func() bool {
+		var createdServices corev1.ServiceList
+		err := k8sClient.List(ctx, &createdServices)
+		if err != nil {
+			return false
+		}
+		for _, s := range createdServices.Items {
+			if len(s.ObjectMeta.OwnerReferences) == 1 && s.ObjectMeta.OwnerReferences[0].UID == gw.GetUID() {
+				svc = s
+				return true
+			}
+		}
+		return false
+	}, timeout, interval, "service not created")
+
+	if svc.Spec.ClusterIP == "" {
+		t.Errorf("Expected service ClusterIP to not be empty")
+	}
+
+	return svc
+}
+
+// Helper function to wait with timeout and interval checking
+func waitForCondition(t *testing.T, condition func() bool, timeout, interval time.Duration, msg string) {
+	t.Helper()
+	
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("Condition not met within timeout: %s", msg)
+}
+
+// Helper function to wait for condition with error
+func waitForConditionWithError(t *testing.T, condition func() error, timeout, interval time.Duration, msg string) {
+	t.Helper()
+	
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := condition(); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("Condition not met within timeout: %s, last error: %v", msg, lastErr)
+}


### PR DESCRIPTION
Description
This PR refactors the controller test suite by migrating from Ginkgo/Gomega to the Go standard testing package. It aligns with the project's initiative to standardize on stdlib testing for improved consistency, simplicity, and maintainability. The refactor replaces Ginkgo constructs like Describe, It, Eventually, and Gomega matchers with native Go testing.T functions and polling utilities.

Key changes include:

- Removing Ginkgo/Gomega dependencies from the controller tests.

-Replacing asynchronous assertion helpers (Eventually) with custom polling loops.

-Using testing.T subtests to organize test scenarios.

-Cleaning up variable scopes to avoid redeclaration issues and enable idiomatic Go testing patterns.

-Retaining existing test coverage and logic while improving clarity and integration with the native Go toolchain.

Change Type
/kind cleanup
/kind design

Changelog
text
Refactored controller test suite to use Go's standard testing package instead of Ginkgo/Gomega, improving consistency and maintainability of tests.
Additional Notes
This change is part of an ongoing effort to reduce external dependencies and improve developer experience in the codebase testing. No behavioural or functional changes are introduced; all tests are functionally equivalent.

