### PR TITLE
e2e: Remove the upgrade-related code from the base suite

### DIFF
--- a/test/kubernetes/e2e/features/agentgateway/extauth/suite.go
+++ b/test/kubernetes/e2e/features/agentgateway/extauth/suite.go
@@ -69,7 +69,7 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	}
 
 	return &testingSuite{
-		BaseTestingSuite: base.NewBaseTestingSuiteWithoutUpgrades(ctx, testInst, setupTestCase, testCases),
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setupTestCase, testCases),
 	}
 }
 

--- a/test/kubernetes/e2e/features/agentgateway/local-rate-limit/suite.go
+++ b/test/kubernetes/e2e/features/agentgateway/local-rate-limit/suite.go
@@ -55,7 +55,7 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	}
 
 	return &testingSuite{
-		BaseTestingSuite: base.NewBaseTestingSuiteWithoutUpgrades(ctx, testInst, setupTestCase, testCases),
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setupTestCase, testCases),
 	}
 }
 

--- a/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
+++ b/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
@@ -21,7 +21,7 @@ type testingSuite struct {
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		base.NewBaseTestingSuiteWithoutUpgrades(ctx, testInst, setupSuite, testCases),
+		base.NewBaseTestingSuite(ctx, testInst, setupSuite, testCases),
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Removed the non-functional / commented out upgrade code in the base testing suite to make the code more readable. (We can always add it back later if needed)

Related to https://github.com/kgateway-dev/kgateway/issues/10609

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
