### PR TITLE
Fix data race with writer trying to log after test cleanup

### DIFF
--- a/internal/kgateway/setup/agentgateway_test.go
+++ b/internal/kgateway/setup/agentgateway_test.go
@@ -49,7 +49,6 @@ func runAgentGatewayScenario(t *testing.T, scenarioDir string, globalSettings *s
 		}
 		for _, f := range files {
 			// run tests with the yaml files (agentgateway dumps json output)
-			parentT := t
 			if strings.HasSuffix(f.Name(), ".yaml") {
 				if os.Getenv("TEST_PREFIX") != "" && !strings.HasPrefix(f.Name(), os.Getenv("TEST_PREFIX")) {
 					continue
@@ -58,7 +57,7 @@ func runAgentGatewayScenario(t *testing.T, scenarioDir string, globalSettings *s
 				t.Run(strings.TrimSuffix(f.Name(), ".yaml"), func(t *testing.T) {
 					writer.set(t)
 					t.Cleanup(func() {
-						writer.set(parentT)
+						writer.set(nil)
 					})
 					testAgentGatewayScenario(t, ctx, kdbg, client, xdsPort, fullpath)
 				})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Race condition occurred when accessing the test context.
It was actually setting the same context (parentT=t) which is redundant. Setting the context to nil under write lock makes sure the Write() function will see a nil and won't try to log after cleanup.

Fixes https://github.com/kgateway-dev/kgateway/issues/11886

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind flake

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
