### PR TITLE
Remove deprecated google_re2

### DIFF
--- a/internal/kgateway/extensions2/plugins/trafficpolicy/csrf_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/csrf_policy.go
@@ -146,9 +146,6 @@ func toEnvoyStringMatcher(origin v1alpha1.StringMatcher) *envoy_matcher_v3.Strin
 	case origin.SafeRegex != nil:
 		matcher.MatchPattern = &envoy_matcher_v3.StringMatcher_SafeRegex{
 			SafeRegex: &envoy_matcher_v3.RegexMatcher{
-				EngineType: &envoy_matcher_v3.RegexMatcher_GoogleRe2{
-					GoogleRe2: &envoy_matcher_v3.RegexMatcher_GoogleRE2{},
-				},
 				Regex: *origin.SafeRegex,
 			},
 		}

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -758,8 +758,7 @@ func (u *urlRewriteIr) apply(
 	if u.FullReplace != "" && policy.IsSettable(outputRoute.GetRoute().GetRegexRewrite(), mergeOpts) {
 		outputRoute.GetRoute().RegexRewrite = &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 			Pattern: &envoy_type_matcher_v3.RegexMatcher{
-				EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{}},
-				Regex:      ".*",
+				Regex: ".*",
 			},
 			Substitution: u.FullReplace,
 		}
@@ -775,8 +774,7 @@ func (u *urlRewriteIr) apply(
 		if path != "" && u.PrefixReplace == "/" && policy.IsSettable(outputRoute.GetRoute().GetRegexRewrite(), mergeOpts) {
 			outputRoute.GetRoute().RegexRewrite = &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 				Pattern: &envoy_type_matcher_v3.RegexMatcher{
-					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{}},
-					Regex:      "^" + path + "\\/*",
+					Regex: "^" + path + "\\/*",
 				},
 				Substitution: "/",
 			}

--- a/internal/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
@@ -93,7 +93,6 @@ routes:
         hostRewriteLiteral: foo.override
         regexRewrite:
           pattern:
-            googleRe2: {}
             regex: .*
           substitution: /headers
       typedPerFilterConfig:

--- a/internal/kgateway/setup/testdata/standard/cors-httproute-rule-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/cors-httproute-rule-out.yaml
@@ -97,7 +97,6 @@ routes:
           allowMethods: POST
           allowOriginStringMatch:
           - safeRegex:
-              googleRe2: {}
               regex: ^https://.*\.notexample\.com$
           - prefix: https://a.b
           - exact: https://exact.domain.com

--- a/internal/kgateway/setup/testdata/standard/cors-trafficpolicy-route-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/cors-trafficpolicy-route-out.yaml
@@ -85,7 +85,6 @@ routes:
           allowOriginStringMatch:
           - exact: https://example.com
           - safeRegex:
-              googleRe2: {}
               regex: ^https://.*\.notexample\.com$
           - prefix: https://a.b
           - prefix: http://

--- a/internal/kgateway/setup/testdata/standard/csrf-gw-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/csrf-gw-out.yaml
@@ -81,7 +81,6 @@ routes:
       - prefix: pref
       - suffix: suff
       - safeRegex:
-          googleRe2: {}
           regex: a.b
       filterEnabled:
         defaultValue:

--- a/internal/kgateway/setup/testdata/standard/csrf-route-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/csrf-route-out.yaml
@@ -89,7 +89,6 @@ routes:
           - suffix: suff
           - contains: cont
           - safeRegex:
-              googleRe2: {}
               regex: a.b
           filterEnabled:
             defaultValue:

--- a/internal/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
+++ b/internal/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
@@ -87,7 +87,6 @@ routes:
           - prefix: pref
           - suffix: suff
           - safeRegex:
-              googleRe2: {}
               regex: a.b
           filterEnabled:
             defaultValue: {}

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
@@ -80,7 +80,6 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
         regexRewrite:
           pattern:
-            googleRe2: {}
             regex: ^/api1\/*
           substitution: /
     - match:
@@ -91,6 +90,5 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
         regexRewrite:
           pattern:
-            googleRe2: {}
             regex: ^/api2\/*
           substitution: /

--- a/pkg/pluginsdk/policy/cors.go
+++ b/pkg/pluginsdk/policy/cors.go
@@ -145,9 +145,6 @@ func ConvertOriginToEnvoyStringMatcher(origin string) *envoymatcherv3.StringMatc
 	return &envoymatcherv3.StringMatcher{
 		MatchPattern: &envoymatcherv3.StringMatcher_SafeRegex{
 			SafeRegex: &envoymatcherv3.RegexMatcher{
-				EngineType: &envoymatcherv3.RegexMatcher_GoogleRe2{
-					GoogleRe2: &envoymatcherv3.RegexMatcher_GoogleRE2{},
-				},
 				Regex: "^" + regexPattern + "$",
 			},
 		},

--- a/pkg/pluginsdk/policy/cors_test.go
+++ b/pkg/pluginsdk/policy/cors_test.go
@@ -47,9 +47,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://.*\\.example\\.com$",
 					},
 				},
@@ -61,9 +58,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://.*\\.example\\.com:8080$",
 					},
 				},
@@ -75,9 +69,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://.*\\.sub\\.example\\.com$",
 					},
 				},
@@ -89,9 +80,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://sub\\..*\\.example\\.com$",
 					},
 				},
@@ -103,9 +91,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://.*\\.sub\\..*\\.example\\.com$",
 					},
 				},
@@ -126,9 +111,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://example\\..*:8080$",
 					},
 				},
@@ -140,9 +122,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://api\\..*\\.example\\.com$",
 					},
 				},
@@ -154,9 +133,6 @@ func TestConvertOriginToEnvoyStringMatcher(t *testing.T) {
 			expected: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: "^https://.*\\.example\\.com$",
 					},
 				},

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -281,7 +281,6 @@ static_resources:
                       routes:
                         - match:
                             safe_regex:
-                              google_re2: {}
                               regex: "[[invalid.regex"  # Invalid regex pattern
                           route:
                             cluster: service_foo


### PR DESCRIPTION
# Description

A concise explanation of the change. You may include:
- **Motivation:** `envoy.type.matcher.v3.RegexMatcher.google_re2` is deprecated and will be removed from Envoy.
- **What changed:** remove this configuration from the output configs.
- **Related issues:** Fixes #11711 


# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes
https://github.com/envoyproxy/envoy/issues/24256#issuecomment-1333078240