### PR TITLE
e2e: Extend route replacement policy tests

### DIFF
--- a/test/kubernetes/e2e/features/routereplacement/testdata/gateway-wide-invalid-policy.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/gateway-wide-invalid-policy.yaml
@@ -1,0 +1,83 @@
+---
+# Gateway with multiple listeners to test gateway-wide invalid policy blast radius
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-gateway-wide
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http-8080
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: http-8081
+    port: 8081
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# HTTPRoute on first listener
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-8080
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-gateway-wide
+    namespace: default
+    sectionName: http-8080
+  hostnames:
+  - "gateway-wide-8080.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# HTTPRoute on second listener
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-8081
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-gateway-wide
+    namespace: default
+    sectionName: http-8081
+  hostnames:
+  - "gateway-wide-8081.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# Invalid TrafficPolicy attached to entire gateway (no sectionName)
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-wide-invalid-policy
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gw-gateway-wide
+  transformation:
+    request:
+      body:
+        parseAs: AsJson
+        value: "{{ invalid_template }"  # Invalid template syntax that envoy will reject

--- a/test/kubernetes/e2e/features/routereplacement/testdata/listener-merge-blast-radius.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/listener-merge-blast-radius.yaml
@@ -1,0 +1,118 @@
+---
+# Gateway with listeners that will be merged (same port) and isolated listeners
+# to test blast radius when one merged listener has invalid policy
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-listener-isolation
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  # These two listeners share port 8080 and will be merged into the same FC/RC.
+  - name: http-merged-affected
+    port: 8080
+    protocol: HTTP
+    hostname: "affected.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: http-merged-unaffected
+    port: 8080
+    protocol: HTTP
+    hostname: "unaffected.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  # This listener is on a different port and should be isolated
+  - name: http-isolated
+    port: 8081
+    protocol: HTTP
+    hostname: "isolated.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# HTTPRoute on affected listener
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-affected
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-listener-isolation
+    namespace: default
+    sectionName: http-merged-affected
+  hostnames:
+  - "affected.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# HTTPRoute on merged listener that should remain unaffected
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-collateral
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-listener-isolation
+    namespace: default
+    sectionName: http-merged-unaffected
+  hostnames:
+  - "unaffected.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# HTTPRoute on isolated listener
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-isolated
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-listener-isolation
+    namespace: default
+    sectionName: http-isolated
+  hostnames:
+  - "isolated.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# Invalid TrafficPolicy attached to one of the merged listeners
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-merge-invalid-policy
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gw-listener-isolation
+    sectionName: http-merged-affected
+  transformation:
+    request:
+      body:
+        parseAs: AsJson
+        value: "{{ invalid_template }"  # Invalid template syntax that envoy will reject

--- a/test/kubernetes/e2e/features/routereplacement/testdata/listener-specific-invalid-policy.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/listener-specific-invalid-policy.yaml
@@ -1,0 +1,84 @@
+---
+# Gateway with multiple listeners to test listener-specific invalid policy isolation
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-listener-specific
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http-affected
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: http-unaffected
+    port: 8081
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# HTTPRoute on affected listener
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-affected
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-listener-specific
+    namespace: default
+    sectionName: http-affected
+  hostnames:
+  - "listener-affected.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# HTTPRoute on unaffected listener
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-unaffected
+  namespace: default
+spec:
+  parentRefs:
+  - name: gw-listener-specific
+    namespace: default
+    sectionName: http-unaffected
+  hostnames:
+  - "listener-unaffected.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: httpbin
+      port: 8000
+---
+# Invalid TrafficPolicy attached to specific listener only
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-specific-invalid-policy
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gw-listener-specific
+    sectionName: http-affected
+  transformation:
+    request:
+      body:
+        parseAs: AsJson
+        value: "{{ invalid_template }"  # Invalid template syntax that envoy will reject

--- a/test/kubernetes/e2e/features/routereplacement/types.go
+++ b/test/kubernetes/e2e/features/routereplacement/types.go
@@ -10,21 +10,37 @@ import (
 )
 
 var (
-	setupManifest                     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
-	strictModeInvalidPolicyManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-policy.yaml")
-	standardModeInvalidPolicyManifest = strictModeInvalidPolicyManifest
-	strictModeInvalidMatcherManifest  = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-matcher.yaml")
-	strictModeInvalidRouteManifest    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-route.yaml")
+	setupManifest                         = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	strictModeInvalidPolicyManifest       = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-policy.yaml")
+	standardModeInvalidPolicyManifest     = strictModeInvalidPolicyManifest
+	strictModeInvalidMatcherManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-matcher.yaml")
+	strictModeInvalidRouteManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-route.yaml")
+	gatewayWideInvalidPolicyManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "gateway-wide-invalid-policy.yaml")
+	listenerSpecificInvalidPolicyManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "listener-specific-invalid-policy.yaml")
+	listenerMergeBlastRadiusManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "listener-merge-blast-radius.yaml")
 
-	// proxy objects (gateway deployment)
 	proxyObjectMeta = metav1.ObjectMeta{
 		Name:      "gw",
 		Namespace: "default",
 	}
 
+	gatewayWideProxyObjectMeta = metav1.ObjectMeta{
+		Name:      "gw-gateway-wide",
+		Namespace: "default",
+	}
+
+	listenerSpecificProxyObjectMeta = metav1.ObjectMeta{
+		Name:      "gw-listener-specific",
+		Namespace: "default",
+	}
+
+	listenerIsolationProxyObjectMeta = metav1.ObjectMeta{
+		Name:      "gw-listener-isolation",
+		Namespace: "default",
+	}
+
 	gatewayPort = 8080
 
-	// route objects for testing
 	invalidPolicyRoute = &gwv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalid-policy-route",
@@ -42,6 +58,50 @@ var (
 	invalidConfigRoute = &gwv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalid-config-route",
+			Namespace: "default",
+		},
+	}
+
+	gatewayWideRoute8080 = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-8080",
+			Namespace: "default",
+		},
+	}
+	gatewayWideRoute8081 = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-8081",
+			Namespace: "default",
+		},
+	}
+	listenerAffectedRoute = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-affected",
+			Namespace: "default",
+		},
+	}
+	listenerUnaffectedRoute = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-unaffected",
+			Namespace: "default",
+		},
+	}
+
+	mergeAffectedRoute = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-affected",
+			Namespace: "default",
+		},
+	}
+	mergeUnaffectedRoute = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-collateral",
+			Namespace: "default",
+		},
+	}
+	mergeIsolatedRoute = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-isolated",
 			Namespace: "default",
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Follow-up to the #12199 PR, which updated the route translator to handle invalid policy attached listener-and-gateway-wide.

This commit introduces several new functional tests to validate the new behavior and compliment existing route-level coverage in the route replacement e2e suite.

Partially fixes #11937.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
