### PR TITLE
test/translator: fix defaulting and detect unknown fields

### DIFF
--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/mcp-backend-selector.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/mcp-backend-selector.yaml
@@ -50,7 +50,6 @@ metadata:
 spec:
   type: MCP
   mcp:
-    name: mcp-server
     targets:
     - name: mcp-app
       selector:

--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/multipool-inline-auth.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/multipool-inline-auth.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   type: AI
   ai:
-    multiPool:
+    multipool:
       priorities:
         - pool:
             - provider:

--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/multipool-priority-levels.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/multipool-priority-levels.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   type: AI
   ai:
-    multiPool:
+    multipool:
       priorities:
         # Priority 0 - Primary providers
         - pool:

--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/multipool-secret-auth.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/backend/multipool-secret-auth.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   type: AI
   ai:
-    multiPool:
+    multipool:
       priorities:
         - pool:
             - provider:

--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/trafficpolicy/ai/route-level-bearer.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/trafficpolicy/ai/route-level-bearer.yaml
@@ -78,9 +78,9 @@ spec:
             pattern: (?i)(hate|kill|harm)
           - name: profanity
             pattern: (?i)(bad|words)
-        builtins:
-          - CREDIT_CARD
-          - SSN
+          builtins:
+            - CREDIT_CARD
+            - SSN
         moderation:
           openAIModeration:
             authToken:
@@ -103,12 +103,6 @@ spec:
             pattern: \b\d{4}\b
           - name: mask-sensitive
             pattern: (?i)(password|secret)
-          openAIModeration:
-            authToken:
-              kind: SecretRef
-              secretRef:
-                name: openai-secret
-            model: text-moderation-latest
   targetRefs:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute

--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/trafficpolicy/ai/route-level.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/trafficpolicy/ai/route-level.yaml
@@ -78,9 +78,9 @@ spec:
             pattern: (?i)(hate|kill|harm)
           - name: profanity
             pattern: (?i)(bad|words)
-        builtins:
-          - CREDIT_CARD
-          - SSN
+          builtins:
+            - CREDIT_CARD
+            - SSN
         moderation:
           openAIModeration:
             authToken:
@@ -103,12 +103,6 @@ spec:
             pattern: \b\d{4}\b
           - name: mask-sensitive
             pattern: (?i)(password|secret)
-          openAIModeration:
-            authToken:
-              kind: SecretRef
-              secretRef:
-                name: openai-secret
-            model: text-moderation-latest
     defaults:
       - field: top_p
         value: "0.95"

--- a/internal/kgateway/agentgatewaysyncer/testdata/inputs/trafficpolicy/rbac/mcp-rbac.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/inputs/trafficpolicy/rbac/mcp-rbac.yaml
@@ -46,7 +46,6 @@ metadata:
 spec:
   type: MCP
   mcp:
-    name: mcp-server
     targets:
     - name: mcp-app
       selector:

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/ai/route-level-bearer.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/ai/route-level-bearer.yaml
@@ -46,6 +46,8 @@ Policies:
             - regex:
                 name: profanity
                 pattern: (?i)(bad|words)
+            - builtin: CREDIT_CARD
+            - builtin: SSN
           rejection:
             body: WW91ciByZXF1ZXN0IHdhcyByZWplY3RlZCBkdWUgdG8gaW5hcHByb3ByaWF0ZSBjb250ZW50
             status: 403
@@ -95,4 +97,3 @@ Routes:
   - path:
       pathPrefix: /v1/chat/completions
   routeName: default/openai-test
-

--- a/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/ai/route-level.yaml
+++ b/internal/kgateway/agentgatewaysyncer/testdata/outputs/trafficpolicy/ai/route-level.yaml
@@ -56,6 +56,8 @@ Policies:
             - regex:
                 name: profanity
                 pattern: (?i)(bad|words)
+            - builtin: CREDIT_CARD
+            - builtin: SSN
           rejection:
             body: WW91ciByZXF1ZXN0IHdhcyByZWplY3RlZCBkdWUgdG8gaW5hcHByb3ByaWF0ZSBjb250ZW50
             status: 403

--- a/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/extproc-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/extproc-full-config.yaml
@@ -90,10 +90,7 @@ spec:
         name: extproc
         port: 9000
       requestTimeout: 300ms
-    # this should be tested, but due to a bug in how the translator tests process
-    # resources, types of `bool` with a value of false don't work correctly.
-    # ref: https://github.com/kgateway-dev/kgateway/issues/12264
-    # failOpen: false
+    failOpen: false
     processingMode:
       requestHeaderMode: SKIP
       responseHeaderMode: SKIP

--- a/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/rate-limit-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/traffic-policy/rate-limit-full-config.yaml
@@ -118,10 +118,7 @@ spec:
       requestTimeout: 200ms # this timeout is specific to the grpcService
     domain: "api-gateway"
     timeout: "50ms"
-    # this should be tested, but due to a bug in how the translator tests process
-    # resources, types of `bool` with a value of false don't work correctly.
-    # ref: https://github.com/kgateway-dev/kgateway/issues/12264
-    # failOpen: false
+    failOpen: false
     xRateLimitHeaders: DraftVersion03
 ---
 apiVersion: v1

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
@@ -105,7 +105,6 @@ Listeners:
                           name: envoy.filters.http.ext_proc
                           typedConfig:
                             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
-                            failureModeAllow: true
                             grpcService:
                               envoyGrpc:
                                 clusterName: kube_infra_extproc_9000

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
@@ -47,13 +47,14 @@ Listeners:
                 envoyGrpc:
                   clusterName: kube_default_ratelimit_8081
               transportApiVersion: V3
-            timeout: 0s
+            timeout: 0.100s
         - disabled: true
           name: ratelimit/default/full-ratelimit
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
             domain: api-gateway
             enableXRatelimitHeaders: DRAFT_VERSION_03
+            failureModeDeny: true
             rateLimitService:
               grpcService:
                 envoyGrpc:

--- a/test/translator/file_loader.go
+++ b/test/translator/file_loader.go
@@ -141,7 +141,7 @@ func parseFile(
 		}
 
 		if structuralSchema, ok := gvkToStructuralSchema[gvk]; ok {
-			objYamlWithDefaults, err := applyDefaults(obj, structuralSchema)
+			objYamlWithDefaults, err := applyDefaults(objYaml, structuralSchema)
 			if err != nil {
 				return nil, fmt.Errorf("failed to apply defaults for %s: %w", gvk, err)
 			}


### PR DESCRIPTION
# Description
- Fixes defaulting so that fields with omitempty are not dropped while applying the defaults.
- Errors on unknown fields in the input.
- Uses structurual pruning similar to k8s API server flow.
- Removes workaround for rate-limit's failOpen.
- Fixes agentgateway tests to use correct field names, indentation, and removes unsupported fields.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes
Resolves #12264