### PR TITLE
fix(metrics): correct delete resource sync xds metric

### DIFF
--- a/internal/kgateway/krtcollections/metrics/metrics.go
+++ b/internal/kgateway/krtcollections/metrics/metrics.go
@@ -614,6 +614,15 @@ func GetResourceMetricEventHandler[T any]() func(krt.Event[T]) {
 					Resource:  resourceType,
 				}.toMetricsLabels()...)
 
+				startResourceSync(ResourceSyncDetails{
+					Gateway:      name,
+					Namespace:    namespace,
+					ResourceType: resourceType,
+					ResourceName: resourceName,
+				})
+
+				// There will not be a status sync for a deleted resource,
+				// so end the resource status sync immediately.
 				EndResourceStatusSync(ResourceSyncDetails{
 					Gateway:      name,
 					Namespace:    namespace,

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -397,15 +397,6 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 				// if _, err := s.proxyTranslator.xdsCache.GetSnapshot(key); err == nil {
 				// 	s.proxyTranslator.xdsCache.ClearSnapshot(e.Latest().proxyKey)
 				// }
-
-				// On gateway deletion, there will not have been a StartResourceXDSSync() call,
-				// so it is necessary to start a resource sync here.
-				kmetrics.StartResourceXDSSync(kmetrics.ResourceSyncDetails{
-					Gateway:      cd.Gateway,
-					Namespace:    cd.Namespace,
-					ResourceType: wellknown.GatewayKind,
-					ResourceName: cd.Gateway,
-				})
 			}
 
 			kmetrics.EndResourceXDSSync(kmetrics.ResourceSyncDetails{


### PR DESCRIPTION
# Description

Fix a bug affecting `kgateway_resources_status_syncs_started_total` metric values upon resource deletion.

**Related issues:**
- https://github.com/kgateway-dev/kgateway/issues/11713

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
NONE
```