### PR TITLE
propagate err for missing extensionRef in route rule

### DIFF
--- a/internal/kgateway/krtcollections/grpc_route.go
+++ b/internal/kgateway/krtcollections/grpc_route.go
@@ -43,7 +43,7 @@ func (h *RoutesIndex) transformGRPCRulesToHttp(
 		httpMatches := h.convertGRPCMatchesToHTTP(r.Matches)
 		httpBackends := h.convertGRPCBackendsToHTTP(kctx, src, r.BackendRefs)
 
-		extensionRefs := h.getExtensionRefs(kctx, src.Namespace, convertFiltersToHTTP(r.Filters))
+		extensionRefs, _ := h.getExtensionRefs(kctx, src.Namespace, convertFiltersToHTTP(r.Filters))
 		var policies ir.AttachedPolicies
 		if r.Name != nil {
 			policies = toAttachedPolicies(h.policies.getTargetingPolicies(kctx, extensionsplug.RouteAttachmentPoint, src, string(*r.Name), srcLabels), opts...)

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -1186,21 +1186,27 @@ func (h *RoutesIndex) transformRules(
 ) []ir.HttpRouteRuleIR {
 	rules := make([]ir.HttpRouteRuleIR, 0, len(i))
 	for _, r := range i {
-		extensionRefs := h.getExtensionRefs(kctx, src.Namespace, r.Filters, opts...)
+		extensionRefs, errs := h.getExtensionRefs(kctx, src.Namespace, r.Filters, opts...)
+
 		var policies ir.AttachedPolicies
 		if r.Name != nil {
 			policies = toAttachedPolicies(h.policies.getTargetingPolicies(kctx, extensionsplug.RouteAttachmentPoint, src, string(*r.Name), srcLabels), opts...)
 		}
+
 		rulePolicies := h.getBuiltInRulePolicies(r, opts...)
 		policies.Append(rulePolicies)
 
-		rules = append(rules, ir.HttpRouteRuleIR{
+		ruleOut := ir.HttpRouteRuleIR{
 			ExtensionRefs:    extensionRefs,
 			AttachedPolicies: policies,
 			Backends:         h.getBackends(kctx, src, r.BackendRefs),
 			Matches:          r.Matches,
 			Name:             emptyIfNil(r.Name),
-		})
+		}
+		if errs != nil {
+			ruleOut.Err = errors.Join(errs...)
+		}
+		rules = append(rules, ruleOut)
 	}
 	return rules
 }
@@ -1210,23 +1216,24 @@ func (h *RoutesIndex) getExtensionRefs(
 	ns string,
 	r []gwv1.HTTPRouteFilter,
 	opts ...ir.PolicyAttachmentOpts,
-) ir.AttachedPolicies {
+) (ir.AttachedPolicies, []error) {
 	ret := ir.AttachedPolicies{
 		Policies: map[schema.GroupKind][]ir.PolicyAtt{},
 	}
+	var errs []error
 	for _, ext := range r {
-		// TODO: propagate error if we can't find the extension
-		policyAtt, errs := h.resolveExtension(kctx, ns, ext)
+		policyAtt, err := h.resolveExtension(kctx, ns, ext)
 		if policyAtt != nil {
 			for _, o := range opts {
 				o(policyAtt)
 			}
 			ret.Policies[policyAtt.GroupKind] = append(ret.Policies[policyAtt.GroupKind], *policyAtt)
-		} else if len(errs) > 0 {
-			logger.Error("unresolved HTTPRouteFilter", "error", errors.Join(errs...))
+		} else if err != nil {
+			errs = append(errs, err)
+			logger.Error("unresolved HTTPRouteFilter", "error", err)
 		}
 	}
-	return ret
+	return ret, errs
 }
 
 func (h *RoutesIndex) getBuiltInRulePolicies(
@@ -1247,7 +1254,7 @@ func (h *RoutesIndex) getBuiltInRulePolicies(
 	return ret
 }
 
-func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext gwv1.HTTPRouteFilter) (*ir.PolicyAtt, []error) {
+func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext gwv1.HTTPRouteFilter) (*ir.PolicyAtt, error) {
 	if ext.Type == gwv1.HTTPRouteFilterExtensionRef {
 		if ext.ExtensionRef == nil {
 			// TODO: report error!!
@@ -1262,7 +1269,7 @@ func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext g
 		}
 		policy := h.policies.fetchPolicy(kctx, key)
 		if policy == nil {
-			return nil, []error{fmt.Errorf("%s: %w", key, ErrPolicyNotFound)}
+			return nil, fmt.Errorf("%s: %w", key, ErrPolicyNotFound)
 		}
 
 		gk := schema.GroupKind{
@@ -1282,7 +1289,7 @@ func (h *RoutesIndex) resolveExtension(kctx krt.HandlerContext, ns string, ext g
 			PolicyRef:  policyRef,
 			Errors:     policy.Errors,
 		}
-		return policyAtt, policy.Errors
+		return policyAtt, nil
 	}
 
 	fromGK := schema.GroupKind{
@@ -1318,7 +1325,7 @@ func toFromBackendRef(fromns string, ref gwv1.BackendObjectReference) ir.ObjectS
 func (h *RoutesIndex) getBackends(kctx krt.HandlerContext, src ir.ObjectSource, backendRefs []gwv1.HTTPBackendRef) []ir.HttpBackendOrDelegate {
 	backends := make([]ir.HttpBackendOrDelegate, 0, len(backendRefs))
 	for _, ref := range backendRefs {
-		extensionRefs := h.getExtensionRefs(kctx, src.Namespace, ref.Filters)
+		extensionRefs, _ := h.getExtensionRefs(kctx, src.Namespace, ref.Filters)
 		fromns := src.Namespace
 
 		to := toFromBackendRef(fromns, ref.BackendObjectReference)

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -1030,6 +1030,37 @@ var _ = DescribeTable("Route Replacement",
 			s.RouteReplacementMode = settings.RouteReplacementStandard
 		}),
 
+	Entry("Standard Mode - HTTPRoute extensionRef to missing policy",
+		translatorTestCase{
+			inputFile:  "route-replacement/standard/httproute-with-missing-extension-ref.yaml",
+			outputFile: "route-replacement/standard/httproute-with-missing-extension-ref-out.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "gwtest",
+				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				route := &gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "gwtest",
+					},
+				}
+				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
+				Expect(routeStatus).NotTo(BeNil())
+				Expect(routeStatus.Parents).To(HaveLen(1))
+
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				Expect(acceptedCond).NotTo(BeNil())
+				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
+				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
+				Expect(acceptedCond.Message).To(ContainSubstring("gateway.kgateway.dev/TrafficPolicy/gwtest/my-tp-that-doesnt-exist: policy not found"))
+			},
+		},
+		func(s *settings.Settings) {
+			s.RouteReplacementMode = settings.RouteReplacementStandard
+		}),
+
 	Entry("Standard Mode - Invalid Rate Limit Global Fields",
 		translatorTestCase{
 			inputFile:  "route-replacement/standard/invalid-ratelimit-global-empty-fields.yaml",

--- a/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/standard/httproute-with-missing-extension-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/standard/httproute-with-missing-extension-ref.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+    hostname: www.example.com
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: gwtest
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: example
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test-route
+  namespace: gwtest
+spec:
+  parentRefs:
+  - name: example-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+          group: gateway.kgateway.dev
+          kind: TrafficPolicy
+          name: my-tp-that-doesnt-exist
+    backendRefs:
+    - name: example-svc
+      port: 80
+---

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/httproute-with-missing-extension-ref-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/httproute-with-missing-extension-ref-out.yaml
@@ -1,0 +1,55 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - directResponse:
+        body:
+          inlineString: invalid route configuration detected and replaced with a direct
+            response.
+        status: 500
+      match:
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-test-route-gwtest-0-0-matcher-0

--- a/internal/kgateway/translator/httproute/gateway_http_route_translator.go
+++ b/internal/kgateway/translator/httproute/gateway_http_route_translator.go
@@ -106,7 +106,6 @@ func translateGatewayHTTPRouteRulesUtil(
 	}
 }
 
-// MARK: translate rules
 func translateGatewayHTTPRouteRule(
 	ctx context.Context,
 	gwroute *query.RouteInfo,
@@ -129,17 +128,18 @@ func translateGatewayHTTPRouteRule(
 		uniqueRouteName := gwroute.UniqueRouteName(ruleIdx, idx, rule.Name)
 
 		outputRoute := ir.HttpRouteRuleMatchIR{
-			ExtensionRefs:     rule.ExtensionRefs,
-			AttachedPolicies:  rule.AttachedPolicies,
-			Parent:            parent,
-			ListenerParentRef: gwroute.ListenerParentRef,
-			ParentRef:         gwroute.ParentRef,
-			Name:              uniqueRouteName,
-			Backends:          nil,
-			MatchIndex:        idx,
-			Match:             match,
-			DelegatingParent:  delegatingParent,
-			PrecedenceWeight:  parent.PrecedenceWeight,
+			ExtensionRefs:        rule.ExtensionRefs,
+			AttachedPolicies:     rule.AttachedPolicies,
+			Parent:               parent,
+			ListenerParentRef:    gwroute.ListenerParentRef,
+			ParentRef:            gwroute.ParentRef,
+			Name:                 uniqueRouteName,
+			Backends:             nil,
+			MatchIndex:           idx,
+			Match:                match,
+			DelegatingParent:     delegatingParent,
+			PrecedenceWeight:     parent.PrecedenceWeight,
+			RouteAcceptanceError: rule.Err,
 		}
 
 		if len(rule.Backends) > 0 {

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -278,4 +278,8 @@ type HttpRouteRuleIR struct {
 	Backends         []HttpBackendOrDelegate
 	Matches          []gwv1.HTTPRouteMatch
 	Name             string
+
+	// Err contains any error encountered during the construction of this HttpRouteRuleIR
+	// that should be propagated through to translation to any derived ir.HttpRouteRuleMatchIRs
+	Err error
 }

--- a/pkg/pluginsdk/ir/routes.go
+++ b/pkg/pluginsdk/ir/routes.go
@@ -79,6 +79,7 @@ func (c HttpRouteIR) Equals(in HttpRouteIR) bool {
 func (c HttpRouteIR) rulesEqual(in HttpRouteIR) bool {
 	// we don't need to check the rules themselves as this is covered by versionEquals.
 	// we do need to check backends and policies
+	// we also need to check the error on rule
 	if len(c.Rules) != len(in.Rules) {
 		return false
 	}
@@ -112,6 +113,17 @@ func (c HttpRouteIR) rulesEqual(in HttpRouteIR) bool {
 			} else {
 				return false
 			}
+		}
+		e1 := rule.Err
+		e2 := in.Rules[i].Err
+		if e1 == nil && e2 != nil {
+			return false
+		}
+		if e1 != nil && e2 == nil {
+			return false
+		}
+		if (e1 != nil && e2 != nil) && e1.Error() != e2.Error() {
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
# Description
When an HTTPRouteRule references a missing extensionRef we need to propagate the error encountered through to translation so the error is correctly surfaced on the status of the HTTPRoute

# Change Type
```
/kind bug_fix
```

# Changelog
```release-note
HTTPRoute status now correctly reflects extensionRefs 
```
