### PR TITLE
Add basic route replacement e2e suite

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         # July 8, 2025: ~9 minutes
         - cluster-name: 'cluster-four'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^ExtProc$$|^TestKgateway$$/^ExtAuth$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^PolicySelector$$|^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$|^TestKgateway$$/^CSRF$$|^TestKgateway$$/^AutoHostRewrite$$|^TestInferenceExtension$$'
+          go-test-run-regex: '^TestKgateway$$/^ExtProc$$|^TestKgateway$$/^ExtAuth$$|^TestKgateway$$/^TCPRouteServices$$|^TestKgateway$$/^PolicySelector$$|^TestKgateway$$/^Backends$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^BackendTLSPolicies$$|^TestKgateway$$/^CSRF$$|^TestKgateway$$/^AutoHostRewrite$$|^TestInferenceExtension$$|^TestKgateway$$/^RouteReplacement$$'
           localstack: 'false'
         # July 8, 2025: ~7 minutes
         - cluster-name: 'cluster-ai'

--- a/test/kubernetes/e2e/defaults/defaults.go
+++ b/test/kubernetes/e2e/defaults/defaults.go
@@ -37,6 +37,17 @@ var (
 
 	HttpEchoPodManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "http_echo.yaml")
 
+	HttpBinLabelSelector = "app=httpbin"
+
+	HttpBinPod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httpbin",
+			Namespace: "default",
+		},
+	}
+
+	HttpBinManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "httpbin.yaml")
+
 	TcpEchoPod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tcp-echo",

--- a/test/kubernetes/e2e/defaults/testdata/httpbin.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/httpbin.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -36,6 +37,7 @@ spec:
         app: httpbin
         version: v1
     spec:
+      terminationGracePeriodSeconds: 0
       serviceAccountName: httpbin
       containers:
         - image: docker.io/mccutchen/go-httpbin:v2.6.0

--- a/test/kubernetes/e2e/features/routereplacement/suite.go
+++ b/test/kubernetes/e2e/features/routereplacement/suite.go
@@ -1,0 +1,302 @@
+package routereplacement
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
+	"github.com/kgateway-dev/kgateway/v2/test/helpers"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
+)
+
+// testConfig maps a manifest to a route replacement mode
+type testConfig struct {
+	manifest string
+	mode     settings.RouteReplacementMode
+}
+
+// testingSuite is a suite of route replacement tests that verify the guardrail behavior
+// for invalid route configurations in both STANDARD and STRICT modes
+type testingSuite struct {
+	suite.Suite
+
+	ctx context.Context
+
+	// testInstallation contains all the metadata/utilities necessary to execute a series of tests
+	// against an installation of kgateway
+	testInstallation *e2e.TestInstallation
+
+	// setupManifests to apply once the suite is set up
+	setupManifests []string
+
+	// testManifests maps test name to its configuration including manifest and required mode
+	testManifests map[string]testConfig
+
+	// original deployment state for cleanup
+	originalDeployment *appsv1.Deployment
+}
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		ctx:              ctx,
+		testInstallation: testInst,
+		setupManifests: []string{
+			testdefaults.CurlPodManifest,
+			testdefaults.HttpBinManifest,
+			setupManifest,
+		},
+		testManifests: map[string]testConfig{
+			"TestStrictModeInvalidPolicyReplacement": {
+				manifest: strictModeInvalidPolicyManifest,
+				mode:     settings.RouteReplacementStrict,
+			},
+			"TestStandardModeInvalidPolicyReplacement": {
+				manifest: standardModeInvalidPolicyManifest,
+				mode:     settings.RouteReplacementStandard,
+			},
+		},
+	}
+}
+
+func (s *testingSuite) SetupSuite() {
+	for _, manifest := range s.setupManifests {
+		err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, manifest)
+		s.Require().NoError(err, "can apply "+manifest)
+	}
+	s.testInstallation.Assertions.EventuallyObjectsExist(
+		s.ctx,
+		proxyDeployment,
+		proxyService,
+		proxyServiceAccount,
+		gateway,
+	)
+
+	// make sure pods are running
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, testdefaults.CurlPod.GetNamespace(), metav1.ListOptions{
+		LabelSelector: testdefaults.CurlPodLabelSelector,
+	})
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, testdefaults.HttpBinPod.GetNamespace(), metav1.ListOptions{
+		LabelSelector: testdefaults.HttpBinLabelSelector,
+	})
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, proxyObjectMeta.GetNamespace(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyObjectMeta.GetName()),
+	})
+
+	// Store original deployment state for cleanup
+	controllerNamespace := s.testInstallation.Metadata.InstallNamespace
+
+	s.originalDeployment = &appsv1.Deployment{}
+	err := s.testInstallation.ClusterContext.Client.Get(s.ctx, client.ObjectKey{
+		Namespace: controllerNamespace,
+		Name:      helpers.DefaultKgatewayDeploymentName,
+	}, s.originalDeployment)
+	s.Require().NoError(err, "can get original controller deployment")
+}
+
+func (s *testingSuite) TearDownSuite() {
+	for _, manifest := range s.setupManifests {
+		err := s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, manifest)
+		s.Require().NoError(err, "can delete "+manifest)
+	}
+	s.testInstallation.Assertions.EventuallyObjectsNotExist(
+		s.ctx,
+		proxyDeployment,
+		proxyService,
+		proxyServiceAccount,
+		gateway,
+	)
+
+	s.testInstallation.Assertions.EventuallyPodsNotExist(s.ctx, testdefaults.CurlPod.GetNamespace(), metav1.ListOptions{
+		LabelSelector: testdefaults.CurlPodLabelSelector,
+	})
+	s.testInstallation.Assertions.EventuallyPodsNotExist(s.ctx, testdefaults.HttpBinPod.GetNamespace(), metav1.ListOptions{
+		LabelSelector: testdefaults.HttpBinLabelSelector,
+	})
+	s.testInstallation.Assertions.EventuallyPodsNotExist(s.ctx, proxyObjectMeta.GetNamespace(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyObjectMeta.GetName()),
+	})
+}
+
+func (s *testingSuite) BeforeTest(suiteName, testName string) {
+	config, exists := s.testManifests[testName]
+	if !exists {
+		s.FailNow(fmt.Sprintf("no configuration found for test %s", testName))
+	}
+
+	// Patch deployment with required route replacement mode
+	s.patchDeploymentWithMode(config.mode)
+
+	// Apply test-specific manifest
+	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, config.manifest)
+	s.Require().NoError(err)
+}
+
+func (s *testingSuite) AfterTest(suiteName, testName string) {
+	config, exists := s.testManifests[testName]
+	if !exists {
+		s.FailNow(fmt.Sprintf("no configuration found for test %s", testName))
+	}
+
+	// Clean up test-specific manifest
+	err := s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, config.manifest)
+	s.Require().NoError(err)
+
+	// Restore original deployment state
+	s.restoreOriginalDeployment()
+}
+
+// TestStrictModeInvalidPolicyReplacement tests that in STRICT mode,
+// routes with valid configuration but invalid custom policies are replaced with direct responses
+func (s *testingSuite) TestStrictModeInvalidPolicyReplacement() {
+	// Verify route status shows Accepted=False with RouteRuleDropped reason (for replacement)
+	s.testInstallation.Assertions.EventuallyHTTPRouteCondition(
+		s.ctx,
+		invalidPolicyRoute.Name,
+		invalidPolicyRoute.Namespace,
+		gwv1.RouteConditionAccepted,
+		metav1.ConditionFalse,
+	)
+
+	// Verify that a route with an invalid policy is replaced with a 500 direct response
+	s.testInstallation.Assertions.AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(proxyObjectMeta)),
+			curl.WithHostHeader("invalid-policy.example.com"),
+			curl.WithPort(gatewayPort),
+			curl.WithPath("/headers"),
+			curl.WithHeader("x-test-header", "some-value-with-policy"),
+		},
+		&testmatchers.HttpResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       gomega.ContainSubstring(`invalid route configuration detected and replaced with a direct response.`),
+		},
+	)
+}
+
+// TestStandardModeInvalidPolicyReplacement tests that in STANDARD mode,
+// routes with invalid policies are handled differently than in STRICT mode
+func (s *testingSuite) TestStandardModeInvalidPolicyReplacement() {
+	// Verify route status shows Accepted=True (STANDARD mode accepts despite invalid policy)
+	s.testInstallation.Assertions.EventuallyHTTPRouteCondition(
+		s.ctx,
+		invalidPolicyRoute.Name,
+		invalidPolicyRoute.Namespace,
+		gwv1.RouteConditionAccepted,
+		metav1.ConditionTrue,
+	)
+
+	// Verify that the route works normally (STANDARD mode doesn't replace with 500)
+	s.testInstallation.Assertions.AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(proxyObjectMeta)),
+			curl.WithHostHeader("invalid-policy.example.com"),
+			curl.WithPort(gatewayPort),
+			curl.WithPath("/headers"),
+			curl.WithHeader("x-test-header", "some-value-with-policy"),
+		},
+		&testmatchers.HttpResponse{
+			StatusCode: http.StatusOK,
+		},
+	)
+}
+
+func (s *testingSuite) patchDeploymentWithMode(mode settings.RouteReplacementMode) {
+	controllerNamespace := s.testInstallation.Metadata.InstallNamespace
+
+	currentDeployment := &appsv1.Deployment{}
+	err := s.testInstallation.ClusterContext.Client.Get(s.ctx, client.ObjectKey{
+		Namespace: controllerNamespace,
+		Name:      helpers.DefaultKgatewayDeploymentName,
+	}, currentDeployment)
+	s.Require().NoError(err, "can get current controller deployment")
+
+	modifiedDeployment := currentDeployment.DeepCopy()
+	containerIndex := -1
+	for i, container := range modifiedDeployment.Spec.Template.Spec.Containers {
+		if container.Name == helpers.KgatewayContainerName {
+			containerIndex = i
+			break
+		}
+	}
+	if containerIndex == -1 {
+		s.FailNow("kgateway container not found in deployment")
+	}
+
+	envVar := corev1.EnvVar{
+		Name:  "KGW_ROUTE_REPLACEMENT_MODE",
+		Value: string(mode),
+	}
+
+	var found bool
+	for i, env := range modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env {
+		if env.Name == "KGW_ROUTE_REPLACEMENT_MODE" {
+			modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env[i] = envVar
+			found = true
+			break
+		}
+	}
+	if !found {
+		modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env = append(
+			modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env,
+			envVar,
+		)
+	}
+
+	modifiedDeployment.ResourceVersion = ""
+	err = s.testInstallation.ClusterContext.Client.Patch(s.ctx, modifiedDeployment, client.MergeFrom(currentDeployment))
+	s.Require().NoError(err, "can patch controller deployment")
+
+	s.testInstallation.Assertions.EventuallyPodContainerContainsEnvVar(
+		s.ctx,
+		controllerNamespace,
+		metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=kgateway",
+		},
+		helpers.KgatewayContainerName,
+		envVar,
+	)
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, controllerNamespace, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=kgateway",
+	})
+}
+
+func (s *testingSuite) restoreOriginalDeployment() {
+	controllerNamespace := s.testInstallation.Metadata.InstallNamespace
+
+	// Get current deployment state
+	currentDeployment := &appsv1.Deployment{}
+	err := s.testInstallation.ClusterContext.Client.Get(s.ctx, client.ObjectKey{
+		Namespace: controllerNamespace,
+		Name:      helpers.DefaultKgatewayDeploymentName,
+	}, currentDeployment)
+	s.Require().NoError(err, "can get current controller deployment")
+
+	// Restore original deployment
+	s.originalDeployment.ResourceVersion = ""
+	err = s.testInstallation.ClusterContext.Client.Patch(s.ctx, s.originalDeployment, client.MergeFrom(currentDeployment))
+	s.Require().NoError(err, "can restore original controller deployment")
+
+	// Wait for pods to be running again
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, controllerNamespace, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=kgateway",
+	})
+}

--- a/test/kubernetes/e2e/features/routereplacement/testdata/setup.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/setup.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+    hostname: "*.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/test/kubernetes/e2e/features/routereplacement/testdata/strict-mode-invalid-policy.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/strict-mode-invalid-policy.yaml
@@ -1,0 +1,39 @@
+---
+# HTTPRoute with valid configuration but invalid TrafficPolicy attached to it.
+# In STRICT mode, this should result in the route being replaced with a 500 direct response.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: invalid-policy-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw
+    namespace: default
+  hostnames:
+  - "invalid-policy.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# Invalid TrafficPolicy with malformed template
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: invalid-traffic-policy
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: invalid-policy-route
+  transformation:
+    request:
+      body:
+        parseAs: AsJson
+        value: "{{ invalid_template }"  # Invalid template syntax that envoy will reject

--- a/test/kubernetes/e2e/features/routereplacement/types.go
+++ b/test/kubernetes/e2e/features/routereplacement/types.go
@@ -1,0 +1,45 @@
+package routereplacement
+
+import (
+	"path/filepath"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+)
+
+var (
+	setupManifest                     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	strictModeInvalidPolicyManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-policy.yaml")
+	standardModeInvalidPolicyManifest = strictModeInvalidPolicyManifest
+
+	// proxy objects (gateway deployment)
+	proxyObjectMeta = metav1.ObjectMeta{
+		Name:      "gw",
+		Namespace: "default",
+	}
+	proxyDeployment     = &appsv1.Deployment{ObjectMeta: proxyObjectMeta}
+	proxyService        = &corev1.Service{ObjectMeta: proxyObjectMeta}
+	proxyServiceAccount = &corev1.ServiceAccount{ObjectMeta: proxyObjectMeta}
+
+	gatewayPort = 8080
+
+	// gateway object
+	gateway = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
+			Namespace: "default",
+		},
+	}
+
+	// route objects for testing
+	invalidPolicyRoute = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "invalid-policy-route",
+			Namespace: "default",
+		},
+	}
+)

--- a/test/kubernetes/e2e/tests/kgateway_tests.go
+++ b/test/kubernetes/e2e/tests/kgateway_tests.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/policyselector"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/rate_limit"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/route_delegation"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/routereplacement"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/grpcroute"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/httproute"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/tcproute"
@@ -53,6 +54,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("HttpListenerPolicy", http_listener_policy.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("Lambda", lambda.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("RouteDelegation", route_delegation.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("RouteReplacement", routereplacement.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("SessionPersistence", session_persistence.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TCPRouteServices", tcproute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TLSRouteServices", tlsroute.NewTestingSuite)

--- a/test/kubernetes/testutils/assertions/objects.go
+++ b/test/kubernetes/testutils/assertions/objects.go
@@ -88,11 +88,9 @@ func (p *Provider) EventuallyNamespaceExists(ctx context.Context, ns string) {
 // we expect the application to fail, with an expected error substring supplied as `expectedOutput`
 func (p *Provider) ExpectObjectAdmitted(manifest string, err error, actualOutput, expectedOutput string) {
 	p.Assert.NoError(err, "can apply "+manifest)
-	return
 }
 
 // TODO clean this up as the validation webhook has been removed
 func (p *Provider) ExpectObjectDeleted(manifest string, err error, actualOutput string) {
 	p.Assert.NoError(err, "can delete "+manifest)
-	return
 }


### PR DESCRIPTION
Introduces a dedicated e2e suite for the route replacement safeguard functionality.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Fixes #11630. Introduces a basic functional suite for the route replacement functionality.

I considered a couple of different approaches:

- Update the common-recommendations.yaml manifest and enable STRICT mode by default for all suites. Dedicated feature suite would then validate invalid routes or valid routes with invalid policy attached to them, etc
- Dedicated route replacement test, enable STRICT mode by default, and keep this feature outside of the TestKgateway test

This suite is intentionally brief. The #11795 and #11766 trackers will expand it with more targeted test cases.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
