### PR TITLE
fix: Fix AttachedRoutes in agentgateway status reporting

### DIFF
--- a/internal/kgateway/agentgatewaysyncer/syncer.go
+++ b/internal/kgateway/agentgatewaysyncer/syncer.go
@@ -793,6 +793,7 @@ func (s *AgentGwSyncer) buildStatusReporting() {
 			}
 			for listener, counts := range p.attachedRoutes {
 				attachedRoutes[p.NamespacedName][listener] += counts
+				p.reports.Gateways[p.NamespacedName].ListenerName(listener).SetAttachedRoutes(counts)
 			}
 		}
 

--- a/test/kubernetes/e2e/features/agentgateway/suite.go
+++ b/test/kubernetes/e2e/features/agentgateway/suite.go
@@ -2,106 +2,56 @@ package agentgateway
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"os"
-	"time"
 
 	"github.com/stretchr/testify/suite"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
-
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
-	"github.com/kgateway-dev/kgateway/v2/test/testutils"
-)
-
-var (
-	// The self-managed Gateway and deployed Gateway should have the same name
-	proxyObjMeta = metav1.ObjectMeta{
-		Name:      "agent-gateway",
-		Namespace: "default",
-	}
-	proxyDeployment = &appsv1.Deployment{ObjectMeta: proxyObjMeta}
-	proxyService    = &corev1.Service{ObjectMeta: proxyObjMeta}
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
 )
 
 type testingSuite struct {
-	suite.Suite
-
-	ctx context.Context
-
-	testInstallation *e2e.TestInstallation
-
-	rootDir string
-
-	installNamespace string
-
-	manifests map[string][]string
+	*base.BaseTestingSuite
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		ctx:              ctx,
-		testInstallation: testInst,
-		rootDir:          testutils.GitRootDirectory(),
-		installNamespace: os.Getenv(testutils.InstallNamespace),
-	}
-}
-
-func (s *testingSuite) SetupSuite() {
-	s.manifests = map[string][]string{
-		"TestAgentGatewayDeployment": {
-			defaults.HttpbinManifest,
-			defaults.CurlPodManifest,
-			deployAgentGatewayManifest,
-		},
-	}
-}
-
-func (s *testingSuite) TearDownSuite() {
-}
-
-func (s *testingSuite) BeforeTest(suiteName, testName string) {
-	manifests := s.manifests[testName]
-	fmt.Printf("Applying manifests for test %s in suite %s", testName, suiteName)
-	for _, manifest := range manifests {
-		err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, manifest)
-		s.Require().NoError(err)
-	}
-}
-
-func (s *testingSuite) AfterTest(suiteName, testName string) {
-	if s.T().Failed() {
-		s.testInstallation.PreFailHandler(s.ctx)
-	}
-	manifests := s.manifests[testName]
-	fmt.Printf("Deleting manifests for test %s in suite %s", testName, suiteName)
-	for _, manifest := range manifests {
-		err := s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, manifest)
-		s.Require().NoError(err)
+		base.NewBaseTestingSuite(ctx, testInst, base.TestCase{}, testCases),
 	}
 }
 
 func (s *testingSuite) TestAgentGatewayDeployment() {
-	// assert the expected resources are created and running before attempting to send traffic
-	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, proxyService, proxyDeployment)
-	// check curl pod is running
-	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, defaults.CurlPod.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=curl",
-	}, time.Minute*2)
-	// match auto labels created by kgateway deployer
-	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, proxyObjMeta.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=agent-gateway",
-	}, time.Minute*2)
+	s.TestInstallation.Assertions.EventuallyGatewayCondition(
+		s.Ctx,
+		gatewayObjectMeta.Name,
+		gatewayObjectMeta.Namespace,
+		gwv1.GatewayConditionProgrammed,
+		metav1.ConditionTrue,
+	)
+	s.TestInstallation.Assertions.EventuallyGatewayCondition(
+		s.Ctx,
+		gatewayObjectMeta.Name,
+		gatewayObjectMeta.Namespace,
+		gwv1.GatewayConditionAccepted,
+		metav1.ConditionTrue,
+	)
+	s.TestInstallation.Assertions.EventuallyGatewayListenerAttachedRoutes(
+		s.Ctx,
+		gatewayObjectMeta.Name,
+		gatewayObjectMeta.Namespace,
+		"http",
+		1,
+	)
 
-	s.testInstallation.Assertions.AssertEventualCurlResponse(
-		s.ctx,
+	s.TestInstallation.Assertions.AssertEventualCurlResponse(
+		s.Ctx,
 		defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHost(kubeutils.ServiceFQDN(gatewayService.ObjectMeta)),

--- a/test/kubernetes/e2e/features/agentgateway/types.go
+++ b/test/kubernetes/e2e/features/agentgateway/types.go
@@ -3,13 +3,25 @@ package agentgateway
 import (
 	"path/filepath"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
 )
 
 var (
+	// The self-managed Gateway and deployed Gateway should have the same name
+	proxyObjMeta = metav1.ObjectMeta{
+		Name:      "agent-gateway",
+		Namespace: "default",
+	}
+	proxyDeployment = &appsv1.Deployment{ObjectMeta: proxyObjMeta}
+	proxyService    = &corev1.Service{ObjectMeta: proxyObjMeta}
+
 	// kgateway managed deployment for the agentgateway
 	deployAgentGatewayManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "agentgateway-deploy.yaml")
 
@@ -19,4 +31,11 @@ var (
 		Namespace: "default",
 	}
 	gatewayService = &corev1.Service{ObjectMeta: gatewayObjectMeta}
+
+	testCases = map[string]base.TestCase{
+		"TestAgentGatewayDeployment": {
+			Manifests: []string{defaults.HttpbinManifest, defaults.CurlPodManifest, deployAgentGatewayManifest},
+			Resources: []client.Object{proxyService, proxyDeployment, defaults.CurlPod},
+		},
+	}
 )


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Fixes a bug where the AttachedRoutes is not set when updating the status of an agentGateway

# Change Type

```
/kind bug_fix
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix a bug where the AttachedRoutes is not set when updating the status of an agentGateway
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
