### PR TITLE
e2e base test suite - handle manifest templates

### DIFF
--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -158,6 +158,13 @@ func (c *Cli) Delete(ctx context.Context, content []byte, extraArgs ...string) e
 		Cause()
 }
 
+// DeleteSafe deletes the resources defined in the bytes, and returns an error if one occurred
+// This differs from DeleteFile in that we always append --ignore-not-found
+func (c *Cli) DeleteSafe(ctx context.Context, content []byte, extraArgs ...string) error {
+	safeArgs := append(extraArgs, "--ignore-not-found")
+	return c.Delete(ctx, content, safeArgs...)
+}
+
 // DeleteFile deletes the resources defined in a file, and returns an error if one occurred
 func (c *Cli) DeleteFile(ctx context.Context, fileName string, extraArgs ...string) error {
 	_, err := c.DeleteFileWithOutput(ctx, fileName, extraArgs...)

--- a/test/kubernetes/e2e/features/metrics/suite.go
+++ b/test/kubernetes/e2e/features/metrics/suite.go
@@ -40,7 +40,7 @@ func (s *testingSuite) checkPodsRunning() {
 	s.TestInstallation.Assertions.EventuallyPodsRunning(s.Ctx, proxyObjectMeta.GetNamespace(), metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=gw2",
 	})
-	s.TestInstallation.Assertions.EventuallyPodsRunning(s.Ctx, kgatewayMetricsObjectMeta.GetNamespace(), metav1.ListOptions{
+	s.TestInstallation.Assertions.EventuallyPodsRunning(s.Ctx, s.TestInstallation.Metadata.InstallNamespace, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=kgateway",
 	})
 }
@@ -68,7 +68,7 @@ func (s *testingSuite) TestMetrics() {
 		s.Ctx,
 		e2edefaults.CurlPodExecOpt,
 		[]curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(kgatewayMetricsObjectMeta)),
+			curl.WithHost(kubeutils.GetServiceHostname(kgatewayMetricsServiceName, s.TestInstallation.Metadata.InstallNamespace)),
 			curl.WithPort(9092),
 			curl.WithPath("/metrics"),
 		},

--- a/test/kubernetes/e2e/features/metrics/testdata/setup-template.yaml
+++ b/test/kubernetes/e2e/features/metrics/testdata/setup-template.yaml
@@ -63,7 +63,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kgateway-metrics
-  namespace: kgateway-test
+  namespace: ${INSTALL_NAMESPACE}
 spec:
   selector:
     app.kubernetes.io/name: kgateway

--- a/test/kubernetes/e2e/features/metrics/types.go
+++ b/test/kubernetes/e2e/features/metrics/types.go
@@ -12,13 +12,14 @@ import (
 
 	v1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	e2edefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
 )
 
 var (
 	// manifests
-	setupManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	setupManifestTemplate = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup-template.yaml")
 
 	// objects
 	proxyObjectMeta = metav1.ObjectMeta{
@@ -30,12 +31,7 @@ var (
 	proxyService        = &corev1.Service{ObjectMeta: proxyObjectMeta}
 	proxyServiceAccount = &corev1.ServiceAccount{ObjectMeta: proxyObjectMeta}
 
-	kgatewayMetricsObjectMeta = metav1.ObjectMeta{
-		Name:      "kgateway-metrics",
-		Namespace: "kgateway-test",
-	}
-
-	kgatewayMetricsService = &corev1.Service{ObjectMeta: kgatewayMetricsObjectMeta}
+	kgatewayMetricsServiceName = "kgateway-metrics"
 
 	exampleSvc = &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -98,9 +94,8 @@ var (
 	}
 
 	setup = base.TestCase{
-		Manifests: []string{setupManifest, e2edefaults.CurlPodManifest},
+		Manifests: []string{e2edefaults.CurlPodManifest},
 		Resources: []client.Object{
-			kgatewayMetricsService,
 			exampleSvc,
 			proxyDeployment,
 			proxyService,
@@ -113,6 +108,15 @@ var (
 			listenerSet1,
 			httpListenerPolicy1,
 			e2edefaults.CurlPod,
+		},
+		ManifestTemplates: []string{setupManifestTemplate},
+		ResourcesFromTemplates: func(ti *e2e.TestInstallation) []client.Object {
+			return []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{
+					Name:      kgatewayMetricsServiceName,
+					Namespace: ti.Metadata.InstallNamespace,
+				}},
+			}
 		},
 	}
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Added support for passing in manifest templates in the BaseTestingSuite. This is useful when test resources depend on values that aren't available until test runtime, for example the test installation namespace.

A manifest template has env vars defined with `${ENV_VAR_NAME}`, e.g.
```
apiVersion: v1
kind: Service
metadata:
  name: my-service
  namespace: ${INSTALL_NAMESPACE}
spec:
  ...
```

TestCase now has the additional fields:
- ManifestTemplates - list of manifest template filenames
- ResourcesFromTemplates - a func that returns resources based on the testInstallation

Updated the metrics suite to use manifest templates as a poc.


<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
