### PR TITLE
e2e headermodifiers flake fix

### DIFF
--- a/test/gomega/matchers/json_contains.go
+++ b/test/gomega/matchers/json_contains.go
@@ -2,7 +2,6 @@ package matchers
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/onsi/gomega"
@@ -28,24 +27,17 @@ func JSONContains(expectedJSON any) gomega.OmegaMatcher {
 	matchers = append(matchers, ContainsDeepMapElements(expected))
 
 	return &JSONContainsMatcher{
-		expected:  expected,
-		matchers:  gomega.And(matchers...),
-		evaluated: false,
+		expected: expected,
+		matchers: gomega.And(matchers...),
 	}
 }
 
 type JSONContainsMatcher struct {
-	expected  interface{}
-	matchers  gomega.OmegaMatcher
-	evaluated bool
+	expected interface{}
+	matchers gomega.OmegaMatcher
 }
 
 func (matcher *JSONContainsMatcher) Match(actualBytes interface{}) (success bool, err error) {
-	if matcher.evaluated {
-		return false, errors.New("using the same matcher twice can lead to inconsistent behaviors")
-	}
-	matcher.evaluated = true
-
 	actualJSON, ok := actualBytes.([]byte)
 	if !ok {
 		return false, nil

--- a/test/gomega/matchers/json_contains.go
+++ b/test/gomega/matchers/json_contains.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
-func JSONContains(expectedJSON any) gomega.OmegaMatcher {
-	matchers := []gomega.OmegaMatcher{
+func JSONContains(expectedJSON any) types.GomegaMatcher {
+	matchers := []types.GomegaMatcher{
 		gomega.Not(gomega.BeNil()),
 		gomega.Not(gomega.BeEmpty()),
 	}
@@ -34,7 +35,7 @@ func JSONContains(expectedJSON any) gomega.OmegaMatcher {
 
 type JSONContainsMatcher struct {
 	expected interface{}
-	matchers gomega.OmegaMatcher
+	matchers types.GomegaMatcher
 }
 
 func (matcher *JSONContainsMatcher) Match(actualBytes interface{}) (success bool, err error) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Fixes https://github.com/kgateway-dev/kgateway/issues/12177

See the [issue comment](https://github.com/kgateway-dev/kgateway/issues/12177#issuecomment-3264591315) for an explanation of this fix. Removing the `evaluated` check so that JSONContains can be called more than once within an Eventually block.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind flake

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
