### PR TITLE
e2e: Refactor route replacement tests to standalone suite

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -53,7 +53,7 @@ jobs:
         # August 29, 2025: ~10 minutes
         - cluster-name: 'cluster-five'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestKgateway$$/^TimeoutRetry$$|^TestKgateway$$/^HeaderModifiers$$|^TestKgateway$$/^RBAC$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^Transforms$$|^TestKgateway$$/^RouteReplacement$$|^TestKgateway$$/^RouteDelegation$$'
+          go-test-run-regex: '^TestKgateway$$/^TimeoutRetry$$|^TestKgateway$$/^HeaderModifiers$$|^TestKgateway$$/^RBAC$$|^TestKgateway$$/^Deployer$$|^TestKgateway$$/^Transforms$$|^TestRouteReplacement$$|^TestKgateway$$/^RouteDelegation$$'
           localstack: 'false'
         # August 29, 2025: ~9 minutes
         - cluster-name: 'cluster-six'

--- a/test/kubernetes/e2e/features/routereplacement/suite.go
+++ b/test/kubernetes/e2e/features/routereplacement/suite.go
@@ -2,22 +2,16 @@ package routereplacement
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kgateway-dev/kgateway/v2/pkg/settings"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
-	"github.com/kgateway-dev/kgateway/v2/test/helpers"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	testdefaults "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
@@ -34,97 +28,55 @@ var (
 		},
 	}
 
-	// TODO(tim): remove mode here, only test in strict mode.
-	testModes = map[string]settings.RouteReplacementMode{
-		"TestStrictModeInvalidPolicyReplacement":      settings.RouteReplacementStrict,
-		"TestStandardModeInvalidPolicyReplacement":    settings.RouteReplacementStandard,
-		"TestStrictModeInvalidMatcherDropsRoute":      settings.RouteReplacementStrict,
-		"TestStrictModeInvalidRouteReplacement":       settings.RouteReplacementStrict,
-		"TestStrictModeGatewayWideInvalidPolicy":      settings.RouteReplacementStrict,
-		"TestStrictModeListenerSpecificInvalidPolicy": settings.RouteReplacementStrict,
-		"TestStrictModeListenerSpecificIsolation":     settings.RouteReplacementStrict,
-	}
-
 	testCases = map[string]*base.TestCase{
-		"TestStrictModeInvalidPolicyReplacement": {
-			Manifests: []string{strictModeInvalidPolicyManifest},
+		"TestRouteAttachedInvalidPolicy": {
+			Manifests: []string{routeAttachedInvalidPolicyManifest},
 		},
-		"TestStandardModeInvalidPolicyReplacement": {
-			Manifests: []string{standardModeInvalidPolicyManifest},
+		"TestInvalidMatcherDropsRoute": {
+			Manifests: []string{invalidMatcherManifest},
 		},
-		"TestStrictModeInvalidMatcherDropsRoute": {
-			Manifests: []string{strictModeInvalidMatcherManifest},
+		"TestInvalidRouteRuleFilter": {
+			Manifests: []string{invalidRouteRuleFilterManifest},
 		},
-		"TestStrictModeInvalidRouteReplacement": {
-			Manifests: []string{strictModeInvalidRouteManifest},
-		},
-		"TestStrictModeGatewayWideInvalidPolicy": {
+		"TestGatewayWideInvalidPolicy": {
 			Manifests: []string{gatewayWideInvalidPolicyManifest},
 		},
-		"TestStrictModeListenerSpecificInvalidPolicy": {
+		"TestListenerSpecificInvalidPolicy": {
 			Manifests: []string{listenerSpecificInvalidPolicyManifest},
 		},
-		"TestStrictModeListenerSpecificIsolation": {
+		"TestListenerSpecificIsolation": {
 			Manifests: []string{listenerMergeBlastRadiusManifest},
 		},
 	}
 )
 
 // testingSuite is a suite of route replacement tests that verify the guardrail behavior
-// for invalid route configurations in both STANDARD and STRICT modes
+// for invalid route configurations
 type testingSuite struct {
 	*base.BaseTestingSuite
-
-	// testModes maps test name to its route replacement mode
-	testModes map[string]settings.RouteReplacementMode
-
-	// original deployment state for cleanup
-	originalDeployment *appsv1.Deployment
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
 		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
-		testModes:        testModes,
 	}
 }
 
 func (s *testingSuite) SetupSuite() {
 	s.BaseTestingSuite.SetupSuite()
-
-	// Store original deployment state for cleanup
-	controllerNamespace := s.TestInstallation.Metadata.InstallNamespace
-
-	s.originalDeployment = &appsv1.Deployment{}
-	err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx, client.ObjectKey{
-		Namespace: controllerNamespace,
-		Name:      helpers.DefaultKgatewayDeploymentName,
-	}, s.originalDeployment)
-	s.Require().NoError(err, "can get original controller deployment")
 }
 
 func (s *testingSuite) TearDownSuite() {
-	// Restore original deployment state
-	s.restoreOriginalDeployment()
-
 	s.BaseTestingSuite.TearDownSuite()
 }
 
 func (s *testingSuite) BeforeTest(suiteName, testName string) {
-	mode, exists := s.testModes[testName]
-	if !exists {
-		s.FailNow(fmt.Sprintf("no mode configuration found for test %s", testName))
-	}
-
-	// Patch deployment with required route replacement mode
-	s.patchDeploymentWithMode(mode)
-
 	s.BaseTestingSuite.BeforeTest(suiteName, testName)
 }
 
-// TestStrictModeInvalidPolicyReplacement tests that in STRICT mode,
-// routes with valid configuration but invalid custom policies are replaced with direct responses
-func (s *testingSuite) TestStrictModeInvalidPolicyReplacement() {
+// TestRouteAttachedInvalidPolicy tests that routes with valid configuration
+// but invalid route-attached policies are replaced with direct responses
+func (s *testingSuite) TestRouteAttachedInvalidPolicy() {
 	// Verify route status shows Accepted=False with RouteRuleDropped reason (for replacement)
 	s.TestInstallation.Assertions.EventuallyHTTPRouteCondition(
 		s.Ctx,
@@ -152,38 +104,8 @@ func (s *testingSuite) TestStrictModeInvalidPolicyReplacement() {
 	)
 }
 
-// TestStandardModeInvalidPolicyReplacement tests that in STANDARD mode,
-// routes with invalid policies are handled differently than in STRICT mode
-func (s *testingSuite) TestStandardModeInvalidPolicyReplacement() {
-	// Verify route status shows Accepted=True (STANDARD mode accepts despite invalid policy)
-	s.TestInstallation.Assertions.EventuallyHTTPRouteCondition(
-		s.Ctx,
-		invalidPolicyRoute.Name,
-		invalidPolicyRoute.Namespace,
-		gwv1.RouteConditionAccepted,
-		metav1.ConditionTrue,
-	)
-
-	// Verify that the route works normally (STANDARD mode doesn't replace with 500)
-	s.TestInstallation.Assertions.AssertEventualCurlResponse(
-		s.Ctx,
-		testdefaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(proxyObjectMeta)),
-			curl.WithHostHeader("invalid-policy.example.com"),
-			curl.WithPort(gatewayPort),
-			curl.WithPath("/headers"),
-			curl.WithHeader("x-test-header", "some-value-with-policy"),
-		},
-		&testmatchers.HttpResponse{
-			StatusCode: http.StatusOK,
-		},
-	)
-}
-
-// TestStrictModeInvalidMatcherDropsRoute tests that in STRICT mode,
-// routes with invalid matchers are dropped entirely
-func (s *testingSuite) TestStrictModeInvalidMatcherDropsRoute() {
+// TestInvalidMatcherDropsRoute tests that routes with invalid matchers are dropped entirely
+func (s *testingSuite) TestInvalidMatcherDropsRoute() {
 	// Verify route status shows Accepted=False with RouteRuleDropped reason
 	s.TestInstallation.Assertions.EventuallyHTTPRouteCondition(
 		s.Ctx,
@@ -210,9 +132,9 @@ func (s *testingSuite) TestStrictModeInvalidMatcherDropsRoute() {
 	)
 }
 
-// TestStrictModeInvalidRouteReplacement tests that in STRICT mode,
-// routes with invalid built-in policies are replaced with direct responses
-func (s *testingSuite) TestStrictModeInvalidRouteReplacement() {
+// TestInvalidRouteRuleFilter tests that routes with invalid built-in route rule filters
+// are replaced with direct responses
+func (s *testingSuite) TestInvalidRouteRuleFilter() {
 	// Verify route status shows Accepted=False with RouteRuleDropped reason (for replacement)
 	s.TestInstallation.Assertions.EventuallyHTTPRouteCondition(
 		s.Ctx,
@@ -239,9 +161,9 @@ func (s *testingSuite) TestStrictModeInvalidRouteReplacement() {
 	)
 }
 
-// TestStrictModeGatewayWideInvalidPolicy tests that in STRICT mode, when an invalid policy
-// is attached to the entire gateway, all routes across all listeners are replaced with 500 responses
-func (s *testingSuite) TestStrictModeGatewayWideInvalidPolicy() {
+// TestGatewayWideInvalidPolicy tests that when an invalid policy is attached to the entire gateway,
+// all routes across all listeners are replaced with 500 responses
+func (s *testingSuite) TestGatewayWideInvalidPolicy() {
 	// Verify Gateway shows Accepted=False with GatewayReplaced reason
 	s.TestInstallation.Assertions.EventuallyGatewayCondition(
 		s.Ctx,
@@ -300,9 +222,9 @@ func (s *testingSuite) TestStrictModeGatewayWideInvalidPolicy() {
 	)
 }
 
-// TestStrictModeListenerSpecificInvalidPolicy tests that in STRICT mode, when an invalid
-// policy is attached to a specific listener, only routes on that listener are affected
-func (s *testingSuite) TestStrictModeListenerSpecificInvalidPolicy() {
+// TestListenerSpecificInvalidPolicy tests that when an invalid policy is attached to a specific listener,
+// only routes on that listener are affected
+func (s *testingSuite) TestListenerSpecificInvalidPolicy() {
 	// Verify Gateway itself remains Accepted=True (listener-specific policy doesn't affect gateway)
 	s.TestInstallation.Assertions.EventuallyGatewayCondition(
 		s.Ctx,
@@ -360,10 +282,9 @@ func (s *testingSuite) TestStrictModeListenerSpecificInvalidPolicy() {
 	)
 }
 
-// TestStrictModeListenerSpecificIsolation tests that in STRICT mode, when listeners share the same
-// port and one has an invalid policy, only the specific listener with the invalid policy is affected
-// (i.e. no collateral damage to other listeners on same port).
-func (s *testingSuite) TestStrictModeListenerSpecificIsolation() {
+// TestListenerSpecificIsolation tests that when listeners share the same port and one has an invalid policy,
+// only the specific listener with the invalid policy is affected (i.e. no collateral damage to other listeners on same port)
+func (s *testingSuite) TestListenerSpecificIsolation() {
 	// Verify Gateway itself remains Accepted=True (listener-specific policy doesn't affect gateway)
 	s.TestInstallation.Assertions.EventuallyGatewayCondition(
 		s.Ctx,
@@ -442,98 +363,4 @@ func (s *testingSuite) TestStrictModeListenerSpecificIsolation() {
 			StatusCode: http.StatusOK,
 		},
 	)
-}
-
-func (s *testingSuite) patchDeploymentWithMode(mode settings.RouteReplacementMode) {
-	controllerNamespace := s.TestInstallation.Metadata.InstallNamespace
-
-	currentDeployment := &appsv1.Deployment{}
-	err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx, client.ObjectKey{
-		Namespace: controllerNamespace,
-		Name:      helpers.DefaultKgatewayDeploymentName,
-	}, currentDeployment)
-	s.Require().NoError(err, "can get current controller deployment")
-
-	modifiedDeployment := currentDeployment.DeepCopy()
-	containerIndex := -1
-	for i, container := range modifiedDeployment.Spec.Template.Spec.Containers {
-		if container.Name == helpers.KgatewayContainerName {
-			containerIndex = i
-			break
-		}
-	}
-	if containerIndex == -1 {
-		s.FailNow("kgateway container not found in deployment")
-	}
-
-	envVar := corev1.EnvVar{
-		Name:  "KGW_ROUTE_REPLACEMENT_MODE",
-		Value: string(mode),
-	}
-
-	var found bool
-	for i, env := range modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env {
-		if env.Name == "KGW_ROUTE_REPLACEMENT_MODE" {
-			modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env[i] = envVar
-			found = true
-			break
-		}
-	}
-	if !found {
-		modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env = append(
-			modifiedDeployment.Spec.Template.Spec.Containers[containerIndex].Env,
-			envVar,
-		)
-	}
-
-	modifiedDeployment.ResourceVersion = ""
-	err = s.TestInstallation.ClusterContext.Client.Patch(s.Ctx, modifiedDeployment, client.MergeFrom(currentDeployment))
-	s.Require().NoError(err, "can patch controller deployment")
-
-	s.TestInstallation.Assertions.EventuallyPodContainerContainsEnvVar(
-		s.Ctx,
-		controllerNamespace,
-		metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/name=kgateway",
-		},
-		helpers.KgatewayContainerName,
-		envVar,
-	)
-	s.TestInstallation.Assertions.EventuallyPodsRunning(s.Ctx, controllerNamespace, metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=kgateway",
-	})
-
-	// Wait until there is only one pod. This way the new pod with the updated env var becomes the leader
-	// and can write the correct status.
-	s.TestInstallation.Assertions.EventuallyReadyReplicas(s.Ctx, metav1.ObjectMeta{
-		Name:      "kgateway",
-		Namespace: s.TestInstallation.Metadata.InstallNamespace,
-	}, gomega.Equal(1))
-	s.TestInstallation.Assertions.Gomega.Eventually(func(g gomega.Gomega) {
-		out, err := s.TestInstallation.Actions.Kubectl().GetContainerLogs(s.Ctx, s.TestInstallation.Metadata.InstallNamespace, testdefaults.KGatewayDeployment)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to get pod logs")
-		g.Expect(out).To(gomega.ContainSubstring("successfully acquired lease"))
-	}, "60s", "10s").Should(gomega.Succeed())
-}
-
-func (s *testingSuite) restoreOriginalDeployment() {
-	controllerNamespace := s.TestInstallation.Metadata.InstallNamespace
-
-	// Get current deployment state
-	currentDeployment := &appsv1.Deployment{}
-	err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx, client.ObjectKey{
-		Namespace: controllerNamespace,
-		Name:      helpers.DefaultKgatewayDeploymentName,
-	}, currentDeployment)
-	s.Require().NoError(err, "can get current controller deployment")
-
-	// Restore original deployment
-	s.originalDeployment.ResourceVersion = ""
-	err = s.TestInstallation.ClusterContext.Client.Patch(s.Ctx, s.originalDeployment, client.MergeFrom(currentDeployment))
-	s.Require().NoError(err, "can restore original controller deployment")
-
-	// Wait for pods to be running again
-	s.TestInstallation.Assertions.EventuallyPodsRunning(s.Ctx, controllerNamespace, metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=kgateway",
-	})
 }

--- a/test/kubernetes/e2e/features/routereplacement/testdata/invalid-matcher.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/invalid-matcher.yaml
@@ -1,6 +1,6 @@
 ---
 # HTTPRoute with invalid regex matcher that will cause RDS validation to fail
-# In STRICT mode, this should result in the route being dropped entirely
+# This should result in the route being dropped entirely
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/routereplacement/testdata/invalid-route-rule-filter.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/invalid-route-rule-filter.yaml
@@ -1,6 +1,6 @@
 ---
 # HTTPRoute with valid configuration but invalid built-in policy (RequestHeaderModifier)
-# In STRICT mode, this should result in the route being replaced with a 500 direct response
+# This should result in the route being replaced with a 500 direct response
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/routereplacement/testdata/route-attached-invalid-policy.yaml
+++ b/test/kubernetes/e2e/features/routereplacement/testdata/route-attached-invalid-policy.yaml
@@ -1,6 +1,6 @@
 ---
 # HTTPRoute with valid configuration but invalid TrafficPolicy attached to it.
-# In STRICT mode, this should result in the route being replaced with a 500 direct response.
+# This should result in the route being replaced with a 500 direct response.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/routereplacement/types.go
+++ b/test/kubernetes/e2e/features/routereplacement/types.go
@@ -11,10 +11,9 @@ import (
 
 var (
 	setupManifest                         = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
-	strictModeInvalidPolicyManifest       = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-policy.yaml")
-	standardModeInvalidPolicyManifest     = strictModeInvalidPolicyManifest
-	strictModeInvalidMatcherManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-matcher.yaml")
-	strictModeInvalidRouteManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "strict-mode-invalid-route.yaml")
+	routeAttachedInvalidPolicyManifest    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "route-attached-invalid-policy.yaml")
+	invalidMatcherManifest                = filepath.Join(fsutils.MustGetThisDir(), "testdata", "invalid-matcher.yaml")
+	invalidRouteRuleFilterManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "invalid-route-rule-filter.yaml")
 	gatewayWideInvalidPolicyManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "gateway-wide-invalid-policy.yaml")
 	listenerSpecificInvalidPolicyManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "listener-specific-invalid-policy.yaml")
 	listenerMergeBlastRadiusManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "listener-merge-blast-radius.yaml")

--- a/test/kubernetes/e2e/tests/kgateway_tests.go
+++ b/test/kubernetes/e2e/tests/kgateway_tests.go
@@ -26,7 +26,6 @@ import (
 	local_rate_limit "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/rate_limit/local"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/rbac"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/route_delegation"
-	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/routereplacement"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/grpcroute"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/httproute"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/services/tcproute"
@@ -59,7 +58,6 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("HttpListenerPolicy", http_listener_policy.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("Lambda", lambda.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("RouteDelegation", route_delegation.NewTestingSuite)
-	kubeGatewaySuiteRunner.Register("RouteReplacement", routereplacement.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("SessionPersistence", session_persistence.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TCPRouteServices", tcproute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TLSRouteServices", tlsroute.NewTestingSuite)

--- a/test/kubernetes/e2e/tests/route_replacement_test.go
+++ b/test/kubernetes/e2e/tests/route_replacement_test.go
@@ -1,0 +1,52 @@
+package tests_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
+	. "github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/testutils/install"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
+)
+
+func TestRouteReplacement(t *testing.T) {
+	ctx := context.Background()
+	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "route-replacement-test")
+	testInstallation := e2e.CreateTestInstallation(
+		t,
+		&install.Context{
+			InstallNamespace:          installNs,
+			ProfileValuesManifestFile: e2e.CommonRecommendationManifest,
+			ValuesManifestFile:        e2e.EmptyValuesManifestPath,
+			ExtraHelmArgs: []string{
+				"--set", "controller.extraEnv.KGW_ROUTE_REPLACEMENT_MODE=STRICT",
+			},
+		},
+	)
+
+	// Set the env to the install namespace if it is not already set
+	if !nsEnvPredefined {
+		os.Setenv(testutils.InstallNamespace, installNs)
+	}
+
+	// We register the cleanup function _before_ we actually perform the installation.
+	// This allows us to uninstall kgateway, in case the original installation only completed partially
+	t.Cleanup(func() {
+		if !nsEnvPredefined {
+			os.Unsetenv(testutils.InstallNamespace)
+		}
+		if t.Failed() {
+			testInstallation.PreFailHandler(ctx)
+		}
+
+		testInstallation.UninstallKgateway(ctx)
+	})
+
+	// Install kgateway
+	testInstallation.InstallKgatewayFromLocalChart(ctx)
+
+	RouteReplacementSuiteRunner().Run(ctx, t, testInstallation)
+}

--- a/test/kubernetes/e2e/tests/route_replacement_tests.go
+++ b/test/kubernetes/e2e/tests/route_replacement_tests.go
@@ -1,0 +1,12 @@
+package tests
+
+import (
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/routereplacement"
+)
+
+func RouteReplacementSuiteRunner() e2e.SuiteRunner {
+	routeReplacementSuiteRunner := e2e.NewSuiteRunner(false)
+	routeReplacementSuiteRunner.Register("RouteReplacement", routereplacement.NewTestingSuite)
+	return routeReplacementSuiteRunner
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Refactor route replacement e2e tests from nested TestKgateway suite to standalone TestRouteReplacement suite with strict mode enabled by default via helm values. This eliminates the complex runtime deployment patching logic that was previously used to switch between standard and strict modes during test execution.

All standard mode testing has been removed to focus exclusively on strict mode behavior. Additionally, test naming has been updated to remove mode-specific language and better reflect the actual attachment patterns being tested.

This refactoring provides proper test isolation with correct configuration from the start, improves test reliability by eliminating deployment restarts during execution, and simplifies the test logic by removing mode management complexity.

The alternative to this approach is enabling strict mode by default for all functional tests, but that requires more discussion.

Fixes #12296.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
