### PR TITLE
feat: dynamically extract agentgateway version from go.mod

### DIFF
--- a/pkg/deployer/agentgateway_version.go
+++ b/pkg/deployer/agentgateway_version.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/modfile"
@@ -16,16 +17,23 @@ func getAgentgatewayVersionFromGoMod() (string, error) {
 		return "", fmt.Errorf("failed to parse go.mod: %w", err)
 	}
 
-	// first prefer replaced with a specific version
-	for _, replace := range packages.Replace {
-		if replace.Old.Path == agentgatewayModule {
-			if replace.New.Version != "" {
-				return normalizeVersion(replace.New.Version), nil
-			}
-			return "", fmt.Errorf("agentgateway is replaced with a local path or commit, cannot determine version")
+	// check if any replace directives exist for agentgateway
+	// if multiple exist, the last one takes precedence
+	var lastReplace *modfile.ReplacedGoPackage
+	for i := range packages.Replace {
+		if packages.Replace[i].Old.Path == agentgatewayModule {
+			lastReplace = &packages.Replace[i]
 		}
 	}
 
+	if lastReplace != nil {
+		if lastReplace.New.Version != "" {
+			return normalizeVersion(lastReplace.New.Version), nil
+		}
+		return "", fmt.Errorf("agentgateway is replaced with a local path or commit, cannot determine version")
+	}
+
+	// no replace directive found, check require directives
 	for _, require := range packages.Require {
 		if require.Path == agentgatewayModule {
 			return normalizeVersion(require.Version), nil
@@ -44,6 +52,7 @@ func normalizeVersion(version string) string {
 func GetAgentgatewayVersion() string {
 	version, err := getAgentgatewayVersionFromGoMod()
 	if err != nil {
+		slog.Warn("failed to get agentgateway version from go.mod, using default", "error", err, "default", AgentgatewayDefaultTag)
 		return AgentgatewayDefaultTag
 	}
 	return version

--- a/pkg/deployer/agentgateway_version.go
+++ b/pkg/deployer/agentgateway_version.go
@@ -1,0 +1,50 @@
+package deployer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/modfile"
+)
+
+const agentgatewayModule = "github.com/agentgateway/agentgateway"
+
+// getAgentgatewayVersionFromGoMod extracts the agentgateway version from go.mod if available.
+func getAgentgatewayVersionFromGoMod() (string, error) {
+	packages, err := modfile.Parse()
+	if err != nil {
+		return "", fmt.Errorf("failed to parse go.mod: %w", err)
+	}
+
+	// first prefer replaced with a specific version
+	for _, replace := range packages.Replace {
+		if replace.Old.Path == agentgatewayModule {
+			if replace.New.Version != "" {
+				return normalizeVersion(replace.New.Version), nil
+			}
+			return "", fmt.Errorf("agentgateway is replaced with a local path or commit, cannot determine version")
+		}
+	}
+
+	for _, require := range packages.Require {
+		if require.Path == agentgatewayModule {
+			return normalizeVersion(require.Version), nil
+		}
+	}
+
+	return "", fmt.Errorf("agentgateway dependency not found in go.mod")
+}
+
+// normalizeVersion removes the 'v' prefix from version strings to match Docker tag format
+func normalizeVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
+// GetAgentgatewayVersion returns the agentgateway version from go.mod,
+func GetAgentgatewayVersion() string {
+	version, err := getAgentgatewayVersionFromGoMod()
+	if err != nil {
+		return AgentgatewayDefaultTag
+	}
+	return version
+}

--- a/pkg/deployer/agentgateway_version_test.go
+++ b/pkg/deployer/agentgateway_version_test.go
@@ -138,6 +138,23 @@ func TestGetAgentgatewayVersion(t *testing.T) {
 	g := NewWithT(t)
 	version := GetAgentgatewayVersion()
 	g.Expect(version).NotTo(BeEmpty())
-	// Should return the actual version from go.mod (0.7.5)
 	g.Expect(version).To(Equal("0.7.5"))
+}
+
+func TestGetAgentgatewayVersionFallback(t *testing.T) {
+	g := NewWithT(t)
+
+	originalWd, err := os.Getwd()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tmpDir, err := os.MkdirTemp("", "nogomod-test-*")
+	g.Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	err = os.Chdir(tmpDir)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer os.Chdir(originalWd)
+
+	version := GetAgentgatewayVersion()
+	g.Expect(version).To(Equal(AgentgatewayDefaultTag))
 }

--- a/pkg/deployer/agentgateway_version_test.go
+++ b/pkg/deployer/agentgateway_version_test.go
@@ -1,0 +1,143 @@
+package deployer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetAgentgatewayVersionFromGoMod(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name         string
+		goModContent string
+		expectedVer  string
+		expectedErr  bool
+	}{
+		{
+			name: "direct dependency with v prefix",
+			goModContent: `module github.com/test/test
+
+go 1.24.6
+
+require (
+	github.com/agentgateway/agentgateway v0.7.5
+	github.com/other/dep v1.0.0
+)`,
+			expectedVer: "0.7.5",
+			expectedErr: false,
+		},
+		{
+			name: "direct dependency with different version",
+			goModContent: `module github.com/test/test
+
+go 1.24.6
+
+require (
+	github.com/agentgateway/agentgateway v0.8.0
+	github.com/other/dep v1.0.0
+)`,
+			expectedVer: "0.8.0",
+			expectedErr: false,
+		},
+		{
+			name: "replaced version",
+			goModContent: `module github.com/test/test
+
+go 1.24.6
+
+require (
+	github.com/agentgateway/agentgateway v0.7.5
+)
+
+replace github.com/agentgateway/agentgateway => github.com/agentgateway/agentgateway v0.9.1`,
+			expectedVer: "0.9.1",
+			expectedErr: false,
+		},
+		{
+			name: "replaced with local path",
+			goModContent: `module github.com/test/test
+
+go 1.24.6
+
+require (
+	github.com/agentgateway/agentgateway v0.7.5
+)
+
+replace github.com/agentgateway/agentgateway => ../local/agentgateway`,
+			expectedVer: "",
+			expectedErr: true,
+		},
+		{
+			name: "no agentgateway dependency",
+			goModContent: `module github.com/test/test
+
+go 1.24.6
+
+require (
+	github.com/other/dep v1.0.0
+)`,
+			expectedVer: "",
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "gomod-test-*")
+			g.Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			goModPath := filepath.Join(tmpDir, "go.mod")
+			err = os.WriteFile(goModPath, []byte(tt.goModContent), 0644)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			originalWd, err := os.Getwd()
+			g.Expect(err).NotTo(HaveOccurred())
+			err = os.Chdir(tmpDir)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer os.Chdir(originalWd)
+
+			version, err := getAgentgatewayVersionFromGoMod()
+			if tt.expectedErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(version).To(Equal(tt.expectedVer))
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3", "1.2.3"},
+		{"v0.7.5", "0.7.5"},
+		{"v1.0.0-alpha", "1.0.0-alpha"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := normalizeVersion(tt.input)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestGetAgentgatewayVersion(t *testing.T) {
+	g := NewWithT(t)
+	version := GetAgentgatewayVersion()
+	g.Expect(version).NotTo(BeEmpty())
+	// Should return the actual version from go.mod (0.7.5)
+	g.Expect(version).To(Equal("0.7.5"))
+}

--- a/pkg/deployer/agentgateway_version_test.go
+++ b/pkg/deployer/agentgateway_version_test.go
@@ -72,6 +72,21 @@ replace github.com/agentgateway/agentgateway => ../local/agentgateway`,
 			expectedErr: true,
 		},
 		{
+			name: "multiple replace directives - last one is used",
+			goModContent: `module github.com/test/test
+
+go 1.24.6
+
+require (
+	github.com/agentgateway/agentgateway v0.7.5
+)
+
+replace github.com/agentgateway/agentgateway => github.com/agentgateway/agentgateway v0.8.0
+replace github.com/agentgateway/agentgateway => github.com/agentgateway/agentgateway v0.9.2`,
+			expectedVer: "0.9.2",
+			expectedErr: false,
+		},
+		{
 			name: "no agentgateway dependency",
 			goModContent: `module github.com/test/test
 

--- a/pkg/deployer/agentgateway_version_test.go
+++ b/pkg/deployer/agentgateway_version_test.go
@@ -138,7 +138,7 @@ func TestGetAgentgatewayVersion(t *testing.T) {
 	g := NewWithT(t)
 	version := GetAgentgatewayVersion()
 	g.Expect(version).NotTo(BeEmpty())
-	g.Expect(version).To(Equal("0.7.5"))
+	g.Expect(version).To(Equal("0.7.8"))
 }
 
 func TestGetAgentgatewayVersionFallback(t *testing.T) {

--- a/pkg/deployer/gateway_parameters.go
+++ b/pkg/deployer/gateway_parameters.go
@@ -250,7 +250,7 @@ func defaultGatewayParameters(imageInfo *ImageInfo) *v1alpha1.GatewayParameters 
 					LogLevel: ptr.To("info"),
 					Image: &v1alpha1.Image{
 						Registry:   ptr.To(AgentgatewayRegistry),
-						Tag:        ptr.To(AgentgatewayDefaultTag),
+						Tag:        ptr.To(GetAgentgatewayVersion()),
 						Repository: ptr.To(AgentgatewayImage),
 						PullPolicy: (*corev1.PullPolicy)(ptr.To(imageInfo.PullPolicy)),
 					},

--- a/pkg/deployer/wellknown.go
+++ b/pkg/deployer/wellknown.go
@@ -18,6 +18,7 @@ const (
 	// AgentgatewayRegistry is the agentgateway registry
 	AgentgatewayRegistry = "ghcr.io/agentgateway"
 	// AgentgatewayDefaultTag is the default agentgateway image tag
+	// This is used as a fallback when the version cannot be determined from go.mod
 	AgentgatewayDefaultTag = "0.7.8"
 	// SdsImage is the image of the sds container.
 	SdsImage = "sds"


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Dynamically extract agentgateway version from go.mod instead of using hardcoded value . This ensures the deployed container version matches the go.mod dependency.

Fixes #11967

<!--
A concise explanation of the change. You may include:

- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind new_feature

<!--
Select one or more of the following by including the corresponding slash-command:

```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature

```

- ->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->


# Changelog

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->