### PR TITLE
Add failover setup tests for custom with custom labels

### DIFF
--- a/internal/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels-out.yaml
+++ b/internal/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels-out.yaml
@@ -1,0 +1,113 @@
+clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_reviews_8080
+  type: EDS
+endpoints:
+- clusterName: kube_gwtest_reviews_8080
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.1.11
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z2s3
+      zone: r1z2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.2.14
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z2s4
+      zone: r1z2
+    priority: 2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.3.3
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z3s4
+      zone: r1z3
+    priority: 2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.4.4
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r2
+      subZone: r2z1s1
+      zone: r2z1
+    priority: 1
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-http-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_reviews_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/internal/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels.yaml
+++ b/internal/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels.yaml
@@ -1,0 +1,111 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: gwtest
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: reviews
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: reviews-slice
+  namespace: gwtest
+  labels:
+    kubernetes.io/service-name: reviews
+    app: reviews
+    service: reviews
+addressType: IPv4
+endpoints:
+  - addresses: # Pod labels: v1 in n1 so should get P0 (highest priority)
+      - 10.244.1.11
+    conditions:
+      ready: true
+    nodeName: worker
+    targetRef:
+      kind: Pod
+      name: reviews-1
+      namespace: gwtest
+  - addresses: # Pod labels: v2 in n2 so should get P2 (lowest priority)
+      - 10.244.2.14
+    conditions:
+      ready: true
+    nodeName: worker2
+    targetRef:
+      kind: Pod
+      name: reviews-2
+      namespace: gwtest
+  - addresses: # Pod labels: no version or network labels so should get P2
+      - 10.244.3.3
+    conditions:
+      ready: true
+    nodeName: worker3
+    targetRef:
+      kind: Pod
+      name: reviews-3
+      namespace: gwtest
+  - addresses: # Pod labels: v1 in n2 so should get P1
+      - 10.244.4.4
+    conditions:
+      ready: true
+    nodeName: worker4
+    targetRef:
+      kind: Pod
+      name: reviews-4
+      namespace: gwtest
+ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: reviews
+          port: 8080
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: do-failover
+  namespace: gwtest
+spec:
+  host: reviews.gwtest.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      localityLbSetting:
+        failoverPriority:
+        - "version=v1"
+        - "topology.istio.io/network=n1"

--- a/internal/kgateway/setup/testdata/istio_destination_rule/failover-label-keys-out.yaml
+++ b/internal/kgateway/setup/testdata/istio_destination_rule/failover-label-keys-out.yaml
@@ -1,0 +1,113 @@
+clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_kubernetes_443
+  type: EDS
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_reviews_8080
+  type: EDS
+endpoints:
+- clusterName: kube_gwtest_reviews_8080
+  endpoints:
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.1.11
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z2s3
+      zone: r1z2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.2.14
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z2s4
+      zone: r1z2
+    priority: 2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.3.3
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r1
+      subZone: r1z3s4
+      zone: r1z3
+    priority: 2
+  - lbEndpoints:
+    - endpoint:
+        address:
+          socketAddress:
+            address: 10.244.4.4
+            portValue: 8080
+      loadBalancingWeight: 1
+    loadBalancingWeight: 1
+    locality:
+      region: r2
+      subZone: r2z1s1
+      zone: r2z1
+    priority: 1
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: listener~8080~www_example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~www_example_com-route-0-httproute-http-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_reviews_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/internal/kgateway/setup/testdata/istio_destination_rule/failover-label-keys.yaml
+++ b/internal/kgateway/setup/testdata/istio_destination_rule/failover-label-keys.yaml
@@ -1,0 +1,111 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  namespace: gwtest
+  labels:
+    app: reviews
+    service: reviews
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: reviews
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: reviews-slice
+  namespace: gwtest
+  labels:
+    kubernetes.io/service-name: reviews
+    app: reviews
+    service: reviews
+addressType: IPv4
+endpoints:
+  - addresses: # Pod labels: v1 in n1 so should get P0 (highest priority)
+      - 10.244.1.11
+    conditions:
+      ready: true
+    nodeName: worker
+    targetRef:
+      kind: Pod
+      name: reviews-1
+      namespace: gwtest
+  - addresses: # Pod labels: v2 in n2 so should get P2 (lowest priority)
+      - 10.244.2.14
+    conditions:
+      ready: true
+    nodeName: worker2
+    targetRef:
+      kind: Pod
+      name: reviews-2
+      namespace: gwtest
+  - addresses: # Pod labels: no version or network labels so should get P2
+      - 10.244.3.3
+    conditions:
+      ready: true
+    nodeName: worker3
+    targetRef:
+      kind: Pod
+      name: reviews-3
+      namespace: gwtest
+  - addresses: # Pod labels: v1 in n2 so should get P1
+      - 10.244.4.4
+    conditions:
+      ready: true
+    nodeName: worker4
+    targetRef:
+      kind: Pod
+      name: reviews-4
+      namespace: gwtest
+ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: http-gw-for-test
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: reviews
+          port: 8080
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: do-failover
+  namespace: gwtest
+spec:
+  host: reviews.gwtest.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      localityLbSetting:
+        failoverPriority:
+        - "version"
+        - "topology.istio.io/network"

--- a/internal/kgateway/setup/testdata/setup_yaml/pods.yaml
+++ b/internal/kgateway/setup/testdata/setup_yaml/pods.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   labels:
     app: gateway
+    version: v1
     topology.istio.io/network: n1
   name: gateway
 spec:
@@ -83,6 +84,7 @@ kind: Pod
 metadata:
   labels:
     app: reviews
+    version: v1
     topology.istio.io/network: n1
   name: reviews-1
 spec:
@@ -103,6 +105,7 @@ kind: Pod
 metadata:
   labels:
     app: reviews
+    version: v2
     topology.istio.io/network: n1
   name: reviews-2
 spec:
@@ -162,6 +165,7 @@ kind: Pod
 metadata:
   labels:
     app: reviews
+    version: v1
     topology.istio.io/network: n2
   name: reviews-4
 spec:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Two new test cases are verifying that the output configuration for DR failover are as described in [the Istio doc](https://istio.io/latest/docs/reference/config/networking/destination-rule/#LocalityLoadBalancerSetting-failover_priority) and have the expected endpoint priorities:
1. `failover-key-val-labels` verifies the priorities if having a list of arbitrary key-value labels
2. `failover-label-keys` verifies the priorities of labels list by their keys and values matching the ones in the connected client

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind new_feature
(couldn't find a better match)

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
Validates https://github.com/solo-io/gloo-gateway/issues/527