### PR TITLE
agentgateway: fix MCP protocol for selector-based Backends

### DIFF
--- a/api/v1alpha1/backend_types.go
+++ b/api/v1alpha1/backend_types.go
@@ -70,6 +70,7 @@ type BackendSpec struct {
 	// +optional
 	DynamicForwardProxy *DynamicForwardProxyBackend `json:"dynamicForwardProxy,omitempty"`
 	// MCP is the mcp backend configuration. The MCP backend type is only supported with agentgateway.
+	// +optional
 	MCP *MCP `json:"mcp,omitempty"`
 }
 

--- a/api/v1alpha1/mcp_backend.go
+++ b/api/v1alpha1/mcp_backend.go
@@ -61,14 +61,18 @@ type McpTarget struct {
 
 	// Protocol is the protocol to use for the connection to the MCP target.
 	// +optional
-	// +kubebuilder:validation:Enum=Undefined;SSE;StreamableHTTP
+	// +kubebuilder:validation:Enum=StreamableHTTP;SSE
 	Protocol MCPProtocol `json:"protocol,omitempty"`
 }
 
+// MCPProtocol defines the protocol to use for the MCP target
 type MCPProtocol string
 
 const (
-	MCPProtocolUndefined      MCPProtocol = "Undefined"
-	MCPProtocolSSE            MCPProtocol = "SSE"
+
+	// MCPProtocolStreamableHTTP specifies Streamable HTTP must be used as the protocol
 	MCPProtocolStreamableHTTP MCPProtocol = "StreamableHTTP"
+
+	// MCPProtocolSSE specifies Server-Sent Events (SSE) must be used as the protocol
+	MCPProtocolSSE MCPProtocol = "SSE"
 )

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
@@ -790,9 +790,8 @@ spec:
                               type: integer
                             protocol:
                               enum:
-                              - Undefined
-                              - SSE
                               - StreamableHTTP
+                              - SSE
                               type: string
                           required:
                           - host

--- a/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
+++ b/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
@@ -373,7 +373,9 @@ func TestTranslationWithExtraPlugins(
 		os.WriteFile(outputFile, outputYaml, 0o644)
 	}
 
-	r.Empty(compareProxy(outputFile, output))
+	diff, err := compareProxy(outputFile, output)
+	r.Empty(diff)
+	r.NoError(err)
 
 	if assertReports != nil {
 		assertReports(gwNN, result.ReportsMap)

--- a/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
+++ b/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
@@ -10,13 +10,14 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/agentgateway/agentgateway/go/api"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -277,7 +278,7 @@ func NewScheme(extraSchemes runtime.SchemeBuilder) *runtime.Scheme {
 }
 
 func TestTranslation(
-	t test.Failer,
+	t *testing.T,
 	ctx context.Context,
 	inputFiles []string,
 	outputFile string,
@@ -289,7 +290,7 @@ func TestTranslation(
 }
 
 func TestTranslationWithExtraPlugins(
-	t test.Failer,
+	t *testing.T,
 	ctx context.Context,
 	inputFiles []string,
 	outputFile string,
@@ -301,14 +302,15 @@ func TestTranslationWithExtraPlugins(
 	settingsOpts ...SettingsOpts,
 ) {
 	scheme := NewScheme(extraSchemes)
+	r := require.New(t)
 
 	results, err := TestCase{
 		InputFiles: inputFiles,
 	}.Run(t, ctx, scheme, extraPluginsFn, extraGroups, settingsOpts...)
-	Expect(err).NotTo(HaveOccurred())
+	r.NoError(err)
 	// TODO allow expecting multiple gateways in the output (map nns -> outputFile?)
-	Expect(results).To(HaveLen(1))
-	Expect(results).To(HaveKey(gwNN))
+	r.Len(results, 1)
+	r.Contains(results, gwNN)
 	result := results[gwNN]
 
 	// TODO: do a json round trip to normalize the output (i.e. things like omit empty)
@@ -360,23 +362,23 @@ func TestTranslationWithExtraPlugins(
 	}
 	outputYaml, err := translator.MarshalAnyYaml(output)
 	fmt.Fprintf(ginkgo.GinkgoWriter, "actual result:\n %s \nerror: %v", outputYaml, err)
-	Expect(err).NotTo(HaveOccurred())
+	r.NoError(err)
 
 	if envutils.IsEnvTruthy("REFRESH_GOLDEN") {
 		// create parent directory if it doesn't exist
 		dir := filepath.Dir(outputFile)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			Expect(err).NotTo(HaveOccurred())
+			r.NoError(err)
 		}
 		os.WriteFile(outputFile, outputYaml, 0o644)
 	}
 
-	Expect(compareProxy(outputFile, output)).To(BeEmpty())
+	r.Empty(compareProxy(outputFile, output))
 
 	if assertReports != nil {
 		assertReports(gwNN, result.ReportsMap)
 	} else {
-		Expect(AreReportsSuccess(result.ReportsMap)).NotTo(HaveOccurred())
+		r.NoError(AreReportsSuccess(result.ReportsMap))
 	}
 }
 

--- a/internal/kgateway/agentgatewaysyncer/agentgateway_translator_test.go
+++ b/internal/kgateway/agentgatewaysyncer/agentgateway_translator_test.go
@@ -3,9 +3,9 @@ package agentgatewaysyncer
 import (
 	"context"
 	"path/filepath"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,29 +23,28 @@ type translatorTestCase struct {
 	gwNN          types.NamespacedName
 }
 
-var _ = DescribeTable("Basic agentgateway Tests",
-	func(in translatorTestCase, settingOpts ...SettingsOpts) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+func TestBasic(t *testing.T) {
+	test := func(t *testing.T, in translatorTestCase, settingOpts ...SettingsOpts) {
 		dir := fsutils.MustGetThisDir()
 
 		inputFiles := []string{filepath.Join(dir, "testdata/inputs/", in.inputFile)}
 		expectedProxyFile := filepath.Join(dir, "testdata/outputs/", in.outputFile)
-		TestTranslation(GinkgoT(), ctx, inputFiles, expectedProxyFile, in.gwNN, in.assertReports, settingOpts...)
-	},
-	Entry(
-		"http gateway with basic http routing",
-		translatorTestCase{
+		TestTranslation(t, t.Context(), inputFiles, expectedProxyFile, in.gwNN, in.assertReports, settingOpts...)
+	}
+
+	t.Run("http gateway with basic http routing", func(t *testing.T) {
+		test(t, translatorTestCase{
 			inputFile:  "http-routing",
 			outputFile: "http-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",
 			},
-		}),
-	Entry(
-		"grpc gateway with basic routing",
-		translatorTestCase{
+		})
+	})
+
+	t.Run("grpc gateway with basic routing", func(t *testing.T) {
+		test(t, translatorTestCase{
 			inputFile:  "grpc-routing/basic.yaml",
 			outputFile: "grpc-routing/basic-proxy.yaml",
 			gwNN: types.NamespacedName{
@@ -60,17 +59,18 @@ var _ = DescribeTable("Basic agentgateway Tests",
 					},
 				}
 				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
-				Expect(routeStatus).NotTo(BeNil())
-				Expect(routeStatus.Parents).To(HaveLen(1))
+				assert.NotNil(t, routeStatus)
+				assert.Len(t, routeStatus.Parents, 1)
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
-				Expect(resolvedRefs).NotTo(BeNil())
-				Expect(resolvedRefs.Status).To(Equal(metav1.ConditionTrue))
-				Expect(resolvedRefs.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
+				assert.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionTrue, resolvedRefs.Status)
+				assert.Equal(t, string(gwv1.RouteReasonResolvedRefs), resolvedRefs.Reason)
 			},
-		}),
-	Entry(
-		"grpcroute with missing backend reports correctly",
-		translatorTestCase{
+		})
+	})
+
+	t.Run("grpcroute with missing backend reports correctly", func(t *testing.T) {
+		test(t, translatorTestCase{
 			inputFile:  "grpc-routing/missing-backend.yaml",
 			outputFile: "grpc-routing/missing-backend.yaml",
 			gwNN: types.NamespacedName{
@@ -85,17 +85,18 @@ var _ = DescribeTable("Basic agentgateway Tests",
 					},
 				}
 				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
-				Expect(routeStatus).NotTo(BeNil())
-				Expect(routeStatus.Parents).To(HaveLen(1))
+				assert.NotNil(t, routeStatus)
+				assert.Len(t, routeStatus.Parents, 1)
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
-				Expect(resolvedRefs).NotTo(BeNil())
-				Expect(resolvedRefs.Status).To(Equal(metav1.ConditionFalse))
-				Expect(resolvedRefs.Message).To(Equal(`backend(example-grpc-svc.default.svc.cluster.local) not found`))
+				assert.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionFalse, resolvedRefs.Status)
+				assert.Equal(t, `backend(example-grpc-svc.default.svc.cluster.local) not found`, resolvedRefs.Message)
 			},
-		}),
-	Entry(
-		"grpcroute with invalid backend reports correctly",
-		translatorTestCase{
+		})
+	})
+
+	t.Run("grpcroute with invalid backend reports correctly", func(t *testing.T) {
+		test(t, translatorTestCase{
 			inputFile:  "grpc-routing/invalid-backend.yaml",
 			outputFile: "grpc-routing/invalid-backend.yaml",
 			gwNN: types.NamespacedName{
@@ -110,224 +111,273 @@ var _ = DescribeTable("Basic agentgateway Tests",
 					},
 				}
 				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
-				Expect(routeStatus).NotTo(BeNil())
-				Expect(routeStatus.Parents).To(HaveLen(1))
+				assert.NotNil(t, routeStatus)
+				assert.Len(t, routeStatus.Parents, 1)
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
-				Expect(resolvedRefs).NotTo(BeNil())
-				Expect(resolvedRefs.Status).To(Equal(metav1.ConditionFalse))
-				Expect(resolvedRefs.Message).To(Equal("referencing unsupported backendRef: group \"\" kind \"ConfigMap\""))
+				assert.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionFalse, resolvedRefs.Status)
+				assert.Equal(t, "referencing unsupported backendRef: group \"\" kind \"ConfigMap\"", resolvedRefs.Message)
 			},
-		}),
-	Entry(
-		"grpc gateway with multiple backend services",
-		translatorTestCase{
+		})
+	})
+
+	t.Run("grpc gateway with multiple backend services", func(t *testing.T) {
+		test(t, translatorTestCase{
 			inputFile:  "grpc-routing/multi-backend.yaml",
 			outputFile: "grpc-routing/multi-backend-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-grpc-gateway",
 			},
-		}),
-	Entry("Proxy with no routes", translatorTestCase{
-		inputFile:  "edge-cases/no-route.yaml",
-		outputFile: "no-route.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("HTTPRoutes with timeout and retry", translatorTestCase{
-		inputFile:  "httproute-timeout-retry/manifest.yaml",
-		outputFile: "httproute-timeout-retry-proxy.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("Service with appProtocol=anything", translatorTestCase{
-		inputFile:  "backend-protocol/svc-default.yaml",
-		outputFile: "backend-protocol/svc-default.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("Static Backend with no appProtocol", translatorTestCase{
-		inputFile:  "backend-protocol/backend-default.yaml",
-		outputFile: "backend-protocol/backend-default.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("MCP Backend with selector target", translatorTestCase{
-		inputFile:  "backend-protocol/mcp-backend-selector.yaml",
-		outputFile: "backend-protocol/mcp-backend-selector.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("MCP Backend with static target", translatorTestCase{
-		inputFile:  "backend-protocol/mcp-backend-static.yaml",
-		outputFile: "backend-protocol/mcp-backend-static.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("AI Backend with openai provider", translatorTestCase{
-		inputFile:  "backend-protocol/openai-backend.yaml",
-		outputFile: "backend-protocol/openai-backend.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("Backend with a2a provider", translatorTestCase{
-		inputFile:  "backend-protocol/a2a-backend.yaml",
-		outputFile: "backend-protocol/a2a-backend.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("AI Backend with bedrock provider", translatorTestCase{
-		inputFile:  "backend-protocol/bedrock-backend.yaml",
-		outputFile: "backend-protocol/bedrock-backend.yaml",
+		})
+	})
 
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("Direct response", translatorTestCase{
-		inputFile:  "direct-response/manifest.yaml",
-		outputFile: "direct-response.yaml",
+	t.Run("Proxy with no routes", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "edge-cases/no-route.yaml",
+			outputFile: "no-route.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
 
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("DirectResponse with missing reference reports correctly", translatorTestCase{
-		inputFile:  "direct-response/missing-ref.yaml",
-		outputFile: "direct-response/missing-ref.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-		assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
-			route := &gwv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "example-route",
-					Namespace: "default",
-				},
-			}
-			routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
-			Expect(routeStatus).NotTo(BeNil())
-			Expect(routeStatus.Parents).To(HaveLen(1))
+	t.Run("HTTPRoutes with timeout and retry", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "httproute-timeout-retry/manifest.yaml",
+			outputFile: "httproute-timeout-retry-proxy.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
 
-			// Assert ResolvedRefs=True since the route structure is valid
-			resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
-			Expect(resolvedRefs).NotTo(BeNil())
-			Expect(resolvedRefs.Status).To(Equal(metav1.ConditionTrue))
-			Expect(resolvedRefs.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
+	t.Run("Service with appProtocol=anything", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backend-protocol/svc-default.yaml",
+			outputFile: "backend-protocol/svc-default.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
 
-			// Assert Accepted=False reports the missing DirectResponse
-			acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
-			Expect(acceptedCond).NotTo(BeNil())
-			Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(acceptedCond.Reason).To(Equal(string(gwv1.RouteReasonBackendNotFound)))
-			Expect(acceptedCond.Message).To(Equal("DirectResponse default/non-existent-ref not found"))
-		},
-	}),
-	Entry("DirectResponse with overlapping filters reports correctly", translatorTestCase{
-		inputFile:  "direct-response/overlapping-filters.yaml",
-		outputFile: "direct-response/overlapping-filters.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-		assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
-			route := &gwv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "example-route",
-					Namespace: "default",
-				},
-			}
-			routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
-			Expect(routeStatus).NotTo(BeNil())
-			Expect(routeStatus.Parents).To(HaveLen(1))
+	t.Run("Static Backend with no appProtocol", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backend-protocol/backend-default.yaml",
+			outputFile: "backend-protocol/backend-default.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
 
-			// Check for Accepted=False condition due to overlapping terminal filters
-			acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
-			Expect(acceptedCond).NotTo(BeNil())
-			Expect(acceptedCond.Status).To(Equal(metav1.ConditionFalse))
-			Expect(acceptedCond.Reason).To(Equal(string(gwv1.RouteReasonIncompatibleFilters)))
-			Expect(acceptedCond.Message).To(ContainSubstring("terminal filter"))
-		},
-	}),
-	Entry("DirectResponse with invalid backendRef filter reports correctly", translatorTestCase{
-		inputFile:  "direct-response/invalid-backendref-filter.yaml",
-		outputFile: "direct-response/invalid-backendref-filter.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-		assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
-			route := &gwv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "example-route",
-					Namespace: "default",
-				},
-			}
-			routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
-			Expect(routeStatus).NotTo(BeNil())
-			Expect(routeStatus.Parents).To(HaveLen(1))
+	t.Run("MCP Backend with selector target", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backend-protocol/mcp-backend-selector.yaml",
+			outputFile: "backend-protocol/mcp-backend-selector.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
 
-			// DirectResponse attached to backendRef should be ignored, route should resolve normally
-			acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
-			Expect(acceptedCond).NotTo(BeNil())
-			Expect(acceptedCond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(acceptedCond.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+	t.Run("MCP Backend with static target", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backend-protocol/mcp-backend-static.yaml",
+			outputFile: "backend-protocol/mcp-backend-static.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
 
-			resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
-			Expect(resolvedRefs).NotTo(BeNil())
-			Expect(resolvedRefs.Status).To(Equal(metav1.ConditionTrue))
-		},
-	}),
-	Entry("TrafficPolicy with extauth on route", translatorTestCase{
-		inputFile:  "trafficpolicy/extauth-route.yaml",
-		outputFile: "trafficpolicy/extauth-route.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-	Entry("TrafficPolicy with extauth on gateway", translatorTestCase{
-		inputFile:  "trafficpolicy/extauth-gateway.yaml",
-		outputFile: "trafficpolicy/extauth-gateway.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
+	t.Run("AI Backend with openai provider", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backend-protocol/openai-backend.yaml",
+			outputFile: "backend-protocol/openai-backend.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("Backend with a2a provider", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backend-protocol/a2a-backend.yaml",
+			outputFile: "backend-protocol/a2a-backend.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("AI Backend with bedrock provider", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backend-protocol/bedrock-backend.yaml",
+			outputFile: "backend-protocol/bedrock-backend.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("Direct response", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "direct-response/manifest.yaml",
+			outputFile: "direct-response.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("DirectResponse with missing reference reports correctly", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "direct-response/missing-ref.yaml",
+			outputFile: "direct-response/missing-ref.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				route := &gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-route",
+						Namespace: "default",
+					},
+				}
+				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
+				assert.NotNil(t, routeStatus)
+				assert.Len(t, routeStatus.Parents, 1)
+
+				// Assert ResolvedRefs=True since the route structure is valid
+				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
+				assert.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionTrue, resolvedRefs.Status)
+				assert.Equal(t, string(gwv1.RouteReasonResolvedRefs), resolvedRefs.Reason)
+
+				// Assert Accepted=False reports the missing DirectResponse
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				assert.NotNil(t, acceptedCond)
+				assert.Equal(t, metav1.ConditionFalse, acceptedCond.Status)
+				assert.Equal(t, string(gwv1.RouteReasonBackendNotFound), acceptedCond.Reason)
+				assert.Equal(t, "DirectResponse default/non-existent-ref not found", acceptedCond.Message)
+			},
+		})
+	})
+
+	t.Run("DirectResponse with overlapping filters reports correctly", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "direct-response/overlapping-filters.yaml",
+			outputFile: "direct-response/overlapping-filters.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				route := &gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-route",
+						Namespace: "default",
+					},
+				}
+				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
+				assert.NotNil(t, routeStatus)
+				assert.Len(t, routeStatus.Parents, 1)
+
+				// Check for Accepted=False condition due to overlapping terminal filters
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				assert.NotNil(t, acceptedCond)
+				assert.Equal(t, metav1.ConditionFalse, acceptedCond.Status)
+				assert.Equal(t, string(gwv1.RouteReasonIncompatibleFilters), acceptedCond.Reason)
+				assert.Contains(t, acceptedCond.Message, "terminal filter")
+			},
+		})
+	})
+
+	t.Run("DirectResponse with invalid backendRef filter reports correctly", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "direct-response/invalid-backendref-filter.yaml",
+			outputFile: "direct-response/invalid-backendref-filter.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				route := &gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-route",
+						Namespace: "default",
+					},
+				}
+				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
+				assert.NotNil(t, routeStatus)
+				assert.Len(t, routeStatus.Parents, 1)
+
+				// DirectResponse attached to backendRef should be ignored, route should resolve normally
+				acceptedCond := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionAccepted))
+				assert.NotNil(t, acceptedCond)
+				assert.Equal(t, metav1.ConditionTrue, acceptedCond.Status)
+				assert.Equal(t, string(gwv1.RouteReasonAccepted), acceptedCond.Reason)
+
+				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
+				assert.NotNil(t, resolvedRefs)
+				assert.Equal(t, metav1.ConditionTrue, resolvedRefs.Status)
+			},
+		})
+	})
+
+	t.Run("TrafficPolicy with extauth on route", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "trafficpolicy/extauth-route.yaml",
+			outputFile: "trafficpolicy/extauth-route.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("TrafficPolicy with extauth on gateway", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "trafficpolicy/extauth-gateway.yaml",
+			outputFile: "trafficpolicy/extauth-gateway.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	// TODO(npolshak): re-enable once listener policies are supported once https://github.com/agentgateway/agentgateway/pull/323 goes in
-	//Entry("TrafficPolicy with extauth on listener", translatorTestCase{
-	//	inputFile:  "trafficpolicy/extauth-listener.yaml",
-	//	outputFile: "trafficpolicy/extauth-listener.yaml",
-	//	gwNN: types.NamespacedName{
-	//		Namespace: "default",
-	//		Name:      "example-gateway",
-	//	},
-	//}),
-	Entry("AI TrafficPolicy on route level", translatorTestCase{
-		inputFile:  "trafficpolicy/ai/route-level.yaml",
-		outputFile: "trafficpolicy/ai/route-level.yaml",
-		gwNN: types.NamespacedName{
-			Namespace: "default",
-			Name:      "example-gateway",
-		},
-	}),
-)
+	// t.Run("TrafficPolicy with extauth on listener", func(t *testing.T) {
+	//	test(t, translatorTestCase{
+	//		inputFile:  "trafficpolicy/extauth-listener.yaml",
+	//		outputFile: "trafficpolicy/extauth-listener.yaml",
+	//		gwNN: types.NamespacedName{
+	//			Namespace: "default",
+	//			Name:      "example-gateway",
+	//		},
+	//	})
+	t.Run("AI TrafficPolicy on route level", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "trafficpolicy/ai/route-level.yaml",
+			outputFile: "trafficpolicy/ai/route-level.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+}

--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend-protocol/mcp-backend-selector.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend-protocol/mcp-backend-selector.yaml
@@ -38,6 +38,10 @@ spec:
       appProtocol: kgateway.dev/mcp
       port: 80
       targetPort: test
+    - protocol: TCP
+      appProtocol: kgateway.dev/mcp-sse
+      port: 90
+      targetPort: test-2
 ---
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: Backend

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/mcp-backend-selector.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/backend-protocol/mcp-backend-selector.yaml
@@ -5,6 +5,7 @@ Addresses:
     namespace: default
     ports:
     - servicePort: 80
+    - servicePort: 90
 Backends:
 - mcp:
     targets:
@@ -12,6 +13,12 @@ Backends:
         port: 80
         service: default/example-svc.default.svc.cluster.local
       name: example-svc-80
+      protocol: STREAMABLE_HTTP
+    - backend:
+        port: 90
+        service: default/example-svc.default.svc.cluster.local
+      name: example-svc-90
+      protocol: SSE
   name: default/mcp-backend
 Binds:
 - key: 80/default/example-gateway

--- a/internal/kgateway/extensions2/plugins/backend/agentgateway/mcp.go
+++ b/internal/kgateway/extensions2/plugins/backend/agentgateway/mcp.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
+	// mcpProtocol specifies that streamable HTTP protocol is to be used for the MCP target
 	mcpProtocol = "kgateway.dev/mcp"
+
+	// mcpProtocolSSE specifies that Server-Sent Events (SSE) protocol is to be used for the MCP target
+	mcpProtocolSSE = "kgateway.dev/mcp-sse"
 )
 
 // ProcessMCPBackendForAgentGateway processes MCP backend using pre-resolved IR data


### PR DESCRIPTION
# Description
- Defaults to Streamable HTTP for MCP services with `appProtocol: kgateway.dev/mcp`.
- Uses legacy SSE for MCP services with `appProtocol: kgateway.dev/mcp-sse`.
- Removes the Undefined Enum for Static MCP backends.

Drops Gingko in favor of Go stdlib for translator tests.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes
Resolves #12036