### PR TITLE
Makefile: Remove prerequisite from the gie-crds target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,7 +504,7 @@ endif
 GIE_CRD_VERSION ?= $(shell go list -m sigs.k8s.io/gateway-api-inference-extension | awk '{print $$2}')
 
 .PHONY: gie-crds
-gie-crds: gw-api-crds ## Install the Gateway API Inference Extension CRDs
+gie-crds: ## Install the Gateway API Inference Extension CRDs
 	kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$(GIE_CRD_VERSION)/manifests.yaml"
 
 .PHONY: kind-metallb


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The manifests being deployed in the gie-crds target do not rely on the Gateway API CRDs. Additionally, having the gw-api-crds as a prerequisite breaks deploying a dev environment with the `CONFORMANCE_CHANNEL="standard"` Gateway API channel locally.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
