### PR TITLE
use Go patch version in submodules

### DIFF
--- a/hack/utils/applier/go.mod
+++ b/hack/utils/applier/go.mod
@@ -1,6 +1,6 @@
 module github.com/kgateway-dev/kgateway/hack/utils/applier
 
-go 1.24
+go 1.24.6
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.0

--- a/test/mocks/mock-ai-provider-server/go.mod
+++ b/test/mocks/mock-ai-provider-server/go.mod
@@ -1,6 +1,6 @@
 module mock-ai-provider-server
 
-go 1.24
+go 1.24.6
 
 require github.com/gin-gonic/gin v1.10.0
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Follow-up to https://github.com/kgateway-dev/kgateway/pull/11973
I was getting errors running `make generate-all`:
```
go: downloading go1.24 (darwin/arm64)
go: download go1.24 for darwin/arm64: toolchain not available
```

To fix it, changed the submodules to also use the patch version (1.24.6).

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
