### PR TITLE
feat(agentgateway): add Path field to McpTarget

### DIFF
--- a/api/applyconfiguration/api/v1alpha1/mcptarget.go
+++ b/api/applyconfiguration/api/v1alpha1/mcptarget.go
@@ -11,6 +11,7 @@ import (
 type McpTargetApplyConfiguration struct {
 	Name     *string                  `json:"name,omitempty"`
 	Host     *string                  `json:"host,omitempty"`
+	Path     *string                  `json:"path,omitempty"`
 	Port     *int32                   `json:"port,omitempty"`
 	Protocol *apiv1alpha1.MCPProtocol `json:"protocol,omitempty"`
 }
@@ -34,6 +35,14 @@ func (b *McpTargetApplyConfiguration) WithName(value string) *McpTargetApplyConf
 // If called multiple times, the Host field is set to the value of the last call.
 func (b *McpTargetApplyConfiguration) WithHost(value string) *McpTargetApplyConfiguration {
 	b.Host = &value
+	return b
+}
+
+// WithPath sets the Path field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Path field is set to the value of the last call.
+func (b *McpTargetApplyConfiguration) WithPath(value string) *McpTargetApplyConfiguration {
+	b.Path = &value
 	return b
 }
 

--- a/api/applyconfiguration/internal/internal.go
+++ b/api/applyconfiguration/internal/internal.go
@@ -1691,6 +1691,10 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    - name: path
+      type:
+        scalar: string
+      default: ""
     - name: port
       type:
         scalar: numeric

--- a/api/v1alpha1/mcp_backend.go
+++ b/api/v1alpha1/mcp_backend.go
@@ -53,6 +53,11 @@ type McpTarget struct {
 	// +kubebuilder:validation:MinLength=1
 	Host string `json:"host"`
 
+	// Path is the URL path of the MCP target endpoint.
+	// Defaults to "/sse" for SSE protocol or "/mcp" for StreamableHTTP protocol if not specified.
+	// +optional
+	Path string `json:"path"`
+
 	// Port is the port number of the MCP target.
 	// +required
 	// +kubebuilder:validation:Minimum=1

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
@@ -783,6 +783,8 @@ spec:
                             name:
                               minLength: 1
                               type: string
+                            path:
+                              type: string
                             port:
                               format: int32
                               maximum: 65535

--- a/internal/kgateway/extensions2/plugins/backend/agentgateway/translate.go
+++ b/internal/kgateway/extensions2/plugins/backend/agentgateway/translate.go
@@ -270,6 +270,7 @@ func buildMCPIr(krtctx krt.HandlerContext, be *v1alpha1.Backend, services krt.Co
 
 			mcpTarget := &api.MCPTarget{
 				Name: targetSelector.StaticTarget.Name,
+				Path: targetSelector.StaticTarget.Path,
 				Backend: &api.BackendReference{
 					Kind: &api.BackendReference_Backend{
 						Backend: staticBackendRef,

--- a/internal/kgateway/extensions2/plugins/backend/agentgateway/translate_test.go
+++ b/internal/kgateway/extensions2/plugins/backend/agentgateway/translate_test.go
@@ -47,6 +47,7 @@ func TestBuildMCPIr(t *testing.T) {
 									Name:     "static-target",
 									Host:     "mcp-server.example.com",
 									Port:     8080,
+									Path:     "override-sse",
 									Protocol: v1alpha1.MCPProtocolSSE,
 								},
 							},
@@ -71,6 +72,7 @@ func TestBuildMCPIr(t *testing.T) {
 						if !(target.Name == "static-target" &&
 							target.Backend.Port == 8080 &&
 							target.Protocol == api.MCPTarget_SSE &&
+							target.Path == "override-sse" &&
 							target.Backend.GetBackend() == "test-ns/static-target") {
 							return false
 						}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -5185,6 +5185,14 @@ func schema_kgateway_v2_api_v1alpha1_McpTarget(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Path is the URL path of the MCP target endpoint. Defaults to \"/sse\" for SSE protocol or \"/mcp\" for StreamableHTTP protocol if not specified.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Port is the port number of the MCP target.",


### PR DESCRIPTION
# Description

Fixes #12080

Adds an optional `path` field to the `McpTarget` struct, enabling URL endpoint configuration for MCP services.

# Change Type

```
/kind new_feature
```

# Changelog


```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
