### PR TITLE
policy: deep-merging API for extAuth, extProc, transformations

### DIFF
--- a/api/annotations/policy.go
+++ b/api/annotations/policy.go
@@ -1,8 +1,20 @@
 package annotations
 
-// InheritedPolicyPriority is the annotation used on a Gateway or parent HTTPRoute to specify
-// the priority of corresponding policies attached that are inherited by attached routes or child routes respectively.
-const InheritedPolicyPriority = "kgateway.dev/inherited-policy-priority"
+const (
+	// InheritedPolicyPriority is the annotation used on a Gateway or parent HTTPRoute to specify
+	// the priority of corresponding policies attached that are inherited by attached routes or child routes respectively.
+	InheritedPolicyPriority = "kgateway.dev/inherited-policy-priority"
+
+	// PolicyPrecedenceWeight is an annotation that can be set on a policy CR to specify the weight of
+	// the policy as an integer value (negative values are allowed).
+	// Policies with higher weight implies higher priority, and are evaluated before policies with lower weight.
+	// By default, policies have a weight of 0.
+	// The policy's weight is relevant to policy prioritization during policy merging, such that higher priority
+	// policies are preferred during a merge conflict or when ordering policies during a merge.
+	// Note: for policies that are implemented using GatewayExtensions, the weight specified on the GatewayExtension
+	// will be used instead.
+	PolicyPrecedenceWeight = "kgateway.dev/policy-weight"
+)
 
 // InheritedPolicyPriorityValue is the value for the InheritedPolicyPriority annotation
 type InheritedPolicyPriorityValue string

--- a/api/annotations/policy.go
+++ b/api/annotations/policy.go
@@ -11,7 +11,7 @@ const (
 	// By default, policies have a weight of 0.
 	// The policy's weight is relevant to policy prioritization during policy merging, such that higher priority
 	// policies are preferred during a merge conflict or when ordering policies during a merge.
-	// Note: for policies that are implemented using GatewayExtensions, the weight specified on the GatewayExtension
+	// Note: for policies that are implemented using GatewayExtensions (such as extAuth, etcProc), the weight specified on the GatewayExtension
 	// will be used instead.
 	PolicyPrecedenceWeight = "kgateway.dev/policy-weight"
 )

--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -85,6 +85,8 @@ spec:
               value: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
             - name: KGW_DISCOVERY_NAMESPACE_SELECTORS
               value: {{ .Values.discoveryNamespaceSelectors | toJson | quote }}
+            - name: KGW_POLICY_MERGE
+              value: {{ .Values.policyMerge | toJson | quote }}
             {{- if .Values.controller.extraEnv }}
             {{- range $key, $value := .Values.controller.extraEnv }}
             - name: {{ $key }}

--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -91,3 +91,10 @@ discoveryNamespaceSelectors: []
 # -- Enable the integration with Agent Gateway, which lets you use kgateway to help manage agent connectivity across MCP servers, A2A agents, and REST APIs.
 agentGateway:
   enabled: false
+
+# -- Policy merging settings. Currently, TrafficPolicy's extAuth, extProc, and transformation policies support deep merging.
+# E.g., to enable deep merging of extProc policy in TrafficPolicy:
+# policyMerge:
+#   trafficPolicy:
+#     extProc: DeepMerge
+policyMerge: {}

--- a/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
+++ b/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
@@ -654,7 +654,7 @@ func (tc TestCase) Run(
 		return nil, err
 	}
 
-	proxySyncerPlugins := proxySyncerPluginFactory(ctx, commoncol, wellknown.DefaultAgentGatewayClassName, extraPluginsFn)
+	proxySyncerPlugins := proxySyncerPluginFactory(ctx, commoncol, wellknown.DefaultAgentGatewayClassName, extraPluginsFn, *settings)
 	commoncol.InitPlugins(ctx, proxySyncerPlugins, *settings)
 
 	cli.RunAndWait(ctx.Done())
@@ -772,8 +772,8 @@ func (tc TestCase) Run(
 	return results, nil
 }
 
-func proxySyncerPluginFactory(ctx context.Context, commoncol *collections.CommonCollections, name string, extraPluginsFn ExtraPluginsFn) pluginsdk.Plugin {
-	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultAgentGatewayClassName)
+func proxySyncerPluginFactory(ctx context.Context, commoncol *collections.CommonCollections, name string, extraPluginsFn ExtraPluginsFn, globalSettings settings.Settings) pluginsdk.Plugin {
+	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultAgentGatewayClassName, globalSettings)
 	plugins = append(plugins, agwbuiltin.NewBuiltinPlugin())
 
 	var extraPlugs []pluginsdk.Plugin

--- a/internal/kgateway/controller/controller_suite_test.go
+++ b/internal/kgateway/controller/controller_suite_test.go
@@ -297,7 +297,7 @@ func newCommonCols(ctx context.Context, kubeClient kube.Client) *collections.Com
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultWaypointClassName)
+	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultWaypointClassName, *settings)
 	plugins = append(plugins, krtcollections.NewBuiltinPlugin(ctx))
 	extensions := registry.MergePlugins(plugins...)
 

--- a/internal/kgateway/controller/start.go
+++ b/internal/kgateway/controller/start.go
@@ -248,7 +248,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 
 func pluginFactoryWithBuiltin(cfg StartConfig) extensions2.K8sGatewayExtensionsFactory {
 	return func(ctx context.Context, commoncol *common.CommonCollections) sdk.Plugin {
-		plugins := registry.Plugins(ctx, commoncol, cfg.WaypointGatewayClassName)
+		plugins := registry.Plugins(ctx, commoncol, cfg.WaypointGatewayClassName, *cfg.SetupOpts.GlobalSettings)
 		plugins = append(plugins, krtcollections.NewBuiltinPlugin(ctx))
 		if cfg.SetupOpts.GlobalSettings.EnableAgentGateway {
 			plugins = append(plugins, agwbuiltin.NewBuiltinPlugin())

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_httpfilters.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_httpfilters.go
@@ -149,8 +149,8 @@ func AddExtprocHTTPFilter() ([]plugins.StagedHttpFilter, error) {
 		wellknown.AIExtProcFilterName,
 		extProcSettings,
 		plugins.HTTPFilterStage{
-			RelativeTo: plugins.RateLimitStage,
-			Weight:     -2,
+			RelativeTo:     plugins.RateLimitStage,
+			RelativeWeight: -2,
 		},
 	)
 	if err != nil {

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
@@ -254,7 +254,7 @@ func NewPlugin(ctx context.Context, commoncol *common.CommonCollections) extensi
 				GetPolicyStatus:           getPolicyStatusFn(commoncol.CrudClient),
 				PatchPolicyStatus:         patchPolicyStatusFn(commoncol.CrudClient),
 				MergePolicies: func(pols []ir.PolicyAtt) ir.PolicyAtt {
-					return policy.MergePolicies(pols, mergePolicies)
+					return policy.MergePolicies(pols, mergePolicies, "" /*no merge settings*/)
 				},
 			},
 		},

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/merge.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/merge.go
@@ -13,6 +13,7 @@ func mergePolicies(
 	p2MergeOrigins ir.MergeOrigins,
 	mergeOpts policy.MergeOptions,
 	mergeOrigins ir.MergeOrigins,
+	_ string, // no merge settings
 ) {
 	if p1 == nil || p2 == nil {
 		return

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
@@ -41,6 +41,9 @@ var ExtAuthzEnabledMetadataMatcher = &envoy_matcher_v3.MetadataMatcher{
 }
 
 type extAuthIR struct {
+	// perProviderConfig is a list of ExtAuth providers that may be the result of a
+	// merge between policy IRs attached to the same resource or just a single IR
+	// when representing a singular policy before a merge
 	perProviderConfig   []*perProviderExtAuthConfig
 	disableAllProviders bool
 	// providerNames is used to track duplicates during policy merging,

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy.go
@@ -2,11 +2,13 @@ package trafficpolicy
 
 import (
 	"fmt"
+	"slices"
 
 	envoy_ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	envoy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/proto"
 	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/pluginutils"
@@ -39,9 +41,17 @@ var ExtAuthzEnabledMetadataMatcher = &envoy_matcher_v3.MetadataMatcher{
 }
 
 type extAuthIR struct {
-	provider            *TrafficPolicyGatewayExtensionIR
+	perProviderConfig   []*perProviderExtAuthConfig
 	disableAllProviders bool
-	perRoute            *envoy_ext_authz_v3.ExtAuthzPerRoute
+	// providerNames is used to track duplicates during policy merging,
+	// and has no relevance to the policy config, so it can be excluded from Equals
+	// +noKrtEquals
+	providerNames sets.Set[string]
+}
+
+type perProviderExtAuthConfig struct {
+	provider       *TrafficPolicyGatewayExtensionIR
+	perRouteConfig *envoy_ext_authz_v3.ExtAuthzPerRoute
 }
 
 var _ PolicySubIR = &extAuthIR{}
@@ -58,15 +68,17 @@ func (e *extAuthIR) Equals(other PolicySubIR) bool {
 	if e.disableAllProviders != otherExtAuth.disableAllProviders {
 		return false
 	}
-	if !proto.Equal(e.perRoute, otherExtAuth.perRoute) {
-		return false
-	}
-	// Compare providers
-	if !cmputils.CompareWithNils(e.provider, otherExtAuth.provider, func(a, b *TrafficPolicyGatewayExtensionIR) bool {
-		return a.Equals(*b)
+	if !slices.EqualFunc(e.perProviderConfig, otherExtAuth.perProviderConfig, func(a, b *perProviderExtAuthConfig) bool {
+		// compare perRouteConfig
+		return proto.Equal(a.perRouteConfig, b.perRouteConfig) &&
+			// compare provider config
+			cmputils.CompareWithNils(a.provider, b.provider, func(a, b *TrafficPolicyGatewayExtensionIR) bool {
+				return a.Equals(*b)
+			})
 	}) {
 		return false
 	}
+
 	return true
 }
 
@@ -74,13 +86,15 @@ func (e *extAuthIR) Validate() error {
 	if e == nil {
 		return nil
 	}
-	if e.perRoute != nil {
-		if err := e.perRoute.ValidateAll(); err != nil {
-			return err
+	for _, p := range e.perProviderConfig {
+		if p.perRouteConfig != nil {
+			if err := p.perRouteConfig.ValidateAll(); err != nil {
+				return err
+			}
 		}
-	}
-	if e.provider != nil {
-		return e.provider.Validate()
+		if p.provider != nil {
+			return p.provider.Validate()
+		}
 	}
 	return nil
 }
@@ -104,8 +118,6 @@ func constructExtAuth(
 		return nil
 	}
 
-	perRouteCfg := buildExtAuthPerRouteFilterConfig(spec)
-
 	// kubebuilder validation ensures the extensionRef is not nil, since disable is nil
 	provider, err := fetchGatewayExtension(krtctx, *spec.ExtensionRef, in.GetNamespace())
 	if err != nil {
@@ -116,8 +128,13 @@ func constructExtAuth(
 	}
 
 	out.extAuth = &extAuthIR{
-		provider: provider,
-		perRoute: perRouteCfg,
+		perProviderConfig: []*perProviderExtAuthConfig{
+			{
+				provider:       provider,
+				perRouteConfig: buildExtAuthPerRouteFilterConfig(spec),
+			},
+		},
+		providerNames: sets.New(providerName(provider)),
 	}
 	return nil
 }
@@ -159,25 +176,27 @@ func extAuthFilterName(name string) string {
 	return fmt.Sprintf("%s/%s", extauthFilterNamePrefix, name)
 }
 
-func (p *trafficPolicyPluginGwPass) handleExtAuth(fcn string, pCtxTypedFilterConfig *ir.TypedFilterConfigMap, extAuth *extAuthIR) {
-	if extAuth == nil {
+func (p *trafficPolicyPluginGwPass) handleExtAuth(filterChain string, pCtxTypedFilterConfig *ir.TypedFilterConfigMap, in *extAuthIR) {
+	if in == nil {
 		return
 	}
 
 	// Add the global disable all filter if all providers are disabled
-	if extAuth.disableAllProviders {
+	if in.disableAllProviders {
 		pCtxTypedFilterConfig.AddTypedConfig(ExtAuthGlobalDisableFilterName, EnableFilterPerRoute)
 		return
 	}
 
-	providerName := extAuth.provider.ResourceName()
-	p.extAuthPerProvider.Add(fcn, providerName, extAuth.provider)
+	for _, cfg := range in.perProviderConfig {
+		providerName := providerName(cfg.provider)
+		p.extAuthPerProvider.Add(filterChain, providerName, cfg.provider)
 
-	// Filter is not disabled, set the PerRouteConfig
-	if extAuth.perRoute != nil {
-		pCtxTypedFilterConfig.AddTypedConfig(extAuthFilterName(providerName), extAuth.perRoute)
-	} else {
-		// if you are on a route and not trying to disable it then we need to override the top level disable on the filter chain
-		pCtxTypedFilterConfig.AddTypedConfig(extAuthFilterName(providerName), EnableFilterPerRoute)
+		// Filter is not disabled, set the PerRouteConfig
+		if cfg.perRouteConfig != nil {
+			pCtxTypedFilterConfig.AddTypedConfig(extAuthFilterName(providerName), cfg.perRouteConfig)
+		} else {
+			// if you are on a route and not trying to disable it then we need to override the top level disable on the filter chain
+			pCtxTypedFilterConfig.AddTypedConfig(extAuthFilterName(providerName), EnableFilterPerRoute)
+		}
 	}
 }

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extproc_policy_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extproc_policy_test.go
@@ -53,49 +53,49 @@ func TestExtprocIREquals(t *testing.T) {
 		{
 			name:     "nil vs non-nil are not equal",
 			extproc1: nil,
-			extproc2: &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)},
+			extproc2: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)}}},
 			expected: false,
 		},
 		{
 			name:     "non-nil vs nil are not equal",
-			extproc1: &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)},
+			extproc1: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)}}},
 			extproc2: nil,
 			expected: false,
 		},
 		{
 			name:     "same instance is equal",
-			extproc1: &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)},
-			extproc2: &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)},
+			extproc1: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)}}},
+			extproc2: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)}}},
 			expected: true,
 		},
 		{
 			name:     "different processing modes are not equal",
-			extproc1: &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)},
-			extproc2: &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SKIP)},
+			extproc1: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)}}},
+			extproc2: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SKIP)}}},
 			expected: false,
 		},
 		{
 			name:     "different providers are not equal",
-			extproc1: &extprocIR{provider: createProvider("service1")},
-			extproc2: &extprocIR{provider: createProvider("service2")},
+			extproc1: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{provider: createProvider("service1")}}},
+			extproc2: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{provider: createProvider("service2")}}},
 			expected: false,
 		},
 		{
 			name:     "same providers are equal",
-			extproc1: &extprocIR{provider: createProvider("service1")},
-			extproc2: &extprocIR{provider: createProvider("service1")},
+			extproc1: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{provider: createProvider("service1")}}},
+			extproc2: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{provider: createProvider("service1")}}},
 			expected: true,
 		},
 		{
 			name:     "nil perRoute fields are equal",
-			extproc1: &extprocIR{perRoute: nil},
-			extproc2: &extprocIR{perRoute: nil},
+			extproc1: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: nil}}},
+			extproc2: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: nil}}},
 			expected: true,
 		},
 		{
 			name:     "nil vs non-nil perRoute fields are not equal",
-			extproc1: &extprocIR{perRoute: nil},
-			extproc2: &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)},
+			extproc1: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: nil}}},
+			extproc2: &extprocIR{perProviderConfig: []*perProviderExtProcConfig{{perRouteConfig: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)}}},
 			expected: false,
 		},
 	}
@@ -110,27 +110,6 @@ func TestExtprocIREquals(t *testing.T) {
 			assert.Equal(t, result, reverseResult, "Equals should be symmetric")
 		})
 	}
-
-	// Test reflexivity: x.Equals(x) should always be true for non-nil values
-	t.Run("reflexivity", func(t *testing.T) {
-		extproc := &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SEND)}
-		assert.True(t, extproc.Equals(extproc), "extproc should equal itself")
-	})
-
-	// Test transitivity: if a.Equals(b) && b.Equals(c), then a.Equals(c)
-	t.Run("transitivity", func(t *testing.T) {
-		createSameExtproc := func() *extprocIR {
-			return &extprocIR{perRoute: createSimpleExtproc(envoy_ext_proc_v3.ProcessingMode_SKIP)}
-		}
-
-		a := createSameExtproc()
-		b := createSameExtproc()
-		c := createSameExtproc()
-
-		assert.True(t, a.Equals(b), "a should equal b")
-		assert.True(t, b.Equals(c), "b should equal c")
-		assert.True(t, a.Equals(c), "a should equal c (transitivity)")
-	})
 }
 
 func TestBuildEnvoyExtProc(t *testing.T) {

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -28,12 +28,13 @@ import (
 )
 
 type TrafficPolicyGatewayExtensionIR struct {
-	Name      string
-	ExtType   v1alpha1.GatewayExtensionType
-	ExtAuth   *envoy_ext_authz_v3.ExtAuthz
-	ExtProc   *envoymatchingv3.ExtensionWithMatcher
-	RateLimit *ratev3.RateLimit
-	Err       error
+	Name             string
+	ExtType          v1alpha1.GatewayExtensionType
+	ExtAuth          *envoy_ext_authz_v3.ExtAuthz
+	ExtProc          *envoymatchingv3.ExtensionWithMatcher
+	RateLimit        *ratev3.RateLimit
+	PrecedenceWeight int32
+	Err              error
 }
 
 // ResourceName returns the unique name for this extension.
@@ -53,6 +54,9 @@ func (e TrafficPolicyGatewayExtensionIR) Equals(other TrafficPolicyGatewayExtens
 		return false
 	}
 	if !proto.Equal(e.RateLimit, other.RateLimit) {
+		return false
+	}
+	if e.PrecedenceWeight != other.PrecedenceWeight {
 		return false
 	}
 
@@ -96,8 +100,9 @@ func (e TrafficPolicyGatewayExtensionIR) Validate() error {
 func TranslateGatewayExtensionBuilder(commoncol *common.CommonCollections) func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {
 	return func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {
 		p := &TrafficPolicyGatewayExtensionIR{
-			Name:    krt.Named{Name: gExt.Name, Namespace: gExt.Namespace}.ResourceName(),
-			ExtType: gExt.Type,
+			Name:             krt.Named{Name: gExt.Name, Namespace: gExt.Namespace}.ResourceName(),
+			ExtType:          gExt.Type,
+			PrecedenceWeight: gExt.PrecedenceWeight,
 		}
 
 		switch gExt.Type {

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/merge.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/merge.go
@@ -197,9 +197,10 @@ func mergeExtAuth(
 		if p1.spec.extAuth == nil {
 			p1.spec.extAuth = &extAuthIR{}
 		}
-		// p2 will always have just 1 item in its providerNames, and if p1 contains that then
-		// it implies that this provider was already considered from a higher priority policy,
-		// so ignore it
+		// as p2 is not a merged policy, it will always have just 1 item in its providerNames
+		// as each extauth policy can only reference a single provider.
+		// If p1 contains the singular provider in p2 then it implies that this provider
+		// was already considered from a higher priority policy, so ignore it
 		if p2.spec.extAuth.providerNames.Len() > 0 && !p1.spec.extAuth.providerNames.IsSuperset(p2.spec.extAuth.providerNames) {
 			// Always Concat so that the original slice in the IR is never modified
 			// Note: p1 is preferred over p2 (slice order)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/merge.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/merge.go
@@ -9,12 +9,25 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/policy"
 )
 
+type mergeOpts struct {
+	TrafficPolicy trafficPolicyMergeOpts `json:"trafficPolicy,omitempty"`
+}
+
+type trafficPolicyMergeOpts struct {
+	ExtAuth string `json:"extAuth,omitempty"`
+
+	ExtProc string `json:"extProc,omitempty"`
+
+	Transformation string `json:"transformation,omitempty"`
+}
+
 func mergeAI(
 	p1, p2 *TrafficPolicy,
 	p2Ref *pluginsdkir.AttachedPolicyRef,
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[aiPolicyIR]{
 		Get: func(spec *trafficPolicySpecIr) *aiPolicyIR { return spec.ai },
@@ -29,12 +42,70 @@ func mergeExtProc(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	tpOpts trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[extprocIR]{
 		Get: func(spec *trafficPolicySpecIr) *extprocIR { return spec.extProc },
 		Set: func(spec *trafficPolicySpecIr, val *extprocIR) { spec.extProc = val },
 	}
-	defaultMerge(p1, p2, p2Ref, p2MergeOrigins, opts, mergeOrigins, accessor, "extProc")
+
+	if tpOpts.ExtProc != "" {
+		// this is merging 2 policies at the same hierarchical level (no parent->child relationship),
+		// so use mergeOpts since it overrides the default merge strategy
+		opts.Strategy = policy.ToInternalMergeStrategy(tpOpts.ExtProc)
+	}
+	if !policy.IsMergeable(p1.spec.extProc, p2.spec.extProc, opts) {
+		return
+	}
+
+	switch opts.Strategy {
+	case policy.AugmentedDeepMerge:
+		if p1.spec.extProc == nil {
+			p1.spec.extProc = &extprocIR{}
+		}
+		// p2 will always have just 1 item in its providerNames, and if p1 contains that then
+		// it implies that this provider was already considered from a higher priority policy,
+		// so ignore it
+		if p2.spec.extProc.providerNames.Len() > 0 && !p1.spec.extProc.providerNames.IsSuperset(p2.spec.extProc.providerNames) {
+			// Always Concat so that the original slice in the IR is never modified
+			// Note: p1 is preferred over p2 (slice order)
+			p1.spec.extProc.perProviderConfig = slices.Concat(p1.spec.extProc.perProviderConfig, p2.spec.extProc.perProviderConfig)
+			// Always Clone so that the original slice in the IR is never modified
+			tmp := p1.spec.extProc.providerNames.Clone()
+			tmp.Insert(p2.spec.extProc.providerNames.UnsortedList()...)
+			p1.spec.extProc.providerNames = tmp
+			mergeOrigins.Append("extProc", p2Ref, p2MergeOrigins)
+		}
+		if p2.spec.extProc.disableAllProviders {
+			p1.spec.extProc.disableAllProviders = true
+			mergeOrigins.SetOne("extProc", p2Ref, p2MergeOrigins)
+		}
+
+	case policy.OverridableDeepMerge:
+		if p1.spec.extProc == nil {
+			p1.spec.extProc = &extprocIR{}
+		}
+		// p2 will always have just 1 item in its providerNames, and if p1 contains that then
+		// it implies that this provider was already considered from a higher priority policy,
+		// so ignore it
+		if p2.spec.extProc.providerNames.Len() > 0 && !p1.spec.extProc.providerNames.IsSuperset(p2.spec.extProc.providerNames) {
+			// Always Concat so that the original slice in the IR is never modified
+			// Note: p2 is preferred over p1 (slice order)
+			p1.spec.extProc.perProviderConfig = slices.Concat(p2.spec.extProc.perProviderConfig, p1.spec.extProc.perProviderConfig)
+			// Always Clone so that the original slice in the IR is never modified
+			tmp := p1.spec.extProc.providerNames.Clone()
+			tmp.Insert(p2.spec.extProc.providerNames.UnsortedList()...)
+			p1.spec.extProc.providerNames = tmp
+			mergeOrigins.Append("extProc", p2Ref, p2MergeOrigins)
+		}
+		if p2.spec.extProc.disableAllProviders {
+			p1.spec.extProc.disableAllProviders = true
+			mergeOrigins.SetOne("extProc", p2Ref, p2MergeOrigins)
+		}
+
+	default:
+		defaultMerge(p1, p2, p2Ref, p2MergeOrigins, opts, mergeOrigins, accessor, "extProc")
+	}
 }
 
 func mergeTransformation(
@@ -43,7 +114,13 @@ func mergeTransformation(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	tpOpts trafficPolicyMergeOpts,
 ) {
+	if tpOpts.Transformation != "" {
+		// this is merging 2 policies at the same hierarchical level (no parent->child relationship),
+		// so use tpOpts since it overrides the default merge strategy
+		opts.Strategy = policy.ToInternalMergeStrategy(tpOpts.Transformation)
+	}
 	if !policy.IsMergeable(p1.spec.transformation, p2.spec.transformation, opts) {
 		return
 	}
@@ -53,8 +130,7 @@ func mergeTransformation(
 		if p1.spec.transformation == nil {
 			p1.spec.transformation = &transformationIR{config: &transformationpb.RouteTransformations{}}
 		}
-		// Always clone so that the original policy in p2 is not modified when
-		// the merge is invoked multiple times
+		// Always Clone so that the original slice in the IR is never modified
 		p1.spec.transformation.config.Transformations = slices.Clone(p2.spec.transformation.config.GetTransformations())
 		mergeOrigins.SetOne("transformation", p2Ref, p2MergeOrigins)
 
@@ -62,8 +138,7 @@ func mergeTransformation(
 		if p1.spec.transformation == nil {
 			p1.spec.transformation = &transformationIR{config: &transformationpb.RouteTransformations{}}
 		}
-		// Always Concat so that the original policy in p1 is not modified when
-		// the merge is invoked multiple times
+		// Always Concat so that the original slice in the IR is never modified
 		p1.spec.transformation.config.Transformations = slices.Concat(p1.spec.transformation.config.GetTransformations(), p2.spec.transformation.config.GetTransformations())
 		mergeOrigins.Append("transformation", p2Ref, p2MergeOrigins)
 
@@ -71,8 +146,7 @@ func mergeTransformation(
 		if p1.spec.transformation == nil {
 			p1.spec.transformation = &transformationIR{config: &transformationpb.RouteTransformations{}}
 		}
-		// Always Concat so that the original policy in p1/p2 is not modified when
-		// the merge is invoked multiple times
+		// Always Concat so that the original slice in the IR is never modified
 		p1.spec.transformation.config.Transformations = slices.Concat(p2.spec.transformation.config.GetTransformations(), p1.spec.transformation.config.GetTransformations())
 		mergeOrigins.Append("transformation", p2Ref, p2MergeOrigins)
 
@@ -87,6 +161,7 @@ func mergeRustformation(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[rustformationIR]{
 		Get: func(spec *trafficPolicySpecIr) *rustformationIR { return spec.rustformation },
@@ -101,12 +176,70 @@ func mergeExtAuth(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	tpOpts trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[extAuthIR]{
 		Get: func(spec *trafficPolicySpecIr) *extAuthIR { return spec.extAuth },
 		Set: func(spec *trafficPolicySpecIr, val *extAuthIR) { spec.extAuth = val },
 	}
-	defaultMerge(p1, p2, p2Ref, p2MergeOrigins, opts, mergeOrigins, accessor, "extAuth")
+
+	if tpOpts.ExtAuth != "" {
+		// this is merging 2 policies at the same hierarchical level (no parent->child relationship),
+		// so use mergeOpts since it overrides the default merge strategy
+		opts.Strategy = policy.ToInternalMergeStrategy(tpOpts.ExtAuth)
+	}
+	if !policy.IsMergeable(p1.spec.extAuth, p2.spec.extAuth, opts) {
+		return
+	}
+
+	switch opts.Strategy {
+	case policy.AugmentedDeepMerge:
+		if p1.spec.extAuth == nil {
+			p1.spec.extAuth = &extAuthIR{}
+		}
+		// p2 will always have just 1 item in its providerNames, and if p1 contains that then
+		// it implies that this provider was already considered from a higher priority policy,
+		// so ignore it
+		if p2.spec.extAuth.providerNames.Len() > 0 && !p1.spec.extAuth.providerNames.IsSuperset(p2.spec.extAuth.providerNames) {
+			// Always Concat so that the original slice in the IR is never modified
+			// Note: p1 is preferred over p2 (slice order)
+			p1.spec.extAuth.perProviderConfig = slices.Concat(p1.spec.extAuth.perProviderConfig, p2.spec.extAuth.perProviderConfig)
+			// Always Clone so that the original slice in the IR is never modified
+			tmp := p1.spec.extAuth.providerNames.Clone()
+			tmp.Insert(p2.spec.extAuth.providerNames.UnsortedList()...)
+			p1.spec.extAuth.providerNames = tmp
+			mergeOrigins.Append("extAuth", p2Ref, p2MergeOrigins)
+		}
+		if p2.spec.extAuth.disableAllProviders {
+			p1.spec.extAuth.disableAllProviders = true
+			mergeOrigins.SetOne("extAuth", p2Ref, p2MergeOrigins)
+		}
+
+	case policy.OverridableDeepMerge:
+		if p1.spec.extAuth == nil {
+			p1.spec.extAuth = &extAuthIR{}
+		}
+		// p2 will always have just 1 item in its providerNames, and if p1 contains that then
+		// it implies that this provider was already considered from a higher priority policy,
+		// so ignore it
+		if p2.spec.extAuth.providerNames.Len() > 0 && !p1.spec.extAuth.providerNames.IsSuperset(p2.spec.extAuth.providerNames) {
+			// Always Concat so that the original slice in the IR is never modified
+			// Note: p2 is preferred over p1 (slice order)
+			p1.spec.extAuth.perProviderConfig = slices.Concat(p2.spec.extAuth.perProviderConfig, p1.spec.extAuth.perProviderConfig)
+			// Always Clone so that the original slice in the IR is never modified
+			tmp := p1.spec.extAuth.providerNames.Clone()
+			tmp.Insert(p2.spec.extAuth.providerNames.UnsortedList()...)
+			p1.spec.extAuth.providerNames = tmp
+			mergeOrigins.Append("extAuth", p2Ref, p2MergeOrigins)
+		}
+		if p2.spec.extAuth.disableAllProviders {
+			p1.spec.extAuth.disableAllProviders = true
+			mergeOrigins.SetOne("extAuth", p2Ref, p2MergeOrigins)
+		}
+
+	default:
+		defaultMerge(p1, p2, p2Ref, p2MergeOrigins, opts, mergeOrigins, accessor, "extAuth")
+	}
 }
 
 func mergeLocalRateLimit(
@@ -115,6 +248,7 @@ func mergeLocalRateLimit(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[localRateLimitIR]{
 		Get: func(spec *trafficPolicySpecIr) *localRateLimitIR { return spec.localRateLimit },
@@ -129,6 +263,7 @@ func mergeGlobalRateLimit(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[globalRateLimitIR]{
 		Get: func(spec *trafficPolicySpecIr) *globalRateLimitIR { return spec.globalRateLimit },
@@ -143,6 +278,7 @@ func mergeCORS(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[corsIR]{
 		Get: func(spec *trafficPolicySpecIr) *corsIR { return spec.cors },
@@ -157,6 +293,7 @@ func mergeCSRF(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[csrfIR]{
 		Get: func(spec *trafficPolicySpecIr) *csrfIR { return spec.csrf },
@@ -171,6 +308,7 @@ func mergeHeaderModifiers(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[headerModifiersIR]{
 		Get: func(spec *trafficPolicySpecIr) *headerModifiersIR { return spec.headerModifiers },
@@ -186,6 +324,7 @@ func mergeBuffer(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[bufferIR]{
 		Get: func(spec *trafficPolicySpecIr) *bufferIR { return spec.buffer },
@@ -200,6 +339,7 @@ func mergeAutoHostRewrite(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[autoHostRewriteIR]{
 		Get: func(spec *trafficPolicySpecIr) *autoHostRewriteIR { return spec.autoHostRewrite },
@@ -214,6 +354,7 @@ func mergeTimeouts(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[timeoutsIR]{
 		Get: func(spec *trafficPolicySpecIr) *timeoutsIR { return spec.timeouts },
@@ -228,6 +369,7 @@ func mergeRBAC(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[rbacIR]{
 		Get: func(spec *trafficPolicySpecIr) *rbacIR { return spec.rbac },
@@ -242,6 +384,7 @@ func mergeRetry(
 	p2MergeOrigins pluginsdkir.MergeOrigins,
 	opts policy.MergeOptions,
 	mergeOrigins pluginsdkir.MergeOrigins,
+	_ trafficPolicyMergeOpts,
 ) {
 	accessor := fieldAccessor[retryIR]{
 		Get: func(spec *trafficPolicySpecIr) *retryIR { return spec.retry },

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/merge_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/merge_test.go
@@ -32,7 +32,7 @@ func TestMergePoliciesPreservesErrors(t *testing.T) {
 		Errors:    []error{err2},
 	}
 
-	merged := policy.MergePolicies([]ir.PolicyAtt{p1, p2}, MergeTrafficPolicies)
+	merged := policy.MergePolicies([]ir.PolicyAtt{p1, p2}, MergeTrafficPolicies, "")
 	require.Len(t, merged.Errors, 2)
 	assert.Contains(t, merged.Errors, err1)
 	assert.Contains(t, merged.Errors, err2)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/utils.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/utils.go
@@ -8,18 +8,23 @@ import (
 )
 
 type ProviderNeededMap struct {
-	// map filter_chain name -> provider name -> provider
-	Providers map[string]map[string]*TrafficPolicyGatewayExtensionIR
+	// map filter_chain name -> providers
+	Providers map[string][]Provider
+}
+
+type Provider struct {
+	Name      string
+	Extension *TrafficPolicyGatewayExtensionIR
 }
 
 func (p *ProviderNeededMap) Add(filterChain, providerName string, provider *TrafficPolicyGatewayExtensionIR) {
 	if p.Providers == nil {
-		p.Providers = make(map[string]map[string]*TrafficPolicyGatewayExtensionIR)
+		p.Providers = make(map[string][]Provider)
 	}
-	if p.Providers[filterChain] == nil {
-		p.Providers[filterChain] = make(map[string]*TrafficPolicyGatewayExtensionIR)
-	}
-	p.Providers[filterChain][providerName] = provider
+	p.Providers[filterChain] = append(p.Providers[filterChain], Provider{
+		Name:      providerName,
+		Extension: provider,
+	})
 }
 
 func AddDisableFilterIfNeeded(

--- a/internal/kgateway/extensions2/plugins/waypoint/filters.go
+++ b/internal/kgateway/extensions2/plugins/waypoint/filters.go
@@ -65,8 +65,8 @@ func customFiltersHelper(
 ) *ir.CustomEnvoyFilter {
 	return &ir.CustomEnvoyFilter{
 		FilterStage: plugins.HTTPOrNetworkFilterStage{
-			RelativeTo: plugins.WellKnownFilterStage(int(stage)),
-			Weight:     int(predicate),
+			RelativeTo:     plugins.WellKnownFilterStage(int(stage)),
+			RelativeWeight: int(predicate),
 		},
 		Name:   name,
 		Config: config,

--- a/internal/kgateway/extensions2/registry/registry.go
+++ b/internal/kgateway/extensions2/registry/registry.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/serviceentry"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/trafficpolicy"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/waypoint"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/settings"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 )
 
@@ -70,11 +71,11 @@ func MergePlugins(plug ...sdk.Plugin) sdk.Plugin {
 	return ret
 }
 
-func Plugins(ctx context.Context, commoncol *common.CommonCollections, waypointGatewayClassName string) []sdk.Plugin {
+func Plugins(ctx context.Context, commoncol *common.CommonCollections, waypointGatewayClassName string, globalSettings settings.Settings) []sdk.Plugin {
 	return []sdk.Plugin{
 		// Add plugins here
 		backend.NewPlugin(ctx, commoncol),
-		trafficpolicy.NewPlugin(ctx, commoncol),
+		trafficpolicy.NewPlugin(ctx, commoncol, globalSettings.PolicyMerge),
 		directresponse.NewPlugin(ctx, commoncol),
 		kubernetes.NewPlugin(ctx, commoncol),
 		istio.NewPlugin(ctx, commoncol),

--- a/internal/kgateway/krtcollections/gateway_extensions.go
+++ b/internal/kgateway/krtcollections/gateway_extensions.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
@@ -44,7 +45,7 @@ func NewGatewayExtensionsCollection(
 	gwExtCol := krt.NewCollection(rawGwExts, func(krtctx krt.HandlerContext, cr *v1alpha1.GatewayExtension) *ir.GatewayExtension {
 		weight, err := pluginsdkutils.ParsePrecedenceWeightAnnotation(cr.Annotations, apiannotations.PolicyPrecedenceWeight)
 		if err != nil {
-			logger.Error("error parsing precedence weight annotation; will default to 0", "error", err)
+			logger.Error("error parsing precedence weight annotation; will default to 0", "resource_ref", ctrlclient.ObjectKeyFromObject(cr), "error", err)
 		}
 		gwExt := &ir.GatewayExtension{
 			ObjectSource: ir.ObjectSource{

--- a/internal/kgateway/krtcollections/gateway_extensions.go
+++ b/internal/kgateway/krtcollections/gateway_extensions.go
@@ -11,11 +11,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 
+	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	krtinternal "github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/client/clientset/versioned"
+	pluginsdkutils "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/utils"
 )
 
 func NewGatewayExtensionsCollection(
@@ -40,6 +42,10 @@ func NewGatewayExtensionsCollection(
 		kclient.Filter{ObjectFilter: client.ObjectFilter()},
 	), krtOpts.ToOptions("GatewayExtension")...)
 	gwExtCol := krt.NewCollection(rawGwExts, func(krtctx krt.HandlerContext, cr *v1alpha1.GatewayExtension) *ir.GatewayExtension {
+		weight, err := pluginsdkutils.ParsePrecedenceWeightAnnotation(cr.Annotations, apiannotations.PolicyPrecedenceWeight)
+		if err != nil {
+			logger.Error("error parsing precedence weight annotation; will default to 0", "error", err)
+		}
 		gwExt := &ir.GatewayExtension{
 			ObjectSource: ir.ObjectSource{
 				Group:     wellknown.GatewayExtensionGVK.GroupKind().Group,
@@ -47,10 +53,11 @@ func NewGatewayExtensionsCollection(
 				Namespace: cr.Namespace,
 				Name:      cr.Name,
 			},
-			Type:      cr.Spec.Type,
-			ExtAuth:   cr.Spec.ExtAuth,
-			ExtProc:   cr.Spec.ExtProc,
-			RateLimit: cr.Spec.RateLimit,
+			Type:             cr.Spec.Type,
+			ExtAuth:          cr.Spec.ExtAuth,
+			ExtProc:          cr.Spec.ExtProc,
+			RateLimit:        cr.Spec.RateLimit,
+			PrecedenceWeight: weight,
 		}
 		return gwExt
 	})

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	extensionsplug "github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/settings"
@@ -907,102 +906,6 @@ func BenchmarkPolicyAttachment(b *testing.B) {
 					a.Len(h.AttachedPolicies.Policies[wellknown.TrafficPolicyGVK.GroupKind()], tc.expectedPoliciesPerRoute)
 				}
 			}
-		})
-	}
-}
-
-func TestParseRoutePrecedenceWeight(t *testing.T) {
-	tests := []struct {
-		name        string
-		annotations map[string]string
-		expected    int32
-		expectError bool
-	}{
-		{
-			name:        "No annotation",
-			annotations: map[string]string{},
-			expected:    0,
-			expectError: false,
-		},
-		{
-			name: "Valid positive weight",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "100",
-			},
-			expected:    100,
-			expectError: false,
-		},
-		{
-			name: "Valid negative weight",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "-50",
-			},
-			expected:    -50,
-			expectError: false,
-		},
-		{
-			name: "Valid zero weight",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "0",
-			},
-			expected:    0,
-			expectError: false,
-		},
-		{
-			name: "Invalid non-numeric value",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "invalid",
-			},
-			expected:    0,
-			expectError: true,
-		},
-		{
-			name: "Invalid decimal value",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "100.5",
-			},
-			expected:    0,
-			expectError: true,
-		},
-		{
-			name: "Empty string value",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "",
-			},
-			expected:    0,
-			expectError: true,
-		},
-		{
-			name: "Value too large for int32",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "2147483648", // int32 max + 1
-			},
-			expected:    0,
-			expectError: true,
-		},
-		{
-			name: "Value too small for int32",
-			annotations: map[string]string{
-				apiannotations.RoutePrecedenceWeight: "-2147483649", // int32 min - 1
-			},
-			expected:    0,
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			a := assert.New(t)
-
-			weight, err := parseRoutePrecedenceWeight(tt.annotations)
-
-			if tt.expectError {
-				a.Error(err)
-				a.Equal(int32(0), weight)
-				return
-			}
-			a.NoError(err)
-			a.Equal(tt.expected, weight)
 		})
 	}
 }

--- a/internal/kgateway/plugins/stages.go
+++ b/internal/kgateway/plugins/stages.go
@@ -52,15 +52,18 @@ func FilterStageComparison[WellKnown ~int](a, b sdkfilters.FilterStage[WellKnown
 func BeforeStage[WellKnown ~int](wellKnown WellKnown) sdkfilters.FilterStage[WellKnown] {
 	return RelativeToStage(wellKnown, -1)
 }
+
 func DuringStage[WellKnown ~int](wellKnown WellKnown) sdkfilters.FilterStage[WellKnown] {
 	return RelativeToStage(wellKnown, 0)
 }
+
 func AfterStage[WellKnown ~int](wellKnown WellKnown) sdkfilters.FilterStage[WellKnown] {
 	return RelativeToStage(wellKnown, 1)
 }
-func RelativeToStage[WellKnown ~int](wellKnown WellKnown, weight int) sdkfilters.FilterStage[WellKnown] {
+
+func RelativeToStage[WellKnown ~int](wellKnown WellKnown, relativeWeight int) sdkfilters.FilterStage[WellKnown] {
 	return sdkfilters.FilterStage[WellKnown]{
-		RelativeTo: wellKnown,
-		Weight:     weight,
+		RelativeTo:     wellKnown,
+		RelativeWeight: relativeWeight,
 	}
 }

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -353,6 +353,48 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("TrafficPolicy ExtAuth deep merge", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "traffic-policy/extauth-deep-merge.yaml",
+			outputFile: "traffic-policy/extauth-deep-merge.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "test",
+			},
+		},
+			func(s *settings.Settings) {
+				s.PolicyMerge = `{"trafficPolicy":{"extAuth":"DeepMerge"}}`
+			})
+	})
+
+	t.Run("TrafficPolicy ExtProc deep merge", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "traffic-policy/extproc-deep-merge.yaml",
+			outputFile: "traffic-policy/extproc-deep-merge.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "test",
+			},
+		},
+			func(s *settings.Settings) {
+				s.PolicyMerge = `{"trafficPolicy":{"extProc":"DeepMerge"}}`
+			})
+	})
+
+	t.Run("TrafficPolicy Transformation deep merge", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "traffic-policy/transformation-deep-merge.yaml",
+			outputFile: "traffic-policy/transformation-deep-merge.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "test",
+			},
+		},
+			func(s *settings.Settings) {
+				s.PolicyMerge = `{"trafficPolicy":{"transformation":"DeepMerge"}}`
+			})
+	})
+
 	t.Run("Load balancer with hash policies", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFile:  "loadbalancer/hash-policies.yaml",

--- a/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/extauth-deep-merge.yaml
@@ -1,0 +1,249 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test
+spec:
+  parentRefs:
+  - name: test
+  hostnames:
+  - "test.com"
+  rules:
+  - name: rule0
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-0
+  - name: rule1
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-1
+  - name: rule2
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+  extAuth:
+    extensionRef:
+      name: extauth-gateway-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+  extAuth:
+    extensionRef:
+      name: extauth-gateway-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+    sectionName: http
+  extAuth:
+    extensionRef:
+      name: extauth-listener-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+    sectionName: http
+  extAuth:
+    extensionRef:
+      name: extauth-listener-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule0
+  extAuth:
+    extensionRef:
+      name: extauth-route-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule0
+  extAuth:
+    extensionRef:
+      name: extauth-route-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-disable
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule1
+  extAuth:
+    disable: {}
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extauth-gateway-1
+spec:
+  type: ExtAuth
+  extAuth:
+    grpcService:
+      backendRef:
+        name: extauth
+        port: 9091
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extauth-gateway-2
+  annotations:
+    kgateway.dev/policy-weight: "1" # higher weight than extauth-gateway-1
+spec:
+  type: ExtAuth
+  extAuth:
+    grpcService:
+      backendRef:
+        name: extauth
+        port: 9091
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extauth-listener-1
+  annotations:
+    kgateway.dev/policy-weight: "-1" # lower weight than extauth-listener-2
+spec:
+  type: ExtAuth
+  extAuth:
+    grpcService:
+      backendRef:
+        name: extauth
+        port: 9092
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extauth-listener-2
+spec:
+  type: ExtAuth
+  extAuth:
+    grpcService:
+      backendRef:
+        name: extauth
+        port: 9092
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extauth-route-1
+spec:
+  type: ExtAuth
+  extAuth:
+    grpcService:
+      backendRef:
+        name: extauth
+        port: 9093
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extauth-route-2
+spec:
+  type: ExtAuth
+  extAuth:
+    grpcService:
+      backendRef:
+        name: extauth
+        port: 9093
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: extauth
+spec:
+  ports:
+  - port: 9091
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c
+    targetPort: 9091
+  - port: 9092
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c
+    targetPort: 9092
+  - port: 9093
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c
+    targetPort: 9093
+  selector:
+    app: extauth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: test

--- a/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/extproc-deep-merge.yaml
@@ -1,0 +1,249 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test
+spec:
+  parentRefs:
+  - name: test
+  hostnames:
+  - "test.com"
+  rules:
+  - name: rule0
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-0
+  - name: rule1
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-1
+  - name: rule2
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+  extProc:
+    extensionRef:
+      name: extproc-gateway-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+  extProc:
+    extensionRef:
+      name: extproc-gateway-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+    sectionName: http
+  extProc:
+    extensionRef:
+      name: extproc-listener-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+    sectionName: http
+  extProc:
+    extensionRef:
+      name: extproc-listener-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule0
+  extProc:
+    extensionRef:
+      name: extproc-route-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule0
+  extProc:
+    extensionRef:
+      name: extproc-route-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-disable
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule1
+  extProc:
+    disable: {}
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extproc-gateway-1
+spec:
+  type: ExtProc
+  extProc:
+    grpcService:
+      backendRef:
+        name: extproc
+        port: 9091
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extproc-gateway-2
+  annotations:
+    kgateway.dev/policy-weight: "1" # higher weight than extproc-gateway-1
+spec:
+  type: ExtProc
+  extProc:
+    grpcService:
+      backendRef:
+        name: extproc
+        port: 9091
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extproc-listener-1
+  annotations:
+    kgateway.dev/policy-weight: "-1" # lower weight than extproc-listener-2
+spec:
+  type: ExtProc
+  extProc:
+    grpcService:
+      backendRef:
+        name: extproc
+        port: 9092
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extproc-listener-2
+spec:
+  type: ExtProc
+  extProc:
+    grpcService:
+      backendRef:
+        name: extproc
+        port: 9092
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extproc-route-1
+spec:
+  type: ExtProc
+  extProc:
+    grpcService:
+      backendRef:
+        name: extproc
+        port: 9093
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: extproc-route-2
+spec:
+  type: ExtProc
+  extProc:
+    grpcService:
+      backendRef:
+        name: extproc
+        port: 9093
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: extproc
+spec:
+  ports:
+  - port: 9091
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c
+    targetPort: 9091
+  - port: 9092
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c
+    targetPort: 9092
+  - port: 9093
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c
+    targetPort: 9093
+  selector:
+    app: extproc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: test

--- a/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/transformation-deep-merge.yaml
@@ -1,0 +1,183 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test
+spec:
+  parentRefs:
+  - name: test
+  hostnames:
+  - "test.com"
+  rules:
+  - name: rule0
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-0
+  - name: rule1
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-1
+  - name: rule2
+    backendRefs:
+    - name: test
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /route-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+  transformation:
+    request:
+      set:
+      - name: source
+        value: gateway-attachment-1
+    response:
+      set:
+      - name: source
+        value: gateway-attachment-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-attachment-2
+  annotations:
+    kgateway.dev/policy-weight: "5" # higher priority than gateway-attachment-1
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+  transformation:
+    request:
+      set:
+      - name: source
+        value: gateway-attachment-2
+    response:
+      set:
+      - name: source
+        value: gateway-attachment-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-attachment-1
+  annotations:
+    kgateway.dev/policy-weight: "-1" # lower priority than listener-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+    sectionName: http
+  transformation:
+    request:
+      set:
+      - name: source
+        value: listener-attachment-1
+    response:
+      set:
+      - name: source
+        value: listener-attachment-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-attachment-2
+  annotations:
+    kgateway.dev/policy-weight: "1" # higher priority than listener-attachment-1  
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test
+    sectionName: http
+  transformation:
+    request:
+      set:
+      - name: source
+        value: listener-attachment-2
+    response:
+      set:
+      - name: source
+        value: listener-attachment-2
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-attachment-1
+  annotations:
+    kgateway.dev/policy-weight: "5" # higher priority than route-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule0
+  transformation:
+    request:
+      set:
+      - name: source
+        value: route-attachment-1
+    response:
+      set:
+      - name: source
+        value: route-attachment-1
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-attachment-2
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test
+    sectionName: rule0
+  transformation:
+    request:
+      set:
+      - name: source
+        value: route-attachment-2
+    response:
+      set:
+      - name: source
+        value: route-attachment-2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  selector:
+    test: test
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: test

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -1,0 +1,253 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_extauth_9091
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_extauth_9092
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_extauth_9093
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_test_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - disabled: true
+          name: global_disable/ext_auth
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+            metadata:
+            - metadataNamespace: dev.kgateway.disable_ext_auth
+              value:
+                disable: true
+        - disabled: true
+          name: ext_auth/default/extauth-gateway-2
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            filterEnabledMetadata:
+              filter: dev.kgateway.disable_ext_auth
+              invert: true
+              path:
+              - key: disable
+              value:
+                boolMatch: true
+            grpcService:
+              envoyGrpc:
+                clusterName: kube_default_extauth_9091
+        - disabled: true
+          name: ext_auth/default/extauth-gateway-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            filterEnabledMetadata:
+              filter: dev.kgateway.disable_ext_auth
+              invert: true
+              path:
+              - key: disable
+              value:
+                boolMatch: true
+            grpcService:
+              envoyGrpc:
+                clusterName: kube_default_extauth_9091
+        - disabled: true
+          name: ext_auth/default/extauth-listener-2
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            filterEnabledMetadata:
+              filter: dev.kgateway.disable_ext_auth
+              invert: true
+              path:
+              - key: disable
+              value:
+                boolMatch: true
+            grpcService:
+              envoyGrpc:
+                clusterName: kube_default_extauth_9092
+        - disabled: true
+          name: ext_auth/default/extauth-route-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            filterEnabledMetadata:
+              filter: dev.kgateway.disable_ext_auth
+              invert: true
+              path:
+              - key: disable
+              value:
+                boolMatch: true
+            grpcService:
+              envoyGrpc:
+                clusterName: kube_default_extauth_9093
+        - disabled: true
+          name: ext_auth/default/extauth-route-2
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            filterEnabledMetadata:
+              filter: dev.kgateway.disable_ext_auth
+              invert: true
+              path:
+              - key: disable
+              value:
+                boolMatch: true
+            grpcService:
+              envoyGrpc:
+                clusterName: kube_default_extauth_9093
+        - disabled: true
+          name: ext_auth/default/extauth-listener-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            filterEnabledMetadata:
+              filter: dev.kgateway.disable_ext_auth
+              invert: true
+              path:
+              - key: disable
+              value:
+                boolMatch: true
+            grpcService:
+              envoyGrpc:
+                clusterName: kube_default_extauth_9092
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-1
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-2
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extAuth:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-1
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-2
+  name: listener~8080
+  typedPerFilterConfig:
+    ext_auth/default/extauth-gateway-1:
+      '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+      config: {}
+    ext_auth/default/extauth-gateway-2:
+      '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+      config: {}
+  virtualHosts:
+  - domains:
+    - test.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          extAuth:
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-attachment-1
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-attachment-2
+    name: listener~8080~test_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /route-0
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-attachment-1
+            - gateway.kgateway.dev/TrafficPolicy/default/route-attachment-2
+      name: listener~8080~test_com-route-0-httproute-test-default-0-0-rule0-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        ext_auth/default/extauth-route-1:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+        ext_auth/default/extauth-route-2:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+    - match:
+        pathSeparatedPrefix: /route-1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extAuth:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-disable
+      name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        global_disable/ext_auth:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+    - match:
+        pathSeparatedPrefix: /route-2
+      name: listener~8080~test_com-route-2-httproute-test-default-2-0-rule2-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    typedPerFilterConfig:
+      ext_auth/default/extauth-listener-1:
+        '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+        config: {}
+      ext_auth/default/extauth-listener-2:
+        '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+        config: {}

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
@@ -1,0 +1,403 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_extproc_9091
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_extproc_9092
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_extproc_9093
+  type: EDS
+  typedExtensionProtocolOptions:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicitHttpConfig:
+        http2ProtocolOptions: {}
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_test_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - disabled: true
+          name: global_disable/ext_proc
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+            metadata:
+            - metadataNamespace: dev.kgateway.disable_ext_proc
+              value:
+                disable: true
+        - disabled: true
+          name: ext_proc/default/extproc-gateway-2
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+            extensionConfig:
+              name: composite_ext_proc
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+            xdsMatcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: composite-action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                        typedConfig:
+                          name: envoy.filters.http.ext_proc
+                          typedConfig:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                            grpcService:
+                              envoyGrpc:
+                                clusterName: kube_default_extproc_9091
+                  predicate:
+                    singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.metadata_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                          invert: true
+                          value:
+                            boolMatch: true
+                      input:
+                        name: disable
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                          filter: dev.kgateway.disable_ext_proc
+                          path:
+                          - key: disable
+        - disabled: true
+          name: ext_proc/default/extproc-gateway-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+            extensionConfig:
+              name: composite_ext_proc
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+            xdsMatcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: composite-action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                        typedConfig:
+                          name: envoy.filters.http.ext_proc
+                          typedConfig:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                            grpcService:
+                              envoyGrpc:
+                                clusterName: kube_default_extproc_9091
+                  predicate:
+                    singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.metadata_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                          invert: true
+                          value:
+                            boolMatch: true
+                      input:
+                        name: disable
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                          filter: dev.kgateway.disable_ext_proc
+                          path:
+                          - key: disable
+        - disabled: true
+          name: ext_proc/default/extproc-listener-2
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+            extensionConfig:
+              name: composite_ext_proc
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+            xdsMatcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: composite-action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                        typedConfig:
+                          name: envoy.filters.http.ext_proc
+                          typedConfig:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                            grpcService:
+                              envoyGrpc:
+                                clusterName: kube_default_extproc_9092
+                  predicate:
+                    singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.metadata_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                          invert: true
+                          value:
+                            boolMatch: true
+                      input:
+                        name: disable
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                          filter: dev.kgateway.disable_ext_proc
+                          path:
+                          - key: disable
+        - disabled: true
+          name: ext_proc/default/extproc-route-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+            extensionConfig:
+              name: composite_ext_proc
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+            xdsMatcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: composite-action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                        typedConfig:
+                          name: envoy.filters.http.ext_proc
+                          typedConfig:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                            grpcService:
+                              envoyGrpc:
+                                clusterName: kube_default_extproc_9093
+                  predicate:
+                    singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.metadata_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                          invert: true
+                          value:
+                            boolMatch: true
+                      input:
+                        name: disable
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                          filter: dev.kgateway.disable_ext_proc
+                          path:
+                          - key: disable
+        - disabled: true
+          name: ext_proc/default/extproc-route-2
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+            extensionConfig:
+              name: composite_ext_proc
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+            xdsMatcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: composite-action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                        typedConfig:
+                          name: envoy.filters.http.ext_proc
+                          typedConfig:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                            grpcService:
+                              envoyGrpc:
+                                clusterName: kube_default_extproc_9093
+                  predicate:
+                    singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.metadata_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                          invert: true
+                          value:
+                            boolMatch: true
+                      input:
+                        name: disable
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                          filter: dev.kgateway.disable_ext_proc
+                          path:
+                          - key: disable
+        - disabled: true
+          name: ext_proc/default/extproc-listener-1
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+            extensionConfig:
+              name: composite_ext_proc
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+            xdsMatcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: composite-action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                        typedConfig:
+                          name: envoy.filters.http.ext_proc
+                          typedConfig:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                            grpcService:
+                              envoyGrpc:
+                                clusterName: kube_default_extproc_9092
+                  predicate:
+                    singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.metadata_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                          invert: true
+                          value:
+                            boolMatch: true
+                      input:
+                        name: disable
+                        typedConfig:
+                          '@type': type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                          filter: dev.kgateway.disable_ext_proc
+                          path:
+                          - key: disable
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extProc:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-1
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-2
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        extProc:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-1
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-2
+  name: listener~8080
+  typedPerFilterConfig:
+    ext_proc/default/extproc-gateway-1:
+      '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+      overrides: {}
+    ext_proc/default/extproc-gateway-2:
+      '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+      overrides: {}
+  virtualHosts:
+  - domains:
+    - test.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          extProc:
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-attachment-1
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-attachment-2
+    name: listener~8080~test_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /route-0
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-attachment-1
+            - gateway.kgateway.dev/TrafficPolicy/default/route-attachment-2
+      name: listener~8080~test_com-route-0-httproute-test-default-0-0-rule0-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        ext_proc/default/extproc-route-1:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides: {}
+        ext_proc/default/extproc-route-2:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+          overrides: {}
+    - match:
+        pathSeparatedPrefix: /route-1
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            extProc:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-disable
+      name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        global_disable/ext_proc:
+          '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
+          config: {}
+    - match:
+        pathSeparatedPrefix: /route-2
+      name: listener~8080~test_com-route-2-httproute-test-default-2-0-rule2-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    typedPerFilterConfig:
+      ext_proc/default/extproc-listener-1:
+        '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+        overrides: {}
+      ext_proc/default/extproc-listener-2:
+        '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+        overrides: {}

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -1,0 +1,195 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_test_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - disabled: true
+          name: transformation
+          typedConfig:
+            '@type': type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        transformation:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-1
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-2
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        transformation:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-1
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-attachment-2
+  name: listener~8080
+  typedPerFilterConfig:
+    transformation:
+      '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
+      transformations:
+      - requestMatch:
+          requestTransformation:
+            transformationTemplate:
+              headers:
+                source:
+                  text: gateway-attachment-2
+              parseBodyBehavior: DontParse
+              passthrough: {}
+          responseTransformation:
+            transformationTemplate:
+              headers:
+                source:
+                  text: gateway-attachment-2
+              parseBodyBehavior: DontParse
+              passthrough: {}
+      - requestMatch:
+          requestTransformation:
+            transformationTemplate:
+              headers:
+                source:
+                  text: gateway-attachment-1
+              parseBodyBehavior: DontParse
+              passthrough: {}
+          responseTransformation:
+            transformationTemplate:
+              headers:
+                source:
+                  text: gateway-attachment-1
+              parseBodyBehavior: DontParse
+              passthrough: {}
+  virtualHosts:
+  - domains:
+    - test.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          transformation:
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-attachment-1
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-attachment-2
+    name: listener~8080~test_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /route-0
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            transformation:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-attachment-1
+            - gateway.kgateway.dev/TrafficPolicy/default/route-attachment-2
+      name: listener~8080~test_com-route-0-httproute-test-default-0-0-rule0-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        transformation:
+          '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
+          transformations:
+          - requestMatch:
+              requestTransformation:
+                transformationTemplate:
+                  headers:
+                    source:
+                      text: route-attachment-1
+                  parseBodyBehavior: DontParse
+                  passthrough: {}
+              responseTransformation:
+                transformationTemplate:
+                  headers:
+                    source:
+                      text: route-attachment-1
+                  parseBodyBehavior: DontParse
+                  passthrough: {}
+          - requestMatch:
+              requestTransformation:
+                transformationTemplate:
+                  headers:
+                    source:
+                      text: route-attachment-2
+                  parseBodyBehavior: DontParse
+                  passthrough: {}
+              responseTransformation:
+                transformationTemplate:
+                  headers:
+                    source:
+                      text: route-attachment-2
+                  parseBodyBehavior: DontParse
+                  passthrough: {}
+    - match:
+        pathSeparatedPrefix: /route-1
+      name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /route-2
+      name: listener~8080~test_com-route-2-httproute-test-default-2-0-rule2-matcher-0
+      route:
+        cluster: kube_default_test_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    typedPerFilterConfig:
+      transformation:
+        '@type': type.googleapis.com/envoy.api.v2.filter.http.RouteTransformations
+        transformations:
+        - requestMatch:
+            requestTransformation:
+              transformationTemplate:
+                headers:
+                  source:
+                    text: listener-attachment-2
+                parseBodyBehavior: DontParse
+                passthrough: {}
+            responseTransformation:
+              transformationTemplate:
+                headers:
+                  source:
+                    text: listener-attachment-2
+                parseBodyBehavior: DontParse
+                passthrough: {}
+        - requestMatch:
+            requestTransformation:
+              transformationTemplate:
+                headers:
+                  source:
+                    text: listener-attachment-1
+                parseBodyBehavior: DontParse
+                passthrough: {}
+            responseTransformation:
+              transformationTemplate:
+                headers:
+                  source:
+                    text: listener-attachment-1
+                parseBodyBehavior: DontParse
+                passthrough: {}

--- a/pkg/pluginsdk/filters/stages.go
+++ b/pkg/pluginsdk/filters/stages.go
@@ -54,9 +54,9 @@ func FilterStageComparison[WellKnown ~int](a, b FilterStage[WellKnown]) int {
 	} else if a.RelativeTo > b.RelativeTo {
 		return 1
 	}
-	if a.Weight < b.Weight {
+	if a.RelativeWeight < b.RelativeWeight {
 		return -1
-	} else if a.Weight > b.Weight {
+	} else if a.RelativeWeight > b.RelativeWeight {
 		return 1
 	}
 	return 0
@@ -65,28 +65,33 @@ func FilterStageComparison[WellKnown ~int](a, b FilterStage[WellKnown]) int {
 func BeforeStage[WellKnown ~int](wellKnown WellKnown) FilterStage[WellKnown] {
 	return RelativeToStage(wellKnown, -1)
 }
+
 func DuringStage[WellKnown ~int](wellKnown WellKnown) FilterStage[WellKnown] {
 	return RelativeToStage(wellKnown, 0)
 }
+
 func AfterStage[WellKnown ~int](wellKnown WellKnown) FilterStage[WellKnown] {
 	return RelativeToStage(wellKnown, 1)
 }
+
 func RelativeToStage[WellKnown ~int](wellKnown WellKnown, weight int) FilterStage[WellKnown] {
 	return FilterStage[WellKnown]{
-		RelativeTo: wellKnown,
-		Weight:     weight,
+		RelativeTo:     wellKnown,
+		RelativeWeight: weight,
 	}
 }
 
 type FilterStage[WellKnown ~int] struct {
-	RelativeTo WellKnown
-	Weight     int
+	RelativeTo     WellKnown
+	RelativeWeight int
 }
 
-type HTTPOrNetworkFilterStage = FilterStage[WellKnownFilterStage]
-type HTTPFilterStage = FilterStage[WellKnownFilterStage]
-type NetworkFilterStage = FilterStage[WellKnownFilterStage]
-type UpstreamHTTPFilterStage = FilterStage[WellKnownUpstreamHTTPFilterStage]
+type (
+	HTTPOrNetworkFilterStage = FilterStage[WellKnownFilterStage]
+	HTTPFilterStage          = FilterStage[WellKnownFilterStage]
+	NetworkFilterStage       = FilterStage[WellKnownFilterStage]
+	UpstreamHTTPFilterStage  = FilterStage[WellKnownUpstreamHTTPFilterStage]
+)
 
 type Filter interface {
 	proto.Message
@@ -97,6 +102,7 @@ type Filter interface {
 type StagedFilter[WellKnown ~int, FilterType Filter] struct {
 	Filter FilterType
 	Stage  FilterStage[WellKnown]
+	Weight int32
 }
 
 type StagedFilterList[WellKnown ~int, FilterType Filter] []StagedFilter[WellKnown, FilterType]
@@ -111,6 +117,16 @@ func (s StagedFilterList[WellKnown, FilterType]) Len() int {
 func (s StagedFilterList[WellKnown, FilterType]) Less(i, j int) bool {
 	if compare := FilterStageComparison(s[i].Stage, s[j].Stage); compare != 0 {
 		return compare < 0
+	}
+
+	// If the filters are of the same type, compare their weights. Higher weights are ordered
+	// before lower weights.
+	if s[i].Filter.GetTypedConfig().GetTypeUrl() == s[j].Filter.GetTypedConfig().GetTypeUrl() {
+		if s[i].Weight > s[j].Weight {
+			return true
+		} else if s[i].Weight < s[j].Weight {
+			return false
+		}
 	}
 
 	if compare := strings.Compare(s[i].Filter.GetName(), s[j].Filter.GetName()); compare != 0 {
@@ -133,13 +149,17 @@ func (s StagedFilterList[WellKnown, FilterType]) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-type StagedHttpFilter = StagedFilter[WellKnownFilterStage, *envoyhttp.HttpFilter]
-type StagedNetworkFilter = StagedFilter[WellKnownFilterStage, *envoylistenerv3.Filter]
-type StagedUpstreamHttpFilter = StagedFilter[WellKnownUpstreamHTTPFilterStage, *envoyhttp.HttpFilter]
+type (
+	StagedHttpFilter         = StagedFilter[WellKnownFilterStage, *envoyhttp.HttpFilter]
+	StagedNetworkFilter      = StagedFilter[WellKnownFilterStage, *envoylistenerv3.Filter]
+	StagedUpstreamHttpFilter = StagedFilter[WellKnownUpstreamHTTPFilterStage, *envoyhttp.HttpFilter]
+)
 
-type StagedHttpFilterList = StagedFilterList[WellKnownFilterStage, *envoyhttp.HttpFilter]
-type StagedNetworkFilterList = StagedFilterList[WellKnownFilterStage, *envoylistenerv3.Filter]
-type StagedUpstreamHttpFilterList = StagedFilterList[WellKnownUpstreamHTTPFilterStage, *envoyhttp.HttpFilter]
+type (
+	StagedHttpFilterList         = StagedFilterList[WellKnownFilterStage, *envoyhttp.HttpFilter]
+	StagedNetworkFilterList      = StagedFilterList[WellKnownFilterStage, *envoylistenerv3.Filter]
+	StagedUpstreamHttpFilterList = StagedFilterList[WellKnownUpstreamHTTPFilterStage, *envoyhttp.HttpFilter]
+)
 
 // MustNewStagedFilter creates an instance of the named filter with the desired stage.
 // Returns a filter even if an error occurred.
@@ -148,6 +168,14 @@ type StagedUpstreamHttpFilterList = StagedFilterList[WellKnownUpstreamHTTPFilter
 // If not directly appending consider using NewStagedFilter instead of this function.
 func MustNewStagedFilter(name string, config proto.Message, stage FilterStage[WellKnownFilterStage]) StagedHttpFilter {
 	s, _ := NewStagedFilter(name, config, stage)
+	return s
+}
+
+// MustNewStagedFilterWithWeight creates an instance of the named filter with the desired stage and weight.
+// The weight is used to order filters of the same type within the same stage based on their weights
+func MustNewStagedFilterWithWeight(name string, config proto.Message, stage FilterStage[WellKnownFilterStage], weight int32) StagedHttpFilter {
+	s, _ := NewStagedFilter(name, config, stage)
+	s.Weight = weight
 	return s
 }
 

--- a/pkg/pluginsdk/filters/stages.go
+++ b/pkg/pluginsdk/filters/stages.go
@@ -74,10 +74,11 @@ func AfterStage[WellKnown ~int](wellKnown WellKnown) FilterStage[WellKnown] {
 	return RelativeToStage(wellKnown, 1)
 }
 
-func RelativeToStage[WellKnown ~int](wellKnown WellKnown, weight int) FilterStage[WellKnown] {
+// RelativeToStage creates a FilterStage that is relative to a well-known stage by a given weight
+func RelativeToStage[WellKnown ~int](wellKnown WellKnown, relativeWeight int) FilterStage[WellKnown] {
 	return FilterStage[WellKnown]{
 		RelativeTo:     wellKnown,
-		RelativeWeight: weight,
+		RelativeWeight: relativeWeight,
 	}
 }
 

--- a/pkg/pluginsdk/ir/gatewayextension.go
+++ b/pkg/pluginsdk/ir/gatewayextension.go
@@ -25,6 +25,11 @@ type GatewayExtension struct {
 	// RateLimit configuration for RateLimit extension type.
 	// This is specifically for global rate limiting that communicates with an external rate limit service.
 	RateLimit *v1alpha1.RateLimitProvider
+
+	// PrecedenceWeight specifies the precedence weight associated with the provider.
+	// A higher weight implies higher priority.
+	// It is used to order provider filters by their weight.
+	PrecedenceWeight int32
 }
 
 var (
@@ -48,6 +53,9 @@ func (e GatewayExtension) Equals(other GatewayExtension) bool {
 		return false
 	}
 	if !reflect.DeepEqual(e.RateLimit, other.RateLimit) {
+		return false
+	}
+	if e.PrecedenceWeight != other.PrecedenceWeight {
 		return false
 	}
 	return true

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -84,6 +84,13 @@ type PolicyAtt struct {
 	// that are at different levels in the config tree hierarchy.
 	HierarchicalPriority int
 
+	// PrecedenceWeight specifies the weight of the policy as an integer value (negative values are allowed).
+	// Policies with higher weight implies higher priority, and are evaluated before policies with lower weight.
+	// By default, policies have a weight of 0.
+	// The policy's weight is relevant to policy prioritization during policy merging, such that higher priority
+	// policies are preferred during a merge conflict or when ordering policies during a merge.
+	PrecedenceWeight int32
+
 	// MergeOrigins maps field names in the PolicyIr to their original source in the merged PolicyAtt.
 	// It can be used to determine which PolicyAtt a merged field came from.
 	// Only relevant to policy merging and does not contribute to KRT events
@@ -142,7 +149,8 @@ func (c PolicyAtt) Equals(in PolicyAtt) bool {
 		c.PolicyIr.Equals(in.PolicyIr) &&
 		ptrEquals(c.PolicyRef, in.PolicyRef) &&
 		c.InheritedPolicyPriority == in.InheritedPolicyPriority &&
-		c.HierarchicalPriority == in.HierarchicalPriority
+		c.HierarchicalPriority == in.HierarchicalPriority &&
+		c.PrecedenceWeight == in.PrecedenceWeight
 }
 
 func ptrEquals[T comparable](a, b *T) bool {

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -295,6 +295,11 @@ type PolicyWrapper struct {
 
 	// Where to attach the policy. This usually comes from the policy CRD.
 	TargetRefs []PolicyRef
+
+	// PrecedenceWeight specifies the weight of the policy as an integer value (negative values are allowed).
+	// Policies with higher weight implies higher priority, and are evaluated before policies with lower weight.
+	// By default, policies have a weight of 0.
+	PrecedenceWeight int32
 }
 
 func (c PolicyWrapper) ResourceName() string {
@@ -332,7 +337,7 @@ func (c PolicyWrapper) Equals(in PolicyWrapper) bool {
 		return false
 	}
 
-	return versionEquals(c.Policy, in.Policy) && c.PolicyIR.Equals(in.PolicyIR)
+	return versionEquals(c.Policy, in.Policy) && c.PolicyIR.Equals(in.PolicyIR) && c.PrecedenceWeight == in.PrecedenceWeight
 }
 
 var ErrNotAttachable = fmt.Errorf("policy is not attachable to this object")

--- a/pkg/pluginsdk/utils/policy.go
+++ b/pkg/pluginsdk/utils/policy.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"fmt"
 	"maps"
+	"strconv"
 
 	"k8s.io/utils/ptr"
 	v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -68,4 +70,20 @@ func TargetRefsToPolicyRefsWithSectionNameV1Alpha2(targetRefs []v1alpha2.LocalPo
 	}
 
 	return refs
+}
+
+// ParsePrecedenceWeightAnnotation parses the given route/policy weight value from the given annotations and key
+func ParsePrecedenceWeightAnnotation(
+	annotations map[string]string,
+	key string,
+) (int32, error) {
+	val, ok := annotations[key]
+	if !ok {
+		return 0, nil
+	}
+	weight, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value for annotation %s: %s; must be a valid integer", key, val)
+	}
+	return int32(weight), nil
 }

--- a/pkg/pluginsdk/utils/policy_test.go
+++ b/pkg/pluginsdk/utils/policy_test.go
@@ -1,0 +1,105 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
+)
+
+func TestParsePrecedenceWeightAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    int32
+		expectError bool
+	}{
+		{
+			name:        "No annotation",
+			annotations: map[string]string{},
+			expected:    0,
+			expectError: false,
+		},
+		{
+			name: "Valid positive weight",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "100",
+			},
+			expected:    100,
+			expectError: false,
+		},
+		{
+			name: "Valid negative weight",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "-50",
+			},
+			expected:    -50,
+			expectError: false,
+		},
+		{
+			name: "Valid zero weight",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "0",
+			},
+			expected:    0,
+			expectError: false,
+		},
+		{
+			name: "Invalid non-numeric value",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "invalid",
+			},
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name: "Invalid decimal value",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "100.5",
+			},
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name: "Empty string value",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "",
+			},
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name: "Value too large for int32",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "2147483648", // int32 max + 1
+			},
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name: "Value too small for int32",
+			annotations: map[string]string{
+				apiannotations.RoutePrecedenceWeight: "-2147483649", // int32 min - 1
+			},
+			expected:    0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
+			weight, err := ParsePrecedenceWeightAnnotation(tt.annotations, apiannotations.RoutePrecedenceWeight)
+
+			if tt.expectError {
+				a.Error(err)
+				a.Equal(int32(0), weight)
+				return
+			}
+			a.NoError(err)
+			a.Equal(tt.expected, weight)
+		})
+	}
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -163,6 +163,8 @@ type Settings struct {
 
 	// Controls if leader election is disabled. Defaults to false.
 	DisableLeaderElection bool `split_words:"true" default:"false"`
+
+	PolicyMerge string `split_words:"true" default:"{}"`
 }
 
 // BuildSettings returns a zero-valued Settings obj if error is encountered when parsing env

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -635,7 +635,7 @@ func (tc TestCase) Run(
 		return nil, err
 	}
 
-	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultWaypointClassName)
+	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultWaypointClassName, *settings)
 	// TODO: consider moving the common code to a util that both proxy syncer and this test call
 	plugins = append(plugins, krtcollections.NewBuiltinPlugin(ctx))
 


### PR DESCRIPTION
# Description
Adds the ability to deep-merge extAuth, extProc, transformation policies when multiple policies target the same resource. Additionally, introduces the `kgateway.dev/policy-weight` annotation for GatewayExtension and TrafficPolicy to control the priority of policies during merging. All policies/extensions default to a policy weight of 0, with a higher value resulting in greater precedence.

Policies are merged in priority order and follow the following precedence rules:
- By default, a policy with earlier creation timestamp is considered higher in priority and is preferred during a deep merge.
- For extAuth and extProc, the policy weight specified using the `kgateway.dev/policy-weight` annotation on the GatewayExtension determines the ordering of the extAuth and extProc filters relative to other policies during merging.
- For transformation, the policy weight specified using the `kgateway.dev/policy-weight` annotation on the TrafficPolicy determines the ordering of request/response transformation rules in the final rule slice.

# Change Type

```
/kind new_feature
```

# Changelog

```release-note
Enables optional deep merging of extAuth, extProc, transformation
policies in TrafficPolicy for policies attached to the same resource.
Enables the ability to prioritize policies and GatewayExtensions using
the kgateway.dev/policy-weight annotation.
```

# Additional Notes
Part of #11275