### PR TITLE
Inference: Bump to v1.0.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/gateway-api v1.3.0
-	sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.1
+	sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.2
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2379,8 +2379,8 @@ sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231019135941-15d7928
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231019135941-15d792835235/go.mod h1:TF/lVLWS+JNNaVqJuDDictY2hZSXSsIHCx4FClMvqFg=
 sigs.k8s.io/gateway-api v1.3.0 h1:q6okN+/UKDATola4JY7zXzx40WO4VISk7i9DIfOvr9M=
 sigs.k8s.io/gateway-api v1.3.0/go.mod h1:d8NV8nJbaRbEKem+5IuxkL8gJGOZ+FJ+NvOIltV8gDk=
-sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.1 h1:X9k0WffbxrQLZD0VLo1zXydc8B7lJ/2OChetfvGyzQQ=
-sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.1/go.mod h1:qxSY10qt2+YnZJ43VfpMXa6wpiENPderI2BnNZ4Kxfc=
+sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.2 h1:2rTHwWvI3FC5qvG9pvHq85PmaopjIZL/o7XIS2ZbvT4=
+sigs.k8s.io/gateway-api-inference-extension v1.0.0-rc.2/go.mod h1:qxSY10qt2+YnZJ43VfpMXa6wpiENPderI2BnNZ4Kxfc=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.27.0 h1:PQ3f0iAWNIj66LYkZ1ivhEg/+Zb6UPMbO+qVei/INZA=

--- a/hack/utils/oss_compliance/osa_provided.md
+++ b/hack/utils/oss_compliance/osa_provided.md
@@ -46,7 +46,7 @@ Name|Version|License
 [k8s.io/utils](https://k8s.io/utils)|v0.0.0-20250604170112-4c0f3b243397|Apache License 2.0
 [sigs.k8s.io/controller-runtime](https://sigs.k8s.io/controller-runtime)|v0.21.0|Apache License 2.0
 [sigs.k8s.io/gateway-api](https://sigs.k8s.io/gateway-api)|v1.3.0|Apache License 2.0
-[sigs.k8s.io/gateway-api-inference-extension](https://sigs.k8s.io/gateway-api-inference-extension)|v1.0.0-rc.1|Apache License 2.0
+[sigs.k8s.io/gateway-api-inference-extension](https://sigs.k8s.io/gateway-api-inference-extension)|v1.0.0-rc.2|Apache License 2.0
 [structured-merge-diff/v4](https://sigs.k8s.io/structured-merge-diff/v4)|v4.7.0|Apache License 2.0
 [sigs.k8s.io/yaml](https://sigs.k8s.io/yaml)|v1.6.0|MIT License
 [cmd/goimports](https://golang.org/x/tools/cmd/goimports)|latest|MIT License

--- a/internal/kgateway/crds/inference-crds.yaml
+++ b/internal/kgateway/crds/inference-crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    inference.networking.k8s.io/bundle-version: v1.0.0-rc.1
+    inference.networking.k8s.io/bundle-version: v1.0.0-rc.2
   creationTimestamp: null
   name: inferenceobjectives.inference.networking.x-k8s.io
 spec:
@@ -204,7 +204,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1173
-    inference.networking.k8s.io/bundle-version: v1.0.0-rc.1
+    inference.networking.k8s.io/bundle-version: v1.0.0-rc.2
   creationTimestamp: null
   name: inferencepools.inference.networking.k8s.io
 spec:
@@ -290,18 +290,33 @@ spec:
                     maxLength: 253
                     minLength: 1
                     type: string
-                  portNumber:
+                  port:
                     description: |-
-                      PortNumber is the port number of the Endpoint Picker extension service. When unspecified,
-                      implementations SHOULD infer a default value of 9002 when the kind field is "Service" or
-                      unspecified (defaults to "Service").
-                    format: int32
-                    maximum: 65535
-                    minimum: 1
-                    type: integer
+                      Port is the port of the Endpoint Picker extension service.
+
+                      Port is required when the referent is a Kubernetes Service. In this
+                      case, the port number is the service port number, not the target port.
+                      For other resources, destination port might be derived from the referent
+                      resource or this field.
+                    properties:
+                      number:
+                        description: |-
+                          Number defines the port number to access the selected model server Pods.
+                          The number must be in the range 1 to 65535.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    required:
+                    - number
+                    type: object
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: port is required when kind is 'Service' or unspecified
+                    (defaults to 'Service')
+                  rule: self.kind != 'Service' || has(self.port)
               selector:
                 description: |-
                   Selector determines which Pods are members of this inference pool.
@@ -525,7 +540,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, experimental-only
-    inference.networking.k8s.io/bundle-version: v1.0.0-rc.1
+    inference.networking.k8s.io/bundle-version: v1.0.0-rc.2
   creationTimestamp: null
   name: inferencepools.inference.networking.x-k8s.io
 spec:

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/backends_test.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/backends_test.go
@@ -48,6 +48,7 @@ func TestProcessPoolBackendObjIR_BuildsLoadAssignment(t *testing.T) {
 			TargetPorts: []inf.Port{inf.Port{Number: 9000}},
 			EndpointPickerRef: inf.EndpointPickerRef{
 				Name: "svc",
+				Port: &inf.Port{Number: inf.PortNumber(9002)},
 			},
 		},
 	}
@@ -109,6 +110,7 @@ func TestProcessPoolBackendObjIR_SkipsOnErrors(t *testing.T) {
 			TargetPorts: []inf.Port{inf.Port{Number: 9000}},
 			EndpointPickerRef: inf.EndpointPickerRef{
 				Name: "svc",
+				Port: &inf.Port{Number: inf.PortNumber(9002)},
 			},
 		},
 	}

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/ir.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/ir.go
@@ -16,11 +16,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
-const (
-	// grpcPort is the default port number for a gRPC service.
-	grpcPort = 9002
-)
-
 // inferencePool defines the internal representation of an inferencePool resource.
 type inferencePool struct {
 	// obj is the original object. Opaque to us other than metadata.
@@ -56,10 +51,9 @@ type targetPort struct {
 
 // newInferencePool returns the internal representation of the given pool.
 func newInferencePool(pool *inf.InferencePool) *inferencePool {
-	// Start with the default port and only override if non-zero.
-	port := servicePort{name: "grpc", portNum: int32(grpcPort)}
-	if pool.Spec.EndpointPickerRef.PortNumber != nil {
-		port.portNum = int32(*pool.Spec.EndpointPickerRef.PortNumber)
+	port := servicePort{
+		name:   "grpc",
+		number: int32(pool.Spec.EndpointPickerRef.Port.Number),
 	}
 
 	svcIR := &service{
@@ -246,8 +240,8 @@ type service struct {
 type servicePort struct {
 	// name is the name of the port.
 	name string
-	// portNum is the port number used to expose the service port.
-	portNum int32
+	// number is the port number used to expose the service port.
+	number int32
 }
 
 func (s service) ResourceName() string {

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/ir_test.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/ir_test.go
@@ -10,7 +10,6 @@ import (
 	"istio.io/istio/pkg/kube/krt/krttest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
@@ -30,8 +29,8 @@ func makePool(opts ...func(*inf.InferencePool)) *inferencePool {
 			},
 			TargetPorts: []inf.Port{{Number: 8080}},
 			EndpointPickerRef: inf.EndpointPickerRef{
-				Name:       "svc",
-				PortNumber: ptr.To(inf.PortNumber(1234)),
+				Name: "svc",
+				Port: &inf.Port{Number: inf.PortNumber(1234)},
 				FailureMode: func() inf.EndpointPickerFailureMode {
 					m := inf.EndpointPickerFailClose
 					return m
@@ -44,22 +43,6 @@ func makePool(opts ...func(*inf.InferencePool)) *inferencePool {
 		o(base)
 	}
 	return newInferencePool(base)
-}
-
-func TestNewInferencePool_DefaultAndOverridePort(t *testing.T) {
-	// Set the default grpcPort
-	p := makePool(func(pool *inf.InferencePool) {
-		pool.Spec.EndpointPickerRef.PortNumber = ptr.To(inf.PortNumber(grpcPort))
-	})
-
-	// We should have exactly one port (grpcPort 9002)
-	assert.Len(t, p.configRef.ports, 1)
-	assert.Equal(t, int32(grpcPort), p.configRef.ports[0].portNum)
-
-	// Now override the port number
-	q := makePool()
-	assert.Len(t, q.configRef.ports, 1)
-	assert.Equal(t, int32(1234), q.configRef.ports[0].portNum)
 }
 
 func TestIsFailOpen(t *testing.T) {

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/plugin.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/plugin.go
@@ -283,7 +283,7 @@ func (p *endpointPickerPass) HttpFilters(ctx context.Context, fc ir.FilterChainC
 		},
 		configRef: &service{
 			ObjectSource: ir.ObjectSource{Name: "placeholder-service"},
-			ports:        []servicePort{{name: "grpc", portNum: 9002}},
+			ports:        []servicePort{{name: "grpc", number: 9002}},
 		},
 	}
 
@@ -390,7 +390,7 @@ func buildExtProcCluster(pool *inferencePool) *envoyclusterv3.Cluster {
 										Address:  fmt.Sprintf("%s.%s.svc", pool.configRef.Name, pool.obj.GetNamespace()),
 										Protocol: envoycorev3.SocketAddress_TCP,
 										PortSpecifier: &envoycorev3.SocketAddress_PortValue{
-											PortValue: uint32(pool.configRef.ports[0].portNum),
+											PortValue: uint32(pool.configRef.ports[0].number),
 										},
 									},
 								},
@@ -443,6 +443,6 @@ func clusterNameExtProc(name, ns string) string {
 func authorityForPool(pool *inferencePool) string {
 	ns := pool.obj.GetNamespace()
 	svc := pool.configRef.Name
-	port := pool.configRef.ports[0].portNum
+	port := pool.configRef.ports[0].number
 	return fmt.Sprintf("%s.%s.svc:%d", svc, ns, port)
 }

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation.go
@@ -34,14 +34,16 @@ func validatePool(pool *inf.InferencePool, svcCol krt.Collection[*corev1.Service
 			fmt.Errorf("invalid InferencePool: must have exactly one target port"))
 	}
 
-	// PortNumber defaults to 9002 and must be 1-65535 (rfc1340 port range)
-	port := inf.PortNumber(grpcPort)
-	if ext.PortNumber != nil {
-		port = *ext.PortNumber
+	// PortNumber must be 1-65535 (rfc1340 port range)
+	if pool.Spec.EndpointPickerRef.Port == nil {
+		errs = append(errs,
+			fmt.Errorf("invalid extensionRef port must be specified"))
+		return errs
 	}
+	port := int32(pool.Spec.EndpointPickerRef.Port.Number)
 	if port < 1 || port > 65535 {
 		errs = append(errs,
-			fmt.Errorf("invalid extensionRef: PortNumber %d is out of range", port))
+			fmt.Errorf("invalid extensionRef port number %d is out of valid 1-65535 range", port))
 	}
 
 	svcNN := types.NamespacedName{Namespace: pool.Namespace, Name: string(ext.Name)}

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation.go
@@ -34,16 +34,11 @@ func validatePool(pool *inf.InferencePool, svcCol krt.Collection[*corev1.Service
 			fmt.Errorf("invalid InferencePool: must have exactly one target port"))
 	}
 
-	// PortNumber must be 1-65535 (rfc1340 port range)
+	// Port must be specified when kind is Service
 	if pool.Spec.EndpointPickerRef.Port == nil {
 		errs = append(errs,
 			fmt.Errorf("invalid extensionRef port must be specified"))
 		return errs
-	}
-	port := int32(pool.Spec.EndpointPickerRef.Port.Number)
-	if port < 1 || port > 65535 {
-		errs = append(errs,
-			fmt.Errorf("invalid extensionRef port number %d is out of valid 1-65535 range", port))
 	}
 
 	svcNN := types.NamespacedName{Namespace: pool.Namespace, Name: string(ext.Name)}
@@ -64,12 +59,13 @@ func validatePool(pool *inf.InferencePool, svcCol krt.Collection[*corev1.Service
 
 	// Service must expose the requested TCP port
 	found := false
+	eppPort := int32(pool.Spec.EndpointPickerRef.Port.Number)
 	for _, sp := range svc.Spec.Ports {
 		proto := sp.Protocol
 		if proto == "" {
 			proto = corev1.ProtocolTCP // default
 		}
-		if sp.Port == int32(port) && proto == corev1.ProtocolTCP {
+		if sp.Port == int32(eppPort) && proto == corev1.ProtocolTCP {
 			found = true
 			break
 		}
@@ -77,7 +73,7 @@ func validatePool(pool *inf.InferencePool, svcCol krt.Collection[*corev1.Service
 	if !found {
 		errs = append(errs,
 			fmt.Errorf("TCP port %d not found on Service %s/%s",
-				port, pool.Namespace, ext.Name))
+				eppPort, pool.Namespace, ext.Name))
 	}
 
 	return errs

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation_test.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation_test.go
@@ -53,15 +53,6 @@ func TestValidatePool(t *testing.T) {
 			wantErrs: 1,
 		},
 		{
-			name: "port number too small",
-			modifyPool: func(p *inf.InferencePool) {
-				p.Spec.EndpointPickerRef.Port.Number = inf.PortNumber(0)
-			},
-			// Service exposes port 0 as well, so only the range-error is produced
-			svc:      makeSvc(ns, svcName, 0, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP),
-			wantErrs: 1,
-		},
-		{
 			name: "service not found",
 			modifyPool: func(p *inf.InferencePool) {
 				p.Spec.EndpointPickerRef.Name = inf.ObjectName("missing-svc")

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation_test.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/validation_test.go
@@ -45,9 +45,17 @@ func TestValidatePool(t *testing.T) {
 			wantErrs: 1,
 		},
 		{
+			name: "port unspecified",
+			modifyPool: func(p *inf.InferencePool) {
+				p.Spec.EndpointPickerRef.Port = nil
+			},
+			svc:      nil,
+			wantErrs: 1,
+		},
+		{
 			name: "port number too small",
 			modifyPool: func(p *inf.InferencePool) {
-				p.Spec.EndpointPickerRef.PortNumber = ptr.To(inf.PortNumber(0))
+				p.Spec.EndpointPickerRef.Port.Number = inf.PortNumber(0)
 			},
 			// Service exposes port 0 as well, so only the range-error is produced
 			svc:      makeSvc(ns, svcName, 0, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP),
@@ -139,10 +147,10 @@ func makeBasePool(ns, svcName string) *inf.InferencePool {
 			},
 			TargetPorts: []inf.Port{{Number: 9002}},
 			EndpointPickerRef: inf.EndpointPickerRef{
-				Group:      ptr.To(inf.Group("")),
-				Kind:       inf.Kind(wellknown.ServiceKind),
-				Name:       inf.ObjectName(svcName),
-				PortNumber: ptr.To(inf.PortNumber(80)),
+				Group: ptr.To(inf.Group("")),
+				Kind:  inf.Kind(wellknown.ServiceKind),
+				Name:  inf.ObjectName(svcName),
+				Port:  &inf.Port{Number: inf.PortNumber(80)},
 			},
 		},
 	}

--- a/internal/kgateway/setup/testdata/agentgateway/inferencepool.yaml
+++ b/internal/kgateway/setup/testdata/agentgateway/inferencepool.yaml
@@ -59,7 +59,8 @@ spec:
     group: ""
     kind: Service
     name: gateway-pool-endpoint-picker
-    portNumber: 9002
+    port:
+      number: 9002
   selector:
     matchLabels:
       app: gateway

--- a/internal/kgateway/setup/testdata/inference_api/inferencepool-basic.yaml
+++ b/internal/kgateway/setup/testdata/inference_api/inferencepool-basic.yaml
@@ -59,7 +59,8 @@ spec:
     group: ""
     kind: Service
     name: gateway-pool-endpoint-picker
-    portNumber: 9002
+    port:
+      number: 9002
   selector:
     matchLabels:
       app: gateway

--- a/pkg/agentgateway/plugins/inference_plugin.go
+++ b/pkg/agentgateway/plugins/inference_plugin.go
@@ -6,7 +6,6 @@ import (
 	"github.com/agentgateway/agentgateway/go/api"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/ptr"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
@@ -55,7 +54,17 @@ func translatePoliciesForInferencePool(pool *inf.InferencePool, domainSuffix str
 		return nil
 	}
 
-	eppPort := ptr.OrDefault(epr.PortNumber, 9002)
+	if epr.Port == nil {
+		logger.Warn("inference pool extension ref port must be specified, skipping", "pool", pool.Name, "kind", epr.Kind)
+		return nil
+	}
+
+	if epr.Port.Number < 1 || epr.Port.Number > 65535 {
+		logger.Warn("inference pool extension ref port number must be 1-65535, skipping", "pool", pool.Name, "kind", epr.Kind)
+		return nil
+	}
+
+	eppPort := epr.Port.Number
 
 	eppSvc := fmt.Sprintf("%v/%v.%v.svc.%v",
 		pool.Namespace, epr.Name, pool.Namespace, domainSuffix)

--- a/pkg/agentgateway/plugins/inference_plugin.go
+++ b/pkg/agentgateway/plugins/inference_plugin.go
@@ -59,11 +59,6 @@ func translatePoliciesForInferencePool(pool *inf.InferencePool, domainSuffix str
 		return nil
 	}
 
-	if epr.Port.Number < 1 || epr.Port.Number > 65535 {
-		logger.Warn("inference pool extension ref port number must be 1-65535, skipping", "pool", pool.Name, "kind", epr.Kind)
-		return nil
-	}
-
 	eppPort := epr.Port.Number
 
 	eppSvc := fmt.Sprintf("%v/%v.%v.svc.%v",

--- a/test/kubernetes/e2e/features/inferenceextension/testdata/epp.yaml
+++ b/test/kubernetes/e2e/features/inferenceextension/testdata/epp.yaml
@@ -41,7 +41,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v1.0.0-rc.1
+        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v1.0.0-rc.2
         imagePullPolicy: Always
         args:
         - -pool-name

--- a/test/kubernetes/e2e/features/inferenceextension/testdata/pool.yaml
+++ b/test/kubernetes/e2e/features/inferenceextension/testdata/pool.yaml
@@ -12,4 +12,5 @@ spec:
   endpointPickerRef:
     failureMode: FailOpen
     name: vllm-llama3-8b-instruct-epp
-    portNumber: 9002
+    port:
+      number: 9002


### PR DESCRIPTION
# Description

Bumps InferencePool to v1.0.0-rc.2. In this version, `inferencePool.spec.endpointPickerRef.portNumber` field has been replaced with `inferencePool.spec.endpointPickerRef.port.number`. The `inferencePool.spec.endpointPickerRef.port` field is a non-pointer and required when `inferencePool.spec.endpointPickerRef.kind` is unset or "Service". The port number `9002` is no longer inferred.

# Change Type

```
/kind cleanup
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Bumps InferencePool to v1.0.0-rc.2. `inferencePool.spec.endpointPickerRef.portNumber` field has been replaced with `inferencePool.spec.endpointPickerRef.port.number`.
```

# Additional Notes

N/A
