### PR TITLE
Attempt to fix flake CSRF tests

### DIFF
--- a/test/kubernetes/e2e/features/csrf/suite.go
+++ b/test/kubernetes/e2e/features/csrf/suite.go
@@ -217,12 +217,10 @@ func (s *testingSuite) assertPreflightResponse(path string, expectedStatus int, 
 		curl.WithPort(8080),
 	}, options...)
 
-	resp := s.testInstallation.Assertions.AssertCurlReturnResponse(
+	s.testInstallation.Assertions.AssertEventuallyConsistentCurlResponse(
 		s.ctx,
 		testdefaults.CurlPodExecOpt,
 		allOptions,
 		&testmatchers.HttpResponse{StatusCode: expectedStatus},
 	)
-	s.Equal(expectedStatus, resp.StatusCode)
-	resp.Body.Close()
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Looking at recent flake tests I noticed that they fail with a connection refused and on the first test in the suite.
I believe it's because the destination service wasn't ready yet.
This should fix it.

Fixes https://github.com/kgateway-dev/kgateway/issues/11644

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind flake

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
