### PR TITLE
httplistenerpolicy: replace deprecated ExactMatch with StringMatch

### DIFF
--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
@@ -13,6 +13,7 @@ import (
 	healthcheckv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	preserve_case_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/header_formatters/preserve_case/v3"
+	envoymatcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -371,8 +372,12 @@ func convertHealthCheckPolicy(policy *v1alpha1.HTTPListenerPolicy) *healthcheckv
 			PassThroughMode: wrapperspb.Bool(false),
 			Headers: []*envoyroutev3.HeaderMatcher{{
 				Name: ":path",
-				HeaderMatchSpecifier: &envoyroutev3.HeaderMatcher_ExactMatch{
-					ExactMatch: policy.Spec.HealthCheck.Path,
+				HeaderMatchSpecifier: &envoyroutev3.HeaderMatcher_StringMatch{
+					StringMatch: &envoymatcherv3.StringMatcher{
+						MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+							Exact: policy.Spec.HealthCheck.Path,
+						},
+					},
 				},
 			}},
 		}

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -45,8 +45,9 @@ Listeners:
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
             headers:
-            - exactMatch: /health_check
-              name: :path
+            - name: :path
+              stringMatch:
+                exact: /health_check
             passThroughMode: false
         - name: envoy.filters.http.router
           typedConfig:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -27,8 +27,9 @@ Listeners:
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
             headers:
-            - exactMatch: /health_check
-              name: :path
+            - name: :path
+              stringMatch:
+                exact: /health_check
             passThroughMode: false
         - name: envoy.filters.http.router
           typedConfig:


### PR DESCRIPTION
# Description

https://github.com/kgateway-dev/kgateway/issues/11891

replace deprecated ExactMatch with StringMatch 

```
type HeaderMatcher_ExactMatch struct {
         // If specified, header match will be performed based on the value of the header.
	// This field is deprecated. Please use :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
```

# Change Type

/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
