### PR TITLE
flake: Add accepted route checks to TestMatcherInheritance test

### DIFF
--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -293,9 +293,6 @@ func (s *tsuite) TestUnresolvedChild() {
 }
 
 func (s *tsuite) TestMatcherInheritance() {
-	// Wait for all routes to be created
-	s.ti.Assertions.EventuallyObjectsExist(s.ctx, routeParent1, routeParent2, routeTeam1)
-
 	// Wait for both parent routes to be accepted before sending traffic
 	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeParent1.Name, routeParent1.Namespace,
 		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)

--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -293,6 +293,17 @@ func (s *tsuite) TestUnresolvedChild() {
 }
 
 func (s *tsuite) TestMatcherInheritance() {
+	// Wait for all routes to be created
+	s.ti.Assertions.EventuallyObjectsExist(s.ctx, routeParent1, routeParent2, routeTeam1)
+
+	// Wait for both parent routes to be accepted before sending traffic
+	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeParent1.Name, routeParent1.Namespace,
+		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)
+	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeParent2.Name, routeParent2.Namespace,
+		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)
+	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeTeam1.Name, routeTeam1.Namespace,
+		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)
+
 	// Assert traffic on parent1's prefix
 	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath("/anything/foo/child")},


### PR DESCRIPTION
# Description

Adds route status checks to TestMatcherInheritance test

**Related issues:** 
Hopefully fixes https://github.com/kgateway-dev/kgateway/issues/10814 

# Change Type

```
/kind flake
```

# Changelog


```release-note
NONE
```

# Additional Notes

TODO: still working on validating locally 


Test flakes on curl assertion:
```
2025-08-13T22:39:48.4462824Z HttpResponse{StatusCode: 200, Body: &matchers.ContainSubstringMatcher{Substr:"/anything/baz/child", Args:[]interface {}(nil)}, Headers: map[], NotHeaders: [], Custom: <nil>}
2025-08-13T22:39:48.4463119Z stdout:
2025-08-13T22:39:48.4463415Z upstream connect error or disconnect/reset before headers. reset reason: connection termination
2025-08-13T22:39:48.4463702Z stderr:  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
2025-08-13T22:39:48.4464321Z                                  Dload  Upload   Total   Spent    Left  Speed
2025-08-13T22:39:48.4464332Z 
2025-08-13T22:39:48.4464531Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 10.96.130.203:8080...
2025-08-13T22:39:48.4464710Z * Connected to http-gateway.infra.svc (10.96.130.203) port 8080 (#0)
2025-08-13T22:39:48.4464801Z > GET /anything/baz/child HTTP/1.1
2025-08-13T22:39:48.4464898Z > Host: http-gateway.infra.svc:8080
2025-08-13T22:39:48.4464987Z > User-Agent: curl/7.83.1-DEV
2025-08-13T22:39:48.4465054Z > Accept: */*
2025-08-13T22:39:48.4465112Z > 
2025-08-13T22:39:48.4465220Z * Mark bundle as not supporting multiuse
2025-08-13T22:39:48.4465306Z < HTTP/1.1 503 Service Unavailable
2025-08-13T22:39:48.4465388Z < content-length: 95
2025-08-13T22:39:48.4465471Z < content-type: text/plain
2025-08-13T22:39:48.4465556Z < date: Wed, 13 Aug 2025 22:39:25 GMT
2025-08-13T22:39:48.4465642Z < server: envoy
2025-08-13T22:39:48.4465751Z < 
2025-08-13T22:39:48.4465876Z { [95 bytes data]
2025-08-13T22:39:48.4465884Z 
2025-08-13T22:39:48.4466083Z 100    95  100    95    0     0  39046      0 --:--:-- --:--:-- --:--:-- 47500
2025-08-13T22:39:48.4466233Z * Connection #0 to host http-gateway.infra.svc left intact
2025-08-13T22:39:48.4466237Z 
2025-08-13T22:39:48.4466241Z 
2025-08-13T22:39:48.4466323Z === NAME  TestKgateway
2025-08-13T22:39:48.4466449Z     curl.go:167: 
2025-08-13T22:39:48.4466573Z         Failed after 1.182s.
2025-08-13T22:39:48.4467362Z         The function passed to Consistently failed at /home/runner/work/kgateway/kgateway/test/kubernetes/testutils/assertions/curl.go:161 with:
2025-08-13T22:39:48.4467462Z         Expected
2025-08-13T22:39:48.4467614Z             <*http.Response>: {
2025-08-13T22:39:48.4467813Z                 Status:     <string>: ""
2025-08-13T22:39:48.4467999Z                 StatusCode: <int>: 503
2025-08-13T22:39:48.4468978Z                 Body:       <string>: "upstream connect error or disconnect/reset before headers. reset reason: connection termination"
2025-08-13T22:39:48.4469073Z             }
2025-08-13T22:39:48.4469422Z         to have HTTP status
2025-08-13T22:39:48.4469563Z             <int>: 200 
2025-08-13T22:39:48.4469640Z         
2025-08-13T22:39:48.4469753Z         expected: {
2025-08-13T22:39:48.4469971Z           "StatusCode": 200,
2025-08-13T22:39:48.4470072Z           "Body": {
2025-08-13T22:39:48.4470280Z             "Substr": "/anything/baz/child",
2025-08-13T22:39:48.4470674Z             "Args": null
2025-08-13T22:39:48.4470821Z           },
2025-08-13T22:39:48.4471026Z           "Headers": null,
2025-08-13T22:39:48.4471174Z           "NotHeaders": null,
2025-08-13T22:39:48.4471293Z           "Custom": null,
2025-08-13T22:39:48.4471429Z           "IgnoreExitCode": 0
2025-08-13T22:39:48.4471503Z         }
2025-08-13T22:39:48.4471656Z httproute.gateway.networking.k8s.io "parent1" deleted
2025-08-13T22:39:48.4471805Z httproute.gateway.networking.k8s.io "parent2" deleted
2025-08-13T22:39:48.4472003Z httproute.gateway.networking.k8s.io "svc1" deleted
2025-08-13T22:39:48.4472181Z === NAME  TestKgateway/RouteDelegation/TestMatcherInheritance
2025-08-13T22:39:48.4473005Z     testing.go:1679: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```