### PR TITLE
flake: bump timeout self managed gw test

### DIFF
--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -258,8 +258,16 @@ func (s *testingSuite) TestSelfManagedGateway() {
 				break
 			}
 		}
-		assert.True(c, accepted, "gateway status not accepted")
-	}, 10*time.Second, 1*time.Second)
+		if !accepted {
+			// Provide more context about the current gateway conditions for debugging
+			var conditionDetails []string
+			for _, condition := range gw.Status.Conditions {
+				conditionDetails = append(conditionDetails, fmt.Sprintf("Type: %s, Status: %s, Reason: %s, Message: %s",
+					condition.Type, condition.Status, condition.Reason, condition.Message))
+			}
+			assert.True(c, accepted, "gateway status not accepted. Current conditions: %v", conditionDetails)
+		}
+	}, 60*time.Second, 1*time.Second)
 
 	s.testInstallation.Assertions.ConsistentlyObjectsNotExist(s.ctx, proxyService, proxyServiceAccount, proxyDeployment)
 }

--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -265,8 +265,9 @@ func (s *testingSuite) TestSelfManagedGateway() {
 				conditionDetails = append(conditionDetails, fmt.Sprintf("Type: %s, Status: %s, Reason: %s, Message: %s",
 					condition.Type, condition.Status, condition.Reason, condition.Message))
 			}
-			assert.True(c, accepted, "gateway status not accepted. Current conditions: %v", conditionDetails)
+			fmt.Printf("Gateway not accepted. Current conditions: %v\n", conditionDetails)
 		}
+		assert.True(c, accepted, "gateway status not accepted")
 	}, 60*time.Second, 1*time.Second)
 
 	s.testInstallation.Assertions.ConsistentlyObjectsNotExist(s.ctx, proxyService, proxyServiceAccount, proxyDeployment)


### PR DESCRIPTION
# Description

Match timeout in https://github.com/kgateway-dev/kgateway/blob/main/test/kubernetes/e2e/features/services/tlsroute/types.go#L88 

Should make https://github.com/kgateway-dev/kgateway/issues/11884 less painful. Should still investigate more why the self managed gateway status is taking longer to update than regular managed gateways.

# Change Type

```
/kind flake
```

# Changelog


```release-note
NONE
```
