### PR TITLE
Log error if failed to start a test SDS server

### DIFF
--- a/internal/sds/pkg/run/run_e2e_test.go
+++ b/internal/sds/pkg/run/run_e2e_test.go
@@ -104,7 +104,6 @@ var _ = Describe("SDS Server E2E Test", Serial, func() {
 		}()
 
 		// Connect with the server
-		var conn *grpc.ClientConn
 		conn, err := grpc.NewClient(testServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()
@@ -144,8 +143,7 @@ var _ = Describe("SDS Server E2E Test", Serial, func() {
 		time.Sleep(1 * time.Second)
 
 		// Connect with the server
-		var conn *grpc.ClientConn
-		conn, err = grpc.NewClient(testServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(testServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()
 		client := envoy_service_secret_v3.NewSecretDiscoveryServiceClient(conn)

--- a/internal/sds/pkg/run/run_e2e_test.go
+++ b/internal/sds/pkg/run/run_e2e_test.go
@@ -105,7 +105,7 @@ var _ = Describe("SDS Server E2E Test", Serial, func() {
 
 		// Connect with the server
 		var conn *grpc.ClientConn
-		conn, err := grpc.Dial(testServerAddress, grpc.WithInsecure())
+		conn, err = grpc.NewClient(testServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()
 		client := envoy_service_secret_v3.NewSecretDiscoveryServiceClient(conn)
@@ -136,7 +136,8 @@ var _ = Describe("SDS Server E2E Test", Serial, func() {
 			}
 
 			secret.SslOcspFile = ocsp
-			_ = run.Run(ctx, []server.Secret{secret}, sdsClient, testServerAddress, logger)
+			err := run.Run(ctx, []server.Secret{secret}, sdsClient, testServerAddress, logger)
+			Expect(err).NotTo(HaveOccurred())
 		}()
 
 		// Give it a second to spin up + read the files

--- a/internal/sds/pkg/run/run_e2e_test.go
+++ b/internal/sds/pkg/run/run_e2e_test.go
@@ -105,7 +105,7 @@ var _ = Describe("SDS Server E2E Test", Serial, func() {
 
 		// Connect with the server
 		var conn *grpc.ClientConn
-		conn, err = grpc.NewClient(testServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(testServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).NotTo(HaveOccurred())
 		defer conn.Close()
 		client := envoy_service_secret_v3.NewSecretDiscoveryServiceClient(conn)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

This isn't a fix.
The purpose is to log the error if a test fails to start an SDS server.
This is to help tracking the flaky tests of: https://github.com/kgateway-dev/kgateway/issues/11870

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind flake

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
