### PR TITLE
e2e route delegation flakes

### DIFF
--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -2,13 +2,11 @@ package route_delegation
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -16,180 +14,130 @@ import (
 	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite
 
-type tsuite struct {
-	suite.Suite
+var (
+	setup = base.TestCase{
+		Manifests: []string{defaults.CurlPodManifest, commonManifest},
+		Resources: []client.Object{
+			defaults.CurlPod,
+			// resources from common manifest
+			httpbinTeam1Service, httpbinTeam1Deployment, httpbinTeam2Service, httpbinTeam2Deployment, gateway,
+			// deployer-generated resources
+			proxyDeployment, proxyService,
+		},
+	}
 
-	ctx context.Context
-	// ti contains all the metadata/utilities necessary to execute a series of tests
-	// against an installation of Gloo Gateway
-	ti *e2e.TestInstallation
+	testCases = map[string]base.TestCase{
+		"TestBasic": {
+			Manifests: []string{basicRoutesManifest},
+			Resources: []client.Object{routeRoot, routeTeam1, routeTeam2},
+		},
+		"TestRecursive": {
+			Manifests: []string{recursiveRoutesManifest},
+			Resources: []client.Object{routeRoot, routeTeam1, routeTeam2Root, routeTeam2},
+		},
+		"TestCyclic": {
+			Manifests: []string{cyclicRoutesManifest},
+			Resources: []client.Object{routeRoot, routeTeam1, routeTeam2Root, routeTeam2},
+		},
+		"TestInvalidChild": {
+			Manifests: []string{invalidChildRoutesManifest},
+			Resources: []client.Object{routeRoot, routeTeam1, routeTeam2},
+		},
+		"TestHeaderQueryMatch": {
+			Manifests: []string{headerQueryMatchRoutesManifest},
+			Resources: []client.Object{routeRoot, routeTeam1, routeTeam2},
+		},
+		"TestMultipleParents": {
+			Manifests: []string{multipleParentsManifest},
+			Resources: []client.Object{routeParent1, routeParent2, routeTeam1, routeTeam2},
+		},
+		"TestInvalidChildValidStandalone": {
+			Manifests: []string{invalidChildValidStandaloneManifest},
+			Resources: []client.Object{gatewayTest, proxyTestService, proxyTestDeployment, routeRoot, routeTeam1, routeTeam2},
+		},
+		"TestUnresolvedChild": {
+			Manifests: []string{unresolvedChildManifest},
+			Resources: []client.Object{routeRoot},
+		},
+		"TestMatcherInheritance": {
+			Manifests: []string{matcherInheritanceManifest},
+			Resources: []client.Object{routeParent1, routeParent2, routeTeam1},
+		},
+		"TestRouteWeight": {
+			Manifests: []string{routeWeightManifest},
+			Resources: []client.Object{routeRoot, routeTeam1, routeTeam2},
+		},
+		"TestPolicyMerging": {
+			Manifests: []string{policyMergingManifest},
+			Resources: []client.Object{routeParent1, routeParent2, routeTeam1, routeTeam2, trafficPolicyParent1Transform, trafficPolicyParent2Transform, trafficPolicySvc1Transform, trafficPolicySvc2Transform},
+		},
+	}
+)
 
-	// maps test name to a list of manifests to apply before the test
-	manifests map[string][]string
-
-	manifestObjects map[string][]client.Object
-
-	// resources from common manifest
-	commonResources []client.Object
+type testingSuite struct {
+	*base.BaseTestingSuite
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
-	return &tsuite{
-		ctx: ctx,
-		ti:  testInst,
-		manifests: map[string][]string{
-			"TestBasic":                       {basicRoutesManifest},
-			"TestRecursive":                   {recursiveRoutesManifest},
-			"TestCyclic":                      {cyclicRoutesManifest},
-			"TestInvalidChild":                {invalidChildRoutesManifest},
-			"TestHeaderQueryMatch":            {headerQueryMatchRoutesManifest},
-			"TestMultipleParents":             {multipleParentsManifest},
-			"TestInvalidChildValidStandalone": {invalidChildValidStandaloneManifest},
-			"TestUnresolvedChild":             {unresolvedChildManifest},
-			"TestMatcherInheritance":          {matcherInheritanceManifest},
-			"TestRouteWeight":                 {routeWeightManifest},
-			"TestPolicyMerging":               {policyMergingManifest},
-		},
+	return &testingSuite{
+		base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
 	}
 }
 
-func (s *tsuite) SetupSuite() {
-	// Not every resource that is applied needs to be verified. We are not testing `kubectl apply`,
-	// but the below code demonstrates how it can be done if necessary
-	s.manifestObjects = map[string][]client.Object{
-		basicRoutesManifest:                 {routeRoot, routeTeam1, routeTeam2},
-		cyclicRoutesManifest:                {routeRoot, routeTeam1, routeTeam2},
-		recursiveRoutesManifest:             {routeRoot, routeTeam1, routeTeam2},
-		invalidChildRoutesManifest:          {routeRoot, routeTeam1, routeTeam2},
-		headerQueryMatchRoutesManifest:      {routeRoot, routeTeam1, routeTeam2},
-		multipleParentsManifest:             {routeParent1, routeParent2, routeTeam1, routeTeam2},
-		invalidChildValidStandaloneManifest: {proxyTestService, proxyTestDeployment, routeRoot, routeTeam1, routeTeam2},
-		unresolvedChildManifest:             {routeRoot},
-		matcherInheritanceManifest:          {routeParent1, routeParent2, routeTeam1},
-	}
-
-	s.commonResources = []client.Object{
-		// resources from manifest
-		httpbinTeam1Service, httpbinTeam1Deployment, httpbinTeam2Service, httpbinTeam2Deployment, gateway,
-		// deployer-generated resources
-		proxyDeployment, proxyService,
-	}
-
-	// set up common resources once
-	err := s.ti.Actions.Kubectl().ApplyFile(s.ctx, commonManifest)
-	s.Require().NoError(err, "can apply common manifest")
-	s.ti.Assertions.EventuallyObjectsExist(s.ctx, s.commonResources...)
-	// make sure pods are running
-	s.ti.Assertions.EventuallyPodsRunning(s.ctx, httpbinTeam1Deployment.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app=httpbin,version=v1",
-	})
-	s.ti.Assertions.EventuallyPodsRunning(s.ctx, httpbinTeam2Deployment.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app=httpbin,version=v2",
-	})
-	s.ti.Assertions.EventuallyPodsRunning(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
-	})
-
-	// set up curl once
-	err = s.ti.Actions.Kubectl().ApplyFile(s.ctx, defaults.CurlPodManifest)
-	s.Require().NoError(err, "can apply curl pod manifest")
-	s.ti.Assertions.EventuallyPodsRunning(s.ctx, defaults.CurlPod.GetNamespace(), metav1.ListOptions{
-		LabelSelector: defaults.CurlPodLabelSelector,
-	})
-}
-
-func (s *tsuite) TearDownSuite() {
-	// clean up curl
-	err := s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, defaults.CurlPodManifest)
-	s.Require().NoError(err, "can delete curl pod manifest")
-	s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, defaults.CurlPod)
-
-	// clean up common resources
-	err = s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, commonManifest)
-	s.Require().NoError(err, "can delete common manifest")
-	s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, s.commonResources...)
-	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, httpbinTeam1Deployment.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app=httpbin,version=v1",
-	})
-	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, httpbinTeam2Deployment.GetNamespace(), metav1.ListOptions{
-		LabelSelector: "app=httpbin,version=v2",
-	})
-	s.ti.Assertions.EventuallyPodsNotExist(s.ctx, proxyMeta.GetNamespace(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", proxyMeta.GetName()),
-	})
-}
-
-func (s *tsuite) BeforeTest(suiteName, testName string) {
-	manifests := s.manifests[testName]
-	for _, manifest := range manifests {
-		err := s.ti.Actions.Kubectl().ApplyFile(s.ctx, manifest)
-		s.Require().NoError(err)
-		s.ti.Assertions.EventuallyObjectsExist(s.ctx, s.manifestObjects[manifest]...)
-	}
-}
-
-func (s *tsuite) AfterTest(suiteName, testName string) {
-	manifests := s.manifests[testName]
-	for _, manifest := range manifests {
-		err := s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, manifest)
-		s.Require().NoError(err)
-		s.ti.Assertions.EventuallyObjectsNotExist(s.ctx, s.manifestObjects[manifest]...)
-	}
-}
-
-func (s *tsuite) TestBasic() {
+func (s *testingSuite) TestBasic() {
 	// Assert traffic to team1 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to team2 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
 }
 
-func (s *tsuite) TestRecursive() {
+func (s *testingSuite) TestRecursive() {
 	// Assert traffic to team1 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to team2 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
 }
 
-func (s *tsuite) TestCyclic() {
+func (s *testingSuite) TestCyclic() {
 	// Assert traffic to team1 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to team2 route fails with HTTP 500 as it is a cyclic route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 
-	s.ti.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.ctx, routeTeam2.Name, routeTeam2.Namespace,
+	s.TestInstallation.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.Ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"cyclic reference detected", 10*time.Second, 1*time.Second)
 }
 
-func (s *tsuite) TestInvalidChild() {
+func (s *testingSuite) TestInvalidChild() {
 	// Assert traffic to team1 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to team2 route fails with HTTP 500 as the route is invalid due to specifying a hostname on the child route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
 		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 
-	s.ti.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.ctx, routeTeam2.Name, routeTeam2.Namespace,
+	s.TestInstallation.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.Ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"spec.hostnames must be unset", 10*time.Second, 1*time.Second)
 }
 
-func (s *tsuite) TestHeaderQueryMatch() {
+func (s *testingSuite) TestHeaderQueryMatch() {
 	// Assert traffic to team1 route with matching header and query parameters
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1),
 			curl.WithHeader("header1", "val1"),
@@ -199,7 +147,7 @@ func (s *tsuite) TestHeaderQueryMatch() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to team2 child route fails with HTTP 404 as it does not match the parent's header and query parameters
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2),
 			curl.WithHeader("headerX", "valX"),
@@ -208,7 +156,7 @@ func (s *tsuite) TestHeaderQueryMatch() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
 
 	// Assert traffic to team2 parent route fails with HTTP 500 due to unresolved child route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2),
 			curl.WithHeader("header2", "val2"),
@@ -217,9 +165,9 @@ func (s *tsuite) TestHeaderQueryMatch() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 }
 
-func (s *tsuite) TestMultipleParents() {
+func (s *testingSuite) TestMultipleParents() {
 	// Assert traffic to parent1.com/anything/team1
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam1),
@@ -228,7 +176,7 @@ func (s *tsuite) TestMultipleParents() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to parent1.com/anything/team2
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam2),
@@ -237,7 +185,7 @@ func (s *tsuite) TestMultipleParents() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
 
 	// Assert traffic to parent2.com/anything/team1
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam1),
@@ -246,7 +194,7 @@ func (s *tsuite) TestMultipleParents() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to parent2.com/anything/team2 fails as it is not selected by parent2 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam2),
@@ -255,9 +203,9 @@ func (s *tsuite) TestMultipleParents() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 }
 
-func (s *tsuite) TestInvalidChildValidStandalone() {
+func (s *testingSuite) TestInvalidChildValidStandalone() {
 	// Assert traffic to team1 route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyTestHostPort),
 			curl.WithPath(pathTeam1),
@@ -266,7 +214,7 @@ func (s *tsuite) TestInvalidChildValidStandalone() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
 
 	// Assert traffic to team2 route on parent hostname fails with HTTP 500 as the route is invalid due to specifying a hostname on the child route
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyTestHostPort),
 			curl.WithPath(pathTeam2),
@@ -275,7 +223,7 @@ func (s *tsuite) TestInvalidChildValidStandalone() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
 
 	// Assert traffic to team2 route on standalone host succeeds
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyTestHostPort),
 			curl.WithPath(pathTeam2),
@@ -283,38 +231,38 @@ func (s *tsuite) TestInvalidChildValidStandalone() {
 		},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
 
-	s.ti.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.ctx, routeTeam2.Name, routeTeam2.Namespace,
+	s.TestInstallation.Assertions.EventuallyHTTPRouteStatusContainsMessage(s.Ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"spec.hostnames must be unset", 10*time.Second, 1*time.Second)
 }
 
-func (s *tsuite) TestUnresolvedChild() {
-	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeRoot.Name, routeRoot.Namespace,
+func (s *testingSuite) TestUnresolvedChild() {
+	s.TestInstallation.Assertions.EventuallyHTTPRouteStatusContainsReason(s.Ctx, routeRoot.Name, routeRoot.Namespace,
 		string(gwv1.RouteReasonBackendNotFound), 10*time.Second, 1*time.Second)
 }
 
-func (s *tsuite) TestMatcherInheritance() {
+func (s *testingSuite) TestMatcherInheritance() {
 	// Wait for both parent routes to be accepted before sending traffic
-	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeParent1.Name, routeParent1.Namespace,
+	s.TestInstallation.Assertions.EventuallyHTTPRouteStatusContainsReason(s.Ctx, routeParent1.Name, routeParent1.Namespace,
 		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)
-	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeParent2.Name, routeParent2.Namespace,
+	s.TestInstallation.Assertions.EventuallyHTTPRouteStatusContainsReason(s.Ctx, routeParent2.Name, routeParent2.Namespace,
 		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)
-	s.ti.Assertions.EventuallyHTTPRouteStatusContainsReason(s.ctx, routeTeam1.Name, routeTeam1.Namespace,
+	s.TestInstallation.Assertions.EventuallyHTTPRouteStatusContainsReason(s.Ctx, routeTeam1.Name, routeTeam1.Namespace,
 		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)
 
 	// Assert traffic on parent1's prefix
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath("/anything/foo/child")},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring("/anything/foo/child")})
 
 	// Assert traffic on parent2's prefix
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath("/anything/baz/child")},
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring("/anything/baz/child")})
 }
 
-func (s *tsuite) TestRouteWeight() {
+func (s *testingSuite) TestRouteWeight() {
 	// Assert traffic to /anything path prefix is always routed to svc1
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
@@ -324,7 +272,7 @@ func (s *tsuite) TestRouteWeight() {
 			},
 		})
 	// Assert traffic to /anything/team2 is also routed to svc1 since its route has higher weight
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
@@ -335,9 +283,9 @@ func (s *tsuite) TestRouteWeight() {
 		})
 }
 
-func (s *tsuite) TestPolicyMerging() {
+func (s *testingSuite) TestPolicyMerging() {
 	// Assert traffic to parent1.com/anything/team1 uses svc1's transformation policy
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam1),
@@ -352,7 +300,7 @@ func (s *tsuite) TestPolicyMerging() {
 		})
 
 	// Assert traffic to parent1.com/anything/team2 uses svc2's transformation policy
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam2),
@@ -367,7 +315,7 @@ func (s *tsuite) TestPolicyMerging() {
 		})
 
 	// Assert traffic to parent2.com/anything/team1 uses parent2's transformation policy
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam1),
@@ -382,7 +330,7 @@ func (s *tsuite) TestPolicyMerging() {
 		})
 
 	// Assert traffic to parent2.com/anything/team2 uses parent2's transformation policy
-	s.ti.Assertions.AssertEventuallyConsistentCurlResponse(s.ctx, defaults.CurlPodExecOpt,
+	s.TestInstallation.Assertions.AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
 		[]curl.Option{
 			curl.WithHostPort(proxyHostPort),
 			curl.WithPath(pathTeam2),

--- a/test/kubernetes/e2e/features/route_delegation/testdata/common.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/testdata/common.yaml
@@ -34,7 +34,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: httpbin
+  name: httpbin-v1
   namespace: team1
 spec:
   replicas: 1
@@ -42,11 +42,13 @@ spec:
     matchLabels:
       app: httpbin
       version: v1
+      app.kubernetes.io/name: httpbin-v1
   template:
     metadata:
       labels:
         app: httpbin
         version: v1
+        app.kubernetes.io/name: httpbin-v1
     spec:
       containers:
       - image: docker.io/kennethreitz/httpbin
@@ -89,7 +91,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: httpbin
+  name: httpbin-v2
   namespace: team2
 spec:
   replicas: 1
@@ -97,11 +99,13 @@ spec:
     matchLabels:
       app: httpbin
       version: v2
+      app.kubernetes.io/name: httpbin-v2
   template:
     metadata:
       labels:
         app: httpbin
         version: v2
+        app.kubernetes.io/name: httpbin-v2
     spec:
       containers:
       - image: docker.io/kennethreitz/httpbin

--- a/test/kubernetes/e2e/features/route_delegation/types.go
+++ b/test/kubernetes/e2e/features/route_delegation/types.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
 )
 
@@ -29,7 +30,7 @@ var (
 	}
 	httpbinTeam1Deployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "httpbin",
+			Name:      "httpbin-v1",
 			Namespace: "team1",
 		},
 	}
@@ -41,7 +42,7 @@ var (
 	}
 	httpbinTeam2Deployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "httpbin",
+			Name:      "httpbin-v2",
 			Namespace: "team2",
 		},
 	}
@@ -108,6 +109,9 @@ var (
 		Name:      "http-gateway-test",
 		Namespace: "infra",
 	}
+	gatewayTest = &gwv1.Gateway{
+		ObjectMeta: proxyTestMeta,
+	}
 	proxyTestDeployment = &appsv1.Deployment{ObjectMeta: proxyTestMeta}
 	proxyTestService    = &corev1.Service{ObjectMeta: proxyTestMeta}
 
@@ -115,6 +119,44 @@ var (
 
 	routeParentHost = "parent.com"
 	routeTeam2Host  = "team2.com"
+)
+
+// ref: cyclic.yaml / recursive.yaml
+var (
+	routeTeam2Root = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team2-root",
+			Namespace: "team2-root",
+		},
+	}
+)
+
+// ref: policy_merging.yaml
+var (
+	trafficPolicyParent1Transform = &v1alpha1.TrafficPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent1-transform",
+			Namespace: "infra",
+		},
+	}
+	trafficPolicyParent2Transform = &v1alpha1.TrafficPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent2-transform",
+			Namespace: "infra",
+		},
+	}
+	trafficPolicySvc1Transform = &v1alpha1.TrafficPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1-transform",
+			Namespace: "team1",
+		},
+	}
+	trafficPolicySvc2Transform = &v1alpha1.TrafficPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc2-transform",
+			Namespace: "team2",
+		},
+	}
 )
 
 var (

--- a/test/kubernetes/testutils/assertions/curl.go
+++ b/test/kubernetes/testutils/assertions/curl.go
@@ -145,21 +145,7 @@ func (p *Provider) AssertEventuallyConsistentCurlResponse(
 	}
 
 	p.Gomega.Consistently(func(g Gomega) {
-		res, err := p.clusterContext.Cli.CurlFromPod(ctx, podOpts, curlOptions...)
-		fmt.Printf("want:\n%+v\nstdout:\n%s\nstderr:%s\n\n", expectedResponse, res.StdOut, res.StdErr)
-		// Ignore certain errors that are expected to occur when the curl command times out
-		if err != nil {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && exitErr.ExitCode() == expectedResponse.IgnoreExitCode {
-				fmt.Printf("Ignoring curl exit code %d: %v\n", expectedResponse.IgnoreExitCode, err)
-			} else {
-				g.Expect(err).NotTo(HaveOccurred())
-			}
-		}
-
-		expectedResponseMatcher := WithTransform(transforms.WithCurlResponse, matchers.HaveHttpResponse(expectedResponse))
-		g.Expect(res).To(expectedResponseMatcher)
-		fmt.Printf("success: %+v", res)
+		p.assertCurlResponse(ctx, podOpts, curlOptions, expectedResponse)
 	}).
 		WithTimeout(pollTimeout).
 		WithPolling(pollInterval).


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Some updates to hopefully help with flakes:
- Convert route delegation suite to use base suite
- Add some more object checks
- In AssertEventuallyConsistentCurlResponse, call the existing helper function which closes the response when done (the responses were not being closed before)

Fixes https://github.com/kgateway-dev/kgateway/issues/11984

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind flake

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
