### PR TITLE
irtranslator: Remove gomega assertions from unit tests

### DIFF
--- a/internal/kgateway/translator/irtranslator/backend_test.go
+++ b/internal/kgateway/translator/irtranslator/backend_test.go
@@ -9,7 +9,8 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
@@ -20,7 +21,6 @@ func testInitBackend(ctx context.Context, in ir.BackendObjectIR, out *envoyclust
 }
 
 func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
-	g := NewWithT(t)
 	var bt irtranslator.BackendTranslator
 	var ucc ir.UniqlyConnectedClient
 	var kctx krt.TestingDummyContext
@@ -40,14 +40,14 @@ func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 	}
 
 	c, err := bt.TranslateBackend(kctx, ucc, backend)
-	g.Expect(err).NotTo(HaveOccurred())
+	require.NoError(t, err)
 	opts := c.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-	g.Expect(opts).NotTo(BeNil())
+	assert.NotNil(t, opts)
 
 	p, err := opts.UnmarshalNew()
-	g.Expect(err).NotTo(HaveOccurred())
+	require.NoError(t, err)
 
 	httpOpts, ok := p.(*envoy_upstreams_v3.HttpProtocolOptions)
-	g.Expect(ok).To(BeTrue())
-	g.Expect(httpOpts.GetExplicitHttpConfig().GetHttp2ProtocolOptions()).NotTo(BeNil())
+	assert.True(t, ok)
+	assert.NotNil(t, httpOpts.GetExplicitHttpConfig().GetHttp2ProtocolOptions())
 }

--- a/internal/kgateway/translator/irtranslator/fc_test.go
+++ b/internal/kgateway/translator/irtranslator/fc_test.go
@@ -5,19 +5,17 @@ import (
 	"testing"
 
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	extensionsplug "github.com/kgateway-dev/kgateway/v2/internal/kgateway/extensions2/plugin"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/plugins"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
-
-	"istio.io/istio/pkg/ptr"
-	"istio.io/istio/pkg/slices"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (
@@ -98,9 +96,7 @@ func TestFilterChains(t *testing.T) {
 	)
 
 	expectedChainCount := len(listener.HttpFilterChain) + len(listener.TcpFilterChain)
-	if len(envoyListener.FilterChains) != expectedChainCount {
-		t.Fatal("got", len(envoyListener.FilterChains), "Envoy filter chains, but wanted", expectedChainCount)
-	}
+	assert.Equal(t, expectedChainCount, len(envoyListener.FilterChains), "unexpected number of Envoy filter chains")
 
 	expectedFilters := []string{testPluginFilterName, testCustomFilterName}
 	for _, filterChain := range envoyListener.FilterChains {
@@ -108,11 +104,7 @@ func TestFilterChains(t *testing.T) {
 			filter := ptr.Flatten(slices.FindFunc(filterChain.Filters, func(filter *envoylistenerv3.Filter) bool {
 				return filter.Name == expectedFilterName
 			}))
-
-			if filter == nil {
-				t.Errorf("filter chain %q missing expected filter %q",
-					filterChain.Name, expectedFilterName)
-			}
+			assert.NotNil(t, filter, "filter chain %q missing expected filter %q", filterChain.Name, expectedFilterName)
 		}
 	}
 }

--- a/internal/kgateway/translator/irtranslator/route_test.go
+++ b/internal/kgateway/translator/irtranslator/route_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	"google.golang.org/protobuf/types/known/wrapperspb"
-
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestValidateWeightedClusters(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

A light refactor for the backend_test.go to remove any gomega-based assertions in favor of testify.
This was the only unit test in the irtranslator directory that imported any gomega/ginkgo dependencies.

Additionally, several unrelated changes that fix import grouping if we ever adopted the gci linter for
this repository.

Related to #11766 while implementing it locally.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
