### PR TITLE
Clarify error when BackendRefs ref'ing to incorrect port

### DIFF
--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -228,7 +228,7 @@ func TestBasic(t *testing.T) {
 				a.NotNil(resolvedRefs)
 				a.Equal(string(gwv1.RouteReasonBackendNotFound), resolvedRefs.Reason)
 				a.Equal(metav1.ConditionFalse, resolvedRefs.Status)
-				a.Equal(`Service "example-svc" not found`, resolvedRefs.Message)
+				a.Equal(`Service "example-svc" not found (port 80)`, resolvedRefs.Message)
 				a.Equal(int64(0), resolvedRefs.ObservedGeneration)
 			},
 		})
@@ -453,7 +453,7 @@ func TestBasic(t *testing.T) {
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
 				a.NotNil(resolvedRefs)
 				a.Equal(metav1.ConditionFalse, resolvedRefs.Status)
-				a.Equal(`Service "example-tcp-svc" not found`, resolvedRefs.Message)
+				a.Equal(`Service "example-tcp-svc" not found (port 8080)`, resolvedRefs.Message)
 			},
 		})
 	})
@@ -545,7 +545,7 @@ func TestBasic(t *testing.T) {
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
 				a.NotNil(resolvedRefs)
 				a.Equal(metav1.ConditionFalse, resolvedRefs.Status)
-				a.Equal("Service \"example-tls-svc\" not found", resolvedRefs.Message)
+				a.Equal("Service \"example-tls-svc\" not found (port 443)", resolvedRefs.Message)
 			},
 		})
 	})
@@ -637,7 +637,7 @@ func TestBasic(t *testing.T) {
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
 				a.NotNil(resolvedRefs)
 				a.Equal(metav1.ConditionFalse, resolvedRefs.Status)
-				a.Equal(`Service "example-grpc-svc" not found`, resolvedRefs.Message)
+				a.Equal(`Service "example-grpc-svc" not found (port 9000)`, resolvedRefs.Message)
 			},
 		})
 	})


### PR DESCRIPTION
# Description

Fixes: #11998 

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
NONE
```

# Additional Notes

1. Tested using 

```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: foo-route
spec:
  parentRefs:
  - name: foo-listenerset
    group: gateway.networking.x-k8s.io
    kind: XListenerSet
  hostnames:
  - "foo.example.com"
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    backendRefs:
    - name: foo-svc
      port: 800
---
apiVersion: v1
kind: Service
metadata:
  name: foo-svc
spec:
  selector:
    test: test
  ports:
    - protocol: HTTP
      port: 8080
      targetPort: test
```

2. Result:

```
Status:
  Parents:
    Conditions:
      Last Transition Time:  2025-08-14T13:26:37Z
      Message:               Service "foo-svc" exists but does not expose port 800
      Observed Generation:   1
      Reason:                BackendNotFound
      Status:                False
      Type:                  ResolvedRefs
      Last Transition Time:  2025-08-14T13:26:37Z
      Message:               Route is accepted
      Observed Generation:   1
      Reason:                Accepted
      Status:                True
      Type:                  Accepted
    Controller Name:         kgateway.dev/kgateway
    Parent Ref:
      Group:  gateway.networking.k8s.io
      Kind:   Gateway
      Name:   http
Events:       <none>
```
