### PR TITLE
fix cel validation for TrafficPolicy buffer MaxRequestSize

### DIFF
--- a/api/v1alpha1/traffic_policy_types.go
+++ b/api/v1alpha1/traffic_policy_types.go
@@ -426,7 +426,7 @@ type Buffer struct {
 	// Requests exceeding this size will receive HTTP 413.
 	// Example format: "1Mi", "512Ki", "1Gi"
 	// +optional
-	// +kubebuilder:validation:XValidation:message="maxRequestSize must be greater than 0 and less than 4Gi",rule="quantity(self).isGreaterThan(quantity('0')) && quantity(self).isLessThan(quantity('4Gi'))"
+	// +kubebuilder:validation:XValidation:message="maxRequestSize must be greater than 0 and less than 4Gi",rule="(type(self) == int && int(self) > 0 && int(self) < 4294967296) || (type(self) == string && quantity(self).isGreaterThan(quantity('0')) && quantity(self).isLessThan(quantity('4Gi')))"
 	MaxRequestSize *resource.Quantity `json:"maxRequestSize,omitempty"`
 
 	// Disable the buffer filter.

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
@@ -289,7 +289,9 @@ spec:
                     x-kubernetes-validations:
                     - message: maxRequestSize must be greater than 0 and less than
                         4Gi
-                      rule: quantity(self).isGreaterThan(quantity('0')) && quantity(self).isLessThan(quantity('4Gi'))
+                      rule: (type(self) == int && int(self) > 0 && int(self) < 4294967296)
+                        || (type(self) == string && quantity(self).isGreaterThan(quantity('0'))
+                        && quantity(self).isLessThan(quantity('4Gi')))
                 type: object
                 x-kubernetes-validations:
                 - message: exactly one of the fields in [maxRequestSize disable] must

--- a/test/kubernetes/e2e/tests/api_validation_test.go
+++ b/test/kubernetes/e2e/tests/api_validation_test.go
@@ -566,6 +566,43 @@ spec:
 			},
 		},
 		{
+			name: "TrafficPolicy Buffer maxRequestSize with integer",
+			input: `---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: test
+spec:
+  buffer:
+    maxRequestSize: 65536
+`,
+		},
+		{
+			name: "TrafficPolicy Buffer maxRequestSize with string",
+			input: `---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: test
+spec:
+  buffer:
+    maxRequestSize: 64Ki
+`,
+		},
+		{
+			name: "TrafficPolicy Buffer maxRequestSize with invalid value",
+			input: `---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: test
+spec:
+  buffer:
+    maxRequestSize: 4Gi
+`,
+			wantErrors: []string{"maxRequestSize must be greater than 0 and less than 4Gi"},
+		},
+		{
 			name: "ProxyDeployment: enforce ExactlyOneOf for replicas and omitReplicas",
 			input: `---
 apiVersion: gateway.kgateway.dev/v1alpha1


### PR DESCRIPTION
# Description

fix cel validation for TrafficPolicy buffer MaxRequestSize.

This was fixed in backendconfigpolicy for similar values of type `resource.Quantity` but missed here. See https://github.com/kgateway-dev/kgateway/issues/11611

Now the cel validation properly handles int or string values.

# Change Type

/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
