### PR TITLE
test: Write output status to golden files

### DIFF
--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
@@ -184,3 +184,19 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
@@ -190,13 +190,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
@@ -247,3 +247,19 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
@@ -253,13 +253,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
@@ -184,3 +184,19 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
@@ -190,13 +190,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
@@ -262,13 +262,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
@@ -256,3 +256,19 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
@@ -232,3 +232,19 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
@@ -238,13 +238,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -171,3 +171,40 @@ Routes:
       route:
         cluster: istio-se_infra_se-b_se-b.example.com_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/waypoint-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: networking.istio.io
+          kind: Hostname
+          name: se-a.example.com

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -177,13 +177,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -193,13 +191,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
@@ -226,3 +226,19 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
@@ -232,13 +232,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
@@ -11,3 +11,19 @@ Clusters:
 - connectTimeout: 5s
   metadata: {}
   name: test-backend-plugin_default_example-svc_80
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
@@ -17,13 +17,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
@@ -157,3 +157,41 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/waypoint-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-waypoint
+          namespace: infra

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
@@ -163,13 +163,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -179,13 +177,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -153,13 +153,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -169,13 +167,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -147,3 +147,40 @@ Routes:
       route:
         cluster: istio-se_infra_se-b_se-b.example.com_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/waypoint-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: networking.istio.io
+          kind: Hostname
+          name: se-a.example.com

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -153,13 +153,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -169,13 +167,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -147,3 +147,41 @@ Routes:
       route:
         cluster: istio-se_infra_se-b_se-b.example.com_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/waypoint-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: networking.istio.io
+          kind: ServiceEntry
+          name: se-a
+          namespace: infra

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
@@ -133,3 +133,41 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/waypoint-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: Service
+          name: svc-a
+          namespace: infra

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
@@ -139,13 +139,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -155,13 +153,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -200,3 +200,19 @@ Routes:
       route:
         cluster: kube_infra_svc-b_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -206,13 +206,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
@@ -87,13 +87,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
@@ -81,3 +81,19 @@ Routes:
       route:
         cluster: istio-se_infra_se-a_se-a.example.com_5000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
@@ -89,13 +89,11 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
@@ -83,3 +83,19 @@ Routes:
       route:
         cluster: kube_infra_helloworld_5000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-waypoint:
+      conditions:
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -249,7 +249,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtinternal.KrtOptions) 
 
 	s.backendPolicyReport = krt.NewSingleton(func(kctx krt.HandlerContext) *report {
 		backends := krt.Fetch(kctx, finalBackends)
-		merged := generateBackendPolicyReport(backends)
+		merged := GenerateBackendPolicyReport(backends)
 		return &report{merged}
 	}, krtopts.ToOptions("BackendsPolicyReport")...)
 

--- a/internal/kgateway/proxy_syncer/status.go
+++ b/internal/kgateway/proxy_syncer/status.go
@@ -18,7 +18,9 @@ type ObjWithAttachedPolicies interface {
 
 var _ ObjWithAttachedPolicies = ir.BackendObjectIR{}
 
-func generateBackendPolicyReport(in []*ir.BackendObjectIR) reports.ReportMap {
+// GenerateBackendPolicyReport generates a report map for all policies attached to the given backends.
+// Exported for testing.
+func GenerateBackendPolicyReport(in []*ir.BackendObjectIR) reports.ReportMap {
 	merged := reports.NewReportMap()
 	reporter := reports.NewReporter(&merged)
 

--- a/internal/kgateway/proxy_syncer/status_test.go
+++ b/internal/kgateway/proxy_syncer/status_test.go
@@ -98,7 +98,7 @@ func TestBackendPolicyStatus(t *testing.T) {
 	backends := []*ir.BackendObjectIR{&backend1, &backend2}
 
 	a := assert.New(t)
-	rm := generateBackendPolicyReport(backends)
+	rm := GenerateBackendPolicyReport(backends)
 
 	// assert 3 unique policies: conn-policy-1, conn-policy-2, tls-policy
 	a.Len(rm.Policies, 3)

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
@@ -69,19 +69,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -91,13 +88,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
@@ -63,3 +63,46 @@ Routes:
         ai.extproc.kgateway.io:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           disabled: true
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
@@ -68,3 +68,46 @@ Routes:
         ai.extproc.kgateway.io:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           disabled: true
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
@@ -74,19 +74,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -96,13 +93,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
@@ -71,19 +71,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -93,13 +90,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
@@ -65,3 +65,46 @@ Routes:
         ai.extproc.kgateway.io:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           disabled: true
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
@@ -57,19 +57,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,13 +76,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
@@ -51,3 +51,46 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
@@ -62,19 +62,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
@@ -56,3 +56,46 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -81,13 +78,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
@@ -53,3 +53,46 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
         upgradeConfigs:
         - upgradeType: websocket
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
@@ -55,19 +55,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
@@ -49,3 +49,47 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    BackendConfigPolicy/default/httpbin-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
@@ -55,19 +55,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
@@ -49,3 +49,47 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    BackendConfigPolicy/default/httpbin-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
@@ -62,3 +62,68 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    BackendConfigPolicy/default/httpbin-grpc-hc-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-grpc
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
@@ -68,19 +68,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -95,13 +92,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -116,13 +111,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
@@ -76,3 +76,89 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    BackendConfigPolicy/default/httpbin-h2c-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-h2c
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin2-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin2
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
@@ -82,19 +82,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -109,13 +106,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -130,13 +125,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -151,13 +144,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
@@ -180,3 +180,173 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    BackendConfigPolicy/default/httpbin-lr-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-lr
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-maglev-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-maglev
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-random-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-random
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-rh-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-rh
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-rr-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-rr
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-weighted-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-weighted
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
@@ -186,19 +186,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -213,13 +210,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -234,13 +229,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -255,13 +248,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -276,13 +267,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -297,13 +286,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -318,13 +305,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -339,13 +324,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
@@ -78,3 +78,68 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    BackendConfigPolicy/default/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.kgateway.dev
+          kind: Backend
+          name: example-backend
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
@@ -84,19 +84,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -111,13 +108,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -132,13 +127,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
@@ -59,3 +59,68 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    BackendConfigPolicy/default/httpbin-grpc-hc-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-grpc
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
@@ -65,19 +65,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -92,13 +89,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -113,13 +108,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
@@ -86,3 +86,68 @@ Routes:
       route:
         cluster: kube_default_backend-service_443
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/default/backend-tls-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
@@ -92,19 +92,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -114,13 +111,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -140,13 +135,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
@@ -77,19 +77,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -99,13 +96,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -125,13 +120,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
@@ -71,3 +71,68 @@ Routes:
         ai.extproc.kgateway.io:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           disabled: true
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/default/backend-tls-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.kgateway.dev
+          kind: Backend
+          name: backend
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
@@ -145,19 +145,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -167,13 +164,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -193,13 +188,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
@@ -139,3 +139,68 @@ Routes:
       route:
         cluster: kube_default_backend-service_443
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/default/backend-tls-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
@@ -108,3 +108,25 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~80
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
@@ -114,19 +114,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
@@ -57,19 +57,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,13 +76,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
@@ -51,3 +51,46 @@ Routes:
       route:
         cluster: test-backend-plugin_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
@@ -132,3 +132,89 @@ Routes:
         ai.extproc.kgateway.io:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           disabled: true
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendTLSPolicy/default/tls-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.kgateway.dev
+          kind: Backend
+          name: backend1
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendTLSPolicy/default/tls-policy2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.kgateway.dev
+          kind: Backend
+          name: backend2
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
@@ -138,19 +138,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -160,13 +157,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -186,13 +181,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -207,13 +200,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
@@ -132,19 +132,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -154,13 +151,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -180,13 +175,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -201,13 +194,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
@@ -126,3 +126,89 @@ Routes:
         ai.extproc.kgateway.io:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           disabled: true
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendTLSPolicy/default/tls-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.kgateway.dev
+          kind: Backend
+          name: backend1
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendTLSPolicy/default/tls-policy2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.kgateway.dev
+          kind: Backend
+          name: backend2
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
@@ -57,19 +57,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,13 +76,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
@@ -51,3 +51,46 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
@@ -81,19 +81,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -103,13 +100,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -124,13 +119,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
@@ -75,3 +75,67 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
@@ -77,3 +77,68 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: spec.hostnames must be unset on a delegatee route as they are inherited
+            from the parent route
+          observedGeneration: 1
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
@@ -83,19 +83,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -106,13 +103,11 @@ Statuses:
         - lastTransitionTime: null
           message: spec.hostnames must be unset on a delegatee route as they are inherited
             from the parent route
-          observedGeneration: 1
           reason: UnsupportedValue
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -127,13 +122,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
@@ -81,19 +81,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -103,13 +100,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -124,13 +119,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
@@ -75,3 +75,67 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -83,19 +83,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -105,13 +102,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -77,3 +77,46 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
@@ -107,3 +107,129 @@ Routes:
           numRetries: 3
           retryOn: cancelled,connect-failure,refused-stream,retriable-headers,retriable-status-codes,unavailable
         timeout: 5s
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    a/route-a2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    b/route-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: foo-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/foo-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
@@ -113,19 +113,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -135,13 +132,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -156,13 +151,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -177,13 +170,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -198,13 +189,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -218,13 +207,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -117,19 +117,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -139,13 +136,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -160,13 +155,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/b/*: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -111,3 +111,67 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/b/*: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -83,3 +83,69 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/a/route-a: ignoring child
+            route a/route-a for parent a/route-a: cyclic reference detected while
+            evaluating delegated routes'
+          observedGeneration: 1
+          reason: RefNotPermitted
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -89,19 +89,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -113,13 +110,11 @@ Statuses:
           message: 'gateway.networking.k8s.io/HTTPRoute/a/route-a: ignoring child
             route a/route-a for parent a/route-a: cyclic reference detected while
             evaluating delegated routes'
-          observedGeneration: 1
           reason: RefNotPermitted
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
@@ -134,13 +129,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -89,19 +89,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -113,13 +110,11 @@ Statuses:
           message: 'gateway.networking.k8s.io/HTTPRoute/a/*: ignoring child route
             a/route-a for parent a-b/route-a-b: cyclic reference detected while evaluating
             delegated routes'
-          observedGeneration: 1
           reason: RefNotPermitted
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
@@ -134,13 +129,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -155,13 +148,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -83,3 +83,90 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a-b/route-a-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/a/*: ignoring child route
+            a/route-a for parent a-b/route-a-b: cyclic reference detected while evaluating
+            delegated routes'
+          observedGeneration: 1
+          reason: RefNotPermitted
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-a
+          namespace: a
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
@@ -69,3 +69,67 @@ Routes:
       route:
         cluster: kube_a_svc-a_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
@@ -75,19 +75,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -97,13 +94,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -118,13 +113,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
@@ -92,19 +92,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -114,13 +111,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -135,13 +130,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
@@ -86,3 +86,67 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -93,19 +93,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -115,13 +112,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -135,13 +130,11 @@ Statuses:
         - lastTransitionTime: null
           message: spec.hostnames must be unset on a delegatee route as they are inherited
             from the parent route
-          observedGeneration: 1
           reason: UnsupportedValue
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -156,13 +149,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -87,3 +87,87 @@ Routes:
       route:
         cluster: kube_a_svc-a_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+      - conditions:
+        - lastTransitionTime: null
+          message: spec.hostnames must be unset on a delegatee route as they are inherited
+            from the parent route
+          observedGeneration: 1
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
@@ -93,19 +93,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -115,13 +112,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -136,13 +131,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -157,13 +150,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -177,13 +168,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
@@ -87,3 +87,109 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    b/route-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/infra-child:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
@@ -98,19 +98,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -120,13 +117,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -141,13 +136,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -162,13 +155,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -181,13 +172,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -202,13 +191,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
@@ -92,3 +92,128 @@ Routes:
           pattern:
             regex: ^/api2\/*
           substitution: /
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/apiproduct-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: api-example-com
+          namespace: infra
+    default/apiproduct-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: api-example-com
+          namespace: infra
+    default/httpbin:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: apiproduct-1
+          namespace: default
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: apiproduct-2
+          namespace: default
+    infra/api-example-com:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
@@ -89,19 +89,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -111,13 +108,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -132,13 +127,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -153,13 +146,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
@@ -83,3 +83,88 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    b/route-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -101,3 +101,127 @@ Routes:
       match:
         pathSeparatedPrefix: /b
       name: listener~80~foo_com-route-2-httproute-foo-route-infra-1-0-matcher-0
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: foo-route
+          namespace: infra
+    b/route-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/foo-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/b/*: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -107,19 +107,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -129,13 +126,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -148,13 +143,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -169,13 +162,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -190,13 +181,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -210,13 +199,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/b/*: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
@@ -159,19 +159,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -181,13 +178,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -202,13 +197,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -223,13 +216,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -244,13 +235,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
@@ -153,3 +153,109 @@ Routes:
       route:
         cluster: kube_a_svc-a_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a-b-d/route-a-b-d:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-a-b
+          namespace: a-b
+    a-b/route-a-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-a
+          namespace: a
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -193,19 +193,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -215,13 +212,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -236,13 +231,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -257,13 +250,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -277,13 +268,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -303,13 +292,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -324,13 +311,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -345,13 +330,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -366,13 +349,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -187,3 +187,193 @@ Routes:
                       text: foo
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example
+          namespace: infra
+    b/b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: foo
+          namespace: infra
+    infra/example:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/foo:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/a/a:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/b/b:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/example:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/foo:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
@@ -96,19 +96,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -118,13 +115,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -139,13 +134,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -160,13 +153,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
@@ -90,3 +90,88 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a-b/route-a-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-a
+          namespace: a
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
@@ -196,3 +196,146 @@ Routes:
       route:
         cluster: kube_a_svc-b_8090
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: foo-route
+          namespace: infra
+    a/route-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: foo-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/foo-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
@@ -202,19 +202,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -224,13 +221,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -243,13 +238,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -264,13 +257,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -283,13 +274,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -304,13 +293,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -324,13 +311,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -109,19 +109,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -131,13 +128,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -152,13 +147,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -178,13 +171,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -103,3 +103,89 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/a/route-a-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -240,19 +240,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -262,13 +259,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -283,13 +278,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -309,13 +302,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -330,13 +321,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Overridden due to conflict with higher priority policy in target(s)
-          observedGeneration: 1
           reason: Overridden
           status: "False"
           type: Attached
@@ -351,13 +340,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -372,13 +359,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -234,3 +234,152 @@ Routes:
                       text: custom-value-def
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/child:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: parent
+          namespace: infra
+    infra/parent:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/a/child-policy-filter:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/a/child-policy-targetref:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Overridden due to conflict with higher priority policy in target(s)
+          observedGeneration: 1
+          reason: Overridden
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/parent-policy-filter:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/parent-policy-targetref:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -121,19 +121,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -143,13 +140,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -164,13 +159,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -190,13 +183,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -115,3 +115,89 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -115,3 +115,110 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/a/route-a-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Overridden due to conflict with higher priority policy in target(s)
+          observedGeneration: 1
+          reason: Overridden
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -121,19 +121,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -143,13 +140,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -164,13 +159,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -190,13 +183,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Overridden due to conflict with higher priority policy in target(s)
-          observedGeneration: 1
           reason: Overridden
           status: "False"
           type: Attached
@@ -211,13 +202,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -137,3 +137,110 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/a/route-a-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -143,19 +143,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -165,13 +162,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -186,13 +181,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -212,13 +205,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -233,13 +224,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -203,3 +203,152 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a-root/route-a-root:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-a-root
+          namespace: a-root
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/a-root/route-a-root-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/a/route-a-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -209,19 +209,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -231,13 +228,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -252,13 +247,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -273,13 +266,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -299,13 +290,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -320,13 +309,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -341,13 +328,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -325,19 +325,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -347,13 +344,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -368,13 +363,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -389,13 +382,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -409,13 +400,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -430,13 +419,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -457,13 +444,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -478,13 +463,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -499,13 +482,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Overridden due to conflict with higher priority policy in target(s)
-          observedGeneration: 1
           reason: Overridden
           status: "False"
           type: Attached
@@ -520,13 +501,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Overridden due to conflict with higher priority policy in target(s)
-          observedGeneration: 1
           reason: Overridden
           status: "False"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -319,3 +319,215 @@ Routes:
                       text: example
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/a1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: mid-a
+          namespace: mid
+    b/b1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: mid-b
+          namespace: mid
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    mid/mid-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    mid/mid-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+  policies:
+    TrafficPolicy/a/a1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/b/b1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Overridden due to conflict with higher priority policy in target(s)
+          observedGeneration: 1
+          reason: Overridden
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/mid/mid:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Overridden due to conflict with higher priority policy in target(s)
+          observedGeneration: 1
+          reason: Overridden
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
@@ -93,19 +93,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -115,13 +112,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -136,13 +131,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -162,13 +155,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
@@ -87,3 +87,89 @@ Routes:
         autoHostRewrite: true
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
@@ -106,3 +106,88 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a-b/route-a-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-a
+          namespace: a
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/a-c/: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/b/*: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
@@ -112,19 +112,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -134,13 +131,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -155,13 +150,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/a-c/: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
@@ -176,13 +169,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/b/*: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
@@ -62,19 +62,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
@@ -56,3 +56,46 @@ Routes:
       route:
         cluster: backend_default_dfp-backend_0
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
@@ -71,19 +71,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -93,13 +90,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
@@ -65,3 +65,46 @@ Routes:
       route:
         cluster: backend_default_dfp-backend_0
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
@@ -51,19 +51,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -73,13 +70,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -99,13 +94,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
@@ -45,3 +45,68 @@ Routes:
       match:
         prefix: /
       name: listener~8080~example_com-route-0-httproute-example-default-0-0-matcher-0
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    DirectResponse/default/direct-response:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
@@ -51,3 +51,68 @@ Routes:
       route:
         cluster: kube_default_httpbin_8000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    DirectResponse/default/robots-txt:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Pending
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
@@ -57,19 +57,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,13 +76,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -105,13 +100,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Pending
           status: "False"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
@@ -44,3 +44,48 @@ Routes:
       match:
         path: /non-existent
       name: listener~8080~www_example_com-route-0-httproute-example-route-default-0-0-matcher-0
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: |-
+            Replaced Rule (0): no action specified
+            gateway.kgateway.dev/DirectResponse/default/non-existent-ref: policy not found
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
@@ -50,19 +50,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,13 +71,11 @@ Statuses:
           message: |-
             Replaced Rule (0): no action specified
             gateway.kgateway.dev/DirectResponse/default/non-existent-ref: policy not found
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
@@ -50,19 +50,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -73,13 +70,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): DirectResponse cannot be applied to route with
             existing action: *routev3.Route_DirectResponse'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -99,13 +94,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -120,13 +113,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
@@ -44,3 +44,90 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-example-route-default-0-0-matcher-0
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): DirectResponse cannot be applied to route with
+            existing action: *routev3.Route_DirectResponse'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    DirectResponse/default/test-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    DirectResponse/default/test-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -128,3 +128,110 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/a/route-a-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -134,19 +134,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -156,13 +153,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -177,13 +172,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -203,13 +196,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -224,13 +215,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -86,3 +86,68 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/infra/example-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -92,19 +92,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -114,13 +111,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'gateway.networking.k8s.io/HTTPRoute/a/*: unresolved reference'
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
@@ -140,13 +135,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
@@ -66,19 +66,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
@@ -60,3 +60,25 @@ Routes:
   name: listener~3000
 - ignorePortInHostMatching: true
   name: listener~80
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
@@ -62,19 +62,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
@@ -56,3 +56,46 @@ Routes:
       route:
         cluster: kube_default_example-grpc-svc_9000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  grpcRoutes:
+    default/example-grpc-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
@@ -42,3 +42,46 @@ Routes:
       route:
         cluster: blackhole-cluster
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  grpcRoutes:
+    default/example-grpc-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: unknown backend kind
+          observedGeneration: 1
+          reason: InvalidKind
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
@@ -48,19 +48,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,13 +67,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: unknown backend kind
-          observedGeneration: 1
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
@@ -42,3 +42,46 @@ Routes:
       route:
         cluster: blackhole-cluster
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  grpcRoutes:
+    default/example-grpc-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Service "example-grpc-svc" not found
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
@@ -48,19 +48,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,13 +67,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Service "example-grpc-svc" not found
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
@@ -75,3 +75,46 @@ Routes:
             weight: 50
           - name: kube_default_grpc-svc-2_9002
             weight: 50
+Statuses:
+  gateways:
+    default/example-grpc-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  grpcRoutes:
+    default/example-grpc-multi-backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-grpc-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
@@ -81,19 +81,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -103,13 +100,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -48,19 +48,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,13 +67,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: unknown backend kind
-          observedGeneration: 1
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -42,3 +42,46 @@ Routes:
       route:
         cluster: blackhole-cluster
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: unknown backend kind
+          observedGeneration: 1
+          reason: InvalidKind
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
@@ -42,3 +42,46 @@ Routes:
       route:
         cluster: blackhole-cluster
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Service "example-svc" not found
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
@@ -48,19 +48,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,13 +67,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Service "example-svc" not found
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
@@ -108,3 +108,86 @@ Routes:
       route:
         cluster: kube_default_foo-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/bar-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/foo-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
@@ -114,19 +114,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -136,13 +133,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -156,13 +151,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -176,13 +169,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
@@ -107,3 +107,46 @@ Routes:
       route:
         cluster: kube_default_example-svc_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/gw:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: gw

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
@@ -113,19 +113,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -135,13 +132,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
@@ -69,19 +69,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -91,13 +88,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -117,13 +112,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
@@ -63,3 +63,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/accept-http10:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
@@ -69,19 +69,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -91,13 +88,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -117,13 +112,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
@@ -63,3 +63,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/default-host-for-http10:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
@@ -68,3 +68,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/default-host-for-http10:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
@@ -74,19 +74,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -96,13 +93,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -122,13 +117,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -140,3 +140,89 @@ Routes:
         xffNumTrustedHops:
         - gateway.kgateway.dev/HTTPListenerPolicy/default/misc
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    HTTPListenerPolicy/default/access-log:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    HTTPListenerPolicy/default/misc:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    HTTPListenerPolicy/default/tracing:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -146,19 +146,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -173,13 +170,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -194,13 +189,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -215,13 +208,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
@@ -73,19 +73,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -95,13 +92,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -121,13 +116,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
@@ -67,3 +67,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/preserve-http1-header-case:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -88,3 +88,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/upgrades:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -94,19 +94,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -116,13 +113,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -142,13 +137,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
@@ -51,3 +51,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/empty:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
@@ -57,19 +57,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,13 +76,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -105,13 +100,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
@@ -67,19 +67,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -89,13 +86,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -115,13 +110,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
@@ -61,3 +61,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/use-remote-address-false:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
@@ -67,19 +67,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -89,13 +86,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -115,13 +110,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
@@ -61,3 +61,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/use-remote-address-true:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
@@ -126,3 +126,146 @@ Routes:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
         timeout: 9s
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route-backend-request-both-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-backend-request-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-retry:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-retry-backend-request:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-retry-both-timeouts:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
@@ -132,19 +132,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -154,13 +151,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -174,13 +169,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -194,13 +187,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -214,13 +205,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -234,13 +223,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -254,13 +241,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
@@ -63,3 +63,46 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
@@ -69,19 +69,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -91,13 +88,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
@@ -69,19 +69,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -91,13 +88,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -117,13 +112,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
@@ -63,3 +63,68 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/upgrades:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
@@ -124,3 +124,66 @@ Routes:
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/second-example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
@@ -130,19 +130,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -152,13 +149,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -172,13 +167,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
@@ -78,3 +78,46 @@ Routes:
       route:
         cluster: kube_default_foo-svc_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsAttached
+        status: "True"
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/foo-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: foo-listenerset

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
@@ -84,19 +84,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsAttached
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -106,13 +103,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
@@ -46,19 +46,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
@@ -40,3 +40,25 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
@@ -112,19 +112,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -134,13 +131,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -154,13 +149,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -180,13 +173,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -201,13 +192,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
@@ -106,3 +106,109 @@ Routes:
       route:
         cluster: kube_default_httpbin-maglev_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route-maglev:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-ringhash:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/default/httpbin-maglev-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-maglev
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    BackendConfigPolicy/default/httpbin-ringhash-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: httpbin-ringhash
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -37,19 +37,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -31,3 +31,25 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~80
+Statuses:
+  gateways:
+    default/http:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
@@ -9,3 +9,25 @@ Listeners:
       ipv4Compat: true
       portValue: 443
   name: listener~443
+Statuses:
+  gateways:
+    default/http:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
@@ -15,19 +15,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
@@ -31,3 +31,25 @@ Listeners:
 Routes:
 - ignorePortInHostMatching: true
   name: listener~80
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
@@ -37,19 +37,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
@@ -1,184 +1,249 @@
 Clusters:
-  - connectTimeout: 5s
-    edsClusterConfig:
-      edsConfig:
-        ads: {}
-        resourceApiVersion: V3
-    ignoreHealthOnHostRemoval: true
-    metadata: {}
-    name: kube_default_example-svc_80
-    type: EDS
-  - connectTimeout: 5s
-    metadata: {}
-    name: test-backend-plugin_default_example-svc_80
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
 Listeners:
-  - address:
-      socketAddress:
-        address: '::'
-        ipv4Compat: true
-        portValue: 80
-    filterChains:
-      - filters:
-          - name: envoy.filters.network.http_connection_manager
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-              httpFilters:
-                - name: envoy.filters.http.rbac
-                  typedConfig:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
-                - name: envoy.filters.http.router
-                  typedConfig:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              mergeSlashes: true
-              normalizePath: true
-              rds:
-                configSource:
-                  ads: {}
-                  resourceApiVersion: V3
-                routeConfigName: listener~80
-              statPrefix: http
-              useRemoteAddress: true
-        name: listener~80
-    metadata:
-      filterMetadata:
-        merge.TrafficPolicy.gateway.kgateway.dev:
-          rbac:
-            - gateway.kgateway.dev/TrafficPolicy/default/parent-gateway-test
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.rbac
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
     name: listener~80
-Routes:
-  - ignorePortInHostMatching: true
-    metadata:
-      filterMetadata:
-        merge.TrafficPolicy.gateway.kgateway.dev:
-          rbac:
-            - gateway.kgateway.dev/TrafficPolicy/default/parent-gateway-test
-    name: listener~80
-    typedPerFilterConfig:
-      envoy.filters.http.rbac:
-        '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
         rbac:
-          matcher:
-            matcherList:
-              matchers:
-                - onMatch:
-                    action:
-                      name: envoy.filters.rbac.action
-                      typedConfig:
-                        '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                        action: DENY
-                        name: deny-request
+        - gateway.kgateway.dev/TrafficPolicy/default/parent-gateway-test
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        rbac:
+        - gateway.kgateway.dev/TrafficPolicy/default/parent-gateway-test
+  name: listener~80
+  typedPerFilterConfig:
+    envoy.filters.http.rbac:
+      '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+      rbac:
+        matcher:
+          matcherList:
+            matchers:
+            - onMatch:
+                action:
+                  name: envoy.filters.rbac.action
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                    action: DENY
+                    name: deny-request
+              predicate:
+                orMatcher:
                   predicate:
-                    orMatcher:
-                      predicate:
-                        - singlePredicate:
-                            customMatch:
-                              name: envoy.matching.matchers.cel_matcher
-                              typedConfig:
-                                '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                exprMatch:
-                                  celExprParsed:
-                                    expr:
-                                      callExpr:
-                                        args:
-                                          - callExpr:
-                                              args:
-                                                - id: "2"
-                                                  selectExpr:
-                                                    field: headers
-                                                    operand:
-                                                      id: "1"
-                                                      identExpr:
-                                                        name: request
-                                                - constExpr:
-                                                    stringValue: x-foo
-                                                  id: "4"
-                                              function: _[_]
-                                            id: "3"
-                                          - constExpr:
-                                              stringValue: bar
-                                            id: "6"
-                                        function: _==_
-                                      id: "5"
-                                    sourceInfo:
-                                      lineOffsets:
-                                        - 34
-                                      location: <input>
-                                      positions:
-                                        "1": 0
-                                        "2": 7
-                                        "3": 15
-                                        "4": 16
-                                        "5": 25
-                                        "6": 28
-                            input:
-                              name: envoy.matching.inputs.cel_data_input
-                              typedConfig:
-                                '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-                        - singlePredicate:
-                            customMatch:
-                              name: envoy.matching.matchers.cel_matcher
-                              typedConfig:
-                                '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                exprMatch:
-                                  celExprParsed:
-                                    expr:
-                                      callExpr:
-                                        args:
-                                          - callExpr:
-                                              args:
-                                                - id: "2"
-                                                  selectExpr:
-                                                    field: headers
-                                                    operand:
-                                                      id: "1"
-                                                      identExpr:
-                                                        name: request
-                                                - constExpr:
-                                                    stringValue: x-bar
-                                                  id: "4"
-                                              function: _[_]
-                                            id: "3"
-                                          - constExpr:
-                                              stringValue: foo
-                                            id: "6"
-                                        function: _==_
-                                      id: "5"
-                                    sourceInfo:
-                                      lineOffsets:
-                                        - 34
-                                      location: <input>
-                                      positions:
-                                        "1": 0
-                                        "2": 7
-                                        "3": 15
-                                        "4": 16
-                                        "5": 25
-                                        "6": 28
-                            input:
-                              name: envoy.matching.inputs.cel_data_input
-                              typedConfig:
-                                '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-            onNoMatch:
-              action:
-                name: action
-                typedConfig:
-                  '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                  action: DENY
-                  name: deny-request
-    virtualHosts:
-      - domains:
-          - example.com
-        name: listener~80~example_com
-        routes:
-          - match:
-              pathSeparatedPrefix: /foo
-            name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
-            route:
-              cluster: kube_default_example-svc_80
-              clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          - match:
-              pathSeparatedPrefix: /bar
-            name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
-            route:
-              cluster: kube_default_example-svc_80
-              clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+                  - singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.cel_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                          exprMatch:
+                            celExprParsed:
+                              expr:
+                                callExpr:
+                                  args:
+                                  - callExpr:
+                                      args:
+                                      - id: "2"
+                                        selectExpr:
+                                          field: headers
+                                          operand:
+                                            id: "1"
+                                            identExpr:
+                                              name: request
+                                      - constExpr:
+                                          stringValue: x-foo
+                                        id: "4"
+                                      function: _[_]
+                                    id: "3"
+                                  - constExpr:
+                                      stringValue: bar
+                                    id: "6"
+                                  function: _==_
+                                id: "5"
+                              sourceInfo:
+                                lineOffsets:
+                                - 34
+                                location: <input>
+                                positions:
+                                  "1": 0
+                                  "2": 7
+                                  "3": 15
+                                  "4": 16
+                                  "5": 25
+                                  "6": 28
+                      input:
+                        name: envoy.matching.inputs.cel_data_input
+                        typedConfig:
+                          '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+                  - singlePredicate:
+                      customMatch:
+                        name: envoy.matching.matchers.cel_matcher
+                        typedConfig:
+                          '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                          exprMatch:
+                            celExprParsed:
+                              expr:
+                                callExpr:
+                                  args:
+                                  - callExpr:
+                                      args:
+                                      - id: "2"
+                                        selectExpr:
+                                          field: headers
+                                          operand:
+                                            id: "1"
+                                            identExpr:
+                                              name: request
+                                      - constExpr:
+                                          stringValue: x-bar
+                                        id: "4"
+                                      function: _[_]
+                                    id: "3"
+                                  - constExpr:
+                                      stringValue: foo
+                                    id: "6"
+                                  function: _==_
+                                id: "5"
+                              sourceInfo:
+                                lineOffsets:
+                                - 34
+                                location: <input>
+                                positions:
+                                  "1": 0
+                                  "2": 7
+                                  "3": 15
+                                  "4": 16
+                                  "5": 25
+                                  "6": 28
+                      input:
+                        name: envoy.matching.inputs.cel_data_input
+                        typedConfig:
+                          '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+          onNoMatch:
+            action:
+              name: action
+              typedConfig:
+                '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                action: DENY
+                name: deny-request
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /foo
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /bar
+      name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/parent-gateway-test:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
@@ -188,19 +188,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -210,13 +207,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -236,13 +231,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
@@ -1,368 +1,433 @@
 Clusters:
-  - connectTimeout: 5s
-    edsClusterConfig:
-      edsConfig:
-        ads: {}
-        resourceApiVersion: V3
-    ignoreHealthOnHostRemoval: true
-    metadata: {}
-    name: kube_default_example-svc_80
-    type: EDS
-  - connectTimeout: 5s
-    metadata: {}
-    name: test-backend-plugin_default_example-svc_80
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
 Listeners:
-  - address:
-      socketAddress:
-        address: '::'
-        ipv4Compat: true
-        portValue: 80
-    filterChains:
-      - filters:
-          - name: envoy.filters.network.http_connection_manager
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-              httpFilters:
-                - name: envoy.filters.http.rbac
-                  typedConfig:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
-                - name: envoy.filters.http.router
-                  typedConfig:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              mergeSlashes: true
-              normalizePath: true
-              rds:
-                configSource:
-                  ads: {}
-                  resourceApiVersion: V3
-                routeConfigName: listener~80
-              statPrefix: http
-              useRemoteAddress: true
-        name: listener~80
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.rbac
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
     name: listener~80
+  name: listener~80
 Routes:
-  - ignorePortInHostMatching: true
-    name: listener~80
-    virtualHosts:
-      - domains:
-          - example.com
-        name: listener~80~example_com
-        routes:
-          - match:
-              pathSeparatedPrefix: /foo
-            metadata:
-              filterMetadata:
-                merge.TrafficPolicy.gateway.kgateway.dev:
-                  rbac:
-                    - gateway.kgateway.dev/TrafficPolicy/default/parent-httproute-test
-            name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
-            route:
-              cluster: kube_default_example-svc_80
-              clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-            typedPerFilterConfig:
-              envoy.filters.http.rbac:
-                '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
-                rbac:
-                  matcher:
-                    matcherList:
-                      matchers:
-                        - onMatch:
-                            action:
-                              name: envoy.filters.rbac.action
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                                name: allow-request
-                          predicate:
-                            orMatcher:
-                              predicate:
-                                - singlePredicate:
-                                    customMatch:
-                                      name: envoy.matching.matchers.cel_matcher
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                        exprMatch:
-                                          celExprParsed:
-                                            expr:
-                                              callExpr:
-                                                args:
-                                                  - callExpr:
-                                                      args:
-                                                        - callExpr:
-                                                            args:
-                                                              - callExpr:
-                                                                  args:
-                                                                    - id: "2"
-                                                                      selectExpr:
-                                                                        field: filter_metadata
-                                                                        operand:
-                                                                          id: "1"
-                                                                          identExpr:
-                                                                            name: metadata
-                                                                    - constExpr:
-                                                                        stringValue: envoy.filters.http.jwt_authn
-                                                                      id: "4"
-                                                                  function: _[_]
-                                                                id: "3"
-                                                              - constExpr:
-                                                                  stringValue: payload
-                                                                id: "6"
-                                                            function: _[_]
-                                                          id: "5"
-                                                        - constExpr:
-                                                            stringValue: test
-                                                          id: "8"
-                                                      function: _[_]
-                                                    id: "7"
+- ignorePortInHostMatching: true
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /foo
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rbac:
+            - gateway.kgateway.dev/TrafficPolicy/default/parent-httproute-test
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        envoy.filters.http.rbac:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+          rbac:
+            matcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: envoy.filters.rbac.action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                        name: allow-request
+                  predicate:
+                    orMatcher:
+                      predicate:
+                      - singlePredicate:
+                          customMatch:
+                            name: envoy.matching.matchers.cel_matcher
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                              exprMatch:
+                                celExprParsed:
+                                  expr:
+                                    callExpr:
+                                      args:
+                                      - callExpr:
+                                          args:
+                                          - callExpr:
+                                              args:
+                                              - callExpr:
+                                                  args:
+                                                  - id: "2"
+                                                    selectExpr:
+                                                      field: filter_metadata
+                                                      operand:
+                                                        id: "1"
+                                                        identExpr:
+                                                          name: metadata
                                                   - constExpr:
-                                                      stringValue: foo
-                                                    id: "10"
-                                                function: _==_
-                                              id: "9"
-                                            sourceInfo:
-                                              lineOffsets:
-                                                - 85
-                                              location: <input>
-                                              positions:
-                                                "1": 0
-                                                "2": 8
-                                                "3": 24
-                                                "4": 25
-                                                "5": 56
-                                                "6": 57
-                                                "7": 67
-                                                "8": 68
-                                                "9": 76
-                                                "10": 79
-                                    input:
-                                      name: envoy.matching.inputs.cel_data_input
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-                                - singlePredicate:
-                                    customMatch:
-                                      name: envoy.matching.matchers.cel_matcher
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                        exprMatch:
-                                          celExprParsed:
-                                            expr:
-                                              callExpr:
-                                                args:
+                                                      stringValue: envoy.filters.http.jwt_authn
+                                                    id: "4"
+                                                  function: _[_]
+                                                id: "3"
+                                              - constExpr:
+                                                  stringValue: payload
+                                                id: "6"
+                                              function: _[_]
+                                            id: "5"
+                                          - constExpr:
+                                              stringValue: test
+                                            id: "8"
+                                          function: _[_]
+                                        id: "7"
+                                      - constExpr:
+                                          stringValue: foo
+                                        id: "10"
+                                      function: _==_
+                                    id: "9"
+                                  sourceInfo:
+                                    lineOffsets:
+                                    - 85
+                                    location: <input>
+                                    positions:
+                                      "1": 0
+                                      "2": 8
+                                      "3": 24
+                                      "4": 25
+                                      "5": 56
+                                      "6": 57
+                                      "7": 67
+                                      "8": 68
+                                      "9": 76
+                                      "10": 79
+                          input:
+                            name: envoy.matching.inputs.cel_data_input
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+                      - singlePredicate:
+                          customMatch:
+                            name: envoy.matching.matchers.cel_matcher
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                              exprMatch:
+                                celExprParsed:
+                                  expr:
+                                    callExpr:
+                                      args:
+                                      - constExpr:
+                                          stringValue: group1
+                                        id: "10"
+                                      function: contains
+                                      target:
+                                        callExpr:
+                                          args:
+                                          - callExpr:
+                                              args:
+                                              - callExpr:
+                                                  args:
+                                                  - id: "2"
+                                                    selectExpr:
+                                                      field: filter_metadata
+                                                      operand:
+                                                        id: "1"
+                                                        identExpr:
+                                                          name: metadata
                                                   - constExpr:
-                                                      stringValue: group1
-                                                    id: "10"
-                                                function: contains
-                                                target:
-                                                  callExpr:
-                                                    args:
-                                                      - callExpr:
-                                                          args:
-                                                            - callExpr:
-                                                                args:
-                                                                  - id: "2"
-                                                                    selectExpr:
-                                                                      field: filter_metadata
-                                                                      operand:
-                                                                        id: "1"
-                                                                        identExpr:
-                                                                          name: metadata
-                                                                  - constExpr:
-                                                                      stringValue: envoy.filters.http.jwt_authn
-                                                                    id: "4"
-                                                                function: _[_]
-                                                              id: "3"
-                                                            - constExpr:
-                                                                stringValue: payload
-                                                              id: "6"
-                                                          function: _[_]
-                                                        id: "5"
-                                                      - constExpr:
-                                                          stringValue: groups
-                                                        id: "8"
-                                                    function: _[_]
-                                                  id: "7"
-                                              id: "9"
-                                            sourceInfo:
-                                              lineOffsets:
-                                                - 97
-                                              location: <input>
-                                              positions:
-                                                "1": 0
-                                                "2": 8
-                                                "3": 24
-                                                "4": 25
-                                                "5": 56
-                                                "6": 57
-                                                "7": 67
-                                                "8": 68
-                                                "9": 86
-                                                "10": 87
-                                    input:
-                                      name: envoy.matching.inputs.cel_data_input
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-                    onNoMatch:
-                      action:
-                        name: action
-                        typedConfig:
-                          '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                          action: DENY
-                          name: deny-request
-          - match:
-              pathSeparatedPrefix: /bar
-            metadata:
-              filterMetadata:
-                merge.TrafficPolicy.gateway.kgateway.dev:
-                  rbac:
-                    - gateway.kgateway.dev/TrafficPolicy/default/parent-httproute-test
-            name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
-            route:
-              cluster: kube_default_example-svc_80
-              clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-            typedPerFilterConfig:
-              envoy.filters.http.rbac:
-                '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
-                rbac:
-                  matcher:
-                    matcherList:
-                      matchers:
-                        - onMatch:
-                            action:
-                              name: envoy.filters.rbac.action
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                                name: allow-request
-                          predicate:
-                            orMatcher:
-                              predicate:
-                                - singlePredicate:
-                                    customMatch:
-                                      name: envoy.matching.matchers.cel_matcher
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                        exprMatch:
-                                          celExprParsed:
-                                            expr:
-                                              callExpr:
-                                                args:
-                                                  - callExpr:
-                                                      args:
-                                                        - callExpr:
-                                                            args:
-                                                              - callExpr:
-                                                                  args:
-                                                                    - id: "2"
-                                                                      selectExpr:
-                                                                        field: filter_metadata
-                                                                        operand:
-                                                                          id: "1"
-                                                                          identExpr:
-                                                                            name: metadata
-                                                                    - constExpr:
-                                                                        stringValue: envoy.filters.http.jwt_authn
-                                                                      id: "4"
-                                                                  function: _[_]
-                                                                id: "3"
-                                                              - constExpr:
-                                                                  stringValue: payload
-                                                                id: "6"
-                                                            function: _[_]
-                                                          id: "5"
-                                                        - constExpr:
-                                                            stringValue: test
-                                                          id: "8"
-                                                      function: _[_]
-                                                    id: "7"
+                                                      stringValue: envoy.filters.http.jwt_authn
+                                                    id: "4"
+                                                  function: _[_]
+                                                id: "3"
+                                              - constExpr:
+                                                  stringValue: payload
+                                                id: "6"
+                                              function: _[_]
+                                            id: "5"
+                                          - constExpr:
+                                              stringValue: groups
+                                            id: "8"
+                                          function: _[_]
+                                        id: "7"
+                                    id: "9"
+                                  sourceInfo:
+                                    lineOffsets:
+                                    - 97
+                                    location: <input>
+                                    positions:
+                                      "1": 0
+                                      "2": 8
+                                      "3": 24
+                                      "4": 25
+                                      "5": 56
+                                      "6": 57
+                                      "7": 67
+                                      "8": 68
+                                      "9": 86
+                                      "10": 87
+                          input:
+                            name: envoy.matching.inputs.cel_data_input
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+              onNoMatch:
+                action:
+                  name: action
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                    action: DENY
+                    name: deny-request
+    - match:
+        pathSeparatedPrefix: /bar
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rbac:
+            - gateway.kgateway.dev/TrafficPolicy/default/parent-httproute-test
+      name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        envoy.filters.http.rbac:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+          rbac:
+            matcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: envoy.filters.rbac.action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                        name: allow-request
+                  predicate:
+                    orMatcher:
+                      predicate:
+                      - singlePredicate:
+                          customMatch:
+                            name: envoy.matching.matchers.cel_matcher
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                              exprMatch:
+                                celExprParsed:
+                                  expr:
+                                    callExpr:
+                                      args:
+                                      - callExpr:
+                                          args:
+                                          - callExpr:
+                                              args:
+                                              - callExpr:
+                                                  args:
+                                                  - id: "2"
+                                                    selectExpr:
+                                                      field: filter_metadata
+                                                      operand:
+                                                        id: "1"
+                                                        identExpr:
+                                                          name: metadata
                                                   - constExpr:
-                                                      stringValue: foo
-                                                    id: "10"
-                                                function: _==_
-                                              id: "9"
-                                            sourceInfo:
-                                              lineOffsets:
-                                                - 85
-                                              location: <input>
-                                              positions:
-                                                "1": 0
-                                                "2": 8
-                                                "3": 24
-                                                "4": 25
-                                                "5": 56
-                                                "6": 57
-                                                "7": 67
-                                                "8": 68
-                                                "9": 76
-                                                "10": 79
-                                    input:
-                                      name: envoy.matching.inputs.cel_data_input
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-                                - singlePredicate:
-                                    customMatch:
-                                      name: envoy.matching.matchers.cel_matcher
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                        exprMatch:
-                                          celExprParsed:
-                                            expr:
-                                              callExpr:
-                                                args:
+                                                      stringValue: envoy.filters.http.jwt_authn
+                                                    id: "4"
+                                                  function: _[_]
+                                                id: "3"
+                                              - constExpr:
+                                                  stringValue: payload
+                                                id: "6"
+                                              function: _[_]
+                                            id: "5"
+                                          - constExpr:
+                                              stringValue: test
+                                            id: "8"
+                                          function: _[_]
+                                        id: "7"
+                                      - constExpr:
+                                          stringValue: foo
+                                        id: "10"
+                                      function: _==_
+                                    id: "9"
+                                  sourceInfo:
+                                    lineOffsets:
+                                    - 85
+                                    location: <input>
+                                    positions:
+                                      "1": 0
+                                      "2": 8
+                                      "3": 24
+                                      "4": 25
+                                      "5": 56
+                                      "6": 57
+                                      "7": 67
+                                      "8": 68
+                                      "9": 76
+                                      "10": 79
+                          input:
+                            name: envoy.matching.inputs.cel_data_input
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+                      - singlePredicate:
+                          customMatch:
+                            name: envoy.matching.matchers.cel_matcher
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                              exprMatch:
+                                celExprParsed:
+                                  expr:
+                                    callExpr:
+                                      args:
+                                      - constExpr:
+                                          stringValue: group1
+                                        id: "10"
+                                      function: contains
+                                      target:
+                                        callExpr:
+                                          args:
+                                          - callExpr:
+                                              args:
+                                              - callExpr:
+                                                  args:
+                                                  - id: "2"
+                                                    selectExpr:
+                                                      field: filter_metadata
+                                                      operand:
+                                                        id: "1"
+                                                        identExpr:
+                                                          name: metadata
                                                   - constExpr:
-                                                      stringValue: group1
-                                                    id: "10"
-                                                function: contains
-                                                target:
-                                                  callExpr:
-                                                    args:
-                                                      - callExpr:
-                                                          args:
-                                                            - callExpr:
-                                                                args:
-                                                                  - id: "2"
-                                                                    selectExpr:
-                                                                      field: filter_metadata
-                                                                      operand:
-                                                                        id: "1"
-                                                                        identExpr:
-                                                                          name: metadata
-                                                                  - constExpr:
-                                                                      stringValue: envoy.filters.http.jwt_authn
-                                                                    id: "4"
-                                                                function: _[_]
-                                                              id: "3"
-                                                            - constExpr:
-                                                                stringValue: payload
-                                                              id: "6"
-                                                          function: _[_]
-                                                        id: "5"
-                                                      - constExpr:
-                                                          stringValue: groups
-                                                        id: "8"
-                                                    function: _[_]
-                                                  id: "7"
-                                              id: "9"
-                                            sourceInfo:
-                                              lineOffsets:
-                                                - 97
-                                              location: <input>
-                                              positions:
-                                                "1": 0
-                                                "2": 8
-                                                "3": 24
-                                                "4": 25
-                                                "5": 56
-                                                "6": 57
-                                                "7": 67
-                                                "8": 68
-                                                "9": 86
-                                                "10": 87
-                                    input:
-                                      name: envoy.matching.inputs.cel_data_input
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-                    onNoMatch:
-                      action:
-                        name: action
-                        typedConfig:
-                          '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                          action: DENY
-                          name: deny-request
+                                                      stringValue: envoy.filters.http.jwt_authn
+                                                    id: "4"
+                                                  function: _[_]
+                                                id: "3"
+                                              - constExpr:
+                                                  stringValue: payload
+                                                id: "6"
+                                              function: _[_]
+                                            id: "5"
+                                          - constExpr:
+                                              stringValue: groups
+                                            id: "8"
+                                          function: _[_]
+                                        id: "7"
+                                    id: "9"
+                                  sourceInfo:
+                                    lineOffsets:
+                                    - 97
+                                    location: <input>
+                                    positions:
+                                      "1": 0
+                                      "2": 8
+                                      "3": 24
+                                      "4": 25
+                                      "5": 56
+                                      "6": 57
+                                      "7": 67
+                                      "8": 68
+                                      "9": 86
+                                      "10": 87
+                          input:
+                            name: envoy.matching.inputs.cel_data_input
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+              onNoMatch:
+                action:
+                  name: action
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                    action: DENY
+                    name: deny-request
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/parent-httproute-test:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
@@ -372,19 +372,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -394,13 +391,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -420,13 +415,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
@@ -219,19 +219,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -241,13 +238,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -267,13 +262,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
@@ -1,215 +1,280 @@
 Clusters:
-  - connectTimeout: 5s
-    edsClusterConfig:
-      edsConfig:
-        ads: {}
-        resourceApiVersion: V3
-    ignoreHealthOnHostRemoval: true
-    metadata: {}
-    name: kube_default_example-svc_80
-    type: EDS
-  - connectTimeout: 5s
-    metadata: {}
-    name: test-backend-plugin_default_example-svc_80
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
 Listeners:
-  - address:
-      socketAddress:
-        address: '::'
-        ipv4Compat: true
-        portValue: 80
-    filterChains:
-      - filters:
-          - name: envoy.filters.network.http_connection_manager
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-              httpFilters:
-                - name: envoy.filters.http.rbac
-                  typedConfig:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
-                - name: envoy.filters.http.router
-                  typedConfig:
-                    '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-              mergeSlashes: true
-              normalizePath: true
-              rds:
-                configSource:
-                  ads: {}
-                  resourceApiVersion: V3
-                routeConfigName: listener~80
-              statPrefix: http
-              useRemoteAddress: true
-        name: listener~80
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.rbac
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
     name: listener~80
+  name: listener~80
 Routes:
-  - ignorePortInHostMatching: true
-    name: listener~80
-    virtualHosts:
-      - domains:
-          - example.com
-        name: listener~80~example_com
-        routes:
-          - match:
-              pathSeparatedPrefix: /foo
-            name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
-            route:
-              cluster: kube_default_example-svc_80
-              clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-          - match:
-              pathSeparatedPrefix: /bar
-            metadata:
-              filterMetadata:
-                merge.TrafficPolicy.gateway.kgateway.dev:
-                  rbac:
-                    - gateway.kgateway.dev/TrafficPolicy/default/route-test
-            name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
-            route:
-              cluster: kube_default_example-svc_80
-              clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-            typedPerFilterConfig:
-              envoy.filters.http.rbac:
-                '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
-                rbac:
-                  matcher:
-                    matcherList:
-                      matchers:
-                        - onMatch:
-                            action:
-                              name: envoy.filters.rbac.action
-                              typedConfig:
-                                '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                                name: allow-request
-                          predicate:
-                            orMatcher:
-                              predicate:
-                                - singlePredicate:
-                                    customMatch:
-                                      name: envoy.matching.matchers.cel_matcher
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                        exprMatch:
-                                          celExprParsed:
-                                            expr:
-                                              callExpr:
-                                                args:
-                                                  - callExpr:
-                                                      args:
-                                                        - callExpr:
-                                                            args:
-                                                              - callExpr:
-                                                                  args:
-                                                                    - id: "2"
-                                                                      selectExpr:
-                                                                        field: filter_metadata
-                                                                        operand:
-                                                                          id: "1"
-                                                                          identExpr:
-                                                                            name: metadata
-                                                                    - constExpr:
-                                                                        stringValue: envoy.filters.http.jwt_authn
-                                                                      id: "4"
-                                                                  function: _[_]
-                                                                id: "3"
-                                                              - constExpr:
-                                                                  stringValue: payload
-                                                                id: "6"
-                                                            function: _[_]
-                                                          id: "5"
-                                                        - constExpr:
-                                                            stringValue: test
-                                                          id: "8"
-                                                      function: _[_]
-                                                    id: "7"
+- ignorePortInHostMatching: true
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /foo
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /bar
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            rbac:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-test
+      name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      typedPerFilterConfig:
+        envoy.filters.http.rbac:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBACPerRoute
+          rbac:
+            matcher:
+              matcherList:
+                matchers:
+                - onMatch:
+                    action:
+                      name: envoy.filters.rbac.action
+                      typedConfig:
+                        '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                        name: allow-request
+                  predicate:
+                    orMatcher:
+                      predicate:
+                      - singlePredicate:
+                          customMatch:
+                            name: envoy.matching.matchers.cel_matcher
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                              exprMatch:
+                                celExprParsed:
+                                  expr:
+                                    callExpr:
+                                      args:
+                                      - callExpr:
+                                          args:
+                                          - callExpr:
+                                              args:
+                                              - callExpr:
+                                                  args:
+                                                  - id: "2"
+                                                    selectExpr:
+                                                      field: filter_metadata
+                                                      operand:
+                                                        id: "1"
+                                                        identExpr:
+                                                          name: metadata
                                                   - constExpr:
-                                                      stringValue: bar
-                                                    id: "10"
-                                                function: _==_
-                                              id: "9"
-                                            sourceInfo:
-                                              lineOffsets:
-                                                - 85
-                                              location: <input>
-                                              positions:
-                                                "1": 0
-                                                "2": 8
-                                                "3": 24
-                                                "4": 25
-                                                "5": 56
-                                                "6": 57
-                                                "7": 67
-                                                "8": 68
-                                                "9": 76
-                                                "10": 79
-                                    input:
-                                      name: envoy.matching.inputs.cel_data_input
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-                                - singlePredicate:
-                                    customMatch:
-                                      name: envoy.matching.matchers.cel_matcher
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
-                                        exprMatch:
-                                          celExprParsed:
-                                            expr:
-                                              callExpr:
-                                                args:
+                                                      stringValue: envoy.filters.http.jwt_authn
+                                                    id: "4"
+                                                  function: _[_]
+                                                id: "3"
+                                              - constExpr:
+                                                  stringValue: payload
+                                                id: "6"
+                                              function: _[_]
+                                            id: "5"
+                                          - constExpr:
+                                              stringValue: test
+                                            id: "8"
+                                          function: _[_]
+                                        id: "7"
+                                      - constExpr:
+                                          stringValue: bar
+                                        id: "10"
+                                      function: _==_
+                                    id: "9"
+                                  sourceInfo:
+                                    lineOffsets:
+                                    - 85
+                                    location: <input>
+                                    positions:
+                                      "1": 0
+                                      "2": 8
+                                      "3": 24
+                                      "4": 25
+                                      "5": 56
+                                      "6": 57
+                                      "7": 67
+                                      "8": 68
+                                      "9": 76
+                                      "10": 79
+                          input:
+                            name: envoy.matching.inputs.cel_data_input
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+                      - singlePredicate:
+                          customMatch:
+                            name: envoy.matching.matchers.cel_matcher
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.CelMatcher
+                              exprMatch:
+                                celExprParsed:
+                                  expr:
+                                    callExpr:
+                                      args:
+                                      - constExpr:
+                                          stringValue: group2
+                                        id: "10"
+                                      function: contains
+                                      target:
+                                        callExpr:
+                                          args:
+                                          - callExpr:
+                                              args:
+                                              - callExpr:
+                                                  args:
+                                                  - id: "2"
+                                                    selectExpr:
+                                                      field: filter_metadata
+                                                      operand:
+                                                        id: "1"
+                                                        identExpr:
+                                                          name: metadata
                                                   - constExpr:
-                                                      stringValue: group2
-                                                    id: "10"
-                                                function: contains
-                                                target:
-                                                  callExpr:
-                                                    args:
-                                                      - callExpr:
-                                                          args:
-                                                            - callExpr:
-                                                                args:
-                                                                  - id: "2"
-                                                                    selectExpr:
-                                                                      field: filter_metadata
-                                                                      operand:
-                                                                        id: "1"
-                                                                        identExpr:
-                                                                          name: metadata
-                                                                  - constExpr:
-                                                                      stringValue: envoy.filters.http.jwt_authn
-                                                                    id: "4"
-                                                                function: _[_]
-                                                              id: "3"
-                                                            - constExpr:
-                                                                stringValue: payload
-                                                              id: "6"
-                                                          function: _[_]
-                                                        id: "5"
-                                                      - constExpr:
-                                                          stringValue: groups
-                                                        id: "8"
-                                                    function: _[_]
-                                                  id: "7"
-                                              id: "9"
-                                            sourceInfo:
-                                              lineOffsets:
-                                                - 97
-                                              location: <input>
-                                              positions:
-                                                "1": 0
-                                                "2": 8
-                                                "3": 24
-                                                "4": 25
-                                                "5": 56
-                                                "6": 57
-                                                "7": 67
-                                                "8": 68
-                                                "9": 86
-                                                "10": 87
-                                    input:
-                                      name: envoy.matching.inputs.cel_data_input
-                                      typedConfig:
-                                        '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
-                    onNoMatch:
-                      action:
-                        name: action
-                        typedConfig:
-                          '@type': type.googleapis.com/envoy.config.rbac.v3.Action
-                          action: DENY
-                          name: deny-request
+                                                      stringValue: envoy.filters.http.jwt_authn
+                                                    id: "4"
+                                                  function: _[_]
+                                                id: "3"
+                                              - constExpr:
+                                                  stringValue: payload
+                                                id: "6"
+                                              function: _[_]
+                                            id: "5"
+                                          - constExpr:
+                                              stringValue: groups
+                                            id: "8"
+                                          function: _[_]
+                                        id: "7"
+                                    id: "9"
+                                  sourceInfo:
+                                    lineOffsets:
+                                    - 97
+                                    location: <input>
+                                    positions:
+                                      "1": 0
+                                      "2": 8
+                                      "3": 24
+                                      "4": 25
+                                      "5": 56
+                                      "6": 57
+                                      "7": 67
+                                      "8": 68
+                                      "9": 86
+                                      "10": 87
+                          input:
+                            name: envoy.matching.inputs.cel_data_input
+                            typedConfig:
+                              '@type': type.googleapis.com/xds.type.matcher.v3.HttpAttributesCelMatchInput
+              onNoMatch:
+                action:
+                  name: action
+                  typedConfig:
+                    '@type': type.googleapis.com/envoy.config.rbac.v3.Action
+                    action: DENY
+                    name: deny-request
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/route-test:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
@@ -53,3 +53,48 @@ Routes:
       match:
         pathSeparatedPrefix: /api
       name: listener~8080~www_example_com-route-0-httproute-invalid-builtin-filter-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-builtin-filter-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-builtin-filter-route-gwtest-0-0-matcher-0:
+            the rewrite invalid-regex-[unclosed-bracket is invalid: must only contain
+            valid characters matching pattern ^(?:([A-Za-z0-9/:@._~!$&''()*+,:=;-]*|[%][0-9a-fA-F]{2}))*$'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,13 +80,11 @@ Statuses:
           message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-builtin-filter-route-gwtest-0-0-matcher-0:
             the rewrite invalid-regex-[unclosed-bracket is invalid: must only contain
             valid characters matching pattern ^(?:([A-Za-z0-9/:@._~!$&''()*+,:=;-]*|[%][0-9a-fA-F]{2}))*$'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
@@ -62,3 +62,46 @@ Routes:
       route:
         cluster: kube_gwtest_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-regex-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
@@ -68,19 +68,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -90,13 +87,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,13 +80,11 @@ Statuses:
           message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0:
             the rewrite /new//../path is invalid: path [/new//../path] cannot contain
             [//]'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
@@ -53,3 +53,48 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0:
+            the rewrite /new//../path is invalid: path [/new//../path] cannot contain
+            [//]'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
@@ -67,19 +67,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -89,13 +86,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -109,13 +104,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
@@ -61,3 +61,66 @@ Routes:
       route:
         cluster: kube_gwtest_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-regex-path-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    gwtest/valid-regex-path-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -57,3 +57,46 @@ Routes:
       route:
         cluster: kube_gwtest_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-rds-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -63,19 +63,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -85,13 +82,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): ai: field invalid_object contains invalid JSON
             string: "model":"gpt-4"}'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -108,13 +103,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: 'ai: field invalid_object contains invalid JSON string: "model":"gpt-4"}'
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
@@ -53,3 +53,69 @@ Routes:
       match:
         prefix: /
       name: listener~80~*-route-0-httproute-example-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): ai: field invalid_object contains invalid JSON
+            string: "model":"gpt-4"}'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/ai-invalid-json-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'ai: field invalid_object contains invalid JSON string: "model":"gpt-4"}'
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): gateway.kgateway.dev/TrafficPolicy/gwtest/my-tp-that-doesnt-exist:
             policy not found'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
@@ -53,3 +53,47 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-test-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): gateway.kgateway.dev/TrafficPolicy/gwtest/my-tp-that-doesnt-exist:
+            policy not found'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-gateway-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-gateway-wide-invalid-out.yaml
@@ -74,3 +74,68 @@ Routes:
       route:
         cluster: kube_gwtest_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/gateway-level-invalid-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-gateway-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-gateway-wide-invalid-out.yaml
@@ -80,19 +80,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -102,13 +99,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -128,13 +123,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-httproute-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-httproute-wide-invalid-out.yaml
@@ -69,3 +69,68 @@ Routes:
                 transformationTemplate:
                   body:
                     text: '{{ invalid_template }'
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-traffic-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-httproute-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-httproute-wide-invalid-out.yaml
@@ -75,19 +75,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -97,13 +94,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -123,13 +118,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-listener-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-listener-wide-invalid-out.yaml
@@ -132,3 +132,68 @@ Routes:
               transformationTemplate:
                 body:
                   text: '{{ invalid_template }'
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/listener-level-invalid-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-listener-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-listener-wide-invalid-out.yaml
@@ -138,19 +138,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -160,13 +157,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -186,13 +181,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
             invalid xds configuration: error initializing configuration '''': Incorrect
             configuration: %REQ(Correlation-Id. Couldn''t find valid command at position
             0'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
@@ -53,3 +53,50 @@ Routes:
       match:
         prefix: /
       name: listener~8080~example_com-route-0-httproute-invalid-request-header-modifier-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-request-header-modifier-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid route configuration: validation failed:
+            invalid xds configuration: error initializing configuration '''': Incorrect
+            configuration: %REQ(Correlation-Id. Couldn''t find valid command at position
+            0'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+          namespace: gwtest

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
@@ -53,3 +53,49 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-invalid-response-header-modifier-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-response-header-modifier-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid route configuration: validation failed:
+            invalid xds configuration: error initializing configuration '''': Incorrect
+            configuration: %RESPONSE(Invalid-Variable). Couldn''t find valid command
+            at position 0'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
             invalid xds configuration: error initializing configuration '''': Incorrect
             configuration: %RESPONSE(Invalid-Variable). Couldn''t find valid command
             at position 0'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
@@ -53,3 +53,48 @@ Routes:
       match:
         pathSeparatedPrefix: /api
       name: listener~8080~www_example_com-route-0-httproute-invalid-builtin-filter-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-builtin-filter-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-builtin-filter-route-gwtest-0-0-matcher-0:
+            the rewrite invalid-regex-[unclosed-bracket is invalid: must only contain
+            valid characters matching pattern ^(?:([A-Za-z0-9/:@._~!$&''()*+,:=;-]*|[%][0-9a-fA-F]{2}))*$'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,13 +80,11 @@ Statuses:
           message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-builtin-filter-route-gwtest-0-0-matcher-0:
             the rewrite invalid-regex-[unclosed-bracket is invalid: must only contain
             valid characters matching pattern ^(?:([A-Za-z0-9/:@._~!$&''()*+,:=;-]*|[%][0-9a-fA-F]{2}))*$'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
@@ -44,3 +44,48 @@ Routes:
   - domains:
     - www.example.com
     name: listener~8080~www_example_com
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-regex-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
+            invalid xds configuration: error initializing configuration '''': missing
+            ]: [invalid-regex'
+          observedGeneration: 1
+          reason: RouteRuleDropped
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
@@ -50,19 +50,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,13 +71,11 @@ Statuses:
           message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
             invalid xds configuration: error initializing configuration '''': missing
             ]: [invalid-regex'
-          observedGeneration: 1
           reason: RouteRuleDropped
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,13 +80,11 @@ Statuses:
           message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0:
             the rewrite /new//../path is invalid: path [/new//../path] cannot contain
             [//]'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
@@ -53,3 +53,48 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid route configuration: error listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0:
+            the rewrite /new//../path is invalid: path [/new//../path] cannot contain
+            [//]'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
@@ -53,3 +53,68 @@ Routes:
       route:
         cluster: kube_gwtest_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-regex-path-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
+            invalid xds configuration: error initializing configuration '''': missing
+            ]: [invalid-regex'
+          observedGeneration: 1
+          reason: RouteRuleDropped
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    gwtest/valid-regex-path-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,13 +80,11 @@ Statuses:
           message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
             invalid xds configuration: error initializing configuration '''': missing
             ]: [invalid-regex'
-          observedGeneration: 1
           reason: RouteRuleDropped
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -103,13 +98,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
@@ -44,3 +44,48 @@ Routes:
   - domains:
     - www.example.com
     name: listener~8080~www_example_com
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-route-matcher-query-params:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
+            invalid xds configuration: error initializing configuration '''': missing
+            ]: [invalid-regex'
+          observedGeneration: 1
+          reason: RouteRuleDropped
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
@@ -50,19 +50,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,13 +71,11 @@ Statuses:
           message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
             invalid xds configuration: error initializing configuration '''': missing
             ]: [invalid-regex'
-          observedGeneration: 1
           reason: RouteRuleDropped
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -50,19 +50,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,13 +71,11 @@ Statuses:
           message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
             invalid xds configuration: error initializing configuration '''': invalid
             named capture group: (?<=foo)bar'
-          observedGeneration: 1
           reason: RouteRuleDropped
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -44,3 +44,48 @@ Routes:
   - domains:
     - www.example.com
     name: listener~8080~www_example_com
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-rds-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Dropped Rule (0): invalid matcher configuration: validation failed:
+            invalid xds configuration: error initializing configuration '''': invalid
+            named capture group: (?<=foo)bar'
+          observedGeneration: 1
+          reason: RouteRuleDropped
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): ai: field invalid_object contains invalid JSON
             string: "model":"gpt-4"}'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -108,13 +103,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: 'ai: field invalid_object contains invalid JSON string: "model":"gpt-4"}'
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
@@ -53,3 +53,69 @@ Routes:
       match:
         prefix: /
       name: listener~80~*-route-0-httproute-example-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): ai: field invalid_object contains invalid JSON
+            string: "model":"gpt-4"}'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/ai-invalid-json-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'ai: field invalid_object contains invalid JSON string: "model":"gpt-4"}'
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
@@ -53,3 +53,70 @@ Routes:
       match:
         pathSeparatedPrefix: /test
       name: listener~80~*-route-0-httproute-test-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid xds configuration: error initializing
+            configuration '''': missing ]: ['
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-csrf-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            missing ]: ['
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): invalid xds configuration: error initializing
             configuration '''': missing ]: ['
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -109,13 +104,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'invalid xds configuration: error initializing configuration '''':
             missing ]: ['
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): extauthz: gateway extension gwtest/non-existent-auth-extension
             not found'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -109,13 +104,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'extauthz: gateway extension gwtest/non-existent-auth-extension
             not found'
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
@@ -53,3 +53,70 @@ Routes:
       match:
         pathSeparatedPrefix: /test
       name: listener~80~*-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): extauthz: gateway extension gwtest/non-existent-auth-extension
+            not found'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-extauth-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'extauthz: gateway extension gwtest/non-existent-auth-extension
+            not found'
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,13 +79,11 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): gateway.kgateway.dev/TrafficPolicy/gwtest/my-tp-that-doesnt-exist:
             policy not found'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
@@ -53,3 +53,47 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-test-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): gateway.kgateway.dev/TrafficPolicy/gwtest/my-tp-that-doesnt-exist:
+            policy not found'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-gateway-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-gateway-wide-invalid-out.yaml
@@ -57,19 +57,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,13 +76,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -107,13 +102,11 @@ Statuses:
           message: 'invalid xds configuration: error initializing configuration '''':
             Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
             (at 1:21) unexpected ''}'''
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-gateway-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-gateway-wide-invalid-out.yaml
@@ -51,3 +51,70 @@ Routes:
       route:
         cluster: kube_gwtest_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/gateway-level-invalid-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
+            (at 1:21) unexpected ''}'''
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
@@ -53,3 +53,50 @@ Routes:
       match:
         prefix: /
       name: listener~8080~example_com-route-0-httproute-invalid-header-template-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-header-template-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid route configuration: validation failed:
+            invalid xds configuration: error initializing configuration '''': Incorrect
+            configuration: %REQ(Correlation-Id. Couldn''t find valid command at position
+            0'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+          namespace: gwtest

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
             invalid xds configuration: error initializing configuration '''': Incorrect
             configuration: %REQ(Correlation-Id. Couldn''t find valid command at position
             0'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-httproute-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-httproute-wide-invalid-out.yaml
@@ -53,3 +53,72 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid xds configuration: error initializing
+            configuration '''': Failed to parse request template: Failed to parse
+            body template [inja.exception.parser_error] (at 1:21) unexpected ''}'''
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-traffic-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
+            (at 1:21) unexpected ''}'''
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-httproute-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-httproute-wide-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,13 +80,11 @@ Statuses:
           message: 'Replaced Rule (0): invalid xds configuration: error initializing
             configuration '''': Failed to parse request template: Failed to parse
             body template [inja.exception.parser_error] (at 1:21) unexpected ''}'''
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -111,13 +106,11 @@ Statuses:
           message: 'invalid xds configuration: error initializing configuration '''':
             Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
             (at 1:21) unexpected ''}'''
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-listener-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-listener-wide-invalid-out.yaml
@@ -96,3 +96,70 @@ Routes:
       route:
         cluster: kube_gwtest_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/listener-level-invalid-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
+            (at 1:21) unexpected ''}'''
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-listener-wide-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-listener-wide-invalid-out.yaml
@@ -102,19 +102,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -124,13 +121,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -152,13 +147,11 @@ Statuses:
           message: 'invalid xds configuration: error initializing configuration '''':
             Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
             (at 1:21) unexpected ''}'''
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -75,19 +75,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -97,13 +94,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -123,13 +118,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -69,3 +69,68 @@ Routes:
                 transformationTemplate:
                   body:
                     text: '{{ invalid_template }}'
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-traffic-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
             configuration '''': Failed to parse request template: Failed to parse
             body template [inja.exception.parser_error] (at 2:31) expected expression
             close, got '''''''
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -112,13 +107,11 @@ Statuses:
           message: 'invalid xds configuration: error initializing configuration '''':
             Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
             (at 2:31) expected expression close, got '''''''
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
@@ -53,3 +53,73 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid xds configuration: error initializing
+            configuration '''': Failed to parse request template: Failed to parse
+            body template [inja.exception.parser_error] (at 2:31) expected expression
+            close, got '''''''
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-traffic-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
+            (at 2:31) expected expression close, got '''''''
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
@@ -53,3 +53,73 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid xds configuration: error initializing
+            configuration '''': Failed to parse request template: Failed to parse
+            header template ''x-forwarded-for'': [inja.exception.parser_error] (at
+            1:31) unknown function request_headers'
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-traffic-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Failed to parse request template: Failed to parse header template ''x-forwarded-for'':
+            [inja.exception.parser_error] (at 1:31) unknown function request_headers'
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
             configuration '''': Failed to parse request template: Failed to parse
             header template ''x-forwarded-for'': [inja.exception.parser_error] (at
             1:31) unknown function request_headers'
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -112,13 +107,11 @@ Statuses:
           message: 'invalid xds configuration: error initializing configuration '''':
             Failed to parse request template: Failed to parse header template ''x-forwarded-for'':
             [inja.exception.parser_error] (at 1:31) unknown function request_headers'
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
@@ -53,3 +53,72 @@ Routes:
       match:
         prefix: /
       name: listener~8080~www_example_com-route-0-httproute-invalid-traffic-policy-route-gwtest-0-0-matcher-0
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    gwtest/invalid-traffic-policy-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Replaced Rule (0): invalid xds configuration: error initializing
+            configuration '''': Failed to parse request template: Failed to parse
+            body template [inja.exception.parser_error] (at 1:21) unexpected ''}'''
+          observedGeneration: 1
+          reason: RouteRuleReplaced
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/gwtest/invalid-traffic-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
+            (at 1:21) unexpected ''}'''
+          observedGeneration: 1
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
@@ -59,19 +59,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,13 +80,11 @@ Statuses:
           message: 'Replaced Rule (0): invalid xds configuration: error initializing
             configuration '''': Failed to parse request template: Failed to parse
             body template [inja.exception.parser_error] (at 1:21) unexpected ''}'''
-          observedGeneration: 1
           reason: RouteRuleReplaced
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -111,13 +106,11 @@ Statuses:
           message: 'invalid xds configuration: error initializing configuration '''':
             Failed to parse request template: Failed to parse body template [inja.exception.parser_error]
             (at 1:21) unexpected ''}'''
-          observedGeneration: 1
           reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
@@ -143,3 +143,129 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/d-higher-weight:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-1
+          namespace: infra
+    infra/d-lower-weight:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-1
+          namespace: infra
+    infra/d-no-weight:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: route-1
+          namespace: infra
+    infra/route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
@@ -149,19 +149,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -171,13 +168,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -192,13 +187,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -213,13 +206,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -234,13 +225,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -254,13 +243,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
@@ -125,3 +125,66 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
@@ -131,19 +131,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -153,13 +150,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -173,13 +168,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -155,3 +155,67 @@ Routes:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: Session-B
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  grpcRoutes:
+    default/example-grpc-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -161,19 +161,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -183,13 +180,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -204,13 +199,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
@@ -64,3 +64,46 @@ Routes:
               typedConfig:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.header.v3.HeaderBasedSessionState
                 name: Session-A
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
@@ -70,19 +70,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -92,13 +89,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -143,3 +143,214 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/policy-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    HTTPListenerPolicy/default/policy-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/extensionref-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/fully-ignored:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Overridden due to conflict with higher priority policy in target(s)
+          observedGeneration: 1
+          reason: Overridden
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/policy-no-merge:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/policy-with-section-name:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/policy-without-section-name:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -149,19 +149,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -171,13 +168,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -191,13 +186,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -238,13 +231,13 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
+          observedGeneration: 2
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
+          observedGeneration: 2
           reason: Merged
           status: "True"
           type: Attached
@@ -280,13 +273,13 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
+          observedGeneration: 4
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Overridden due to conflict with higher priority policy in target(s)
-          observedGeneration: 1
+          observedGeneration: 4
           reason: Overridden
           status: "False"
           type: Attached
@@ -322,13 +315,13 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
+          observedGeneration: 2
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
+          observedGeneration: 2
           reason: Merged
           status: "True"
           type: Attached
@@ -343,13 +336,13 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
+          observedGeneration: 3
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
+          observedGeneration: 3
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
@@ -26,3 +26,46 @@ Listeners:
         statPrefix: listener~8080-default.example-tcp-route-rule-0
     name: listener~8080-default.example-tcp-route-rule-0
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tcpRoutes:
+    default/example-tcp-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
@@ -32,19 +32,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -54,13 +51,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
@@ -23,19 +23,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -45,13 +42,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: unknown backend kind
-          observedGeneration: 1
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
@@ -17,3 +17,46 @@ Listeners:
         statPrefix: listener~8080-default.example-tcp-route-rule-0
     name: listener~8080-default.example-tcp-route-rule-0
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tcpRoutes:
+    default/example-tcp-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: unknown backend kind
+          observedGeneration: 1
+          reason: InvalidKind
+          status: "False"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
@@ -23,19 +23,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -45,13 +42,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Service "example-tcp-svc" not found
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
@@ -17,3 +17,46 @@ Listeners:
         statPrefix: listener~8080-default.example-tcp-route-rule-0
     name: listener~8080-default.example-tcp-route-rule-0
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tcpRoutes:
+    default/example-tcp-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Service "example-tcp-svc" not found
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
@@ -46,19 +46,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -68,13 +65,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
@@ -40,3 +40,46 @@ Listeners:
             weight: 35
     name: listener~8080-default.example-tcp-route-rule-0
   name: listener~8080
+Statuses:
+  gateways:
+    default/example-tcp-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tcpRoutes:
+    default/example-tcp-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-tcp-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
@@ -39,19 +39,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -61,13 +58,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
@@ -33,3 +33,46 @@ Listeners:
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   name: listener~8443
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tlsRoutes:
+    default/example-tls-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
@@ -39,19 +39,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -61,13 +58,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: unknown backend kind
-          observedGeneration: 1
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
@@ -33,3 +33,46 @@ Listeners:
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   name: listener~8443
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tlsRoutes:
+    default/example-tls-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: unknown backend kind
+          observedGeneration: 1
+          reason: InvalidKind
+          status: "False"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
@@ -24,3 +24,46 @@ Listeners:
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   name: listener~8443
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tlsRoutes:
+    default/example-tls-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Service "example-tls-svc" not found
+          observedGeneration: 1
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
@@ -30,19 +30,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -52,13 +49,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Service "example-tls-svc" not found
-          observedGeneration: 1
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
@@ -53,19 +53,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -75,13 +72,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: ""
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
@@ -47,3 +47,46 @@ Listeners:
     typedConfig:
       '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   name: listener~8443
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  tlsRoutes:
+    default/example-tls-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
@@ -51,3 +51,47 @@ Routes:
       '@type': type.googleapis.com/envoy.extensions.filters.http.buffer.v3.BufferPerRoute
       buffer:
         maxRequestBytes: 65536
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  policies:
+    TrafficPolicy/default/buffer-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
@@ -57,19 +57,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,13 +81,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
@@ -133,3 +133,109 @@ Routes:
       route:
         cluster: kube_default_example-svc-2_3000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/buffer-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/disable-buffer:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
@@ -139,19 +139,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -161,13 +158,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -181,13 +176,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -207,13 +200,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -228,13 +219,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -257,19 +257,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -279,13 +276,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -305,13 +300,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -326,13 +319,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -347,13 +338,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -368,13 +357,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -389,13 +376,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -410,13 +395,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -431,13 +414,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -251,3 +251,194 @@ Routes:
       ext_auth/default/extauth-listener-2:
         '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
         config: {}
+Statuses:
+  gateways:
+    default/test:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/test:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: test
+  policies:
+    TrafficPolicy/default/gateway-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/gateway-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-disable:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
@@ -424,19 +424,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -446,13 +443,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -466,13 +461,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -486,13 +479,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -506,13 +497,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -526,13 +515,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -546,13 +533,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -566,13 +551,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -592,13 +575,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -613,13 +594,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -634,13 +613,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Overridden due to conflict with higher priority policy in target(s)
-          observedGeneration: 1
           reason: Overridden
           status: "False"
           type: Attached
@@ -655,13 +632,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -676,13 +651,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -697,13 +670,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -718,13 +689,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
@@ -418,3 +418,314 @@ Routes:
       route:
         cluster: kube_infra_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/example-route-no-extauth:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/example-tls-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/example-tls-route-extension-ref:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/example-tls-route-no-extauth:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/example-tls-sibling-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    infra/route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/infra/disable-all-extauth-for-route-2-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/extauth-for-extension-ref:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/extauth-for-gateway:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Overridden due to conflict with higher priority policy in target(s)
+          observedGeneration: 1
+          reason: Overridden
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/extauth-for-gateway-section-name:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/extauth-for-http-route:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/extauth-for-route-2-0:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/extauth-for-route-section-name:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
@@ -407,19 +407,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -429,13 +426,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -455,13 +450,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -476,13 +469,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -497,13 +488,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -518,13 +507,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -539,13 +526,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -560,13 +545,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -581,13 +564,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
@@ -401,3 +401,194 @@ Routes:
       ext_proc/default/extproc-listener-2:
         '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
         overrides: {}
+Statuses:
+  gateways:
+    default/test:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/test:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: test
+  policies:
+    TrafficPolicy/default/gateway-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/gateway-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-disable:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
@@ -271,3 +271,131 @@ Routes:
       ext_proc/default/extproc-listener:
         '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
         overrides: {}
+Statuses:
+  gateways:
+    default/test:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/test:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: test
+  policies:
+    TrafficPolicy/default/gateway-attachment:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-attachment:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-attachment:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-disable:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
@@ -277,19 +277,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -299,13 +296,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -325,13 +320,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -346,13 +339,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -367,13 +358,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -388,13 +377,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
@@ -77,3 +77,68 @@ Routes:
             fillInterval: 33s
             maxTokens: 99
             tokensPerFill: 1
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/infra/test-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
@@ -83,19 +83,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -105,13 +102,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -131,13 +126,13 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
+          observedGeneration: 42
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
+          observedGeneration: 42
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
@@ -268,19 +268,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsAttached
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -290,13 +287,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -311,13 +306,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -338,13 +331,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -357,13 +348,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -378,13 +367,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -399,13 +386,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -420,13 +405,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
@@ -262,3 +262,172 @@ Routes:
                 key: X-Custom-Response-Header-Set
                 value: custom-response-value-ls
           - remove: X-Envoy-Upstream-Service-Time
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsAttached
+        status: "True"
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/svc-route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+          namespace: default
+    default/svc-route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: ls
+          namespace: default
+  policies:
+    TrafficPolicy/default/header-modifiers-gw-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+      - ancestorRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: ls
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/header-modifiers-ls-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: ls
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/header-modifiers-route-policy-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/header-modifiers-route-policy-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: ls
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
@@ -97,19 +97,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: NoResources
         status: "False"
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -119,13 +116,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -146,13 +141,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
@@ -91,3 +91,69 @@ Routes:
       route:
         cluster: kube_default_example-svc_8000
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: NoResources
+        status: "False"
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/svc-route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+          namespace: default
+  policies:
+    TrafficPolicy/default/header-modifiers-gw-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
@@ -159,3 +159,111 @@ Routes:
                   key: X-Custom-Response-Header-Set
                   value: custom-response-value-route
             - remove: X-Envoy-Upstream-Service-Time
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsAttached
+        status: "True"
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/svc-route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+          namespace: default
+    default/svc-route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: ls
+          namespace: default
+  policies:
+    TrafficPolicy/default/header-modifiers-route-policy-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/header-modifiers-route-policy-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: ls
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
@@ -165,19 +165,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsAttached
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -187,13 +184,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -208,13 +203,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -235,13 +228,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -256,13 +247,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -145,19 +145,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -167,13 +164,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -193,13 +188,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -214,13 +207,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -235,13 +226,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -139,3 +139,110 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/infra/accesslog:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/rate-limit:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/transform:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -156,19 +156,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -178,13 +175,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -204,13 +199,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -225,13 +218,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -246,13 +237,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -267,13 +256,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -150,3 +150,131 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/infra/accesslog:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/rate-limit:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/transform:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/kgateway-system/global-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -106,3 +106,110 @@ Routes:
                       text: custom-value-abc
                   parseBodyBehavior: DontParse
                   passthrough: {}
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/infra/extensionref-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/policy-with-section-name:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/infra/policy-without-section-name:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: infra
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Merged with other policies in target(s) and attached
+          observedGeneration: 1
+          reason: Merged
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -112,19 +112,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -134,13 +131,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -160,13 +155,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -181,13 +174,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached
@@ -202,13 +193,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Merged with other policies in target(s) and attached
-          observedGeneration: 1
           reason: Merged
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit.yaml
@@ -111,3 +111,68 @@ Routes:
             fillInterval: 33s
             maxTokens: 99
             tokensPerFill: 1
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/rate-limit:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit.yaml
@@ -117,19 +117,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -139,13 +136,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -165,13 +160,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
@@ -199,3 +199,233 @@ Routes:
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
         idleTimeout: 5s
         timeout: 9s
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  grpcRoutes:
+    default/example-grpc-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  httpRoutes:
+    default/example-route-retry:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-retry-and-timeouts:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-timeout:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/route-builtin-policies:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/example-gateway-retry-and-timeout:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/example-route-retry:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/example-route-retry-and-timeouts:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/example-route-timeout:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/overridden-by-builtin-policies:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
@@ -205,19 +205,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -227,13 +224,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -248,13 +243,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -268,13 +261,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -288,13 +279,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -308,13 +297,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -334,13 +321,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -355,13 +340,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -376,13 +359,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -397,13 +378,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -418,13 +397,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -193,3 +193,173 @@ Routes:
                     text: listener-attachment-1
                 parseBodyBehavior: DontParse
                 passthrough: {}
+Statuses:
+  gateways:
+    default/test:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        observedGeneration: 1
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        observedGeneration: 1
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        observedGeneration: 1
+        reason: Programmed
+        status: "True"
+        type: Programmed
+  httpRoutes:
+    default/test:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          observedGeneration: 1
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          observedGeneration: 1
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: test
+  policies:
+    TrafficPolicy/default/gateway-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/gateway-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-attachment-1:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-attachment-2:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: test
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -199,19 +199,16 @@ Statuses:
       conditions:
       - lastTransitionTime: null
         message: ""
-        observedGeneration: 1
         reason: ListenerSetsNotAllowed
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
-        observedGeneration: 1
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
-        observedGeneration: 1
         reason: Programmed
         status: "True"
         type: Programmed
@@ -221,13 +218,11 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: Route is accepted
-          observedGeneration: 1
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Route has valid refs
-          observedGeneration: 1
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -247,13 +242,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -268,13 +261,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -289,13 +280,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -310,13 +299,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -331,13 +318,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached
@@ -352,13 +337,11 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
-          observedGeneration: 1
           reason: Valid
           status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Attached to all targets
-          observedGeneration: 1
           reason: Attached
           status: "True"
           type: Attached

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 )
 
@@ -136,23 +137,20 @@ func (d *dockerValidator) Validate(ctx context.Context, yaml string) error {
 // ignoring Docker pull progress and other noise that comes before the error.
 func extractEnvoyError(stderr string) string {
 	lines := strings.Split(stderr, "\n")
-	for i, line := range lines {
-		line = strings.TrimSpace(line)
-		// skip lines that don't contain the well known error message from
-		// envoy validate mode output to reduce noise. see:
-		// https://github.com/envoyproxy/envoy/blob/d552b66f5d70ddd9e13c68c40f70729a45fb24e0/source/server/config_validation/server.cc#L75
-		if !strings.Contains(line, "error initializing configuration") {
-			continue
-		}
-		// extract all remaining lines that are relevant error context
-		remainingLines := make([]string, 0, len(lines)-i)
-		remainingLines = append(remainingLines, line)
-		for j := i + 1; j < len(lines); j++ {
-			if nextLine := strings.TrimSpace(lines[j]); nextLine != "" {
-				remainingLines = append(remainingLines, nextLine)
-			}
-		}
-		return strings.Join(remainingLines, " ")
+	// find the first line containing the Envoy error message. see:
+	// https://github.com/envoyproxy/envoy/blob/d552b66f5d70ddd9e13c68c40f70729a45fb24e0/source/server/config_validation/server.cc#L75
+	errorIndex := slices.IndexFunc(lines, func(line string) bool {
+		return strings.Contains(strings.TrimSpace(line), "error initializing configuration")
+	})
+	if errorIndex == -1 {
+		return ""
 	}
-	return ""
+	// extract all remaining lines that are relevant error context
+	remainingLines := make([]string, 0, len(lines)-errorIndex)
+	for i := errorIndex; i < len(lines); i++ {
+		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
+			remainingLines = append(remainingLines, trimmed)
+		}
+	}
+	return strings.Join(remainingLines, " ")
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -95,7 +95,8 @@ type dockerValidator struct {
 var _ Validator = &dockerValidator{}
 
 func (d *dockerValidator) Validate(ctx context.Context, yaml string) error {
-	cmd := exec.CommandContext(ctx,
+	cmd := exec.CommandContext(
+		ctx,
 		"docker", "run",
 		"--rm",
 		"-i",
@@ -117,10 +118,12 @@ func (d *dockerValidator) Validate(ctx context.Context, yaml string) error {
 		return nil
 	}
 
-	// TODO(tim): Just return first match from "error initializing configuration"?
 	rawErr := strings.TrimSpace(stderr.String())
-	rawErr = stripDockerWarn(rawErr)
 	if _, ok := err.(*exec.ExitError); ok {
+		// Extract just the envoy error message, ignoring Docker pull output
+		if envoyErr := extractEnvoyError(rawErr); envoyErr != "" {
+			return fmt.Errorf("%w: %s", ErrInvalidXDS, envoyErr)
+		}
 		if rawErr == "" {
 			rawErr = err.Error()
 		}
@@ -129,14 +132,27 @@ func (d *dockerValidator) Validate(ctx context.Context, yaml string) error {
 	return fmt.Errorf("envoy validate invocation failed: %v", err)
 }
 
-// stripDockerWarn removes the platform-mismatch warning Docker prints on ARM hosts.
-func stripDockerWarn(s string) string {
-	lines := strings.Split(s, "\n")
-	cleaned := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if !strings.HasPrefix(line, "WARNING: The requested image's platform") {
-			cleaned = append(cleaned, line)
+// extractEnvoyError extracts the actual Envoy validation error from stderr output,
+// ignoring Docker pull progress and other noise that comes before the error.
+func extractEnvoyError(stderr string) string {
+	lines := strings.Split(stderr, "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		// skip lines that don't contain the well known error message from
+		// envoy validate mode output to reduce noise. see:
+		// https://github.com/envoyproxy/envoy/blob/d552b66f5d70ddd9e13c68c40f70729a45fb24e0/source/server/config_validation/server.cc#L75
+		if !strings.Contains(line, "error initializing configuration") {
+			continue
 		}
+		// extract all remaining lines that are relevant error context
+		remainingLines := make([]string, 0, len(lines)-i)
+		remainingLines = append(remainingLines, line)
+		for j := i + 1; j < len(lines); j++ {
+			if nextLine := strings.TrimSpace(lines[j]); nextLine != "" {
+				remainingLines = append(remainingLines, nextLine)
+			}
+		}
+		return strings.Join(remainingLines, " ")
 	}
-	return strings.TrimSpace(strings.Join(cleaned, "\n"))
+	return ""
 }

--- a/test/translator/status.go
+++ b/test/translator/status.go
@@ -1,0 +1,267 @@
+package translator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+type Statuses struct {
+	Gateways   map[string]*gwv1.GatewayStatus  `json:"gateways,omitempty"`
+	HTTPRoutes map[string]*gwv1.RouteStatus    `json:"httpRoutes,omitempty"`
+	TCPRoutes  map[string]*gwv1.RouteStatus    `json:"tcpRoutes,omitempty"`
+	TLSRoutes  map[string]*gwv1.RouteStatus    `json:"tlsRoutes,omitempty"`
+	GRPCRoutes map[string]*gwv1.RouteStatus    `json:"grpcRoutes,omitempty"`
+	Policies   map[string]*gwv1a2.PolicyStatus `json:"policies,omitempty"`
+}
+
+func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
+	ctx := context.Background()
+
+	// Fixed values for deterministic golden file tests. Use the zero time
+	// for consistency and to avoid confusion about the significance of a
+	// specific date.
+	fixedTime := metav1.Time{Time: time.Time{}}
+	fixedObservedGeneration := int64(1)
+
+	statuses := &Statuses{
+		Gateways:   make(map[string]*gwv1.GatewayStatus),
+		HTTPRoutes: make(map[string]*gwv1.RouteStatus),
+		TCPRoutes:  make(map[string]*gwv1.RouteStatus),
+		TLSRoutes:  make(map[string]*gwv1.RouteStatus),
+		GRPCRoutes: make(map[string]*gwv1.RouteStatus),
+		Policies:   make(map[string]*gwv1a2.PolicyStatus),
+	}
+
+	// Build Gateway statuses
+	for gwNN := range reportsMap.Gateways {
+		gw := gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gwNN.Name,
+				Namespace: gwNN.Namespace,
+			},
+		}
+		if status := reportsMap.BuildGWStatus(ctx, gw, nil); status != nil {
+			normalizeStatus(status, fixedTime, fixedObservedGeneration)
+			statuses.Gateways[gwNN.String()] = status
+		}
+	}
+
+	// Build HTTPRoute statuses
+	for routeNN := range reportsMap.HTTPRoutes {
+		route := gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      routeNN.Name,
+				Namespace: routeNN.Namespace,
+			},
+		}
+		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
+			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			statuses.HTTPRoutes[routeNN.String()] = status
+		}
+	}
+
+	// Build TCPRoute statuses
+	for routeNN := range reportsMap.TCPRoutes {
+		route := gwv1a2.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      routeNN.Name,
+				Namespace: routeNN.Namespace,
+			},
+		}
+		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
+			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			statuses.TCPRoutes[routeNN.String()] = status
+		}
+	}
+
+	// Build TLSRoute statuses
+	for routeNN := range reportsMap.TLSRoutes {
+		route := gwv1a2.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      routeNN.Name,
+				Namespace: routeNN.Namespace,
+			},
+		}
+		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
+			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			statuses.TLSRoutes[routeNN.String()] = status
+		}
+	}
+
+	// Build GRPCRoute statuses
+	for routeNN := range reportsMap.GRPCRoutes {
+		route := gwv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      routeNN.Name,
+				Namespace: routeNN.Namespace,
+			},
+		}
+		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
+			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			statuses.GRPCRoutes[routeNN.String()] = status
+		}
+	}
+
+	// Build Policy statuses
+	for policyKey := range reportsMap.Policies {
+		policyKeyStr := fmt.Sprintf("%s/%s/%s", policyKey.Kind, policyKey.Namespace, policyKey.Name)
+		if status := reportsMap.BuildPolicyStatus(ctx, policyKey, wellknown.DefaultGatewayControllerName, gwv1a2.PolicyStatus{}); status != nil {
+			normalizePolicyStatus(status, fixedTime, fixedObservedGeneration)
+			statuses.Policies[policyKeyStr] = status
+		}
+	}
+
+	return statuses
+}
+
+// normalizeStatus sets all fields (e.g. LastTransitionTime and ObservedGeneration) to fixed values for deterministic testing
+func normalizeStatus(status *gwv1.GatewayStatus, time metav1.Time, gen int64) {
+	for i := range status.Conditions {
+		status.Conditions[i].LastTransitionTime = time
+		status.Conditions[i].ObservedGeneration = gen
+	}
+	for i := range status.Listeners {
+		for j := range status.Listeners[i].Conditions {
+			status.Listeners[i].Conditions[j].LastTransitionTime = time
+			status.Listeners[i].Conditions[j].ObservedGeneration = gen
+		}
+	}
+}
+
+// normalizeRouteStatus sets all fields (e.g. LastTransitionTime and ObservedGeneration) to fixed values for deterministic testing
+func normalizeRouteStatus(status *gwv1.RouteStatus, time metav1.Time, gen int64) {
+	for i := range status.Parents {
+		for j := range status.Parents[i].Conditions {
+			status.Parents[i].Conditions[j].LastTransitionTime = time
+			status.Parents[i].Conditions[j].ObservedGeneration = gen
+		}
+	}
+}
+
+// normalizePolicyStatus sets all fields (e.g. LastTransitionTime and ObservedGeneration) to fixed values for deterministic testing
+func normalizePolicyStatus(status *gwv1a2.PolicyStatus, time metav1.Time, gen int64) {
+	for i := range status.Ancestors {
+		for j := range status.Ancestors[i].Conditions {
+			status.Ancestors[i].Conditions[j].LastTransitionTime = time
+			status.Ancestors[i].Conditions[j].ObservedGeneration = gen
+		}
+	}
+}
+
+func compareStatuses(expectedFile string, actualStatuses *Statuses) (string, error) {
+	expectedOutput := &translationResult{}
+	if err := ReadYamlFile(expectedFile, expectedOutput); err != nil {
+		return "", err
+	}
+
+	if expectedOutput.Statuses == nil && actualStatuses == nil {
+		return "", nil
+	}
+	if expectedOutput.Statuses == nil {
+		return "expected no statuses but got some", nil
+	}
+	if actualStatuses == nil {
+		return "expected statuses but got none", nil
+	}
+
+	// Sort statuses for consistent comparison
+	expectedSorted := sortStatuses(expectedOutput.Statuses)
+	actualSorted := sortStatuses(actualStatuses)
+
+	// Use custom comparison options to ignore timestamp differences and handle nil vs empty slice
+	opts := []cmp.Option{
+		cmpopts.EquateNaNs(),
+		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+		cmpopts.EquateEmpty(),
+	}
+
+	return cmp.Diff(expectedSorted, actualSorted, opts...), nil
+}
+
+func sortStatuses(statuses *Statuses) *Statuses {
+	if statuses == nil {
+		return nil
+	}
+
+	sorted := &Statuses{
+		Gateways:   make(map[string]*gwv1.GatewayStatus),
+		HTTPRoutes: make(map[string]*gwv1.RouteStatus),
+		TCPRoutes:  make(map[string]*gwv1.RouteStatus),
+		TLSRoutes:  make(map[string]*gwv1.RouteStatus),
+		GRPCRoutes: make(map[string]*gwv1.RouteStatus),
+		Policies:   make(map[string]*gwv1a2.PolicyStatus),
+	}
+
+	// Sort gateways
+	gatewayKeys := make([]string, 0, len(statuses.Gateways))
+	for k := range statuses.Gateways {
+		gatewayKeys = append(gatewayKeys, k)
+	}
+	sort.Strings(gatewayKeys)
+	for _, k := range gatewayKeys {
+		sorted.Gateways[k] = statuses.Gateways[k]
+	}
+
+	// Sort HTTP routes
+	httpRouteKeys := make([]string, 0, len(statuses.HTTPRoutes))
+	for k := range statuses.HTTPRoutes {
+		httpRouteKeys = append(httpRouteKeys, k)
+	}
+	sort.Strings(httpRouteKeys)
+	for _, k := range httpRouteKeys {
+		sorted.HTTPRoutes[k] = statuses.HTTPRoutes[k]
+	}
+
+	// Sort TCP routes
+	tcpRouteKeys := make([]string, 0, len(statuses.TCPRoutes))
+	for k := range statuses.TCPRoutes {
+		tcpRouteKeys = append(tcpRouteKeys, k)
+	}
+	sort.Strings(tcpRouteKeys)
+	for _, k := range tcpRouteKeys {
+		sorted.TCPRoutes[k] = statuses.TCPRoutes[k]
+	}
+
+	// Sort TLS routes
+	tlsRouteKeys := make([]string, 0, len(statuses.TLSRoutes))
+	for k := range statuses.TLSRoutes {
+		tlsRouteKeys = append(tlsRouteKeys, k)
+	}
+	sort.Strings(tlsRouteKeys)
+	for _, k := range tlsRouteKeys {
+		sorted.TLSRoutes[k] = statuses.TLSRoutes[k]
+	}
+
+	// Sort GRPC routes
+	grpcRouteKeys := make([]string, 0, len(statuses.GRPCRoutes))
+	for k := range statuses.GRPCRoutes {
+		grpcRouteKeys = append(grpcRouteKeys, k)
+	}
+	sort.Strings(grpcRouteKeys)
+	for _, k := range grpcRouteKeys {
+		sorted.GRPCRoutes[k] = statuses.GRPCRoutes[k]
+	}
+
+	// Sort policies
+	policyKeys := make([]string, 0, len(statuses.Policies))
+	for k := range statuses.Policies {
+		policyKeys = append(policyKeys, k)
+	}
+	sort.Strings(policyKeys)
+	for _, k := range policyKeys {
+		sorted.Policies[k] = statuses.Policies[k]
+	}
+
+	return sorted
+}

--- a/test/translator/status.go
+++ b/test/translator/status.go
@@ -32,7 +32,6 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 	// for consistency and to avoid confusion about the significance of a
 	// specific date.
 	fixedTime := metav1.Time{Time: time.Time{}}
-	fixedObservedGeneration := int64(1)
 
 	statuses := &Statuses{
 		Gateways:   make(map[string]*gwv1.GatewayStatus),
@@ -52,7 +51,7 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 			},
 		}
 		if status := reportsMap.BuildGWStatus(ctx, gw, nil); status != nil {
-			normalizeStatus(status, fixedTime, fixedObservedGeneration)
+			normalizeStatus(status, fixedTime)
 			statuses.Gateways[gwNN.String()] = status
 		}
 	}
@@ -66,7 +65,7 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 			},
 		}
 		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
-			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			normalizeRouteStatus(status, fixedTime)
 			statuses.HTTPRoutes[routeNN.String()] = status
 		}
 	}
@@ -80,7 +79,7 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 			},
 		}
 		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
-			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			normalizeRouteStatus(status, fixedTime)
 			statuses.TCPRoutes[routeNN.String()] = status
 		}
 	}
@@ -94,7 +93,7 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 			},
 		}
 		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
-			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			normalizeRouteStatus(status, fixedTime)
 			statuses.TLSRoutes[routeNN.String()] = status
 		}
 	}
@@ -108,7 +107,7 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 			},
 		}
 		if status := reportsMap.BuildRouteStatus(ctx, &route, wellknown.DefaultGatewayClassName); status != nil {
-			normalizeRouteStatus(status, fixedTime, fixedObservedGeneration)
+			normalizeRouteStatus(status, fixedTime)
 			statuses.GRPCRoutes[routeNN.String()] = status
 		}
 	}
@@ -117,7 +116,7 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 	for policyKey := range reportsMap.Policies {
 		policyKeyStr := fmt.Sprintf("%s/%s/%s", policyKey.Kind, policyKey.Namespace, policyKey.Name)
 		if status := reportsMap.BuildPolicyStatus(ctx, policyKey, wellknown.DefaultGatewayControllerName, gwv1a2.PolicyStatus{}); status != nil {
-			normalizePolicyStatus(status, fixedTime, fixedObservedGeneration)
+			normalizePolicyStatus(status, fixedTime)
 			statuses.Policies[policyKeyStr] = status
 		}
 	}
@@ -125,36 +124,32 @@ func buildStatusesFromReports(reportsMap reports.ReportMap) *Statuses {
 	return statuses
 }
 
-// normalizeStatus sets all fields (e.g. LastTransitionTime and ObservedGeneration) to fixed values for deterministic testing
-func normalizeStatus(status *gwv1.GatewayStatus, time metav1.Time, gen int64) {
+// normalizeStatus sets all fields (e.g. LastTransitionTime) to fixed values for deterministic testing
+func normalizeStatus(status *gwv1.GatewayStatus, time metav1.Time) {
 	for i := range status.Conditions {
 		status.Conditions[i].LastTransitionTime = time
-		status.Conditions[i].ObservedGeneration = gen
 	}
 	for i := range status.Listeners {
 		for j := range status.Listeners[i].Conditions {
 			status.Listeners[i].Conditions[j].LastTransitionTime = time
-			status.Listeners[i].Conditions[j].ObservedGeneration = gen
 		}
 	}
 }
 
-// normalizeRouteStatus sets all fields (e.g. LastTransitionTime and ObservedGeneration) to fixed values for deterministic testing
-func normalizeRouteStatus(status *gwv1.RouteStatus, time metav1.Time, gen int64) {
+// normalizeRouteStatus sets all fields (e.g. LastTransitionTime) to fixed values for deterministic testing
+func normalizeRouteStatus(status *gwv1.RouteStatus, time metav1.Time) {
 	for i := range status.Parents {
 		for j := range status.Parents[i].Conditions {
 			status.Parents[i].Conditions[j].LastTransitionTime = time
-			status.Parents[i].Conditions[j].ObservedGeneration = gen
 		}
 	}
 }
 
-// normalizePolicyStatus sets all fields (e.g. LastTransitionTime and ObservedGeneration) to fixed values for deterministic testing
-func normalizePolicyStatus(status *gwv1a2.PolicyStatus, time metav1.Time, gen int64) {
+// normalizePolicyStatus sets all fields (e.g. LastTransitionTime) to fixed values for deterministic testing
+func normalizePolicyStatus(status *gwv1a2.PolicyStatus, time metav1.Time) {
 	for i := range status.Ancestors {
 		for j := range status.Ancestors[i].Conditions {
 			status.Ancestors[i].Conditions[j].LastTransitionTime = time
-			status.Ancestors[i].Conditions[j].ObservedGeneration = gen
 		}
 	}
 }

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -732,9 +733,7 @@ func (tc TestCase) Run(
 
 		// Merge gateway reports with backend policy reports
 		mergedReports := reportsMap
-		for policyKey, policyReport := range backendPolicyReports.Policies {
-			mergedReports.Policies[policyKey] = policyReport
-		}
+		maps.Copy(mergedReports.Policies, backendPolicyReports.Policies)
 
 		actual := ActualTestResult{
 			Proxy:      xdsSnap,

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -31,12 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gwxv1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
+	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	extensionsplug "github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/registry"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/proxy_syncer"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/listener"
@@ -61,6 +62,7 @@ type translationResult struct {
 	Listeners     []*envoylistenerv3.Listener
 	ExtraClusters []*envoyclusterv3.Cluster
 	Clusters      []*envoyclusterv3.Cluster
+	Statuses      *Statuses
 }
 
 func (tr *translationResult) MarshalJSON() ([]byte, error) {
@@ -69,7 +71,7 @@ func (tr *translationResult) MarshalJSON() ([]byte, error) {
 	}
 
 	// Create a map to hold the marshaled fields
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 
 	// Marshal each field using protojson
 	if len(tr.Routes) > 0 {
@@ -102,6 +104,11 @@ func (tr *translationResult) MarshalJSON() ([]byte, error) {
 			return nil, err
 		}
 		result["Clusters"] = clusters
+	}
+
+	// Add statuses if they exist
+	if tr.Statuses != nil {
+		result["Statuses"] = tr.Statuses
 	}
 
 	// Marshal the result map to JSON
@@ -180,17 +187,25 @@ func (tr *translationResult) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	// Unmarshal statuses if they exist
+	if statusesData, ok := result["Statuses"]; ok {
+		tr.Statuses = &Statuses{}
+		if err := json.Unmarshal(statusesData, tr.Statuses); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
-func marshalProtoMessages[T proto.Message](messages []T, m protojson.MarshalOptions) ([]interface{}, error) {
-	var result []interface{}
+func marshalProtoMessages[T proto.Message](messages []T, m protojson.MarshalOptions) ([]any, error) {
+	var result []any
 	for _, msg := range messages {
 		data, err := m.Marshal(msg)
 		if err != nil {
 			return nil, err
 		}
-		var jsonObj interface{}
+		var jsonObj any
 		if err := json.Unmarshal(data, &jsonObj); err != nil {
 			return nil, err
 		}
@@ -259,6 +274,7 @@ func TestTranslationWithExtraPlugins(
 		Listeners:     result.Proxy.Listeners,
 		ExtraClusters: result.Proxy.ExtraClusters,
 		Clusters:      result.Clusters,
+		Statuses:      buildStatusesFromReports(result.ReportsMap),
 	}
 	outputYaml, err := MarshalAnyYaml(output)
 	r.NoErrorf(err, "error marshaling output to YAML; actual result: %s", outputYaml)
@@ -280,6 +296,10 @@ func TestTranslationWithExtraPlugins(
 	gotClusters, err := compareClusters(outputFile, result.Clusters)
 	r.Emptyf(gotClusters, "unexpected diff in clusters output; actual result: %s", outputYaml)
 	r.NoError(err, "error comparing clusters output")
+
+	gotStatuses, err := compareStatuses(outputFile, output.Statuses)
+	r.Emptyf(gotStatuses, "unexpected diff in statuses output; actual result: %s", outputYaml)
+	r.NoError(err, "error comparing statuses output")
 
 	if assertReports != nil {
 		assertReports(gwNN, result.ReportsMap)
@@ -494,7 +514,7 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 	}
 
 	for ls := range reportsMap.ListenerSets {
-		l := gwxv1.XListenerSet{
+		l := gwxv1a1.XListenerSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      ls.Name,
 				Namespace: ls.Namespace,
@@ -699,9 +719,26 @@ func (tc TestCase) Run(
 
 		xdsSnap, reportsMap := translator.TranslateGateway(krt.TestingDummyContext{}, ctx, gw)
 
+		// Backend policies (e.g. BackendConfigPolicy) use a different reporting pipeline than gateway policies.
+		// Gateway policies (HTTPListenerPolicy, TrafficPolicy) are reported during gateway translation via the
+		// standard reporter mechanism. Backend policies are processed differently - they don't use the reporter
+		// during translation, instead their reports are generated separately by GenerateBackendPolicyReport().
+		// We need to merge both report types to capture all policy statuses for golden file testing.
+		var backendIRs []*ir.BackendObjectIR
+		for _, col := range commoncol.BackendIndex.BackendsWithPolicy() {
+			backendIRs = append(backendIRs, col.List()...)
+		}
+		backendPolicyReports := proxy_syncer.GenerateBackendPolicyReport(backendIRs)
+
+		// Merge gateway reports with backend policy reports
+		mergedReports := reportsMap
+		for policyKey, policyReport := range backendPolicyReports.Policies {
+			mergedReports.Policies[policyKey] = policyReport
+		}
+
 		actual := ActualTestResult{
 			Proxy:      xdsSnap,
-			ReportsMap: reportsMap,
+			ReportsMap: mergedReports,
 		}
 		results[gwNN] = actual
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Updates the translator test suite to additionally write the output status for each Gateway API + extension API resource used for each test case attached to that suite and treats them as a single artifact. This makes it easier to reason about the state of those resources in addition to the output xDS being written to those files.

The potential risk here is an increased impact on noise generated in reviews. However, this provides a single source of truth in addition to the explicit status assertions already codified in the translator suite.

Fixes #11932.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
