### PR TITLE
translator: Add separate reasons for dropping vs replacing invalid routes

### DIFF
--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -15,6 +15,7 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
@@ -270,9 +271,11 @@ func TestBasic(t *testing.T) {
 				Namespace: "infra",
 				Name:      "example-gateway",
 			},
-			assertReports: translatortest.AssertRouteInvalidReplaced(
+			assertReports: translatortest.AssertRouteInvalid(
 				t,
 				"example-route",
+				"default",
+				reporter.RouteRuleReplacedReason,
 				"infra",
 				`field invalid_object contains invalid JSON string: "model":"gpt-4"`,
 				`field invalid_slices contains invalid JSON string: [1,2,3`,
@@ -775,7 +778,7 @@ func TestBasic(t *testing.T) {
 				Namespace: "default",
 				Name:      "example-gateway",
 			},
-			assertReports: translatortest.AssertRouteInvalidReplaced(t, "example-route", "default", "no action specified"),
+			assertReports: translatortest.AssertRouteInvalid(t, "example-route", "default", reporter.RouteRuleReplacedReason, "no action specified"),
 		})
 	})
 
@@ -787,7 +790,7 @@ func TestBasic(t *testing.T) {
 				Namespace: "default",
 				Name:      "example-gateway",
 			},
-			assertReports: translatortest.AssertRouteInvalidReplaced(t, "example-route", "default", "cannot be applied to route with existing action"),
+			assertReports: translatortest.AssertRouteInvalid(t, "example-route", "default", reporter.RouteRuleReplacedReason, "cannot be applied to route with existing action"),
 		})
 	})
 
@@ -1110,18 +1113,20 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "matcher-path-prefix-invalid.yaml",
 			minMode:   settings.RouteReplacementStandard,
 			assertStandard: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"the rewrite /new//../path is invalid",
 				)
 			},
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"the rewrite /new//../path is invalid",
 				)
 			},
@@ -1133,10 +1138,11 @@ func TestRouteReplacement(t *testing.T) {
 			minMode:        settings.RouteReplacementStandard,
 			assertStandard: nil,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-rds-route",
 					"gwtest",
+					reporter.RouteRuleDroppedReason,
 					"invalid named capture group",
 				)
 			},
@@ -1148,10 +1154,11 @@ func TestRouteReplacement(t *testing.T) {
 			minMode:        settings.RouteReplacementStandard,
 			assertStandard: nil,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-regex-path-route",
 					"gwtest",
+					reporter.RouteRuleDroppedReason,
 					"missing ]",
 				)
 			},
@@ -1163,10 +1170,11 @@ func TestRouteReplacement(t *testing.T) {
 			minMode:        settings.RouteReplacementStandard,
 			assertStandard: nil,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-regex-route",
 					"gwtest",
+					reporter.RouteRuleDroppedReason,
 					"error initializing configuration '': missing ]: [invalid-regex",
 				)
 			},
@@ -1177,18 +1185,20 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-extension-ref-invalid.yaml",
 			minMode:   settings.RouteReplacementStandard,
 			assertStandard: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"test-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"gateway.kgateway.dev/TrafficPolicy/gwtest/my-tp-that-doesnt-exist: policy not found",
 				)
 			},
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"test-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"gateway.kgateway.dev/TrafficPolicy/gwtest/my-tp-that-doesnt-exist: policy not found",
 				)
 			},
@@ -1249,18 +1259,20 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "urlrewrite-invalid.yaml",
 			minMode:   settings.RouteReplacementStandard,
 			assertStandard: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-builtin-filter-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"must only contain valid characters matching pattern",
 				)
 			},
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-builtin-filter-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"must only contain valid characters matching pattern",
 				)
 			},
@@ -1271,10 +1283,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "matcher-query-regex-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-route-matcher-query-params",
 					"gwtest",
+					reporter.RouteRuleDroppedReason,
 					"invalid matcher configuration",
 				)
 			},
@@ -1285,10 +1298,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-csrf-regex-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"test-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"invalid xds configuration",
 				)
 			},
@@ -1299,10 +1313,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-extauth-extension-ref-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"extauthz: gateway extension gwtest/non-existent-auth-extension not found",
 				)
 			},
@@ -1313,10 +1328,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-transformation-body-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"invalid xds configuration",
 				)
 			},
@@ -1327,10 +1343,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-transformation-header-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"invalid xds configuration",
 				)
 			},
@@ -1341,10 +1358,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-transformation-malformed-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"invalid xds configuration",
 				)
 			},
@@ -1361,10 +1379,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-header-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-header-template-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"invalid xds configuration",
 				)
 			},
@@ -1375,10 +1394,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "request-header-modifier-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-request-header-modifier-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"invalid route configuration",
 				)
 			},
@@ -1389,10 +1409,11 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "response-header-modifier-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidReplaced(
+				return translatortest.AssertRouteInvalid(
 					t,
 					"invalid-response-header-modifier-route",
 					"gwtest",
+					reporter.RouteRuleReplacedReason,
 					"Incorrect configuration: %RESPONSE(Invalid-Variable",
 				)
 			},

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -274,9 +274,8 @@ func TestBasic(t *testing.T) {
 			assertReports: translatortest.AssertRouteInvalid(
 				t,
 				"example-route",
-				"default",
-				reporter.RouteRuleReplacedReason,
 				"infra",
+				reporter.RouteRuleReplacedReason,
 				`field invalid_object contains invalid JSON string: "model":"gpt-4"`,
 				`field invalid_slices contains invalid JSON string: [1,2,3`,
 			),

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -792,7 +792,7 @@ func TestBasic(t *testing.T) {
 				Namespace: "default",
 				Name:      "example-gateway",
 			},
-			assertReports: translatortest.AssertRouteInvalidDropped(t, "example-route", "default", "no action specified"),
+			assertReports: translatortest.AssertRouteInvalidReplaced(t, "example-route", "default", "no action specified"),
 		})
 	})
 
@@ -804,7 +804,7 @@ func TestBasic(t *testing.T) {
 				Namespace: "default",
 				Name:      "example-gateway",
 			},
-			assertReports: translatortest.AssertRouteInvalidDropped(t, "example-route", "default", "cannot be applied to route with existing action"),
+			assertReports: translatortest.AssertRouteInvalidReplaced(t, "example-route", "default", "cannot be applied to route with existing action"),
 		})
 	})
 
@@ -1127,7 +1127,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "matcher-path-prefix-invalid.yaml",
 			minMode:   settings.RouteReplacementStandard,
 			assertStandard: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
@@ -1135,7 +1135,7 @@ func TestRouteReplacement(t *testing.T) {
 				)
 			},
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
@@ -1194,7 +1194,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-extension-ref-invalid.yaml",
 			minMode:   settings.RouteReplacementStandard,
 			assertStandard: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"test-route",
 					"gwtest",
@@ -1202,7 +1202,7 @@ func TestRouteReplacement(t *testing.T) {
 				)
 			},
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"test-route",
 					"gwtest",
@@ -1266,7 +1266,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "urlrewrite-invalid.yaml",
 			minMode:   settings.RouteReplacementStandard,
 			assertStandard: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-builtin-filter-route",
 					"gwtest",
@@ -1274,7 +1274,7 @@ func TestRouteReplacement(t *testing.T) {
 				)
 			},
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-builtin-filter-route",
 					"gwtest",
@@ -1302,7 +1302,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-csrf-regex-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"test-route",
 					"gwtest",
@@ -1316,7 +1316,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-extauth-extension-ref-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
@@ -1330,7 +1330,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-transformation-body-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
@@ -1344,7 +1344,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-transformation-header-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
@@ -1358,7 +1358,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-transformation-malformed-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-traffic-policy-route",
 					"gwtest",
@@ -1367,11 +1367,10 @@ func TestRouteReplacement(t *testing.T) {
 			},
 		},
 		{
-			name:         "Template Structure Invalid",
-			category:     "policy",
-			inputFile:    "policy-template-structure-invalid.yaml",
-			minMode:      settings.RouteReplacementStrict,
-			assertStrict: nil,
+			name:      "Template Structure Invalid",
+			category:  "policy",
+			inputFile: "policy-template-structure-invalid.yaml",
+			minMode:   settings.RouteReplacementStrict,
 		},
 		{
 			name:      "Header Template Invalid",
@@ -1379,7 +1378,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "policy-header-template-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-header-template-route",
 					"gwtest",
@@ -1393,7 +1392,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "request-header-modifier-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-request-header-modifier-route",
 					"gwtest",
@@ -1407,7 +1406,7 @@ func TestRouteReplacement(t *testing.T) {
 			inputFile: "response-header-modifier-invalid.yaml",
 			minMode:   settings.RouteReplacementStrict,
 			assertStrict: func(t *testing.T) translatortest.AssertReports {
-				return translatortest.AssertRouteInvalidDropped(
+				return translatortest.AssertRouteInvalidReplaced(
 					t,
 					"invalid-response-header-modifier-route",
 					"gwtest",

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -15,7 +15,6 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
@@ -263,7 +262,7 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
-	t.Run("TrafficPolicy with ai invalided default values", func(t *testing.T) {
+	t.Run("TrafficPolicy with AI invalided default values", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFile:  "traffic-policy/ai-invalid-default-value.yaml",
 			outputFile: "traffic-policy/ai-invalid-default-value.yaml",
@@ -271,29 +270,13 @@ func TestBasic(t *testing.T) {
 				Namespace: "infra",
 				Name:      "example-gateway",
 			},
-			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
-				a := assert.New(t)
-				// we expect the httproute to reflect an invalid status
-				route := &gwv1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "example-route",
-						Namespace: "infra",
-					},
-				}
-				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
-				a.NotNil(routeStatus)
-				a.Len(routeStatus.Parents, 1)
-
-				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
-				a.NotNil(acceptedCond)
-				a.Equal(metav1.ConditionFalse, acceptedCond.Status)
-				a.Equal(reporter.RouteRuleDroppedReason, acceptedCond.Reason)
-				a.Equal(2, strings.Count(acceptedCond.Message, `field invalid_object contains invalid JSON string: "model":"gpt-4"}`),
-					"Expected 'invalid_object' message to appear exactly twice")
-				a.Equal(2, strings.Count(acceptedCond.Message, `field invalid_slices contains invalid JSON string: [1,2,3`),
-					"Expected 'invalid_slices' message to appear exactly twice")
-				a.Equal(int64(0), acceptedCond.ObservedGeneration)
-			},
+			assertReports: translatortest.AssertRouteInvalidReplaced(
+				t,
+				"example-route",
+				"infra",
+				`field invalid_object contains invalid JSON string: "model":"gpt-4"`,
+				`field invalid_slices contains invalid JSON string: [1,2,3`,
+			),
 		})
 	})
 

--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -233,26 +233,15 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 			return nil
 		}
 
-		// If routeAcceptanceErr is set, report Accepted=False with Reason=RouteRuleReplaced.
-		// For legacy behavior, we may report Accepted=False with Reason=RouteRuleDropped.
-		var (
-			reason  gwv1.RouteConditionReason
-			message string
-		)
-		switch h.routeReplacementMode {
-		case settings.RouteReplacementStandard, settings.RouteReplacementStrict:
-			reason = gwv1.RouteConditionReason(reportssdk.RouteRuleReplacedReason)
-			message = fmt.Sprintf("Replaced Rule (%d): %v", in.MatchIndex, routeAcceptanceErr)
-		default:
-			reason = gwv1.RouteConditionReason(reportssdk.RouteRuleDroppedReason)
-			message = fmt.Sprintf("Dropped Rule (%d): %v", in.MatchIndex, routeAcceptanceErr)
+		// If routeAcceptanceErr is set, report Accepted=False with Reason=RouteRuleReplaced
+		if routeAcceptanceErr != nil {
+			routeReport.SetCondition(reportssdk.RouteCondition{
+				Type:    gwv1.RouteConditionAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  gwv1.RouteConditionReason(reportssdk.RouteRuleReplacedReason),
+				Message: fmt.Sprintf("Replaced Rule (%d): %v", in.MatchIndex, routeAcceptanceErr),
+			})
 		}
-		routeReport.SetCondition(reportssdk.RouteCondition{
-			Type:    gwv1.RouteConditionAccepted,
-			Status:  metav1.ConditionFalse,
-			Reason:  reason,
-			Message: message,
-		})
 
 		if h.routeReplacementMode == settings.RouteReplacementStandard || h.routeReplacementMode == settings.RouteReplacementStrict {
 			// Clear all headers and filter configs when the route is replaced with a direct response
@@ -274,8 +263,6 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 			}
 			return out
 		}
-		// Drop the route entirely (legacy behavior, will be removed in the future)
-		return nil
 	}
 
 	return out

--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -233,18 +233,28 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 			return nil
 		}
 
-		// If routeAcceptanceErr is set, report Accepted=False with Reason=RouteRuleReplaced
-		if routeAcceptanceErr != nil {
-			routeReport.SetCondition(reportssdk.RouteCondition{
-				Type:    gwv1.RouteConditionAccepted,
-				Status:  metav1.ConditionFalse,
-				Reason:  gwv1.RouteConditionReason(reportssdk.RouteRuleDroppedReason),
-				Message: fmt.Sprintf("Dropped Rule (%d): %v", in.MatchIndex, routeAcceptanceErr),
-			})
-		}
-
+		// If routeAcceptanceErr is set, report Accepted=False with Reason=RouteRuleReplaced.
+		// For legacy behavior, we may report Accepted=False with Reason=RouteRuleDropped.
+		var (
+			reason  gwv1.RouteConditionReason
+			message string
+		)
 		switch h.routeReplacementMode {
 		case settings.RouteReplacementStandard, settings.RouteReplacementStrict:
+			reason = gwv1.RouteConditionReason(reportssdk.RouteRuleReplacedReason)
+			message = fmt.Sprintf("Replaced Rule (%d): %v", in.MatchIndex, routeAcceptanceErr)
+		default:
+			reason = gwv1.RouteConditionReason(reportssdk.RouteRuleDroppedReason)
+			message = fmt.Sprintf("Dropped Rule (%d): %v", in.MatchIndex, routeAcceptanceErr)
+		}
+		routeReport.SetCondition(reportssdk.RouteCondition{
+			Type:    gwv1.RouteConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  reason,
+			Message: message,
+		})
+
+		if h.routeReplacementMode == settings.RouteReplacementStandard || h.routeReplacementMode == settings.RouteReplacementStrict {
 			// Clear all headers and filter configs when the route is replaced with a direct response
 			out.TypedPerFilterConfig = nil
 			out.RequestHeadersToAdd = nil
@@ -263,10 +273,9 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 				},
 			}
 			return out
-		default:
-			// Drop the route entirely (legacy behavior, will be removed in the future)
-			return nil
 		}
+		// Drop the route entirely (legacy behavior, will be removed in the future)
+		return nil
 	}
 
 	return out

--- a/pkg/pluginsdk/reporter/types.go
+++ b/pkg/pluginsdk/reporter/types.go
@@ -19,8 +19,12 @@ const (
 
 	PolicyOverriddenMsg = "Overridden due to conflict with higher priority policy in target(s)"
 
-	// RouteRuleDroppedReason is used with the Accepted=False condition when the route rule is dropped
+	// RouteRuleDroppedReason is used with the Accepted=False condition when the route rule is dropped.
 	RouteRuleDroppedReason = "RouteRuleDropped"
+
+	// RouteRuleReplacedReason is used with the Accepted=False condition when the route rule is replaced
+	// with a direct response.
+	RouteRuleReplacedReason = "RouteRuleReplaced"
 )
 
 // PolicyAttachmentState represents the state of a policy attachment

--- a/test/translator/assertions.go
+++ b/test/translator/assertions.go
@@ -47,6 +47,17 @@ func AssertPolicyStatusWithGeneration(t *testing.T, reportsMap reports.ReportMap
 // AssertRouteInvalidDropped is a helper for asserting that a route has the Accepted=false status condition
 // for dropped rules with variadic expected message substrings.
 func AssertRouteInvalidDropped(t *testing.T, routeName, namespace string, expectedMsgSubstrings ...string) AssertReports {
+	return assertRouteInvalid(t, routeName, namespace, reporter.RouteRuleDroppedReason, expectedMsgSubstrings...)
+}
+
+// AssertRouteInvalidReplaced is a helper for asserting that a route has the Accepted=false status condition
+// for replaced rules with variadic expected message substrings.
+func AssertRouteInvalidReplaced(t *testing.T, routeName, namespace string, expectedMsgSubstrings ...string) AssertReports {
+	return assertRouteInvalid(t, routeName, namespace, reporter.RouteRuleReplacedReason, expectedMsgSubstrings...)
+}
+
+// assertRouteInvalid is the common implementation for both dropped and replaced route assertions
+func assertRouteInvalid(t *testing.T, routeName, namespace, expectedReason string, expectedMsgSubstrings ...string) AssertReports {
 	return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
 		t.Helper()
 		a := assert.New(t)
@@ -69,7 +80,7 @@ func AssertRouteInvalidDropped(t *testing.T, routeName, namespace string, expect
 		accepted := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
 		a.NotNil(accepted, "Accepted condition should not be nil")
 		a.Equal(metav1.ConditionFalse, accepted.Status, "Accepted Status mismatch")
-		a.Equal(string(reporter.RouteRuleDroppedReason), accepted.Reason, "Accepted Reason mismatch")
+		a.Equal(expectedReason, accepted.Reason, "Accepted Reason mismatch")
 		for _, msgSubstring := range expectedMsgSubstrings {
 			a.Contains(accepted.Message, msgSubstring, "Accepted Message mismatch")
 		}

--- a/test/translator/assertions.go
+++ b/test/translator/assertions.go
@@ -44,20 +44,9 @@ func AssertPolicyStatusWithGeneration(t *testing.T, reportsMap reports.ReportMap
 	}
 }
 
-// AssertRouteInvalidDropped is a helper for asserting that a route has the Accepted=false status condition
-// for dropped rules with variadic expected message substrings.
-func AssertRouteInvalidDropped(t *testing.T, routeName, namespace string, expectedMsgSubstrings ...string) AssertReports {
-	return assertRouteInvalid(t, routeName, namespace, reporter.RouteRuleDroppedReason, expectedMsgSubstrings...)
-}
-
-// AssertRouteInvalidReplaced is a helper for asserting that a route has the Accepted=false status condition
-// for replaced rules with variadic expected message substrings.
-func AssertRouteInvalidReplaced(t *testing.T, routeName, namespace string, expectedMsgSubstrings ...string) AssertReports {
-	return assertRouteInvalid(t, routeName, namespace, reporter.RouteRuleReplacedReason, expectedMsgSubstrings...)
-}
-
-// assertRouteInvalid is the common implementation for both dropped and replaced route assertions
-func assertRouteInvalid(t *testing.T, routeName, namespace, expectedReason string, expectedMsgSubstrings ...string) AssertReports {
+// AssertRouteInvalid is a helper for asserting that a route has the Accepted=false status condition
+// with the specified reason and variadic expected message substrings.
+func AssertRouteInvalid(t *testing.T, routeName, namespace, expectedReason string, expectedMsgSubstrings ...string) AssertReports {
 	return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
 		t.Helper()
 		a := assert.New(t)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Previously, both dropped and replaced route rules used a single custom reason "RouteRuleDropped". Now the route translator uses distinct reasons based on the actual action taken:

- RouteRuleDropped: When routes are dropped entirely (invalid matchers or legacy mode)
- RouteRuleReplaced: When routes are replaced with direct responses (standard/strict mode)

This provides clearer status reporting for users to understand whether their invalid routes were dropped or replaced with error responses.

Resolves #11977

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind fix
/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

No need imo - the custom RouteRuleDropped condition reason was introduced in the 2.1 cycle.

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
