### PR TITLE
refactored tests from ginkgo to stdlib

### DIFF
--- a/internal/kgateway/controller/inferencepool_controller_test.go
+++ b/internal/kgateway/controller/inferencepool_controller_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestInferencePoolController(t *testing.T) {
 	ctx := context.Background()
-	
+
 	t.Run("when Inference Extension deployer is enabled", func(t *testing.T) {
 		t.Run("should reconcile an InferencePool referenced by a managed HTTPRoute and deploy the endpoint picker", func(t *testing.T) {
 			goroutineMonitor := assertions.NewGoRoutineMonitor()
@@ -139,7 +139,7 @@ func TestInferencePoolController(t *testing.T) {
 			// We expect the deployer to render and deploy an endpoint picker Deployment with name "pool1-endpoint-picker".
 			expectedName := fmt.Sprintf("%s-endpoint-picker", pool.Name)
 			var deploy appsv1.Deployment
-			
+
 			err = retryWithTimeout(10*time.Second, 1*time.Second, func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: expectedName}, &deploy)
 			})
@@ -189,7 +189,7 @@ func TestInferencePoolController(t *testing.T) {
 
 			// Consistently check that no endpoint picker deployment is created.
 			expectedName := fmt.Sprintf("%s-endpoint-picker", pool.Name)
-			
+
 			// Check multiple times over 5 seconds that deployment is NOT created
 			for i := 0; i < 5; i++ {
 				var dep appsv1.Deployment
@@ -256,7 +256,7 @@ func TestInferencePoolController(t *testing.T) {
 			assert.NoError(t, err)
 
 			expectedName := fmt.Sprintf("%s-endpoint-picker", pool.Name)
-			
+
 			// Check multiple times over 5 seconds that deployment is NOT created
 			for i := 0; i < 5; i++ {
 				var dep appsv1.Deployment

--- a/internal/kgateway/controller/inferencepool_controller_test.go
+++ b/internal/kgateway/controller/inferencepool_controller_test.go
@@ -1,10 +1,13 @@
 package controller_test
 
 import (
+	"context"
 	"fmt"
+	"testing"
+	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,29 +20,25 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/gomega/assertions"
 )
 
-var _ = Describe("InferencePool controller", func() {
-	var (
-		goroutineMonitor *assertions.GoRoutineMonitor
-	)
+func TestInferencePoolController(t *testing.T) {
+	ctx := context.Background()
+	
+	t.Run("when Inference Extension deployer is enabled", func(t *testing.T) {
+		t.Run("should reconcile an InferencePool referenced by a managed HTTPRoute and deploy the endpoint picker", func(t *testing.T) {
+			goroutineMonitor := assertions.NewGoRoutineMonitor()
+			var cancel context.CancelFunc
+			defer func() {
+				if cancel != nil {
+					cancel()
+				}
+				waitForGoroutinesToFinish(goroutineMonitor)
+			}()
 
-	BeforeEach(func() {
-		goroutineMonitor = assertions.NewGoRoutineMonitor()
-	})
-
-	AfterEach(func() {
-		cancel()
-		waitForGoroutinesToFinish(goroutineMonitor)
-	})
-
-	Context("when Inference Extension deployer is enabled", func() {
-		BeforeEach(func() {
+			inferenceExt := new(deployer.InferenceExtInfo)
 			var err error
-			inferenceExt = new(deployer.InferenceExtInfo)
 			cancel, err = createManager(ctx, inferenceExt, nil)
-			Expect(err).NotTo(HaveOccurred())
-		})
+			require.NoError(t, err)
 
-		It("should reconcile an InferencePool referenced by a managed HTTPRoute and deploy the endpoint picker", func() {
 			// Create a test Gateway that will be referenced by the HTTPRoute.
 			testGw := &apiv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -57,8 +56,8 @@ var _ = Describe("InferencePool controller", func() {
 					},
 				},
 			}
-			err := k8sClient.Create(ctx, testGw)
-			Expect(err).NotTo(HaveOccurred())
+			err = k8sClient.Create(ctx, testGw)
+			assert.NoError(t, err)
 
 			// Create an HTTPRoute without a status.
 			httpRoute := &apiv1.HTTPRoute{
@@ -85,7 +84,7 @@ var _ = Describe("InferencePool controller", func() {
 				},
 			}
 			err = k8sClient.Create(ctx, httpRoute)
-			Expect(err).NotTo(HaveOccurred())
+			assert.NoError(t, err)
 
 			// Now update the status to include a valid Parents field.
 			httpRoute.Status = apiv1.HTTPRouteStatus{
@@ -103,9 +102,12 @@ var _ = Describe("InferencePool controller", func() {
 					},
 				},
 			}
-			Eventually(func() error {
+
+			// Retry updating status until successful
+			err = retryWithTimeout(10*time.Second, 1*time.Second, func() error {
 				return k8sClient.Status().Update(ctx, httpRoute)
-			}, "10s", "1s").Should(Succeed())
+			})
+			assert.NoError(t, err)
 
 			// Create an InferencePool resource that is referenced by the HTTPRoute.
 			pool := &infextv1a2.InferencePool{
@@ -131,18 +133,34 @@ var _ = Describe("InferencePool controller", func() {
 				},
 			}
 			err = k8sClient.Create(ctx, pool)
-			Expect(err).NotTo(HaveOccurred())
+			assert.NoError(t, err)
 
 			// The secondary watch on HTTPRoute should now trigger reconciliation of pool "pool1".
 			// We expect the deployer to render and deploy an endpoint picker Deployment with name "pool1-endpoint-picker".
 			expectedName := fmt.Sprintf("%s-endpoint-picker", pool.Name)
 			var deploy appsv1.Deployment
-			Eventually(func() error {
+			
+			err = retryWithTimeout(10*time.Second, 1*time.Second, func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: expectedName}, &deploy)
-			}, "10s", "1s").Should(Succeed())
+			})
+			assert.NoError(t, err, "Expected deployment %s to be created", expectedName)
 		})
 
-		It("should ignore an InferencePool not referenced by any HTTPRoute and not deploy the endpoint picker", func() {
+		t.Run("should ignore an InferencePool not referenced by any HTTPRoute and not deploy the endpoint picker", func(t *testing.T) {
+			goroutineMonitor := assertions.NewGoRoutineMonitor()
+			var cancel context.CancelFunc
+			defer func() {
+				if cancel != nil {
+					cancel()
+				}
+				waitForGoroutinesToFinish(goroutineMonitor)
+			}()
+
+			inferenceExt := new(deployer.InferenceExtInfo)
+			var err error
+			cancel, err = createManager(ctx, inferenceExt, nil)
+			require.NoError(t, err)
+
 			// Create an InferencePool that is not referenced by any HTTPRoute.
 			pool := &infextv1a2.InferencePool{
 				TypeMeta: metav1.TypeMeta{
@@ -166,26 +184,37 @@ var _ = Describe("InferencePool controller", func() {
 					},
 				},
 			}
-			err := k8sClient.Create(ctx, pool)
-			Expect(err).NotTo(HaveOccurred())
+			err = k8sClient.Create(ctx, pool)
+			assert.NoError(t, err)
 
 			// Consistently check that no endpoint picker deployment is created.
-			Consistently(func() error {
+			expectedName := fmt.Sprintf("%s-endpoint-picker", pool.Name)
+			
+			// Check multiple times over 5 seconds that deployment is NOT created
+			for i := 0; i < 5; i++ {
 				var dep appsv1.Deployment
-				return k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: fmt.Sprintf("%s-endpoint-picker", pool.Name)}, &dep)
-			}, "5s", "1s").ShouldNot(Succeed())
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: expectedName}, &dep)
+				assert.Error(t, err, "Deployment %s should not exist", expectedName)
+				time.Sleep(1 * time.Second)
+			}
 		})
 	})
 
-	Context("when Inference Extension deployer is disabled", func() {
-		BeforeEach(func() {
-			var err error
-			inferenceExt = nil
-			cancel, err = createManager(ctx, inferenceExt, nil)
-			Expect(err).NotTo(HaveOccurred())
-		})
+	t.Run("when Inference Extension deployer is disabled", func(t *testing.T) {
+		t.Run("should not deploy endpoint picker resources", func(t *testing.T) {
+			goroutineMonitor := assertions.NewGoRoutineMonitor()
+			var cancel context.CancelFunc
+			defer func() {
+				if cancel != nil {
+					cancel()
+				}
+				waitForGoroutinesToFinish(goroutineMonitor)
+			}()
 
-		It("should not deploy endpoint picker resources", func() {
+			var err error
+			cancel, err = createManager(ctx, nil, nil)
+			require.NoError(t, err)
+
 			httpRoute := &apiv1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-route-disabled",
@@ -205,7 +234,8 @@ var _ = Describe("InferencePool controller", func() {
 					}},
 				},
 			}
-			Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
+			err = k8sClient.Create(ctx, httpRoute)
+			assert.NoError(t, err)
 
 			pool := &infextv1a2.InferencePool{
 				ObjectMeta: metav1.ObjectMeta{
@@ -222,13 +252,30 @@ var _ = Describe("InferencePool controller", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+			err = k8sClient.Create(ctx, pool)
+			assert.NoError(t, err)
 
 			expectedName := fmt.Sprintf("%s-endpoint-picker", pool.Name)
-			Consistently(func() error {
+			
+			// Check multiple times over 5 seconds that deployment is NOT created
+			for i := 0; i < 5; i++ {
 				var dep appsv1.Deployment
-				return k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: expectedName}, &dep)
-			}, "5s", "1s").ShouldNot(Succeed())
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: expectedName}, &dep)
+				assert.Error(t, err, "Deployment %s should not exist when deployer is disabled", expectedName)
+				time.Sleep(1 * time.Second)
+			}
 		})
 	})
-})
+}
+
+// Helper function to retry operations with timeout
+func retryWithTimeout(timeout, interval time.Duration, fn func() error) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := fn(); err == nil {
+			return nil
+		}
+		time.Sleep(interval)
+	}
+	return fn() // Final attempt
+}


### PR DESCRIPTION
Description
This PR refactors the controller test suite by migrating from Ginkgo/Gomega to the Go standard testing package. It aligns with the project's initiative to standardize on stdlib testing for improved consistency, simplicity, and maintainability. The refactor replaces Ginkgo constructs like Describe, It, Eventually, and Gomega matchers with native Go testing.T functions and polling utilities. 

Fixes: #10971 

Key changes include:

- Removing Ginkgo/Gomega dependencies from the controller tests.
- Replacing asynchronous assertion helpers (Eventually) with custom polling loops.
- Using testing.T subtests to organize test scenarios.
- Cleaning up variable scopes to avoid redeclaration issues and enable idiomatic Go testing patterns.
- Retaining existing test coverage and logic while improving clarity and integration with the native Go toolchain.

Change Type
/kind cleanup

Changelog
text
Refactored controller test suite to use Go's standard testing package instead of Ginkgo/Gomega, improving consistency and maintainability of tests.

Additional Notes
This change is part of an ongoing effort to reduce external dependencies and improve developer experience in the codebase testing. No behavioural or functional changes are introduced; all tests are functionally equivalent.

```release-note
NONE
```
