### PR TITLE
feat(inference): Add test coverage for ListenerSet parentRefs

### DIFF
--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/status.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/status.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/client-go/util/retry"
 	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	// ADDED: Import for the XListenerSet API type
+	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/common"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
@@ -224,7 +226,10 @@ func isPoolBackend(be gwv1.HTTPBackendRef, poolNN types.NamespacedName) bool {
 
 // referencedGateways returns all Gateways that are parents of any non-deleted
 // HTTPRoute still pointing at the given pool.
+// MODIFIED: Signature and logic updated to support ListenerSet.
 func referencedGateways(
+	ctx context.Context,
+	commonCol *common.CommonCollections,
 	routes []ir.HttpRouteIR, poolNN types.NamespacedName,
 ) map[types.NamespacedName]struct{} {
 	gws := make(map[types.NamespacedName]struct{})
@@ -252,19 +257,10 @@ func referencedGateways(
 			continue
 		}
 
-		// Collect every Gateway parentRef on that route
+		// Collect every Gateway-like parentRef on that route (Gateway or ListenerSet)
+		// by calling the new helper function.
 		for _, pr := range rt.Spec.ParentRefs {
-			if pr.Group != nil && *pr.Group != gwv1.GroupName {
-				continue
-			}
-			if pr.Kind != nil && string(*pr.Kind) != wellknown.GatewayKind {
-				continue
-			}
-			ns := rt.Namespace
-			if pr.Namespace != nil {
-				ns = string(*pr.Namespace)
-			}
-			gws[types.NamespacedName{Namespace: ns, Name: string(pr.Name)}] = struct{}{}
+			addGatewaysFromParentRef(ctx, commonCol, rt.Namespace, pr, gws)
 		}
 	}
 	return gws
@@ -335,7 +331,8 @@ func updatePoolStatus(
 	}
 
 	// Compute the authoritative set of Gateways that still reference the pool
-	activeGws := referencedGateways(routes, poolNN)
+	// MODIFIED: Pass context and commonCol to the updated function.
+	activeGws := referencedGateways(ctx, commonCol, routes, poolNN)
 
 	// Merge any Gateways supplied by the caller (may be nil/no-op)
 	for g := range parentGws {
@@ -414,6 +411,68 @@ func updatePoolStatus(
 		})
 	if retryErr != nil {
 		logger.Error("failed to update InferencePool status", "pool", poolNN, "err", retryErr)
+	}
+}
+
+// ADDED: This entire helper function is new.
+// addGatewaysFromParentRef resolves a ParentReference on an HTTPRoute into concrete Gateway
+// names and adds them to the provided set. It supports:
+// - Kind: Gateway (group gateway.networking.k8s.io)
+// - Kind: ListenerSet or XListenerSet (group gateway.networking.k8s.io or gateway.networking.x-k8s.io)
+func addGatewaysFromParentRef(
+	ctx context.Context,
+	commonCol *common.CommonCollections,
+	routeNamespace string,
+	pr gwv1.ParentReference,
+	dest map[types.NamespacedName]struct{},
+) {
+	// Determine kind
+	kind := wellknown.GatewayKind
+	if pr.Kind != nil && *pr.Kind != "" {
+		kind = string(*pr.Kind)
+	}
+
+	// Determine group
+	group := gwv1.GroupName
+	if pr.Group != nil && *pr.Group != "" {
+		group = string(*pr.Group)
+	}
+
+	// Determine namespace defaulting to the HTTPRoute's namespace
+	ns := routeNamespace
+	if pr.Namespace != nil && *pr.Namespace != "" {
+		ns = string(*pr.Namespace)
+	}
+
+	switch kind {
+	case wellknown.GatewayKind:
+		if group != gwv1.GroupName {
+			return
+		}
+		dest[types.NamespacedName{Namespace: ns, Name: string(pr.Name)}] = struct{}{}
+		return
+	case wellknown.ListenerSetKind, wellknown.XListenerSetKind:
+		// Support both stable "ListenerSet" and experimental "XListenerSet" kinds
+		if group != gwv1.GroupName && group != wellknown.XListenerSetGroup {
+			return
+		}
+		// Resolve the XListenerSet object to find its parent Gateway
+		lsNN := types.NamespacedName{Namespace: ns, Name: string(pr.Name)}
+		var ls gwxv1a1.XListenerSet
+		if err := commonCol.CrudClient.Get(ctx, lsNN, &ls); err != nil {
+			// If the LS cannot be fetched, skip silently to avoid blocking status updates
+			logger.Error("failed to get XListenerSet for ParentRef", "listenerset", lsNN, "err", err)
+			return
+		}
+		// Extract parent gateway from the ListenerSet spec
+		pns := ls.Namespace
+		if ls.Spec.ParentRef.Namespace != nil && *ls.Spec.ParentRef.Namespace != "" {
+			pns = string(*ls.Spec.ParentRef.Namespace)
+		}
+		dest[types.NamespacedName{Namespace: pns, Name: string(ls.Spec.ParentRef.Name)}] = struct{}{}
+		return
+	default:
+		return
 	}
 }
 

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/status_test.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/status_test.go
@@ -21,6 +21,9 @@ import (
 	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	// ADDED: Import for ListenerSet types.
+	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
+
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/common"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
@@ -34,6 +37,8 @@ func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
 	require.NoError(t, corev1.AddToScheme(sch))
 	require.NoError(t, inf.AddToScheme(sch))
 	require.NoError(t, gwv1.Install(sch))
+	// ADDED: Register ListenerSet with the scheme for the fake client.
+	require.NoError(t, gwxv1a1.Install(sch))
 
 	// Create a fake client with the provided objects
 	b := fakeclient.NewClientBuilder().WithScheme(sch)
@@ -500,125 +505,346 @@ func TestUpdatePoolStatus_WithExtraGws(t *testing.T) {
 	}, updated.Status.Parents[0].ParentRef)
 }
 
+// REPLACED: This test is now table-driven and includes ListenerSet cases to fix the compiler error.
 func TestReferencedGateways(t *testing.T) {
-	// Set up the test with a namespace, pool name, and two gateways in different namespaces
 	ns := "default"
 	poolNN := types.NamespacedName{Namespace: ns, Name: "my-pool"}
-	gw1 := types.NamespacedName{Namespace: ns, Name: "gw1"}
-	gw2 := types.NamespacedName{Namespace: "other", Name: "gw2"}
 
-	// Create two gateways with different namespaces
-	route1 := ir.HttpRouteIR{
-		SourceObject: &gwv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns,
-			},
-			Spec: gwv1.HTTPRouteSpec{
-				CommonRouteSpec: gwv1.CommonRouteSpec{
-					ParentRefs: []gwv1.ParentReference{
-						{
-							Group: ptr.To(gwv1.Group(gwv1.GroupName)),
-							Kind:  ptr.To(gwv1.Kind(wellknown.GatewayKind)),
-							Name:  gwv1.ObjectName(gw1.Name),
-						},
-						{
-							Group:     ptr.To(gwv1.Group(gwv1.GroupName)),
-							Kind:      ptr.To(gwv1.Kind(wellknown.GatewayKind)),
-							Namespace: ptr.To(gwv1.Namespace(gw2.Namespace)),
-							Name:      gwv1.ObjectName(gw2.Name),
-						},
-					},
-				},
-				Rules: []gwv1.HTTPRouteRule{
-					{
-						BackendRefs: []gwv1.HTTPBackendRef{
-							{
-								BackendRef: gwv1.BackendRef{
-									BackendObjectReference: gwv1.BackendObjectReference{
-										Group: ptr.To(gwv1.Group(inf.GroupVersion.Group)),
-										Kind:  ptr.To(gwv1.Kind(wellknown.InferencePoolKind)),
-										Name:  gwv1.ObjectName(poolNN.Name),
-									},
-								},
-							},
-						},
-					},
-				},
+	// Common backend ref for all routes
+	backendRef := gwv1.HTTPBackendRef{
+		BackendRef: gwv1.BackendRef{
+			BackendObjectReference: gwv1.BackendObjectReference{
+				Group: ptr.To(gwv1.Group(inf.GroupVersion.Group)),
+				Kind:  ptr.To(gwv1.Kind(wellknown.InferencePoolKind)),
+				Name:  gwv1.ObjectName(poolNN.Name),
 			},
 		},
 	}
-	route2 := ir.HttpRouteIR{
-		SourceObject: &gwv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:         ns,
-				DeletionTimestamp: ptr.To(metav1.Now()),
-			},
-			Spec: gwv1.HTTPRouteSpec{
-				CommonRouteSpec: gwv1.CommonRouteSpec{
-					ParentRefs: []gwv1.ParentReference{
-						{
-							Group: ptr.To(gwv1.Group(gwv1.GroupName)),
-							Kind:  ptr.To(gwv1.Kind(wellknown.GatewayKind)),
-							Name:  gwv1.ObjectName("deleted-gw"),
+
+	// Test cases
+	tests := []struct {
+		name         string
+		routes       []ir.HttpRouteIR
+		extraObjects []client.Object
+		expected     map[types.NamespacedName]struct{}
+	}{
+		{
+			name:     "no routes",
+			expected: map[types.NamespacedName]struct{}{},
+		},
+		{
+			name: "with standard gateway parent refs",
+			routes: []ir.HttpRouteIR{
+				{
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{
+								ParentRefs: []gwv1.ParentReference{
+									{Name: "gw1"}, // Same namespace
+									{Name: "gw2", Namespace: ptr.To(gwv1.Namespace("other"))},
+								},
+							},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
 						},
 					},
 				},
-				Rules: []gwv1.HTTPRouteRule{
-					{
-						BackendRefs: []gwv1.HTTPBackendRef{
-							{
-								BackendRef: gwv1.BackendRef{
-									BackendObjectReference: gwv1.BackendObjectReference{
-										Group: ptr.To(gwv1.Group(inf.GroupVersion.Group)),
-										Kind:  ptr.To(gwv1.Kind(wellknown.InferencePoolKind)),
-										Name:  gwv1.ObjectName(poolNN.Name),
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: ns, Name: "gw1"}:      {},
+				{Namespace: "other", Name: "gw2"}: {},
+			},
+		},
+		{
+			name: "ignores deleted routes and routes for other backends",
+			routes: []ir.HttpRouteIR{
+				{ // This route should be processed
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw1"}}},
+							Rules:           []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
+						},
+					},
+				},
+				{ // This route is being deleted
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns, DeletionTimestamp: ptr.To(metav1.Now())},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "deleted-gw"}}},
+							Rules:           []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
+						},
+					},
+				},
+				{ // This route points to a different backend
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "unrelated-gw"}}},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{
+								{BackendRef: gwv1.BackendRef{BackendObjectReference: gwv1.BackendObjectReference{Name: "some-other-service"}}},
+							}}},
+						},
+					},
+				},
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: ns, Name: "gw1"}: {},
+			},
+		},
+		{
+			name: "with XListenerSet parent",
+			routes: []ir.HttpRouteIR{
+				{
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{
+								ParentRefs: []gwv1.ParentReference{
+									{
+										Group: ptr.To(gwv1.Group(wellknown.XListenerSetGroup)),
+										Kind:  ptr.To(gwv1.Kind(wellknown.XListenerSetKind)),
+										Name:  "xls-1",
 									},
 								},
 							},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
 						},
 					},
 				},
+			},
+			extraObjects: []client.Object{
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "xls-1"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{
+							Name: "parent-gw-from-xls",
+						},
+					},
+				},
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: ns, Name: "parent-gw-from-xls"}: {},
 			},
 		},
-	}
-	route3 := ir.HttpRouteIR{
-		SourceObject: &gwv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: ns,
-			},
-			Spec: gwv1.HTTPRouteSpec{
-				CommonRouteSpec: gwv1.CommonRouteSpec{
-					ParentRefs: []gwv1.ParentReference{
-						{
-							Group: ptr.To(gwv1.Group(gwv1.GroupName)),
-							Kind:  ptr.To(gwv1.Kind(wellknown.GatewayKind)),
-							Name:  gwv1.ObjectName("unrelated-gw"),
-						},
-					},
-				},
-				Rules: []gwv1.HTTPRouteRule{
-					{
-						BackendRefs: []gwv1.HTTPBackendRef{
-							{
-								BackendRef: gwv1.BackendRef{
-									BackendObjectReference: gwv1.BackendObjectReference{
+		{
+			name: "with ListenerSet parent",
+			routes: []ir.HttpRouteIR{
+				{
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{
+								ParentRefs: []gwv1.ParentReference{
+									{
 										Group: ptr.To(gwv1.Group(gwv1.GroupName)),
-										Kind:  ptr.To(gwv1.Kind(wellknown.ServiceKind)),
-										Name:  gwv1.ObjectName("unrelated"),
+										Kind:  ptr.To(gwv1.Kind(wellknown.ListenerSetKind)),
+										Name:  "ls-1",
 									},
 								},
 							},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
 						},
 					},
 				},
 			},
+			extraObjects: []client.Object{
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "ls-1"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{
+							Name:      "parent-gw-from-ls",
+							Namespace: ptr.To(gwxv1a1.Namespace("other-ns")),
+						},
+					},
+				},
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: "other-ns", Name: "parent-gw-from-ls"}: {},
+			},
+		},
+		{
+			name: "with mixed GW, LS, and xLS parents",
+			routes: []ir.HttpRouteIR{
+				{
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{
+								ParentRefs: []gwv1.ParentReference{
+									{Name: "direct-gw"}, // Direct Gateway
+									{ // ListenerSet
+										Group: ptr.To(gwv1.Group(gwv1.GroupName)),
+										Kind:  ptr.To(gwv1.Kind(wellknown.ListenerSetKind)),
+										Name:  "ls-2",
+									},
+									{ // XListenerSet
+										Group: ptr.To(gwv1.Group(wellknown.XListenerSetGroup)),
+										Kind:  ptr.To(gwv1.Kind(wellknown.XListenerSetKind)),
+										Name:  "xls-2",
+									},
+								},
+							},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
+						},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "ls-2"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{Name: "parent-from-ls"},
+					},
+				},
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "xls-2"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{Name: "parent-from-xls"},
+					},
+				},
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: ns, Name: "direct-gw"}:       {},
+				{Namespace: ns, Name: "parent-from-ls"}:  {},
+				{Namespace: ns, Name: "parent-from-xls"}: {},
+			},
+		},
+		{
+			name: "with XListenerSet parent only",
+			routes: []ir.HttpRouteIR{
+				{
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{
+								ParentRefs: []gwv1.ParentReference{
+									{
+										Group: ptr.To(gwv1.Group(wellknown.XListenerSetGroup)),
+										Kind:  ptr.To(gwv1.Kind(wellknown.XListenerSetKind)),
+										Name:  "xls-only",
+									},
+								},
+							},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
+						},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "xls-only"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{
+							Name:      "xls-parent-gw",
+							Namespace: ptr.To(gwxv1a1.Namespace("xls-gw-ns")),
+						},
+					},
+				},
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: "xls-gw-ns", Name: "xls-parent-gw"}: {},
+			},
+		},
+		{
+			name: "with ListenerSet parent only",
+			routes: []ir.HttpRouteIR{
+				{
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{
+								ParentRefs: []gwv1.ParentReference{
+									{
+										Group: ptr.To(gwv1.Group(gwv1.GroupName)),
+										Kind:  ptr.To(gwv1.Kind(wellknown.ListenerSetKind)),
+										Name:  "ls-only",
+									},
+								},
+							},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
+						},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "ls-only"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{
+							Name: "ls-parent-gw",
+						},
+					},
+				},
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: ns, Name: "ls-parent-gw"}: {},
+			},
+		},
+		{
+			name: "with complex mixed parentRefs (GW + xLS + LS)",
+			routes: []ir.HttpRouteIR{
+				{
+					SourceObject: &gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{Namespace: ns},
+						Spec: gwv1.HTTPRouteSpec{
+							CommonRouteSpec: gwv1.CommonRouteSpec{
+								ParentRefs: []gwv1.ParentReference{
+									{Name: "direct-gateway"}, // Direct Gateway
+									{ // XListenerSet
+										Group: ptr.To(gwv1.Group(wellknown.XListenerSetGroup)),
+										Kind:  ptr.To(gwv1.Kind(wellknown.XListenerSetKind)),
+										Name:  "complex-xls",
+									},
+									{ // ListenerSet
+										Group: ptr.To(gwv1.Group(gwv1.GroupName)),
+										Kind:  ptr.To(gwv1.Kind(wellknown.ListenerSetKind)),
+										Name:  "complex-ls",
+									},
+								},
+							},
+							Rules: []gwv1.HTTPRouteRule{{BackendRefs: []gwv1.HTTPBackendRef{backendRef}}},
+						},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "complex-xls"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{
+							Name:      "xls-complex-parent",
+							Namespace: ptr.To(gwxv1a1.Namespace("complex-ns")),
+						},
+					},
+				},
+				&gwxv1a1.XListenerSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "complex-ls"},
+					Spec: gwxv1a1.ListenerSetSpec{
+						ParentRef: gwxv1a1.ParentGatewayReference{
+							Name: "ls-complex-parent",
+						},
+					},
+				},
+			},
+			expected: map[types.NamespacedName]struct{}{
+				{Namespace: ns, Name: "direct-gateway"}:               {},
+				{Namespace: "complex-ns", Name: "xls-complex-parent"}: {},
+				{Namespace: ns, Name: "ls-complex-parent"}:            {},
+			},
 		},
 	}
-	gws := referencedGateways([]ir.HttpRouteIR{route1, route2, route3}, poolNN)
-	assert.Equal(t, map[types.NamespacedName]struct{}{
-		gw1: {},
-		gw2: {},
-	}, gws)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := newFakeClient(t, tt.extraObjects...)
+			commonCol := &common.CommonCollections{
+				CrudClient: fakeClient,
+			}
+			gws := referencedGateways(context.Background(), commonCol, tt.routes, poolNN)
+			assert.Equal(t, tt.expected, gws)
+		})
+	}
 }
 
 func TestIsPoolBackend(t *testing.T) {

--- a/internal/kgateway/wellknown/gwapi.go
+++ b/internal/kgateway/wellknown/gwapi.go
@@ -28,6 +28,9 @@ const (
 	ReferenceGrantKind   = "ReferenceGrant"
 	BackendTLSPolicyKind = "BackendTLSPolicy"
 
+	// Kind string for ListenerSet resource
+    ListenerSetKind      = "ListenerSet"
+	
 	// Kind string for XListenerSet resource
 	XListenerSetKind = "XListenerSet"
 

--- a/test/kubernetes/e2e/features/inferenceextension/testdata/listenerset.yaml
+++ b/test/kubernetes/e2e/features/inferenceextension/testdata/listenerset.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+kind: ListenerSet
+metadata:
+  name: inference-listenerset
+  namespace: inf-ext-e2e
+spec:
+  parentRef:
+    name: inference-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io

--- a/test/kubernetes/e2e/features/inferenceextension/testdata/route-listenerset.yaml
+++ b/test/kubernetes/e2e/features/inferenceextension/testdata/route-listenerset.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route-listenerset
+  namespace: inf-ext-e2e
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: inference-listenerset
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-llama3-8b-instruct
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s

--- a/test/kubernetes/e2e/features/inferenceextension/testdata/route-mixed-parents.yaml
+++ b/test/kubernetes/e2e/features/inferenceextension/testdata/route-mixed-parents.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route-mixed-parents
+  namespace: inf-ext-e2e
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: inference-listenerset
+    - group: gateway.networking.x-k8s.io
+      kind: XListenerSet
+      name: inference-xlistenerset
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-llama3-8b-instruct
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s

--- a/test/kubernetes/e2e/features/inferenceextension/testdata/route-xlistenerset.yaml
+++ b/test/kubernetes/e2e/features/inferenceextension/testdata/route-xlistenerset.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route-xlistenerset
+  namespace: inf-ext-e2e
+spec:
+  parentRefs:
+    - group: gateway.networking.x-k8s.io
+      kind: XListenerSet
+      name: inference-xlistenerset
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-llama3-8b-instruct
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        request: 300s

--- a/test/kubernetes/e2e/features/inferenceextension/testdata/xlistenerset.yaml
+++ b/test/kubernetes/e2e/features/inferenceextension/testdata/xlistenerset.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.x-k8s.io/v1alpha1
+kind: XListenerSet
+metadata:
+  name: inference-xlistenerset
+  namespace: inf-ext-e2e
+spec:
+  parentRef:
+    name: inference-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io

--- a/test/kubernetes/e2e/features/inferenceextension/types.go
+++ b/test/kubernetes/e2e/features/inferenceextension/types.go
@@ -44,6 +44,21 @@ var (
 	// clientManifest is the manifest for the curl client
 	//go:embed testdata/curl_pod.yaml
 	clientManifest []byte
+	// listenersetManifest is the manifest for the ListenerSet resource
+	//go:embed testdata/listenerset.yaml
+	listenersetManifest []byte
+	// xlistenersetManifest is the manifest for the XListenerSet resource
+	//go:embed testdata/xlistenerset.yaml
+	xlistenersetManifest []byte
+	// routeListenerSetManifest is the manifest for the HTTPRoute with ListenerSet parentRef
+	//go:embed testdata/route-listenerset.yaml
+	routeListenerSetManifest []byte
+	// routeXListenerSetManifest is the manifest for the HTTPRoute with XListenerSet parentRef
+	//go:embed testdata/route-xlistenerset.yaml
+	routeXListenerSetManifest []byte
+	// routeMixedParentsManifest is the manifest for the HTTPRoute with mixed parentRefs
+	//go:embed testdata/route-mixed-parents.yaml
+	routeMixedParentsManifest []byte
 
 	// The Gateway resources created by kgateway
 	gtwObjectMeta = metav1.ObjectMeta{


### PR DESCRIPTION
# Description

Enhances the inference endpointpickers’ HTTPRoute status reporting to handle ParentRefs to ListenerSet resources, reflecting recent Gateway API extensions.

## What changed:

- When an HTTPRoute references a ListenerSet in its parentRefs, we now resolve the ListenerSet’s spec.parentRef to determine its parent Gateway(s) and treat those as parents of the route for status purposes.
- Updated referencedGateways(...) logic and added an explicit Gateway/ListenerSet resolver helper.
- No changes to fast-path parentGateways(...) (still Gateway-only).
- Imports XListenerSet CRD from the extended API group.

Fixes: #11719

# Change Type
```
/kind new_feature
```

# Changelog
```release-note
Status logic for inference extension now supports HTTPRoute ParentRefs to ListenerSet resources, resolving them to their parent Gateways for accurate status reporting.
```

# Additional Notes
- Only ListenerSets with valid Gateway parentRefs are supported.
- Existing Gateway-only flows are unchanged and remain fast.
- Non-E2E unit tests pass; consider adding E2E coverage for complex ListenerSet-parented route scenarios.
