### PR TITLE
api/rate-limit: reject invalid fillInterval value

### DIFF
--- a/api/v1alpha1/traffic_policy_types.go
+++ b/api/v1alpha1/traffic_policy_types.go
@@ -308,6 +308,7 @@ type TokenBucket struct {
 	// It determines the frequency of token replenishment.
 	// +required
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
+	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('50ms')",message="must be at least 50ms"
 	FillInterval metav1.Duration `json:"fillInterval"`
 }
 

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
@@ -704,6 +704,8 @@ spec:
                             x-kubernetes-validations:
                             - message: invalid duration value
                               rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                            - message: must be at least 50ms
+                              rule: duration(self) >= duration('50ms')
                           maxTokens:
                             format: int32
                             minimum: 1


### PR DESCRIPTION
# Description
Rejects invalid fillInterval values.
Based on:
https://github.com/envoyproxy/envoy/blob/e15295f2319133a0fd4b1df0ca94868fd378a9bb/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.cc#L104

Resolves #11560

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```