### PR TITLE
Fix: PromptGuard webhook config parsing

### DIFF
--- a/python/ai_extension/ext_proc/server.py
+++ b/python/ai_extension/ext_proc/server.py
@@ -376,8 +376,8 @@ class ExtProcServer(external_processor_pb2_grpc.ExternalProcessorServicer):
                 response: (
                     PromptMessages | RejectAction | None
                 ) = await make_request_webhook_request(
-                    webhook_host=webhook_cfg.host,
-                    webhook_port=webhook_cfg.port,
+                    webhook_host=webhook_cfg.host.host,
+                    webhook_port=webhook_cfg.host.port,
                     headers=headers,
                     promptMessages=handler.provider.construct_request_webhook_request_body(
                         body
@@ -616,8 +616,8 @@ class ExtProcServer(external_processor_pb2_grpc.ExternalProcessorServicer):
                                 response: (
                                     ResponseChoices | None
                                 ) = await make_response_webhook_request(
-                                    webhook_host=handler.resp_webhook.host,
-                                    webhook_port=handler.resp_webhook.port,
+                                    webhook_host=handler.resp_webhook.host.host,
+                                    webhook_port=handler.resp_webhook.host.port,
                                     headers=handler.resp.headers,
                                     rc=handler.provider.construct_response_webhook_request_body(
                                         body=jsn

--- a/python/ai_extension/test/test_server.py
+++ b/python/ai_extension/test/test_server.py
@@ -302,3 +302,60 @@ def test_handle_response_body_with_end_of_stream(
     assert json.loads(
         response.response_body.response.body_mutation.body.decode("utf-8")
     ) == json.loads(resp_body_content)
+
+
+def test_webhook_config_parsing():
+    req_webhook_json = """
+    {
+        "webhook": {
+            "host": {
+                "host": "ai-guardrail-webhook.kgateway-system.svc.cluster.local",
+                "port": 8000
+            }
+        }
+    }
+    """
+    
+    metadict = {
+        "x-llm-provider": "openai",
+        "x-req-guardrails-config": req_webhook_json,
+        "x-req-guardrails-config-hash": "test-hash"
+    }
+    
+    headers = external_processor_pb2.HttpHeaders()
+    handler = asyncio.run(
+        extproc_server.parse_handler_config(
+            StreamHandler.from_metadata(metadict), metadict, headers
+        )
+    )
+    
+    assert handler.req_webhook is not None
+    assert handler.req_webhook.host.host == "ai-guardrail-webhook.kgateway-system.svc.cluster.local"
+    assert handler.req_webhook.host.port == 8000
+    
+    resp_webhook_json = """
+    {
+        "webhook": {
+            "host": {
+                "host": "response-webhook.example.com",
+                "port": 9000
+            }
+        }
+    }
+    """
+    
+    metadict_resp = {
+        "x-llm-provider": "openai",
+        "x-resp-guardrails-config": resp_webhook_json,
+        "x-resp-guardrails-config-hash": "test-hash-resp"
+    }
+    
+    handler_resp = asyncio.run(
+        extproc_server.parse_handler_config(
+            StreamHandler.from_metadata(metadict_resp), metadict_resp, headers
+        )
+    )
+    
+    assert handler_resp.resp_webhook is not None
+    assert handler_resp.resp_webhook.host.host == "response-webhook.example.com"
+    assert handler_resp.resp_webhook.host.port == 9000


### PR DESCRIPTION
# Description

Fixes: #11115 

Resolves issue where TrafficPolicy webhook configuration caused "Error with guardrails webhook" due to API spec mismatch between nested webhook.host structure and flat access pattern in ext_proc.

# Change Type

```
/kind bug_fix
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

NONE
