### PR TITLE
bump envoy-gloo to v1.34.6-patch1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 # ATTENTION: when updating to a new major version of Envoy, check if
 # universal header validation has been enabled and if so, we expect
 # failures in `test/e2e/header_validation_test.go`.
-export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.34.1-patch3
+export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.34.6-patch1
 export LDFLAGS := -X 'github.com/kgateway-dev/kgateway/v2/internal/version.Version=$(VERSION)'
 export GCFLAGS ?=
 

--- a/internal/envoyinit/rustformations/Cargo.lock
+++ b/internal/envoyinit/rustformations/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "envoy-proxy-dynamic-modules-rust-sdk"
 version = "0.1.0"
-source = "git+https://github.com/envoyproxy/envoy?rev=c435eeccd4201f8d6a200922b166f5dcee08272b#c435eeccd4201f8d6a200922b166f5dcee08272b"
+source = "git+https://github.com/envoyproxy/envoy?rev=d6a11bfd3436aef5d3aff3237a6cddb18db01d82#d6a11bfd3436aef5d3aff3237a6cddb18db01d82"
 dependencies = [
  "bindgen",
  "mockall",

--- a/internal/envoyinit/rustformations/Cargo.toml
+++ b/internal/envoyinit/rustformations/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "c435eeccd4201f8d6a200922b166f5dcee08272b" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "d6a11bfd3436aef5d3aff3237a6cddb18db01d82" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.9.0"


### PR DESCRIPTION
# Description
- bump envoy-gloo to latest v1.34 version
- update rust sdk hash to match the envoy release v1.34.6

envoy release note:
- https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.34/v1.34.2
- https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.34/v1.34.3
- https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.34/v1.34.4
- https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.34/v1.34.5
- https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.34/v1.34.6 (envoy has not update their doc yet. See https://github.com/envoyproxy/envoy/releases/v1.34.6 for now)

envoy-gloo release note:
- https://github.com/solo-io/envoy-gloo/releases/tag/v1.34.1-patch4
- https://github.com/solo-io/envoy-gloo/releases/tag/v1.34.5-patch1
- https://github.com/solo-io/envoy-gloo/releases/tag/v1.34.6-patch1

envoy-go-control-plane:
envoy doesn't seem to sync patch release over to go-control-plane which makes sense because patch release should not change any API's. The existing go-control-plane from 20250507 is already newer than the date from envoy v1.34.0 (20250415), so no update is needed.

# Change Type
/kind cleanup

# Changelog
```release-note
Updated envoy to v1.34.6
```

