### PR TITLE
translator: Enhance golden file status generation

### DIFF
--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
@@ -198,3 +198,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
@@ -261,3 +261,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
@@ -198,3 +198,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
@@ -270,3 +270,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
@@ -246,3 +246,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -185,6 +185,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     infra/waypoint-route:
       parents:

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
@@ -240,3 +240,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
@@ -25,3 +25,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
@@ -171,6 +171,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     infra/waypoint-route:
       parents:

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -161,6 +161,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     infra/waypoint-route:
       parents:

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -161,6 +161,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     infra/waypoint-route:
       parents:

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
@@ -147,6 +147,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     infra/waypoint-route:
       parents:

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -214,3 +214,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
@@ -95,3 +95,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
@@ -97,3 +97,30 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: proxy
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -1297,6 +1297,36 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("listener set accepted with rejected individual listener", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "listener-sets/accepted-ls-rejected-listener.yaml",
+			outputFile: "listener-sets/accepted-ls-rejected-listener.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				// The ListenerSet should be accepted since the Gateway allows listener sets
+				expectedLS := gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-listenerset",
+						Namespace: "default",
+					},
+				}
+				expectedAccepted := metav1.Condition{
+					Type:    string(gwxv1a1.ListenerSetConditionAccepted),
+					Status:  metav1.ConditionTrue,
+					Reason:  string(gwxv1a1.ListenerSetReasonAccepted),
+					Message: "ListenerSet is accepted",
+				}
+				translatortest.AssertListenerSetCondition(t, reportsMap, expectedLS, expectedAccepted)
+				// note: we can't assert on individual listener set status due to how
+				// BuildListenerSetStatus() works where it skips rejected listeners
+				// and only returns the status for accepted listeners.
+			},
+		})
+	})
+
 	t.Run("TrafficPolicy: rate limit", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFile:  "traffic-policy/rate-limit.yaml",

--- a/internal/kgateway/translator/gateway/testutils/inputs/listener-sets/accepted-ls-rejected-listener.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/listener-sets/accepted-ls-rejected-listener.yaml
@@ -8,6 +8,9 @@ spec:
   - name: http-8080
     protocol: HTTP
     port: 8080
+  allowedListeners:
+    namespaces:
+      from: All
 ---
 apiVersion: gateway.networking.x-k8s.io/v1alpha1
 kind: XListenerSet
@@ -22,6 +25,12 @@ spec:
   - name: http-9090
     protocol: HTTP
     port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: udp-9091
+    protocol: UDP  # This should trigger unsupported protocol rejection
+    port: 9091
     allowedRoutes:
       namespaces:
         from: All
@@ -54,6 +63,6 @@ spec:
   selector:
     test: test
   ports:
-    - protocol: HTTP
+    - protocol: TCP
       port: 8080
       targetPort: test

--- a/internal/kgateway/translator/gateway/testutils/inputs/listener-sets/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/listener-sets/basic.yaml
@@ -3,7 +3,7 @@ kind: Gateway
 metadata:
   name: example-gateway
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: kgateway
   listeners:
   - name: http-8080
     protocol: HTTP
@@ -60,4 +60,3 @@ spec:
     - protocol: HTTP
       port: 8080
       targetPort: test
-

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
@@ -82,6 +82,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
@@ -87,6 +87,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
@@ -84,6 +84,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
@@ -70,6 +70,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
@@ -75,6 +75,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
@@ -68,6 +68,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     BackendConfigPolicy/default/httpbin-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
@@ -68,6 +68,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     BackendConfigPolicy/default/httpbin-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
@@ -81,6 +81,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     BackendConfigPolicy/default/httpbin-grpc-hc-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
@@ -95,6 +95,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     BackendConfigPolicy/default/httpbin-h2c-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
@@ -199,6 +199,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     BackendConfigPolicy/default/httpbin-lr-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
@@ -97,6 +97,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     BackendConfigPolicy/default/example-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
@@ -78,6 +78,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     BackendConfigPolicy/default/httpbin-grpc-hc-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
@@ -105,6 +105,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/backend-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
@@ -90,6 +90,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
@@ -158,6 +158,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/backend-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
@@ -127,3 +127,32 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
@@ -70,6 +70,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
@@ -151,6 +151,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
@@ -145,6 +145,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
@@ -70,6 +70,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
@@ -94,6 +94,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
@@ -96,6 +96,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
@@ -94,6 +94,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -96,6 +96,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
@@ -126,6 +126,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a1:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -130,6 +130,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -102,6 +102,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -102,6 +102,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a-b/route-a-b:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
@@ -88,6 +88,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
@@ -105,6 +105,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-b:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -106,6 +106,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
@@ -106,6 +106,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
@@ -111,6 +111,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/apiproduct-1:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
@@ -102,6 +102,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -120,6 +120,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
@@ -172,6 +172,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a-b-d/route-a-b-d:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -206,6 +206,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
@@ -215,6 +215,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -122,6 +122,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -253,6 +253,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/child:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -134,6 +134,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -134,6 +134,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -156,6 +156,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -222,6 +222,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a-root/route-a-root:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -338,6 +338,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/a1:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
@@ -106,6 +106,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
@@ -125,6 +125,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a-b/route-a-b:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
@@ -75,6 +75,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
@@ -84,6 +84,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
@@ -64,6 +64,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
@@ -70,6 +70,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
@@ -63,6 +63,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
@@ -63,6 +63,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -147,6 +147,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     a/route-a:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -105,6 +105,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
@@ -79,3 +79,60 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http2
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
@@ -75,6 +75,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: grpc
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   grpcRoutes:
     default/example-grpc-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
@@ -61,6 +61,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: grpc
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   grpcRoutes:
     default/example-grpc-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
@@ -61,6 +61,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: grpc
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   grpcRoutes:
     default/example-grpc-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
@@ -94,6 +94,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: grpc
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   grpcRoutes:
     default/example-grpc-multi-backend-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -61,6 +61,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
@@ -61,6 +61,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
@@ -127,6 +127,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 3
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/bar-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
@@ -126,6 +126,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
@@ -82,6 +82,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
@@ -82,6 +82,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
@@ -87,6 +87,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -159,6 +159,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     HTTPListenerPolicy/default/access-log:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
@@ -86,6 +86,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -107,6 +107,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route-timeout:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
@@ -70,6 +70,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route-timeout:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
@@ -80,6 +80,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route-timeout:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
@@ -80,6 +80,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route-timeout:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
@@ -145,6 +145,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 6
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route-backend-request-both-timeout:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
@@ -82,6 +82,89 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Secret default/missing-cert not found.
+          reason: InvalidCertificateRef
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Secret default/missing-cert not found.
+          reason: Invalid
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid TLS secret default/invalid-cert: tls: failed to find any
+            PEM data in key input'
+          reason: InvalidCertificateRef
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: 'invalid TLS secret default/invalid-cert: tls: failed to find any
+            PEM data in key input'
+          reason: Invalid
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        name: https2
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
@@ -82,6 +82,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route-timeout:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
@@ -143,6 +143,59 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https-with-hostname
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
@@ -6,34 +6,7 @@ Clusters:
       resourceApiVersion: V3
   ignoreHealthOnHostRemoval: true
   metadata: {}
-  name: kube_a-b_svc-a-b_8080
-  type: EDS
-- connectTimeout: 5s
-  edsClusterConfig:
-    edsConfig:
-      ads: {}
-      resourceApiVersion: V3
-  ignoreHealthOnHostRemoval: true
-  metadata: {}
-  name: kube_a_svc-a_8080
-  type: EDS
-- connectTimeout: 5s
-  edsClusterConfig:
-    edsConfig:
-      ads: {}
-      resourceApiVersion: V3
-  ignoreHealthOnHostRemoval: true
-  metadata: {}
-  name: kube_b_svc-b_8080
-  type: EDS
-- connectTimeout: 5s
-  edsClusterConfig:
-    edsConfig:
-      ads: {}
-      resourceApiVersion: V3
-  ignoreHealthOnHostRemoval: true
-  metadata: {}
-  name: kube_infra_example-svc_80
+  name: kube_default_foo-svc_8080
   type: EDS
 - connectTimeout: 5s
   metadata: {}
@@ -43,7 +16,7 @@ Listeners:
     socketAddress:
       address: '::'
       ipv4Compat: true
-      portValue: 80
+      portValue: 8080
   filterChains:
   - filters:
     - name: envoy.filters.network.http_connection_manager
@@ -59,45 +32,60 @@ Listeners:
           configSource:
             ads: {}
             resourceApiVersion: V3
-          routeConfigName: listener~80
+          routeConfigName: listener~8080
         statPrefix: http
         useRemoteAddress: true
-    name: listener~80
-  name: listener~80
+    name: listener~8080
+  name: listener~8080
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 9090
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~9090
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~9090
+  name: listener~9090
 Routes:
 - ignorePortInHostMatching: true
-  name: listener~80
+  name: listener~8080
+- ignorePortInHostMatching: true
+  name: listener~9090
   virtualHosts:
   - domains:
-    - example.com
-    name: listener~80~example_com
+    - foo.example.com
+    name: listener~9090~foo_example_com
     routes:
     - match:
-        pathSeparatedPrefix: /a/b/1
-      name: listener~80~example_com-route-0-httproute-route-a-b-a-b-0-0-matcher-0
-      route:
-        cluster: kube_a-b_svc-a-b_8080
-        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-    - match:
-        pathSeparatedPrefix: /a/1
-      name: listener~80~example_com-route-1-httproute-route-a-a-0-0-matcher-0
-      route:
-        cluster: kube_a_svc-a_8080
-        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-    - match:
         prefix: /
-      name: listener~80~example_com-route-4-httproute-example-route-infra-0-0-matcher-0
+      name: listener~9090~foo_example_com-route-0-httproute-foo-route-default-0-0-matcher-0
       route:
-        cluster: kube_infra_example-svc_80
+        cluster: kube_default_foo-svc_8080
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
 Statuses:
   gateways:
-    infra/example-gateway:
+    default/example-gateway:
       conditions:
       - lastTransitionTime: null
         message: ""
-        reason: ListenerSetsNotAllowed
-        status: Unknown
+        reason: ListenerSetsAttached
+        status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
         message: Gateway is accepted
@@ -106,6 +94,67 @@ Statuses:
         type: Accepted
       - lastTransitionTime: null
         message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-8080
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/foo-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.x-k8s.io
+          kind: XListenerSet
+          name: foo-listenerset
+  listenerSets:
+    default/foo-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: ListenerSet is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ListenerSet is programmed
         reason: Programmed
         status: "True"
         type: Programmed
@@ -132,66 +181,35 @@ Statuses:
           reason: Programmed
           status: "True"
           type: Programmed
-        name: http
+        name: http-9090
+        port: 9090
         supportedKinds:
         - group: gateway.networking.k8s.io
           kind: HTTPRoute
         - group: gateway.networking.k8s.io
           kind: GRPCRoute
-  httpRoutes:
-    a-b/route-a-b:
-      parents:
-      - conditions:
+      - attachedRoutes: 0
+        conditions:
         - lastTransitionTime: null
-          message: Route is accepted
-          reason: Accepted
-          status: "True"
+          message: Protocol UDP is unsupported.
+          reason: UnsupportedProtocol
+          status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
-        controllerName: kgateway
-        parentRef:
-          group: gateway.networking.k8s.io
-          kind: HTTPRoute
-          name: route-a
-          namespace: a
-    a/route-a:
-      parents:
-      - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
-          reason: Accepted
+          message: Listener is programmed
+          reason: Programmed
           status: "True"
-          type: Accepted
-        - lastTransitionTime: null
-          message: Route has valid refs
-          reason: ResolvedRefs
-          status: "True"
-          type: ResolvedRefs
-        controllerName: kgateway
-        parentRef:
-          group: gateway.networking.k8s.io
-          kind: HTTPRoute
-          name: example-route
-          namespace: infra
-    infra/example-route:
-      parents:
-      - conditions:
-        - lastTransitionTime: null
-          message: Route is accepted
-          reason: Accepted
-          status: "True"
-          type: Accepted
-        - lastTransitionTime: null
-          message: Route has valid refs
-          reason: ResolvedRefs
-          status: "True"
-          type: ResolvedRefs
-        controllerName: kgateway
-        parentRef:
-          group: ""
-          kind: ""
-          name: example-gateway
+          type: Programmed
+        name: udp-9091
+        port: 9091
+        supportedKinds: []

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
@@ -97,6 +97,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-8080
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/foo-route:
       parents:
@@ -116,3 +145,46 @@ Statuses:
           group: gateway.networking.x-k8s.io
           kind: XListenerSet
           name: foo-listenerset
+  listenerSets:
+    default/foo-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: ListenerSet is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ListenerSet is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-9090
+        port: 9090
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
@@ -59,3 +59,45 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-8080
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  listenerSets:
+    default/foo-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: Unable to attach to parent, gateway has not enabled allowedListeners
+        reason: NotAllowed
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Unable to attach to parent, gateway has not enabled allowedListeners
+        reason: NotAllowed
+        status: "False"
+        type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
@@ -125,6 +125,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route-maglev:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -50,3 +50,60 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-httpbin
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-bookinfo
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
@@ -28,3 +28,56 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Secret default/bookinfo-tls-secret not found.
+          reason: InvalidCertificateRef
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Secret default/bookinfo-tls-secret not found.
+          reason: Invalid
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        name: https-httpbin
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https-bookinfo
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
@@ -50,3 +50,32 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
@@ -201,6 +201,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
@@ -385,6 +385,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
@@ -232,6 +232,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
@@ -161,6 +161,61 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     gwtest/test-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
@@ -108,6 +108,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
@@ -151,6 +151,61 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     gwtest/test-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
@@ -171,6 +171,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-8080
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/test-route:
       parents:
@@ -190,6 +219,76 @@ Statuses:
           group: gateway.networking.x-k8s.io
           kind: XListenerSet
           name: test-listenerset
+  listenerSets:
+    gwtest/test-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: ListenerSet is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ListenerSet is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-9090
+        port: 9090
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https-8443
+        port: 8443
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   policies:
     TrafficPolicy/gwtest/invalid-traffic-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-builtin-filter-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
@@ -81,6 +81,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-regex-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
@@ -80,6 +80,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-regex-path-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -76,6 +76,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-rds-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/test-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
@@ -115,6 +115,61 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     gwtest/test-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
@@ -80,6 +80,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
@@ -115,6 +115,61 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     gwtest/test-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
@@ -135,6 +135,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-8080
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/test-route:
       parents:
@@ -154,6 +183,76 @@ Statuses:
           group: gateway.networking.x-k8s.io
           kind: XListenerSet
           name: test-listenerset
+  listenerSets:
+    gwtest/test-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: ListenerSet is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ListenerSet is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-9090
+        port: 9090
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https-8443
+        port: 8443
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   policies:
     TrafficPolicy/gwtest/invalid-traffic-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-request-header-modifier-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-response-header-modifier-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-builtin-filter-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
@@ -63,6 +63,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-regex-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-regex-path-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
@@ -63,6 +63,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-route-matcher-query-params:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -63,6 +63,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-rds-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/test-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/test-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-header-template-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -88,6 +88,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
@@ -72,6 +72,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     gwtest/invalid-traffic-policy-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
@@ -162,6 +162,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/d-higher-weight:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
@@ -144,6 +144,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/route-1:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -174,6 +174,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   grpcRoutes:
     default/example-grpc-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
@@ -83,6 +83,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -162,6 +162,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/route-1:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
@@ -45,6 +45,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tcp
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute
   tcpRoutes:
     default/example-tcp-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
@@ -36,6 +36,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tcp
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute
   tcpRoutes:
     default/example-tcp-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
@@ -36,6 +36,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tcp
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute
   tcpRoutes:
     default/example-tcp-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
@@ -59,6 +59,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tcp
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute
   tcpRoutes:
     default/example-tcp-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
@@ -52,6 +52,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tls
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute
   tlsRoutes:
     default/example-tls-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
@@ -52,6 +52,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tls
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute
   tlsRoutes:
     default/example-tls-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
@@ -43,6 +43,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tls
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute
   tlsRoutes:
     default/example-tls-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
@@ -66,6 +66,33 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tls
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute
   tlsRoutes:
     default/example-tls-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
@@ -70,6 +70,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     TrafficPolicy/default/buffer-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
@@ -152,6 +152,63 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http2
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -270,6 +270,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/test:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
@@ -437,6 +437,115 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http1
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http2
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 3
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tls1
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tls2
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
   httpRoutes:
     infra/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
@@ -420,6 +420,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/test:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
@@ -290,6 +290,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/test:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
@@ -96,6 +96,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
@@ -281,6 +281,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/svc-route-1:
       parents:
@@ -320,6 +349,49 @@ Statuses:
           kind: XListenerSet
           name: ls
           namespace: default
+  listenerSets:
+    default/ls:
+      conditions:
+      - lastTransitionTime: null
+        message: ListenerSet is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ListenerSet is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: foo
+        port: 8081
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     TrafficPolicy/default/header-modifiers-gw-policy:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
@@ -110,6 +110,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/svc-route-1:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
@@ -178,6 +178,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/svc-route-1:
       parents:
@@ -217,6 +246,49 @@ Statuses:
           kind: XListenerSet
           name: ls
           namespace: default
+  listenerSets:
+    default/ls:
+      conditions:
+      - lastTransitionTime: null
+        message: ListenerSet is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ListenerSet is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: foo
+        port: 8081
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   policies:
     TrafficPolicy/default/header-modifiers-route-policy-1:
       ancestors:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -158,6 +158,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -169,6 +169,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -125,6 +125,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     infra/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit.yaml
@@ -130,6 +130,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/example-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
@@ -218,6 +218,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 5
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   grpcRoutes:
     default/example-grpc-route:
       parents:

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -212,6 +212,35 @@ Statuses:
         reason: Programmed
         status: "True"
         type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
   httpRoutes:
     default/test:
       parents:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Fixes #12142. Copying the issue's description here:


> Follow-up to https://github.com/kgateway-dev/kgateway/pull/12131. The newly added golden file status generation correctly captures top-level Gateway and XListenerSet conditions, but it's missing the detailed status information for individual listeners within those resources.
> 
> When a Gateway has multiple listeners (like http and https), the golden files should include status for each listener showing whether it's accepted, any conflicts, how many routes are attached, etc. Currently these listener details are completely missing from the test output files.
>
>This means our golden file tests aren't validating the full status picture that gets reported in real deployments, leaving a gap in test coverage for listener-level status reporting.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
