### PR TITLE
add gwext name to error message

### DIFF
--- a/internal/kgateway/extensions2/plugins/trafficpolicy/constructor.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/constructor.go
@@ -101,13 +101,14 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 }
 
 func (c *TrafficPolicyConstructor) FetchGatewayExtension(krtctx krt.HandlerContext, extensionRef *corev1.LocalObjectReference, ns string) (*TrafficPolicyGatewayExtensionIR, error) {
-	var gatewayExtension *TrafficPolicyGatewayExtensionIR
-	if extensionRef != nil {
-		gwExtName := types.NamespacedName{Name: extensionRef.Name, Namespace: ns}
-		gatewayExtension = krt.FetchOne(krtctx, c.gatewayExtensions, krt.FilterObjectName(gwExtName))
+	if extensionRef == nil {
+		return nil, fmt.Errorf("gateway extension ref is nil")
 	}
+
+	gwExtNN := types.NamespacedName{Name: extensionRef.Name, Namespace: ns}
+	gatewayExtension := krt.FetchOne(krtctx, c.gatewayExtensions, krt.FilterObjectName(gwExtNN))
 	if gatewayExtension == nil {
-		return nil, fmt.Errorf("extension not found")
+		return nil, fmt.Errorf("gateway extension %s not found", gwExtNN.String())
 	}
 	if gatewayExtension.Err != nil {
 		return gatewayExtension, gatewayExtension.Err

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -1230,7 +1230,7 @@ var _ = DescribeTable("Route Replacement",
 				Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
 				Expect(acceptedCond.Reason).To(Equal(reporter.RouteRuleDroppedReason))
 				Expect(acceptedCond.Message).To(ContainSubstring("Dropped Rule (0)"))
-				Expect(acceptedCond.Message).To(ContainSubstring("extauthz: extension not found"))
+				Expect(acceptedCond.Message).To(ContainSubstring("extauthz: gateway extension gwtest/non-existent-auth-extension not found"))
 				Expect(acceptedCond.ObservedGeneration).To(Equal(int64(0)))
 			},
 		},


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

When there is an invalid extensionRef, print the ref in the resource status, to help with debugging.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
