### PR TITLE
fix(agentgateway): add missing fields in translationResult.MarshalJSON

### DIFF
--- a/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
+++ b/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
@@ -111,6 +111,22 @@ func (tr *translationResult) MarshalJSON() ([]byte, error) {
 		result["Addresses"] = addresses
 	}
 
+	if len(tr.Backends) > 0 {
+		backends, err := marshalProtoMessages(tr.Backends, m)
+		if err != nil {
+			return nil, err
+		}
+		result["Backends"] = backends
+	}
+
+	if len(tr.Policies) > 0 {
+		policies, err := marshalProtoMessages(tr.Policies, m)
+		if err != nil {
+			return nil, err
+		}
+		result["Policies"] = policies
+	}
+
 	// Marshal the result map to JSON
 	return json.Marshal(result)
 }

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/a2a-backend.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/a2a-backend.yaml
@@ -1,32 +1,32 @@
 Addresses:
-  - service:
-      hostname: a2a-agent.default.svc.cluster.local
-      name: a2a-agent
-      namespace: default
-      ports:
-        - servicePort: 9090
-          targetPort: 9090
+- service:
+    hostname: a2a-agent.default.svc.cluster.local
+    name: a2a-agent
+    namespace: default
+    ports:
+    - servicePort: 9090
+      targetPort: 9090
 Binds:
-  - key: 80/default/example-gateway
-    port: 80
+- key: 80/default/example-gateway
+  port: 80
 Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          port: 9090
-          service: default/a2a-agent.default.svc.cluster.local
-        weight: 1
-    key: default.a2a.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/a2a
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Policies:
-  - name: a2a/default/a2a-agent/9090
-    target:
-      backend: default/a2a-agent:9090
-    spec:
-      a2a: {}
+- name: a2a/default/a2a-agent/9090
+  spec:
+    a2a: {}
+  target:
+    backend: default/a2a-agent:9090
+Routes:
+- backends:
+  - backend:
+      port: 9090
+      service: default/a2a-agent.default.svc.cluster.local
+    weight: 1
+  key: default.a2a.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/a2a

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/backend-default.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/backend-default.yaml
@@ -1,24 +1,24 @@
-Binds:
-  - key: 80/default/example-gateway
-    port: 80
-Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          backend: default/example-backend
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
 Backends:
-  - name: default/example-backend
-    static:
-      host: example.com
-      port: 8080
+- name: default/example-backend
+  static:
+    host: example.com
+    port: 8080
+Binds:
+- key: 80/default/example-gateway
+  port: 80
+Listeners:
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
+Routes:
+- backends:
+  - backend:
+      backend: default/example-backend
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/bedrock-backend.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/bedrock-backend.yaml
@@ -1,39 +1,39 @@
-Binds:
-  - key: 80/default/example-gateway
-    port: 80
-Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          backend: default/bedrock
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
 Backends:
-  - name: default/bedrock
-    ai:
-      bedrock:
-        model: anthropic.claude-3-5-haiku-20241022-v1:0
-        region: us-west-2
-        guardrail_identifier: guardrail-policy-id
-        guardrail_version: guardrail-policy-version
+- ai:
+    bedrock:
+      guardrailIdentifier: guardrail-policy-id
+      guardrailVersion: guardrail-policy-version
+      model: anthropic.claude-3-5-haiku-20241022-v1:0
+      region: us-west-2
+  name: default/bedrock
+Binds:
+- key: 80/default/example-gateway
+  port: 80
+Listeners:
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Policies:
-  - name: auth-default/bedrock
-    target:
-      backend: "default/bedrock"
-    spec:
-      auth:
-        aws:
-          explicitConfig:
-            region: us-west-2
-            sessionToken: ""
-            accessKeyId: "fakeAccessKeyId"
-            secretAccessKey: "fakeSecretKeyString"
+- name: auth-default/bedrock
+  spec:
+    auth:
+      aws:
+        explicitConfig:
+          accessKeyId: fakeAccessKeyId
+          region: us-west-2
+          secretAccessKey: fakeSecretKeyString
+          sessionToken: ""
+  target:
+    backend: default/bedrock
+Routes:
+- backends:
+  - backend:
+      backend: default/bedrock
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/mcp-backend-selector.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/mcp-backend-selector.yaml
@@ -1,34 +1,34 @@
 Addresses:
-  - service:
-      hostname: example-svc.default.svc.cluster.local
-      name: example-svc
-      namespace: default
-      ports:
-        - servicePort: 80
-Binds:
-  - key: 80/default/example-gateway
-    port: 80
-Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          backend: default/mcp-backend
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
+- service:
+    hostname: example-svc.default.svc.cluster.local
+    name: example-svc
+    namespace: default
+    ports:
+    - servicePort: 80
 Backends:
-  - name: default/mcp-backend
-    mcp:
-      targets:
-        - name: example-svc-80
-          backend:
-            service: default/example-svc.default.svc.cluster.local
-            port: 80
+- mcp:
+    targets:
+    - backend:
+        port: 80
+        service: default/example-svc.default.svc.cluster.local
+      name: example-svc-80
+  name: default/mcp-backend
+Binds:
+- key: 80/default/example-gateway
+  port: 80
+Listeners:
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
+Routes:
+- backends:
+  - backend:
+      backend: default/mcp-backend
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/mcp-backend-static.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/mcp-backend-static.yaml
@@ -1,32 +1,32 @@
-Binds:
-  - key: 80/default/example-gateway
-    port: 80
-Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          backend: default/mcp-backend
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
 Backends:
-  - name: default/mcp-backend
-    mcp:
-      targets:
-      - name: mcp-target
-        backend:
-          backend: default/mcp-target
-          port: 8000
-        protocol: STREAMABLE_HTTP
-  - name: default/mcp-target
-    static:
-      host: mcp-app.default.svc.cluster.local
-      port: 8000
+- mcp:
+    targets:
+    - backend:
+        backend: default/mcp-target
+        port: 8000
+      name: mcp-target
+      protocol: STREAMABLE_HTTP
+  name: default/mcp-backend
+- name: default/mcp-target
+  static:
+    host: mcp-app.default.svc.cluster.local
+    port: 8000
+Binds:
+- key: 80/default/example-gateway
+  port: 80
+Listeners:
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
+Routes:
+- backends:
+  - backend:
+      backend: default/mcp-backend
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/openai-backend.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/openai-backend.yaml
@@ -1,32 +1,32 @@
-Binds:
-  - key: 80/default/example-gateway
-    port: 80
-Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          backend: default/openai
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
 Backends:
-  - name: default/openai
-    ai:
-      openai:
-        model: gpt-4o-mini
+- ai:
+    openai:
+      model: gpt-4o-mini
+  name: default/openai
+Binds:
+- key: 80/default/example-gateway
+  port: 80
+Listeners:
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Policies:
-  - name: auth-default/openai
-    target:
+- name: auth-default/openai
+  spec:
+    auth:
+      key:
+        secret: mysecretkey
+  target:
+    backend: default/openai
+Routes:
+- backends:
+  - backend:
       backend: default/openai
-    spec:
-      auth:
-        key:
-          secret: mysecretkey
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/svc-default.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/svc-default.yaml
@@ -1,27 +1,27 @@
 Addresses:
-  - service:
-      hostname: example-svc.default.svc.cluster.local
-      name: example-svc
-      namespace: default
-      ports:
-        - servicePort: 80
+- service:
+    hostname: example-svc.default.svc.cluster.local
+    name: example-svc
+    namespace: default
+    ports:
+    - servicePort: 80
 Binds:
-  - key: 80/default/example-gateway
-    port: 80
+- key: 80/default/example-gateway
+  port: 80
 Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Routes:
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/basic-proxy.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/basic-proxy.yaml
@@ -1,30 +1,30 @@
 Addresses:
-  - service:
-      hostname: example-grpc-svc.default.svc.cluster.local
-      name: example-grpc-svc
-      namespace: default
-      ports:
-        - appProtocol: HTTP2
-          servicePort: 9000
-          targetPort: 9000
+- service:
+    hostname: example-grpc-svc.default.svc.cluster.local
+    name: example-grpc-svc
+    namespace: default
+    ports:
+    - appProtocol: HTTP2
+      servicePort: 9000
+      targetPort: 9000
 Binds:
-  - key: 8090/default/example-gateway
-    port: 8090
+- key: 8090/default/example-gateway
+  port: 8090
 Listeners:
-  - bindKey: 8090/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/grpc
-    name: grpc
-    protocol: HTTP
+- bindKey: 8090/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/grpc
+  name: grpc
+  protocol: HTTP
 Routes:
-  - backends:
-      - backend:
-          port: 9000
-          service: default/example-grpc-svc.default.svc.cluster.local
-        weight: 1
-    key: default.example-grpc-route.0.grpc
-    listenerKey: default/example-gateway/grpc
-    matches:
-      - path:
-          exact: /example.grpc.Service/ExampleMethod
-    routeName: default/example-grpc-route
+- backends:
+  - backend:
+      port: 9000
+      service: default/example-grpc-svc.default.svc.cluster.local
+    weight: 1
+  key: default.example-grpc-route.0.grpc
+  listenerKey: default/example-gateway/grpc
+  matches:
+  - path:
+      exact: /example.grpc.Service/ExampleMethod
+  routeName: default/example-grpc-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/invalid-backend.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/invalid-backend.yaml
@@ -1,18 +1,18 @@
 Binds:
-  - key: 8090/default/example-gateway
-    port: 8090
+- key: 8090/default/example-gateway
+  port: 8090
 Listeners:
-  - bindKey: 8090/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/grpc
-    name: grpc
-    protocol: HTTP
+- bindKey: 8090/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/grpc
+  name: grpc
+  protocol: HTTP
 Routes:
-  - backends:
-      - {}
-    key: default.example-grpc-route.0.grpc
-    listenerKey: default/example-gateway/grpc
-    matches:
-      - path:
-          exact: /example.grpc.Service/ExampleMethod
-    routeName: default/example-grpc-route
+- backends:
+  - {}
+  key: default.example-grpc-route.0.grpc
+  listenerKey: default/example-gateway/grpc
+  matches:
+  - path:
+      exact: /example.grpc.Service/ExampleMethod
+  routeName: default/example-grpc-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/missing-backend.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/missing-backend.yaml
@@ -1,21 +1,21 @@
 Binds:
-  - key: 8090/default/example-gateway
-    port: 8090
+- key: 8090/default/example-gateway
+  port: 8090
 Listeners:
-  - bindKey: 8090/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/grpc
-    name: grpc
-    protocol: HTTP
+- bindKey: 8090/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/grpc
+  name: grpc
+  protocol: HTTP
 Routes:
-  - backends:
-      - backend:
-          port: 9000
-          service: default/example-grpc-svc.default.svc.cluster.local
-        weight: 1
-    key: default.example-grpc-route.0.grpc
-    listenerKey: default/example-gateway/grpc
-    matches:
-      - path:
-          exact: /example.grpc.Service/ExampleMethod
-    routeName: default/example-grpc-route
+- backends:
+  - backend:
+      port: 9000
+      service: default/example-grpc-svc.default.svc.cluster.local
+    weight: 1
+  key: default.example-grpc-route.0.grpc
+  listenerKey: default/example-gateway/grpc
+  matches:
+  - path:
+      exact: /example.grpc.Service/ExampleMethod
+  routeName: default/example-grpc-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/grpc-routing/multi-backend-proxy.yaml
@@ -1,42 +1,42 @@
 Addresses:
-  - service:
-      hostname: grpc-svc-1.default.svc.cluster.local
-      name: grpc-svc-1
-      namespace: default
-      ports:
-        - appProtocol: HTTP2
-          servicePort: 9001
-          targetPort: 9001
-  - service:
-      hostname: grpc-svc-2.default.svc.cluster.local
-      name: grpc-svc-2
-      namespace: default
-      ports:
-        - appProtocol: HTTP2
-          servicePort: 9002
-          targetPort: 9002
+- service:
+    hostname: grpc-svc-1.default.svc.cluster.local
+    name: grpc-svc-1
+    namespace: default
+    ports:
+    - appProtocol: HTTP2
+      servicePort: 9001
+      targetPort: 9001
+- service:
+    hostname: grpc-svc-2.default.svc.cluster.local
+    name: grpc-svc-2
+    namespace: default
+    ports:
+    - appProtocol: HTTP2
+      servicePort: 9002
+      targetPort: 9002
 Binds:
-  - key: 8090/default/example-grpc-gateway
-    port: 8090
+- key: 8090/default/example-grpc-gateway
+  port: 8090
 Listeners:
-  - bindKey: 8090/default/example-grpc-gateway
-    gatewayName: default/example-grpc-gateway
-    key: default/example-grpc-gateway/grpc
-    name: grpc
-    protocol: HTTP
+- bindKey: 8090/default/example-grpc-gateway
+  gatewayName: default/example-grpc-gateway
+  key: default/example-grpc-gateway/grpc
+  name: grpc
+  protocol: HTTP
 Routes:
-  - backends:
-      - backend:
-          port: 9001
-          service: default/grpc-svc-1.default.svc.cluster.local
-        weight: 50
-      - backend:
-          port: 9002
-          service: default/grpc-svc-2.default.svc.cluster.local
-        weight: 50
-    key: default.example-grpc-multi-backend-route.0.grpc
-    listenerKey: default/example-grpc-gateway/grpc
-    matches:
-      - path:
-          exact: /example.multi.Service/MultiMethod
-    routeName: default/example-grpc-multi-backend-route
+- backends:
+  - backend:
+      port: 9001
+      service: default/grpc-svc-1.default.svc.cluster.local
+    weight: 50
+  - backend:
+      port: 9002
+      service: default/grpc-svc-2.default.svc.cluster.local
+    weight: 50
+  key: default.example-grpc-multi-backend-route.0.grpc
+  listenerKey: default/example-grpc-gateway/grpc
+  matches:
+  - path:
+      exact: /example.multi.Service/MultiMethod
+  routeName: default/example-grpc-multi-backend-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/http-routing-proxy.yaml
@@ -1,82 +1,82 @@
 Addresses:
-  - service:
-      hostname: bar-svc.default.svc.cluster.local
-      name: bar-svc
-      namespace: default
-      ports:
-        - servicePort: 80
-  - service:
-      hostname: bar-svc-canary.default.svc.cluster.local
-      name: bar-svc-canary
-      namespace: default
-      ports:
-        - servicePort: 80
-  - service:
-      hostname: example-svc.default.svc.cluster.local
-      name: example-svc
-      namespace: default
-      ports:
-        - servicePort: 80
-  - service:
-      hostname: foo-svc.default.svc.cluster.local
-      name: foo-svc
-      namespace: default
-      ports:
-        - servicePort: 80
+- service:
+    hostname: bar-svc.default.svc.cluster.local
+    name: bar-svc
+    namespace: default
+    ports:
+    - servicePort: 80
+- service:
+    hostname: bar-svc-canary.default.svc.cluster.local
+    name: bar-svc-canary
+    namespace: default
+    ports:
+    - servicePort: 80
+- service:
+    hostname: example-svc.default.svc.cluster.local
+    name: example-svc
+    namespace: default
+    ports:
+    - servicePort: 80
+- service:
+    hostname: foo-svc.default.svc.cluster.local
+    name: foo-svc
+    namespace: default
+    ports:
+    - servicePort: 80
 Binds:
-  - key: 80/default/example-gateway
-    port: 80
+- key: 80/default/example-gateway
+  port: 80
 Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Routes:
-  - backends:
-      - backend:
-          port: 80
-          service: default/bar-svc-canary.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - bar.example.com
-    key: default.bar-route.0.0.http
-    listenerKey: default/example-gateway/http
-    matches:
-      - headers:
-          - exact: canary
-            name: env
-    routeName: default/bar-route
-  - backends:
-      - backend:
-          port: 80
-          service: default/bar-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - bar.example.com
-    key: default.bar-route.1.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/bar-route
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
-  - backends:
-      - backend:
-          port: 80
-          service: default/foo-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - foo.example.com
-    key: default.foo-route.0.0.http
-    listenerKey: default/example-gateway/http
-    matches:
-      - path:
-          pathPrefix: /login
-    routeName: default/foo-route
+- backends:
+  - backend:
+      port: 80
+      service: default/foo-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - foo.example.com
+  key: default.foo-route.0.0.http
+  listenerKey: default/example-gateway/http
+  matches:
+  - path:
+      pathPrefix: /login
+  routeName: default/foo-route
+- backends:
+  - backend:
+      port: 80
+      service: default/bar-svc-canary.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - bar.example.com
+  key: default.bar-route.0.0.http
+  listenerKey: default/example-gateway/http
+  matches:
+  - headers:
+    - exact: canary
+      name: env
+  routeName: default/bar-route
+- backends:
+  - backend:
+      port: 80
+      service: default/bar-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - bar.example.com
+  key: default.bar-route.1.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/bar-route
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/httproute-timeout-retry-proxy.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/httproute-timeout-retry-proxy.yaml
@@ -1,103 +1,103 @@
 Addresses:
-  - service:
-      hostname: example-svc.default.svc.cluster.local
-      name: example-svc
-      namespace: default
-      ports:
-        - servicePort: 80
+- service:
+    hostname: example-svc.default.svc.cluster.local
+    name: example-svc
+    namespace: default
+    ports:
+    - servicePort: 80
 Binds:
-  - key: 80/default/example-gateway
-    port: 80
+- key: 80/default/example-gateway
+  port: 80
 Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Routes:
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example-retry-backend-request.com
-    key: default.example-route-retry-backend-request.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route-retry-backend-request
-    trafficPolicy:
-      backendRequestTimeout: 9s
-      retry:
-        attempts: 2
-        backoff: 1s
-        retryStatusCodes:
-          - 500
-          - 503
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example-retry-both-timeouts.com
-    key: default.example-route-retry-both-timeouts.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route-retry-both-timeouts
-    trafficPolicy:
-      backendRequestTimeout: 5s
-      requestTimeout: 10s
-      retry:
-        attempts: 3
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route-timeout.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route-timeout
-    trafficPolicy:
-      requestTimeout: 9s
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example-backend-request-both-timeout.com
-    key: default.example-route-backend-request-both-timeout.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route-backend-request-both-timeout
-    trafficPolicy:
-      backendRequestTimeout: 9s
-      requestTimeout: 10s
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example-backend-request-timeout.com
-    key: default.example-route-backend-request-timeout.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route-backend-request-timeout
-    trafficPolicy:
-      backendRequestTimeout: 7s
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example-retry.com
-    key: default.example-route-retry.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route-retry
-    trafficPolicy:
-      retry:
-        attempts: 2
-        backoff: 1s
-        retryStatusCodes:
-          - 503
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route-timeout.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route-timeout
+  trafficPolicy:
+    requestTimeout: 9s
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example-backend-request-both-timeout.com
+  key: default.example-route-backend-request-both-timeout.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route-backend-request-both-timeout
+  trafficPolicy:
+    backendRequestTimeout: 9s
+    requestTimeout: 10s
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example-backend-request-timeout.com
+  key: default.example-route-backend-request-timeout.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route-backend-request-timeout
+  trafficPolicy:
+    backendRequestTimeout: 7s
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example-retry.com
+  key: default.example-route-retry.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route-retry
+  trafficPolicy:
+    retry:
+      attempts: 2
+      backoff: 1s
+      retryStatusCodes:
+      - 503
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example-retry-backend-request.com
+  key: default.example-route-retry-backend-request.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route-retry-backend-request
+  trafficPolicy:
+    backendRequestTimeout: 9s
+    retry:
+      attempts: 2
+      backoff: 1s
+      retryStatusCodes:
+      - 500
+      - 503
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example-retry-both-timeouts.com
+  key: default.example-route-retry-both-timeouts.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route-retry-both-timeouts
+  trafficPolicy:
+    backendRequestTimeout: 5s
+    requestTimeout: 10s
+    retry:
+      attempts: 3

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/no-route.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/no-route.yaml
@@ -1,9 +1,9 @@
 Binds:
-  - key: 80/default/example-gateway
-    port: 80
+- key: 80/default/example-gateway
+  port: 80
 Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/extauth-gateway.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/extauth-gateway.yaml
@@ -1,44 +1,44 @@
 Addresses:
-  - service:
-      hostname: example-svc.default.svc.cluster.local
-      name: example-svc
-      namespace: default
-      ports:
-        - servicePort: 80
-  - service:
-      hostname: ext-authz.default.svc.cluster.local
-      name: ext-authz
-      namespace: default
-      ports:
-        - appProtocol: HTTP2
-          servicePort: 4444
-          targetPort: 9000
+- service:
+    hostname: example-svc.default.svc.cluster.local
+    name: example-svc
+    namespace: default
+    ports:
+    - servicePort: 80
+- service:
+    hostname: ext-authz.default.svc.cluster.local
+    name: ext-authz
+    namespace: default
+    ports:
+    - appProtocol: HTTP2
+      servicePort: 4444
+      targetPort: 9000
 Binds:
-  - key: 80/default/example-gateway
-    port: 80
+- key: 80/default/example-gateway
+  port: 80
 Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Policies:
-  - name: trafficpolicy/default/secure-route-policy/example-gateway:extauth
-    target:
-      gateway: default/example-gateway
-    spec:
-      ext_authz:
-        target:
-          service: default/ext-authz.default.svc.cluster.local
-          port: 4444
+- name: trafficpolicy/default/secure-route-policy/example-gateway:extauth
+  spec:
+    extAuthz:
+      target:
+        port: 4444
+        service: default/ext-authz.default.svc.cluster.local
+  target:
+    gateway: default/example-gateway
+Routes:
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/extauth-route.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/extauth-route.yaml
@@ -1,44 +1,44 @@
 Addresses:
-  - service:
-      hostname: example-svc.default.svc.cluster.local
-      name: example-svc
-      namespace: default
-      ports:
-        - servicePort: 80
-  - service:
-      hostname: ext-authz.default.svc.cluster.local
-      name: ext-authz
-      namespace: default
-      ports:
-        - appProtocol: HTTP2
-          servicePort: 4444
-          targetPort: 9000
+- service:
+    hostname: example-svc.default.svc.cluster.local
+    name: example-svc
+    namespace: default
+    ports:
+    - servicePort: 80
+- service:
+    hostname: ext-authz.default.svc.cluster.local
+    name: ext-authz
+    namespace: default
+    ports:
+    - appProtocol: HTTP2
+      servicePort: 4444
+      targetPort: 9000
 Binds:
-  - key: 80/default/example-gateway
-    port: 80
+- key: 80/default/example-gateway
+  port: 80
 Listeners:
-  - bindKey: 80/default/example-gateway
-    gatewayName: default/example-gateway
-    key: default/example-gateway/http
-    name: http
-    protocol: HTTP
-Routes:
-  - backends:
-      - backend:
-          port: 80
-          service: default/example-svc.default.svc.cluster.local
-        weight: 1
-    hostnames:
-      - example.com
-    key: default.example-route.0.0.http
-    listenerKey: default/example-gateway/http
-    routeName: default/example-route
+- bindKey: 80/default/example-gateway
+  gatewayName: default/example-gateway
+  key: default/example-gateway/http
+  name: http
+  protocol: HTTP
 Policies:
 - name: trafficpolicy/default/secure-route-policy/example-route:extauth
+  spec:
+    extAuthz:
+      target:
+        port: 4444
+        service: default/ext-authz.default.svc.cluster.local
   target:
     route: default/example-route
-  spec:
-    ext_authz:
-      target:
-        service: default/ext-authz.default.svc.cluster.local
-        port: 4444
+Routes:
+- backends:
+  - backend:
+      port: 80
+      service: default/example-svc.default.svc.cluster.local
+    weight: 1
+  hostnames:
+  - example.com
+  key: default.example-route.0.0.http
+  listenerKey: default/example-gateway/http
+  routeName: default/example-route


### PR DESCRIPTION
# Description

Fixes #12108

The `translationResult.MarshalJSON()` method was missing serialization logic for the Backends and Policies fields, causing these fields to be omitted from the YAML output even when they contained data in the struct instance.
# Change Type

```
/kind bug_fix
```


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
