### PR TITLE
Docs: Update Releasing Guide for GW API Bump

### DIFF
--- a/devel/contributing/releasing.md
+++ b/devel/contributing/releasing.md
@@ -88,10 +88,18 @@ If needed, clone the [Kgateway.dev repo](https://github.com/kgateway-dev/kgatewa
 git clone -o $REMOTE https://github.com/kgateway-dev/kgateway.dev.git && cd kgateway.dev
 ```
 
-Bump the Kgateway version used by the docs. The following is an example of bumping from v2.0.3 to 2.0.4:
+Bump the Kgateway version used by the docs. The following is an example of bumping from v2.0.3 to v2.0.4:
 
 ```bash
 sed -i '' '1s/^2\.0\.3$/2.0.4/' assets/docs/versions/n-patch.md
+```
+
+Optionally, update the Gateway API version if Kgateway bumps this dependency. The following is an example
+of bumping Gateway API from v1.2.1 to v1.3.0:
+
+```bash
+GW_API_VERSION=$(cd ../kgateway && go list -m sigs.k8s.io/gateway-api | awk '{print $2}' | sed 's/^v//' && cd ../kgateway.dev)
+sed -i '' "1s/.*/${GW_API_VERSION}/" assets/docs/versions/k8s-gw-version.md
 ```
 
 Sign, commit, and push the changes to the Gateway API Inference Extension repo.


### PR DESCRIPTION
# Description

Updates the release guide to include an optional step to bump the GW API version.

# Change Type

```
/kind documentation
```

# Changelog

```release-note
NONE
```

# Additional Notes

N/A
