### PR TITLE
More descriptive error message about unexpected port in backendref

### DIFF
--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -39,7 +39,6 @@ var (
 	ErrMissingReferenceGrant = errors.New("missing reference grant")
 	ErrUnknownBackendKind    = errors.New("unknown backend kind")
 	ErrPolicyNotFound        = errors.New("policy not found")
-	ErrBackendPortNotAllowed = errors.New("do not specify a port when referencing a Backend resource, as it defines its own")
 )
 
 type NotFoundError struct {
@@ -49,6 +48,14 @@ type NotFoundError struct {
 
 func (n *NotFoundError) Error() string {
 	return fmt.Sprintf("%s \"%s\" not found", n.NotFoundObj.Kind, n.NotFoundObj.Name)
+}
+
+type BackendPortNotAllowedError struct {
+	BackendName string
+}
+
+func (e *BackendPortNotAllowedError) Error() string {
+	return fmt.Sprintf("BackendRef to \"%s\" includes a port. Do not specify a port when referencing a Backend resource, as it defines its own port configuration", e.BackendName)
 }
 
 // MARK: BackendIndex
@@ -164,7 +171,7 @@ func (i *BackendIndex) getBackend(kctx krt.HandlerContext, gk schema.GroupKind, 
 
 	// Check if this is a Backend reference and validate that it doesn't specify a port
 	if gk.Group == wellknown.BackendGVK.Group && gk.Kind == wellknown.BackendGVK.Kind && gwport != nil {
-		return nil, fmt.Errorf("%s \"%s\": %w", key.Kind, key.Name, ErrBackendPortNotAllowed)
+		return nil, &BackendPortNotAllowedError{BackendName: key.Name}
 	}
 
 	var port int32

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -39,7 +39,7 @@ var (
 	ErrMissingReferenceGrant = errors.New("missing reference grant")
 	ErrUnknownBackendKind    = errors.New("unknown backend kind")
 	ErrPolicyNotFound        = errors.New("policy not found")
-	ErrBackendPortNotAllowed = errors.New("backend reference should not specify a port")
+	ErrBackendPortNotAllowed = errors.New("do not specify a port when referencing a Backend resource, as it defines its own")
 )
 
 type NotFoundError struct {

--- a/internal/kgateway/krtcollections/policy.go
+++ b/internal/kgateway/krtcollections/policy.go
@@ -39,6 +39,7 @@ var (
 	ErrMissingReferenceGrant = errors.New("missing reference grant")
 	ErrUnknownBackendKind    = errors.New("unknown backend kind")
 	ErrPolicyNotFound        = errors.New("policy not found")
+	ErrBackendPortNotAllowed = errors.New("backend reference should not specify a port")
 )
 
 type NotFoundError struct {
@@ -159,6 +160,11 @@ func (i *BackendIndex) getBackend(kctx krt.HandlerContext, gk schema.GroupKind, 
 		Kind:      gk.Kind,
 		Namespace: n.Namespace,
 		Name:      n.Name,
+	}
+
+	// Check if this is a Backend reference and validate that it doesn't specify a port
+	if gk.Group == wellknown.BackendGVK.Group && gk.Kind == wellknown.BackendGVK.Kind && gwport != nil {
+		return nil, fmt.Errorf("%s \"%s\": %w", key.Kind, key.Name, ErrBackendPortNotAllowed)
 	}
 
 	var port int32

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -475,7 +475,7 @@ func TestBackendPortNotAllowed(t *testing.T) {
 			b := getBackends(ir)[0]
 
 			require.Error(t, b.Err)
-			assert.Contains(t, b.Err.Error(), "backend reference should not specify a port")
+			assert.Contains(t, b.Err.Error(), ErrBackendPortNotAllowed.Error())
 			assert.Contains(t, b.Err.Error(), "test-backend")
 		})
 	}

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -475,8 +475,7 @@ func TestBackendPortNotAllowed(t *testing.T) {
 			b := getBackends(ir)[0]
 
 			require.Error(t, b.Err)
-			assert.Contains(t, b.Err.Error(), ErrBackendPortNotAllowed.Error())
-			assert.Contains(t, b.Err.Error(), "test-backend")
+			assert.Contains(t, b.Err.Error(), (&BackendPortNotAllowedError{BackendName: "test-backend"}).Error())
 		})
 	}
 }

--- a/internal/kgateway/krtcollections/policy_test.go
+++ b/internal/kgateway/krtcollections/policy_test.go
@@ -40,6 +40,10 @@ var (
 		Group: inf.GroupVersion.Group,
 		Kind:  wellknown.InferencePoolKind,
 	}
+	backendGk = schema.GroupKind{
+		Group: wellknown.BackendGVK.Group,
+		Kind:  wellknown.BackendGVK.Kind,
+	}
 )
 
 func backends(refN, refNs string) []any {
@@ -425,6 +429,58 @@ func TestInferencePoolPortOverride(t *testing.T) {
 	}
 }
 
+func TestBackendPortNotAllowed(t *testing.T) {
+	cases := []struct {
+		name        string
+		backendNs   string
+		refGrant    *gwv1beta1.ReferenceGrant
+		expectError bool
+	}{
+		{
+			name:        "same namespace with port",
+			backendNs:   "",
+			refGrant:    nil,
+			expectError: true,
+		},
+		{
+			name:        "cross namespace with port and ref grant",
+			backendNs:   "default2",
+			refGrant:    refGrantWithBackend(),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Determine the actual namespace for the backend
+			backendNs := tc.backendNs
+			if backendNs == "" {
+				backendNs = "default"
+			}
+
+			inputs := []any{
+				backend(backendNs),
+			}
+			if tc.refGrant != nil {
+				inputs = append(inputs, tc.refGrant)
+			}
+
+			// Create HTTPRoute with Backend reference with port (this should always fail)
+			portVal := gwv1.PortNumber(8080)
+			route := httpRouteWithBackendRef("test-backend", tc.backendNs, &portVal)
+			inputs = append(inputs, route)
+
+			ir := translateRoute(t, inputs)
+			require.NotNil(t, ir)
+			b := getBackends(ir)[0]
+
+			require.Error(t, b.Err)
+			assert.Contains(t, b.Err.Error(), "backend reference should not specify a port")
+			assert.Contains(t, b.Err.Error(), "test-backend")
+		})
+	}
+}
+
 // Helper to build a Namespace pointer, or nil if empty
 func ptrToNamespace(ns string) *gwv1.Namespace {
 	if ns == "" {
@@ -520,6 +576,89 @@ func refGrantWithNs(ns string) *gwv1beta1.ReferenceGrant {
 	return rg
 }
 
+// Helper that creates a ReferenceGrant for Backend resources
+func refGrantWithBackend() *gwv1beta1.ReferenceGrant {
+	return &gwv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default2",
+			Name:      "backend-ref-grant",
+		},
+		Spec: gwv1beta1.ReferenceGrantSpec{
+			From: []gwv1beta1.ReferenceGrantFrom{
+				{
+					Group:     gwv1.Group("gateway.networking.k8s.io"),
+					Kind:      gwv1.Kind("HTTPRoute"),
+					Namespace: gwv1.Namespace("default"),
+				},
+			},
+			To: []gwv1beta1.ReferenceGrantTo{
+				{
+					Group: gwv1.Group(wellknown.BackendGVK.Group),
+					Kind:  gwv1.Kind(wellknown.BackendGVK.Kind),
+				},
+			},
+		},
+	}
+}
+
+// Helper that creates a Backend resource
+func backend(ns string) *v1alpha1.Backend {
+	if ns == "" {
+		ns = "default"
+	}
+	return &v1alpha1.Backend{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backend",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.BackendSpec{
+			Type: v1alpha1.BackendTypeStatic,
+			Static: &v1alpha1.StaticBackend{
+				Hosts: []v1alpha1.Host{
+					{
+						Host: "1.2.3.4",
+						Port: gwv1.PortNumber(8080),
+					},
+				},
+			},
+		},
+	}
+}
+
+// Helper that creates an HTTPRoute with a Backend reference
+func httpRouteWithBackendRef(refN, refNs string, port *gwv1.PortNumber) *gwv1.HTTPRoute {
+	var ns *gwv1.Namespace
+	if refNs != "" {
+		n := gwv1.Namespace(refNs)
+		ns = &n
+	}
+	return &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httproute",
+			Namespace: "default",
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			Rules: []gwv1.HTTPRouteRule{
+				{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{
+							BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Group:     ptr.To(gwv1.Group(wellknown.BackendGVK.Group)),
+									Kind:      ptr.To(gwv1.Kind(wellknown.BackendGVK.Kind)),
+									Name:      gwv1.ObjectName(refN),
+									Namespace: ns,
+									Port:      port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func k8sSvcUpstreams(services krt.Collection[*corev1.Service]) krt.Collection[ir.BackendObjectIR] {
 	return krt.NewManyCollection(services, func(kctx krt.HandlerContext, svc *corev1.Service) []ir.BackendObjectIR {
 		uss := []ir.BackendObjectIR{}
@@ -551,6 +690,26 @@ func infPoolUpstreams(poolCol krt.Collection[*inf.InferencePool]) krt.Collection
 		backend.GvPrefix = "endpoint-picker"
 		backend.CanonicalHostname = ""
 		return &backend
+	})
+}
+
+func backendUpstreams(backendCol krt.Collection[*v1alpha1.Backend]) krt.Collection[ir.BackendObjectIR] {
+	return krt.NewCollection(backendCol, func(kctx krt.HandlerContext, backend *v1alpha1.Backend) *ir.BackendObjectIR {
+		// Create a BackendObjectIR IR representation from the given Backend.
+		// For static backends, use the port from the first host
+		var port int32 = 8080 // default port
+		if backend.Spec.Static != nil && len(backend.Spec.Static.Hosts) > 0 {
+			port = int32(backend.Spec.Static.Hosts[0].Port)
+		}
+
+		backendIR := ir.NewBackendObjectIR(ir.ObjectSource{
+			Kind:      backendGk.Kind,
+			Group:     backendGk.Group,
+			Namespace: backend.Namespace,
+			Name:      backend.Name,
+		}, port, "")
+		backendIR.Obj = backend
+		return &backendIR
 	})
 }
 
@@ -699,6 +858,8 @@ func preRouteIndex(t test.Failer, inputs []any) *RoutesIndex {
 	upstreams.AddBackends(svcGk, k8sSvcUpstreams(services))
 	pools := krttest.GetMockCollection[*inf.InferencePool](mock)
 	upstreams.AddBackends(infPoolGk, infPoolUpstreams(pools))
+	backends := krttest.GetMockCollection[*v1alpha1.Backend](mock)
+	upstreams.AddBackends(backendGk, backendUpstreams(backends))
 
 	httproutes := krttest.GetMockCollection[*gwv1.HTTPRoute](mock)
 	tcpproutes := krttest.GetMockCollection[*gwv1a2.TCPRoute](mock)

--- a/internal/kgateway/query/utils.go
+++ b/internal/kgateway/query/utils.go
@@ -20,7 +20,7 @@ func ProcessBackendError(err error, reporter reports.ParentRefReporter) {
 			Reason:  gwv1.RouteReasonInvalidKind,
 			Message: err.Error(),
 		})
-	case errors.Is(err, krtcollections.ErrBackendPortNotAllowed):
+	case errors.Is(err, &krtcollections.BackendPortNotAllowedError{}):
 		reporter.SetCondition(reports.RouteCondition{
 			Type:    gwv1.RouteConditionResolvedRefs,
 			Status:  metav1.ConditionFalse,

--- a/internal/kgateway/query/utils.go
+++ b/internal/kgateway/query/utils.go
@@ -20,6 +20,13 @@ func ProcessBackendError(err error, reporter reports.ParentRefReporter) {
 			Reason:  gwv1.RouteReasonInvalidKind,
 			Message: err.Error(),
 		})
+	case errors.Is(err, krtcollections.ErrBackendPortNotAllowed):
+		reporter.SetCondition(reports.RouteCondition{
+			Type:    gwv1.RouteConditionResolvedRefs,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.RouteReasonBackendNotFound,
+			Message: err.Error(),
+		})
 	case errors.Is(err, krtcollections.ErrMissingReferenceGrant):
 		reporter.SetCondition(reports.RouteCondition{
 			Type:    gwv1.RouteConditionResolvedRefs,

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -288,7 +288,7 @@ func TestBasic(t *testing.T) {
 				a.NotNil(resolvedRefs)
 				a.Equal(string(gwv1.RouteReasonBackendNotFound), resolvedRefs.Reason)
 				a.Equal(metav1.ConditionFalse, resolvedRefs.Status)
-				a.Equal(`Backend "example-backend": `+krtcollections.ErrBackendPortNotAllowed.Error(), resolvedRefs.Message)
+				a.Equal((&krtcollections.BackendPortNotAllowedError{BackendName: "example-backend"}).Error(), resolvedRefs.Message)
 				a.Equal(int64(0), resolvedRefs.ObservedGeneration)
 			},
 		})

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -15,6 +15,7 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
@@ -259,6 +260,35 @@ func TestBasic(t *testing.T) {
 				a.Equal(string(gwv1.RouteReasonInvalidKind), resolvedRefs.Reason)
 				a.Equal(metav1.ConditionFalse, resolvedRefs.Status)
 				a.Equal(`unknown backend kind`, resolvedRefs.Message)
+				a.Equal(int64(0), resolvedRefs.ObservedGeneration)
+			},
+		})
+	})
+
+	t.Run("httproute with backend port error reports correctly", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backends/backend-ref-port-error.yaml",
+			outputFile: "backends/backend-ref-port-error.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+			assertReports: func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+				a := assert.New(t)
+				route := &gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-route",
+						Namespace: "default",
+					},
+				}
+				routeStatus := reportsMap.BuildRouteStatus(context.Background(), route, wellknown.DefaultGatewayClassName)
+				a.NotNil(routeStatus)
+				a.Len(routeStatus.Parents, 1)
+				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
+				a.NotNil(resolvedRefs)
+				a.Equal(string(gwv1.RouteReasonBackendNotFound), resolvedRefs.Reason)
+				a.Equal(metav1.ConditionFalse, resolvedRefs.Status)
+				a.Equal(`Backend "example-backend": `+krtcollections.ErrBackendPortNotAllowed.Error(), resolvedRefs.Message)
 				a.Equal(int64(0), resolvedRefs.ObservedGeneration)
 			},
 		})

--- a/internal/kgateway/translator/gateway/testutils/inputs/backends/backend-ref-port-error.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/backends/backend-ref-port-error.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-backend
+      kind: Backend
+      group: gateway.kgateway.dev
+      port: 8080  # This should trigger ErrBackendPortNotAllowed
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: Backend
+metadata:
+  name: example-backend
+spec:
+  type: Static
+  static:
+    hosts:
+    - host: example.com
+      port: 8080

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
@@ -1,0 +1,129 @@
+Clusters:
+- connectTimeout: 5s
+  dnsLookupFamily: V4_PREFERRED
+  loadAssignment:
+    clusterName: backend_default_example-backend_0
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: example.com
+              portValue: 8080
+          healthCheckConfig:
+            hostname: example.com
+          hostname: example.com
+  metadata: {}
+  name: backend_default_example-backend_0
+  type: STRICT_DNS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: blackhole-cluster
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Backend "example-backend": do not specify a port when referencing
+            a Backend resource, as it defines its own'
+          reason: BackendNotFound
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
@@ -112,8 +112,9 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: 'Backend "example-backend": do not specify a port when referencing
-            a Backend resource, as it defines its own'
+          message: BackendRef to "example-backend" includes a port. Do not specify
+            a port when referencing a Backend resource, as it defines its own port
+            configuration
           reason: BackendNotFound
           status: "False"
           type: ResolvedRefs


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

When specifying a port in the backend ref, although [doc warns users that they shouldn't](https://kgateway.dev/docs/traffic-management/destination-types/backends/#routing), we ended up with a generic `Backend "ext-httpbin" not found` error message in the HTTPRoute status condition.

E.g. for:
```yaml
backendRefs:
    - name: ext-httpbin
      kind: Backend
      group: gateway.kgateway.dev
      port: 443
```

This PR is modifying the error message in this case to be a little more descriptive and hint the actual error rather than backend not found.

E.g.:

```yaml
- conditions:
     - lastTransitionTime: "2025-09-03T12:16:14Z"
       message: BackendRef to "ext-httpbin" includes a port. Do not specify a port
        when referencing a Backend resource, as it defines its own port configuration
       observedGeneration: 1
       reason: BackendNotFound
       status: "False"
       type: ResolvedRefs
```

Fixes #12192

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Descriptive ResolvedRefs condition error message about specifying port in the backendRef
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
