### PR TITLE
DNM: Attempt to optimize the gateway translator suite runtime.

### DIFF
--- a/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
+++ b/internal/kgateway/agentgatewaysyncer/agentgateway_testutils.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/schemes"
 	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 	"github.com/kgateway-dev/kgateway/v2/test/translator"
 )
@@ -772,7 +773,7 @@ func (tc TestCase) Run(
 }
 
 func proxySyncerPluginFactory(ctx context.Context, commoncol *collections.CommonCollections, name string, extraPluginsFn ExtraPluginsFn, globalSettings settings.Settings) pluginsdk.Plugin {
-	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultAgentGatewayClassName, globalSettings)
+	plugins := registry.Plugins(ctx, commoncol, validator.NewBinaryValidator(""), wellknown.DefaultAgentGatewayClassName, globalSettings)
 
 	var extraPlugs []pluginsdk.Plugin
 	if extraPluginsFn != nil {

--- a/internal/kgateway/controller/controller_suite_test.go
+++ b/internal/kgateway/controller/controller_suite_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/pkg/schemes"
 	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 	"github.com/kgateway-dev/kgateway/v2/test/gomega/assertions"
 )
 
@@ -297,7 +298,11 @@ func newCommonCols(ctx context.Context, kubeClient kube.Client) *collections.Com
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	plugins := registry.Plugins(ctx, commoncol, wellknown.DefaultWaypointClassName, *settings)
+	// using the binary validator is fine since we aren't enabling strict mode
+	// in this controller suite.
+	validator := validator.NewBinaryValidator("")
+
+	plugins := registry.Plugins(ctx, commoncol, validator, wellknown.DefaultWaypointClassName, *settings)
 	plugins = append(plugins, krtcollections.NewBuiltinPlugin(ctx))
 	extensions := registry.MergePlugins(plugins...)
 

--- a/internal/kgateway/controller/start.go
+++ b/internal/kgateway/controller/start.go
@@ -36,6 +36,7 @@ import (
 	kgtwschemes "github.com/kgateway-dev/kgateway/v2/pkg/schemes"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/namespaces"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
 
 const (
@@ -76,6 +77,7 @@ type StartConfig struct {
 	ExtraAgentgatewayPlugins func(ctx context.Context, agw *agentgatewayplugins.AgwCollections) []agentgatewayplugins.AgentgatewayPlugin
 	ExtraGatewayParameters   func(cli client.Client, inputs *deployer.Inputs) []deployer.ExtraGatewayParameters
 	Client                   istiokube.Client
+	Validator                validator.Validator
 
 	AgwCollections    *agentgatewayplugins.AgwCollections
 	CommonCollections *common.CommonCollections
@@ -155,6 +157,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		cfg.UniqueClients,
 		mergedPlugins,
 		cfg.CommonCollections,
+		cfg.Validator,
 		cfg.SetupOpts.Cache,
 		cfg.AgentGatewayClassName,
 	)
@@ -247,7 +250,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 
 func pluginFactoryWithBuiltin(cfg StartConfig) extensions2.K8sGatewayExtensionsFactory {
 	return func(ctx context.Context, commoncol *common.CommonCollections) sdk.Plugin {
-		plugins := registry.Plugins(ctx, commoncol, cfg.WaypointGatewayClassName, *cfg.SetupOpts.GlobalSettings)
+		plugins := registry.Plugins(ctx, commoncol, cfg.Validator, cfg.WaypointGatewayClassName, *cfg.SetupOpts.GlobalSettings)
 		plugins = append(plugins, krtcollections.NewBuiltinPlugin(ctx))
 		if cfg.ExtraPlugins != nil {
 			plugins = append(plugins, cfg.ExtraPlugins(ctx, commoncol, cfg.SetupOpts.GlobalSettings.PolicyMerge)...)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -224,7 +224,12 @@ func registerTypes(ourCli versioned.Interface) {
 	)
 }
 
-func NewPlugin(ctx context.Context, commoncol *common.CommonCollections, mergeSettings string) extensionsplug.Plugin {
+func NewPlugin(
+	ctx context.Context,
+	commoncol *common.CommonCollections,
+	v validator.Validator,
+	mergeSettings string,
+) extensionsplug.Plugin {
 	registerTypes(commoncol.OurClient)
 
 	useRustformations = commoncol.Settings.UseRustFormations // stash the state of the env setup for rustformation usage
@@ -236,7 +241,6 @@ func NewPlugin(ctx context.Context, commoncol *common.CommonCollections, mergeSe
 	gk := wellknown.TrafficPolicyGVK.GroupKind()
 
 	translator := NewTrafficPolicyConstructor(ctx, commoncol)
-	v := validator.New()
 
 	// TrafficPolicy IR will have TypedConfig -> implement backendroute method to add prompt guard, etc.
 	policyCol := krt.NewCollection(col, func(krtctx krt.HandlerContext, policyCR *v1alpha1.TrafficPolicy) *ir.PolicyWrapper {

--- a/internal/kgateway/extensions2/registry/registry.go
+++ b/internal/kgateway/extensions2/registry/registry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugins/waypoint"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/settings"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
 
 func mergedGw(funcs []sdk.GwTranslatorFactory) sdk.GwTranslatorFactory {
@@ -71,11 +72,17 @@ func MergePlugins(plug ...sdk.Plugin) sdk.Plugin {
 	return ret
 }
 
-func Plugins(ctx context.Context, commoncol *common.CommonCollections, waypointGatewayClassName string, globalSettings settings.Settings) []sdk.Plugin {
+func Plugins(
+	ctx context.Context,
+	commoncol *common.CommonCollections,
+	v validator.Validator,
+	waypointGatewayClassName string,
+	globalSettings settings.Settings,
+) []sdk.Plugin {
 	return []sdk.Plugin{
 		// Add plugins here
 		backend.NewPlugin(ctx, commoncol),
-		trafficpolicy.NewPlugin(ctx, commoncol, globalSettings.PolicyMerge),
+		trafficpolicy.NewPlugin(ctx, commoncol, v, globalSettings.PolicyMerge),
 		directresponse.NewPlugin(ctx, commoncol),
 		kubernetes.NewPlugin(ctx, commoncol),
 		istio.NewPlugin(ctx, commoncol),

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	plug "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
 
 var _ manager.LeaderElectionRunnable = &ProxySyncer{}
@@ -138,6 +139,7 @@ func NewProxySyncer(
 	uniqueClients krt.Collection[ir.UniqlyConnectedClient],
 	mergedPlugins plug.Plugin,
 	commonCols *common.CommonCollections,
+	validator validator.Validator,
 	xdsCache envoycache.SnapshotCache,
 	agentGatewayClassName string,
 ) *ProxySyncer {
@@ -149,7 +151,7 @@ func NewProxySyncer(
 		istioClient:              client,
 		proxyTranslator:          NewProxyTranslator(xdsCache),
 		uniqueClients:            uniqueClients,
-		translator:               translator.NewCombinedTranslator(ctx, mergedPlugins, commonCols),
+		translator:               translator.NewCombinedTranslator(ctx, mergedPlugins, commonCols, validator),
 		plugins:                  mergedPlugins,
 		reportQueue:              utils.NewAsyncQueue[reports.ReportMap](),
 		backendPolicyReportQueue: utils.NewAsyncQueue[reports.ReportMap](),

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	common "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
 
 type Options struct {
@@ -31,6 +32,7 @@ type Options struct {
 	CtrlMgrOptions           func(context.Context) *ctrl.Options
 	// extra controller manager config, like registering additional controllers
 	ExtraManagerConfig []func(ctx context.Context, mgr manager.Manager, objectFilter kubetypes.DynamicObjectFilter) error
+	Validator          validator.Validator
 }
 
 func New(opts Options) (core.Server, error) {
@@ -47,5 +49,6 @@ func New(opts Options) (core.Server, error) {
 		core.WithRestConfig(opts.RestConfig),
 		core.WithControllerManagerOptions(opts.CtrlMgrOptions),
 		core.WithExtraManagerConfig(opts.ExtraManagerConfig...),
+		core.WithValidator(opts.Validator),
 	)
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -3,11 +3,16 @@ package validator
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os/exec"
 	"slices"
 	"strings"
+	"sync"
+
+	"github.com/avast/retry-go"
 )
 
 var (
@@ -26,47 +31,70 @@ type Validator interface {
 	Validate(context.Context, string) error
 }
 
-// Option is a functional option for New.
-type Option func(*config)
-
-// WithBinaryPath overrides the Envoy binary path.
-func WithBinaryPath(p string) Option { return func(c *config) { c.binaryPath = p } }
-
-// WithDockerImage overrides the Docker image used for validation.
-func WithDockerImage(img string) Option { return func(c *config) { c.dockerImage = img } }
-
-// config stores the validator configuration.
-type config struct {
-	binaryPath  string
-	dockerImage string
+// validationCache caches validation results to avoid redundant validations
+type validationCache struct {
+	cache map[string]error
+	mu    sync.RWMutex
 }
 
-// New chooses the best validator available.
-func New(o ...Option) Validator {
-	c := &config{}
-	for _, opt := range o {
-		opt(c)
+// cachedValidator wraps another validator with caching
+type cachedValidator struct {
+	underlying Validator
+	cache      *validationCache
+}
+
+var _ Validator = &cachedValidator{}
+
+// NewCachedValidator wraps any validator with caching to avoid redundant validations
+func NewCachedValidator(underlying Validator) Validator {
+	return &cachedValidator{
+		underlying: underlying,
+		cache: &validationCache{
+			cache: make(map[string]error),
+		},
 	}
-	// use defaults if not set by options
-	binaryPath := c.binaryPath
-	if binaryPath == "" {
-		binaryPath = defaultEnvoyPath
+}
+
+func (cv *cachedValidator) Validate(ctx context.Context, yaml string) error {
+	return cv.cache.validate(ctx, yaml, cv.underlying.Validate)
+}
+
+// validate checks cache first, then delegates to actual validator if needed
+func (vc *validationCache) validate(ctx context.Context, yaml string, actualValidator func(context.Context, string) error) error {
+	// Create hash of the YAML content
+	hash := sha256.Sum256([]byte(yaml))
+	key := hex.EncodeToString(hash[:])
+
+	// Check cache first
+	vc.mu.RLock()
+	if result, exists := vc.cache[key]; exists {
+		vc.mu.RUnlock()
+		return result
 	}
-	dockerImage := c.dockerImage
-	if dockerImage == "" {
-		dockerImage = defaultEnvoyImage
-	}
-	// check if envoy is in the path
-	if _, err := exec.LookPath(binaryPath); err == nil {
-		return &binaryValidator{path: binaryPath}
-	}
-	// otherwise, fallback to docker
-	return &dockerValidator{img: dockerImage}
+	vc.mu.RUnlock()
+
+	// Not in cache, perform actual validation
+	result := actualValidator(ctx, yaml)
+
+	// Store result in cache
+	vc.mu.Lock()
+	vc.cache[key] = result
+	vc.mu.Unlock()
+
+	return result
 }
 
 // binaryValidator validates envoy using the binary.
 type binaryValidator struct {
 	path string
+}
+
+func NewBinaryValidator(path string) Validator {
+	if path == "" {
+		path = defaultEnvoyPath
+	}
+	// TODO(tim): check if the binary exists.
+	return &binaryValidator{path: path}
 }
 
 var _ Validator = &binaryValidator{}
@@ -89,22 +117,108 @@ func (b *binaryValidator) Validate(ctx context.Context, yaml string) error {
 	return nil
 }
 
-type dockerValidator struct {
-	img string
+// PersistentValidator is a validator that supports cleanup operations.
+type PersistentValidator interface {
+	Validator
+	// Start explicitly starts the validator (e.g., container startup).
+	Start(context.Context) error
+	// Cleanup performs any necessary cleanup operations.
+	Cleanup(context.Context) error
 }
 
-var _ Validator = &dockerValidator{}
+// persistentDockerValidator uses a long-running Docker container for validation
+// to avoid the overhead of starting a new container for each validation.
+type persistentDockerValidator struct {
+	img           string
+	containerName string
+	started       bool
+}
 
-func (d *dockerValidator) Validate(ctx context.Context, yaml string) error {
-	cmd := exec.CommandContext(
+var _ PersistentValidator = &persistentDockerValidator{}
+
+func NewPersistentDockerValidator(img string) PersistentValidator {
+	if img == "" {
+		img = defaultEnvoyImage
+	}
+	return &persistentDockerValidator{
+		img:           img,
+		containerName: "envoy-validator-persistent",
+		started:       false,
+	}
+}
+
+func (p *persistentDockerValidator) Start(ctx context.Context) error {
+	// If it already exists, just start it
+	if err := exec.CommandContext(ctx, "docker", "inspect", p.containerName).Run(); err == nil {
+		if err := exec.CommandContext(ctx, "docker", "start", "-d", p.containerName).Run(); err != nil {
+			return fmt.Errorf("failed to start existing container: %w", err)
+		}
+		p.started = true
+		return nil
+	}
+
+	// Otherwise, create it with full config
+	// Override entrypoint to keep container alive for validation commands
+	if err := exec.CommandContext(
 		ctx,
-		"docker", "run",
-		"--rm",
-		"-i",
+		"docker", "create",
+		"--name", p.containerName,
 		"--platform", "linux/amd64",
-		d.img,
-		"--mode",
-		"validate",
+		"--memory", "512m",
+		"--memory-swap", "512m", // no swap
+		"--restart", "no",
+		"--entrypoint", "sh",
+		"--read-only",
+		"--pids-limit", "256",
+		"--network", "none",
+		"--tmpfs", "/tmp:rw,exec",
+		p.img,
+		"-c", "trap 'exit 0' TERM; sleep 3600 & wait",
+	).Run(); err != nil {
+		return fmt.Errorf("failed to create container: %w", err)
+	}
+
+	startCmd := exec.CommandContext(ctx, "docker", "start", p.containerName)
+	stderr := new(bytes.Buffer)
+	startCmd.Stderr = stderr
+	if err := startCmd.Run(); err != nil {
+		rawErr := strings.TrimSpace(stderr.String())
+		if rawErr != "" {
+			return fmt.Errorf("failed to start container: %w: %s", err, rawErr)
+		}
+		return fmt.Errorf("failed to start container: %w", err)
+	}
+	p.started = true
+
+	if err := waitRunningWithRetry(ctx, p.containerName); err != nil {
+		return fmt.Errorf("failed to wait for container to be running: %w", err)
+	}
+
+	return nil
+}
+
+func waitRunningWithRetry(ctx context.Context, name string) error {
+	return retry.Do(
+		func() error {
+			out, err := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{.State.Running}}", name).Output()
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(string(out)) != "true" {
+				return fmt.Errorf("not running yet")
+			}
+			return nil
+		},
+		retry.Attempts(5),
+	)
+}
+
+func (p *persistentDockerValidator) Validate(ctx context.Context, yaml string) error {
+	cmd := exec.CommandContext(
+		ctx, "docker", "exec", "-i",
+		p.containerName,
+		"/usr/local/bin/envoy",
+		"--mode", "validate",
 		"--config-yaml", yaml,
 		"-l", "critical",
 		"--log-format", "%v",
@@ -131,6 +245,16 @@ func (d *dockerValidator) Validate(ctx context.Context, yaml string) error {
 		return fmt.Errorf("%w: %s", ErrInvalidXDS, rawErr)
 	}
 	return fmt.Errorf("envoy validate invocation failed: %v", err)
+}
+
+// Cleanup stops and removes the persistent container
+func (p *persistentDockerValidator) Cleanup(ctx context.Context) error {
+	// Always try to clean up, regardless of started status
+	// Use short timeout since sleep doesn't handle SIGTERM gracefully
+	exec.CommandContext(ctx, "docker", "stop", "-t", "1", p.containerName).Run()
+	exec.CommandContext(ctx, "docker", "rm", p.containerName).Run()
+	p.started = false
+	return nil
 }
 
 // extractEnvoyError extracts the actual Envoy validation error from stderr output,

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -2,417 +2,48 @@ package validator
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestNew(t *testing.T) {
-	tests := []struct {
-		name         string
-		options      []Option
-		setupEnvoy   bool
-		expectedType string
-		expectedPath string
-		expectedImg  string
-	}{
-		{
-			name:         "default - returns binary validator when envoy executable exists",
-			options:      nil,
-			setupEnvoy:   true,
-			expectedType: "*validator.binaryValidator",
-		},
-		{
-			name:         "default - returns docker validator when envoy not in path",
-			options:      nil,
-			setupEnvoy:   false,
-			expectedType: "*validator.dockerValidator",
-		},
-		{
-			name:         "custom binary path - overrides binary validator when exists",
-			options:      nil,
-			setupEnvoy:   true,
-			expectedType: "*validator.binaryValidator",
-		},
-		{
-			name: "custom docker image - override default envoy image",
-			options: []Option{
-				WithDockerImage("envoyproxy/envoy:v1.28.0"),
-			},
-			setupEnvoy:   false,
-			expectedType: "*validator.dockerValidator",
-			expectedImg:  "envoyproxy/envoy:v1.28.0",
-		},
-		{
-			name: "custom both - binary takes precedence when exists",
-			options: []Option{
-				WithBinaryPath("/path/to/envoy"),
-				WithDockerImage("custom/envoy:latest"),
-			},
-			setupEnvoy:   true,
-			expectedType: "*validator.binaryValidator",
-		},
-		{
-			name: "custom both - docker fallback when binary not found and docker image is set",
-			options: []Option{
-				WithBinaryPath("/nonexistent/envoy"),
-				WithDockerImage("custom/envoy:latest"),
-			},
-			setupEnvoy:   false,
-			expectedType: "*validator.dockerValidator",
-			expectedImg:  "custom/envoy:latest",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var tmpFile *os.File
-			if tt.setupEnvoy {
-				var err error
-				tmpFile, err = os.CreateTemp("", "envoy")
-				require.NoError(t, err)
-				defer os.Remove(tmpFile.Name())
-				require.NoError(t, os.Chmod(tmpFile.Name(), 0755))
-
-				// Set up custom binary path options for relevant tests
-				if tt.name == "custom binary path - binary validator" {
-					tt.options = []Option{WithBinaryPath(tmpFile.Name())}
-					tt.expectedPath = tmpFile.Name()
-				} else if tt.name == "custom both - binary takes precedence when exists" {
-					tt.options = []Option{
-						WithBinaryPath(tmpFile.Name()),
-						WithDockerImage("custom/envoy:latest"),
-					}
-					tt.expectedPath = tmpFile.Name()
-				} else if tt.options == nil {
-					// For default tests, modify global defaultEnvoyPath temporarily
-					origEnvoyPath := defaultEnvoyPath
-					defaultEnvoyPath = tmpFile.Name()
-					defer func() { defaultEnvoyPath = origEnvoyPath }()
-				}
-			}
-
-			validator := New(tt.options...)
-			assert.Equal(t, tt.expectedType, fmt.Sprintf("%T", validator))
-
-			// Verify the internal configuration
-			switch v := validator.(type) {
-			case *binaryValidator:
-				if tt.expectedPath != "" {
-					assert.Equal(t, tt.expectedPath, v.path)
-				}
-			case *dockerValidator:
-				if tt.expectedImg != "" {
-					assert.Equal(t, tt.expectedImg, v.img)
-				}
-			}
-		})
-	}
+func TestNewBinaryValidator(t *testing.T) {
+	validator := NewBinaryValidator("/usr/local/bin/envoy")
+	assert.NotNil(t, validator)
 }
 
-func TestBinaryValidator_Validate(t *testing.T) {
-	// note: actual config content doesn't matter for these tests. we cannot easily
-	// test valid/invalid config with the binary validator, so we mock it as there's no
-	// guarantee that the envoy binary is available and we cannot force it to be
-	// due to multi-arch issues. instead, invalid configuration is tested in the docker
-	// validator tests.
-	tests := []struct {
-		name        string
-		yaml        string
-		mockBinary  func(t *testing.T) string
-		expectError bool
-		errorMsg    string
-	}{
-		{
-			name: "successful validation",
-			yaml: "any-config-here",
-			mockBinary: func(t *testing.T) string {
-				script := `#!/bin/sh
-if [ "$1" != "--mode" ] || [ "$2" != "validate" ] || [ "$3" != "--config-yaml" ]; then
-    echo "Invalid arguments, expected: --mode validate --config-yaml" >&2
-    exit 1
-fi
-exit 0
-`
-				return createMockBinary(t, script)
-			},
-			expectError: false,
-		},
-		{
-			name: "validation error with envoy-style message",
-			yaml: "any-config-here", // actual config content doesn't matter for this test
-			mockBinary: func(t *testing.T) string {
-				script := `#!/bin/sh
-if [ "$1" != "--mode" ] || [ "$2" != "validate" ] || [ "$3" != "--config-yaml" ]; then
-    echo "Invalid arguments, expected: --mode validate --config-yaml" >&2
-    exit 1
-fi
-echo "error initializing configuration '': missing ]:" >&2
-exit 1
-`
-				return createMockBinary(t, script)
-			},
-			expectError: true,
-			errorMsg:    "invalid xds configuration: error initializing configuration '': missing ]:",
-		},
-		{
-			name: "binary execution failure",
-			yaml: "any-config-here", // actual config content doesn't matter for this test
-			mockBinary: func(t *testing.T) string {
-				script := `#!/bin/sh
-# Simulate a binary execution failure (e.g. segfault)
-exit 2
-`
-				return createMockBinary(t, script)
-			},
-			expectError: true,
-			errorMsg:    "invalid xds configuration",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockPath := tt.mockBinary(t)
-			defer os.Remove(mockPath)
-
-			validator := &binaryValidator{path: mockPath}
-			err := validator.Validate(context.Background(), tt.yaml)
-
-			if tt.expectError {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errorMsg)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+func TestNewCachedValidator(t *testing.T) {
+	baseValidator := NewBinaryValidator("/usr/local/bin/envoy")
+	cachedValidator := NewCachedValidator(baseValidator)
+	assert.NotNil(t, cachedValidator)
 }
 
-func TestDockerValidator_Validate(t *testing.T) {
-	tests := []struct {
-		name        string
-		yaml        string
-		expectError bool
-		errorMsg    string
-	}{
-		{
-			name: "valid configuration",
-			yaml: `node:
-  id: test-id
-  cluster: test-cluster
-static_resources:
-  listeners:
-    - name: listener_0
-      address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 10000
-      filter_chains:
-        - filters:
-            - name: envoy.filters.network.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                stat_prefix: ingress_http
-                route_config:
-                  name: local_route
-                  virtual_hosts:
-                    - name: local_service
-                      domains: ["*"]
-                      routes:
-                        - match:
-                            prefix: "/"
-                          route:
-                            cluster: service_foo
-  clusters:
-    - name: service_foo
-      connect_timeout: 0.25s
-      type: STATIC
-      lb_policy: ROUND_ROBIN
-      load_assignment:
-        cluster_name: service_foo
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: 127.0.0.1
-                      port_value: 8080`,
-			expectError: false,
-		},
-		{
-			name: "missing listener address",
-			yaml: `node:
-  id: test-id
-  cluster: test-cluster
-static_resources:
-  listeners:
-    - name: listener_0
-      # Missing required address field`,
-			expectError: true,
-			errorMsg:    `error initializing configuration '': error adding listener named 'listener_0': address is necessary`,
-		},
-		{
-			name: "invalid regex in route match",
-			yaml: `node:
-  id: test-id
-  cluster: test-cluster
-static_resources:
-  listeners:
-    - name: listener_0
-      address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 10000
-      filter_chains:
-        - filters:
-            - name: envoy.filters.network.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                stat_prefix: ingress_http
-                route_config:
-                  name: local_route
-                  virtual_hosts:
-                    - name: local_service
-                      domains: ["*"]
-                      routes:
-                        - match:
-                            safe_regex:
-                              regex: "[[invalid.regex"  # Invalid regex pattern
-                          route:
-                            cluster: service_foo
-  clusters:
-    - name: service_foo
-      connect_timeout: 0.25s
-      type: STATIC
-      lb_policy: ROUND_ROBIN
-      load_assignment:
-        cluster_name: service_foo
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: 127.0.0.1
-                      port_value: 8080`,
-			expectError: true,
-			errorMsg:    `error initializing configuration '': missing ]:`,
-		},
+func TestValidationCache(t *testing.T) {
+	cache := &validationCache{
+		cache: make(map[string]error),
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			validator := &dockerValidator{img: defaultEnvoyImage}
-			err := validator.Validate(context.Background(), tt.yaml)
-
-			if tt.expectError {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errorMsg)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestExtractEnvoyError(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "no error message",
-			input:    "some random output\nno errors here",
-			expected: "",
-		},
-		{
-			name:     "simple error message",
-			input:    "error initializing configuration '': invalid named capture group: (?<=foo)bar",
-			expected: "error initializing configuration '': invalid named capture group: (?<=foo)bar",
-		},
-		{
-			name: "error message with context",
-			input: `error initializing configuration '': missing ]:
-  in regex filter at line 42
-  validation context: http_connection_manager`,
-			expected: "error initializing configuration '': missing ]: in regex filter at line 42 validation context: http_connection_manager",
-		},
-		{
-			name: "docker pull logs present",
-			input: `Unable to find image 'quay.io/solo-io/envoy-gloo:1.34.1-patch3' locally
-1.34.1-patch3: Pulling from solo-io/envoy-gloo
-f90c8eb4724c: Pulling fs layer
-9f37c34398c2: Pulling fs layer
-1cc4dfe322cb: Pulling fs layer
-e800bbdc2f77: Pulling fs layer
-e800bbdc2f77: Waiting
-1cc4dfe322cb: Download complete
-9f37c34398c2: Verifying Checksum
-9f37c34398c2: Download complete
-f90c8eb4724c: Verifying Checksum
-f90c8eb4724c: Download complete
-e800bbdc2f77: Verifying Checksum
-e800bbdc2f77: Download complete
-f90c8eb4724c: Pull complete
-9f37c34398c2: Pull complete
-1cc4dfe322cb: Pull complete
-e800bbdc2f77: Pull complete
-Digest: sha256:98c645568997299a1c4301e6077a1d2f566bb20828c0739e6c4177a821524dad
-Status: Downloaded newer image for quay.io/solo-io/envoy-gloo:1.34.1-patch3
-error initializing configuration '': invalid named capture group: (?<=foo)bar`,
-			expected: "error initializing configuration '': invalid named capture group: (?<=foo)bar",
-		},
-		{
-			name: "docker pull logs with multi-line error",
-			input: `Unable to find image 'quay.io/solo-io/envoy-gloo:1.34.1-patch3' locally
-1.34.1-patch3: Pulling from solo-io/envoy-gloo
-f90c8eb4724c: Pull complete
-Status: Downloaded newer image for quay.io/solo-io/envoy-gloo:1.34.1-patch3
-error initializing configuration '': missing ]:
-  at line 42 in filter configuration
-  regex validation failed`,
-			expected: "error initializing configuration '': missing ]: at line 42 in filter configuration regex validation failed",
-		},
-		{
-			name: "platform warning with error",
-			input: `WARNING: The requested image's platform (linux/amd64) does not match the detected host platform
-error initializing configuration '': listener validation failed
-  invalid port configuration`,
-			expected: "error initializing configuration '': listener validation failed invalid port configuration",
-		},
-		{
-			name: "error with empty lines",
-			input: `error initializing configuration '': validation error
-
-additional context here
-
-more details`,
-			expected: "error initializing configuration '': validation error additional context here more details",
-		},
+	// Mock validator that counts calls
+	callCount := 0
+	mockValidator := func(ctx context.Context, yaml string) error {
+		callCount++
+		return nil
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractEnvoyError(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
+	yaml := "test: config"
 
-func createMockBinary(t *testing.T, script string) string {
-	t.Helper()
+	// First call should invoke the validator
+	err := cache.validate(context.Background(), yaml, mockValidator)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, callCount)
 
-	tmpDir, err := os.MkdirTemp("", "mock-envoy")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	// Second call with same YAML should use cache
+	err = cache.validate(context.Background(), yaml, mockValidator)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, callCount) // Should not increment
 
-	mockPath := filepath.Join(tmpDir, "mock-envoy")
-	err = os.WriteFile(mockPath, []byte(script), 0755)
-	require.NoError(t, err)
-
-	return mockPath
+	// Different YAML should invoke validator again
+	err = cache.validate(context.Background(), "different: config", mockValidator)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

WIP: Optimize the gateway translator suite runtime. The TestRouteReplacement suite accounts for most of the performance because we need to enable STRICT validation mode, and because we're running this locally, we need to use the docker-based validator, which runs the envoy-gloo container image and shells out to envoy validate mode NxM where N is the number of sub-tests and M is the number of times translation calls the Validate method.

This commit explores two optimizations efforts:

1. Use a persistent docker that's managed in the RR suite
2. Wrap the validator instance and cache the results

For the former, this approach dramatically reduces system resource usage, but doesn't influence overall runtime in any meaningful way.

Before:

```bash
$ time go test -failfast ./internal/kgateway/translator/gateway
ok       github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/gateway        53.701s
go test -failfast ./internal/kgateway/translator/gateway  52.29s user 7.54s system 88% cpu 1:07.66 total
```

After:

```
$ time go test -failfast ./internal/kgateway/translator/gateway
ok       github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/gateway        55.206s
go test -failfast ./internal/kgateway/translator/gateway  12.36s user 2.24s system 25% cpu 57.973 total
```

That's ~12% runtime improvement. When wrapping the persistent docker-based validator with caching, we start to see considerable runtime improvements:

After:

```bash
$ time go test -failfast ./internal/kgateway/translator/gateway
ok       github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/gateway        27.217s
go test -failfast ./internal/kgateway/translator/gateway  23.69s user 3.34s system 80% cpu 33.583 total
```

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
