### PR TITLE
Add the traffic distribution type to the endpoints hash

### DIFF
--- a/internal/kgateway/krtcollections/endpoints_test.go
+++ b/internal/kgateway/krtcollections/endpoints_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
@@ -280,6 +281,119 @@ func TestEndpointsForUpstreamWithDifferentNameButSameEndpoints(t *testing.T) {
 	h2 := result3.LbEpsEqualityHash ^ result4.LbEpsEqualityHash
 
 	g.Expect(h1).NotTo(Equal(h2), "not expected %v, got %v", h1, h2)
+}
+
+func TestEndpointsForUpstreamWithDifferentTrafficDistributionButSameEndpoints(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create base backend object
+	baseObj := ir.BackendObjectIR{
+		ObjectSource: ir.ObjectSource{
+			Namespace: "ns",
+			Name:      "svc",
+			Group:     "",
+			Kind:      "Service",
+		},
+		Port: 8080,
+		Obj: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "svc",
+				Namespace: "ns",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "http",
+						Port: 8080,
+					},
+				},
+			},
+		},
+	}
+
+	// Create two backends with different traffic distributions
+	us1 := newBackendObjectIR(baseObj)
+	us1.TrafficDistribution = wellknown.TrafficDistributionAny
+
+	us2 := newBackendObjectIR(baseObj)
+	us2.TrafficDistribution = wellknown.TrafficDistributionPreferSameZone
+
+	// Create endpoints with same metadata
+	emd := ir.EndpointWithMd{
+		LbEndpoint: &envoyendpointv3.LbEndpoint{
+			HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
+				Endpoint: &envoyendpointv3.Endpoint{
+					Address: &envoycorev3.Address{
+						Address: &envoycorev3.Address_SocketAddress{
+							SocketAddress: &envoycorev3.SocketAddress{
+								Address: "1.2.3.4",
+								PortSpecifier: &envoycorev3.SocketAddress_PortValue{
+									PortValue: 8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		EndpointMd: ir.EndpointMetadata{
+			Labels: map[string]string{
+				corev1.LabelTopologyRegion: "region",
+				corev1.LabelTopologyZone:   "zone",
+			},
+		},
+	}
+
+	// Create EndpointsForBackend from both backends with same endpoints
+	result1 := ir.NewEndpointsForBackend(us1)
+	result1.Add(ir.PodLocality{
+		Region: "region",
+		Zone:   "zone",
+	}, emd)
+
+	result2 := ir.NewEndpointsForBackend(us2)
+	result2.Add(ir.PodLocality{
+		Region: "region",
+		Zone:   "zone",
+	}, emd)
+
+	// Verify that the hashes are different due to different traffic distribution
+	g.Expect(result1.LbEpsEqualityHash).NotTo(Equal(result2.LbEpsEqualityHash),
+		"Hash should be different when traffic distribution changes")
+
+	// Test with more traffic distribution values
+	us3 := newBackendObjectIR(baseObj)
+	us3.TrafficDistribution = wellknown.TrafficDistributionPreferSameNode
+
+	us4 := newBackendObjectIR(baseObj)
+	us4.TrafficDistribution = wellknown.TrafficDistributionPreferSameNetwork
+
+	result3 := ir.NewEndpointsForBackend(us3)
+	result3.Add(ir.PodLocality{
+		Region: "region",
+		Zone:   "zone",
+	}, emd)
+
+	result4 := ir.NewEndpointsForBackend(us4)
+	result4.Add(ir.PodLocality{
+		Region: "region",
+		Zone:   "zone",
+	}, emd)
+
+	// All hashes should be different
+	hashes := []uint64{
+		result1.LbEpsEqualityHash,
+		result2.LbEpsEqualityHash,
+		result3.LbEpsEqualityHash,
+		result4.LbEpsEqualityHash,
+	}
+
+	// Check that all hashes are unique
+	hashMap := make(map[uint64]bool)
+	for _, hash := range hashes {
+		g.Expect(hashMap[hash]).To(BeFalse(), "Hash should be unique for each traffic distribution")
+		hashMap[hash] = true
+	}
 }
 
 func TestEndpoints(t *testing.T) {

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -131,6 +131,8 @@ func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
 		h.Write([]byte{0})
 		h.Write([]byte(k + "=" + v))
 	}
+	h.Write([]byte{0})
+	h.Write([]byte{byte(us.TrafficDistribution)})
 	upstreamHash := h.Sum64()
 
 	return &EndpointsForBackend{


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Adding the traffic distribution mode to the hash so that changing it would results in updating the endpoints in the client.

Fixes https://github.com/kgateway-dev/kgateway/issues/11952

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fixed an issue when dynamically modifying the traffic distribution won't change the distribution.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
