### PR TITLE
translator: Implement CDS validation

### DIFF
--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/lb.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/lb.go
@@ -198,7 +198,8 @@ func applyLoadBalancerConfig(config *LoadBalancerConfigIR, out *envoyclusterv3.C
 	}
 
 	if config.useHostnameForHashing && out.GetType() != envoyclusterv3.Cluster_STRICT_DNS {
-		logger.Error("useHostnameForHashing is only supported for STRICT_DNS clusters. Ignoring useHostnameForHashing.", "cluster", out.GetName())
+		logger.Error("useHostnameForHashing is only supported for STRICT_DNS clusters. Ignoring useHostnameForHashing.",
+			"cluster", out.GetName())
 		if config.loadBalancingPolicy != nil && len(config.loadBalancingPolicy.Policies) > 0 {
 			typedCfg := config.loadBalancingPolicy.Policies[0].GetTypedExtensionConfig()
 			disableUseHostnameForHashingIfPresent(typedCfg)

--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	pluginsdkutils "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmputils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
 
 const PreserveCasePlugin = "envoy.http.stateful_header_formatters.preserve_case"
@@ -123,31 +124,29 @@ func registerTypes(ourCli versioned.Interface) {
 	)
 }
 
-func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sdk.Plugin {
+func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, v validator.Validator) sdk.Plugin {
 	registerTypes(commoncol.OurClient)
 	col := krt.WrapClient(kclient.NewFiltered[*v1alpha1.BackendConfigPolicy](
 		commoncol.Client,
 		kclient.Filter{ObjectFilter: commoncol.Client.ObjectFilter()},
 	), commoncol.KrtOpts.ToOptions("BackendConfigPolicy")...)
 	backendConfigPolicyCol := krt.NewCollection(col, func(krtctx krt.HandlerContext, b *v1alpha1.BackendConfigPolicy) *ir.PolicyWrapper {
-		objSrc := ir.ObjectSource{
-			Group:     wellknown.BackendConfigPolicyGVK.Group,
-			Kind:      wellknown.BackendConfigPolicyGVK.Kind,
-			Namespace: b.Namespace,
-			Name:      b.Name,
-		}
-
-		policyIR, err := translate(commoncol, krtctx, b)
-		errs := []error{}
-		if err != nil {
+		policyIR, errs := translate(commoncol, krtctx, b)
+		if err := validateXDS(ctx, policyIR, v, commoncol.Settings.RouteReplacementMode); err != nil {
 			errs = append(errs, err)
 		}
+
 		return &ir.PolicyWrapper{
-			ObjectSource: objSrc,
-			Policy:       b,
-			PolicyIR:     policyIR,
-			TargetRefs:   pluginsdkutils.TargetRefsToPolicyRefs(b.Spec.TargetRefs, b.Spec.TargetSelectors),
-			Errors:       errs,
+			ObjectSource: ir.ObjectSource{
+				Group:     wellknown.BackendConfigPolicyGVK.Group,
+				Kind:      wellknown.BackendConfigPolicyGVK.Kind,
+				Namespace: b.Namespace,
+				Name:      b.Name,
+			},
+			Policy:     b,
+			PolicyIR:   policyIR,
+			TargetRefs: pluginsdkutils.TargetRefsToPolicyRefs(b.Spec.TargetRefs, b.Spec.TargetSelectors),
+			Errors:     errs,
 		}
 	}, commoncol.KrtOpts.ToOptions("BackendConfigPolicyIRs")...)
 	return sdk.Plugin{
@@ -208,7 +207,12 @@ func processBackend(_ context.Context, polir ir.PolicyIR, backend ir.BackendObje
 	}
 }
 
-func translate(commoncol *collections.CommonCollections, krtctx krt.HandlerContext, pol *v1alpha1.BackendConfigPolicy) (*BackendConfigPolicyIR, error) {
+func translate(
+	commoncol *collections.CommonCollections,
+	krtctx krt.HandlerContext,
+	pol *v1alpha1.BackendConfigPolicy,
+) (*BackendConfigPolicyIR, []error) {
+	var errs []error
 	ir := BackendConfigPolicyIR{
 		ct: pol.CreationTimestamp.Time,
 	}
@@ -230,7 +234,7 @@ func translate(commoncol *collections.CommonCollections, krtctx krt.HandlerConte
 	if pol.Spec.Http1ProtocolOptions != nil {
 		http1ProtocolOptions, err := translateHttp1ProtocolOptions(pol.Spec.Http1ProtocolOptions)
 		if err != nil {
-			return &ir, err
+			errs = append(errs, err)
 		}
 		ir.http1ProtocolOptions = http1ProtocolOptions
 	}
@@ -242,7 +246,7 @@ func translate(commoncol *collections.CommonCollections, krtctx krt.HandlerConte
 	if pol.Spec.TLS != nil {
 		tlsConfig, err := translateTLSConfig(NewDefaultSecretGetter(commoncol.Secrets, krtctx), pol.Spec.TLS, pol.Namespace)
 		if err != nil {
-			return &ir, err
+			errs = append(errs, err)
 		}
 		ir.tlsConfig = tlsConfig
 	}
@@ -250,7 +254,7 @@ func translate(commoncol *collections.CommonCollections, krtctx krt.HandlerConte
 	if pol.Spec.LoadBalancer != nil {
 		loadBalancerConfig, err := translateLoadBalancerConfig(pol.Spec.LoadBalancer, pol.Name, pol.Namespace)
 		if err != nil {
-			return &ir, err
+			errs = append(errs, err)
 		}
 		ir.loadBalancerConfig = loadBalancerConfig
 	}
@@ -263,7 +267,7 @@ func translate(commoncol *collections.CommonCollections, krtctx krt.HandlerConte
 		ir.outlierDetection = translateOutlierDetection(pol.Spec.OutlierDetection)
 	}
 
-	return &ir, nil
+	return &ir, errs
 }
 
 func translateTCPKeepalive(tcpKeepalive *v1alpha1.TCPKeepalive) *envoycorev3.TcpKeepalive {

--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils"
 )
 
-func TestBackendConfigPolicyFlow(t *testing.T) {
+func TestBackendConfigPolicyTranslation(t *testing.T) {
 	tests := []struct {
 		name    string
 		policy  *v1alpha1.BackendConfigPolicy
@@ -241,12 +241,12 @@ func TestBackendConfigPolicyFlow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// First translate the policy
-			policyIR, err := translate(nil, nil, tt.policy)
+			policyIR, errs := translate(nil, nil, tt.policy)
 			if tt.wantErr {
-				assert.Error(t, err)
+				assert.NotEmpty(t, errs)
 				return
 			}
-			require.NoError(t, err)
+			require.Empty(t, errs)
 
 			// Then process the backend with the translated policy
 			cluster := tt.cluster
@@ -263,7 +263,7 @@ func TestBackendConfigPolicyFlow(t *testing.T) {
 	}
 }
 
-// Helper function to handle MessageToAny error in test cases
+// mustMessageToAny is a helper function to handle MessageToAny error in test cases
 func mustMessageToAny(t *testing.T, msg proto.Message) *anypb.Any {
 	a, err := utils.MessageToAny(msg)
 	require.NoError(t, err, "failed to convert message to Any")

--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/protocoloptions.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/protocoloptions.go
@@ -79,7 +79,7 @@ func translateHttp2ProtocolOptions(http2ProtocolOptions *v1alpha1.Http2ProtocolO
 	return out
 }
 
-func applyCommonHttpProtocolOptions(commonHttpProtocolOptions *envoycorev3.HttpProtocolOptions, backend ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
+func applyCommonHttpProtocolOptions(commonHttpProtocolOptions *envoycorev3.HttpProtocolOptions, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
 	if commonHttpProtocolOptions == nil {
 		return
 	}

--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/validate.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/validate.go
@@ -1,0 +1,68 @@
+package backendconfigpolicy
+
+import (
+	"context"
+	"time"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/kgateway-dev/kgateway/v2/api/settings"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
+	"github.com/kgateway-dev/kgateway/v2/pkg/xds/bootstrap"
+)
+
+// validateXDS performs xDS validation checks on the BCP IR definition. This acts as a
+// safety net to catch bugs in the IR construction logic and prevents invalid configuration
+// from being applied when STRICT mode is enabled.
+func validateXDS(
+	ctx context.Context,
+	policyIR *BackendConfigPolicyIR,
+	v validator.Validator,
+	mode settings.RouteReplacementMode,
+) error {
+	if mode != settings.RouteReplacementStrict || v == nil {
+		return nil
+	}
+
+	// default to STATIC cluster for validation, but switch to STRICT_DNS when
+	// useHostnameForHashing is enabled to avoid false positives. The load balancer
+	// logic requires STRICT_DNS clusters for hostname-based hashing to work properly.
+	discoveryType := envoyclusterv3.Cluster_STATIC
+	if policyIR.loadBalancerConfig != nil && policyIR.loadBalancerConfig.useHostnameForHashing {
+		discoveryType = envoyclusterv3.Cluster_STRICT_DNS
+	}
+
+	testCluster := &envoyclusterv3.Cluster{
+		Name: "test-cluster-for-validation",
+		ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
+			Type: discoveryType,
+		},
+		ConnectTimeout: durationpb.New(5 * time.Second),
+	}
+	dummyBackend := ir.BackendObjectIR{
+		ObjectSource: ir.ObjectSource{
+			Group:     "core",
+			Kind:      "Service",
+			Name:      "test-backend",
+			Namespace: "test",
+		},
+		Port: 80,
+	}
+	processBackend(ctx, policyIR, dummyBackend, testCluster)
+
+	builder := bootstrap.New()
+	builder.AddCluster(testCluster)
+	bootstrap, err := builder.Build()
+	if err != nil {
+		return err
+	}
+	data, err := protojson.Marshal(bootstrap)
+	if err != nil {
+		return err
+	}
+
+	return v.Validate(ctx, string(data))
+}

--- a/internal/kgateway/extensions2/plugins/backendconfigpolicy/validate_test.go
+++ b/internal/kgateway/extensions2/plugins/backendconfigpolicy/validate_test.go
@@ -1,0 +1,183 @@
+package backendconfigpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	envoybootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/kgateway-dev/kgateway/v2/api/settings"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
+)
+
+// mockValidator implements validator.Validator for testing
+type mockValidator struct {
+	validateFunc func(ctx context.Context, config string) error
+}
+
+var _ validator.Validator = &mockValidator{}
+
+func (m *mockValidator) Validate(ctx context.Context, config string) error {
+	if m.validateFunc != nil {
+		return m.validateFunc(ctx, config)
+	}
+	return nil
+}
+
+func TestBackendConfigPolicyXDSValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		policyIR  *BackendConfigPolicyIR
+		validator *mockValidator
+		mode      settings.RouteReplacementMode
+		wantErr   bool
+	}{
+		{
+			name: "valid policy with successful validation in strict mode",
+			policyIR: &BackendConfigPolicyIR{
+				ct:             time.Now(),
+				connectTimeout: durationpb.New(5 * time.Second),
+			},
+			validator: &mockValidator{
+				validateFunc: func(ctx context.Context, config string) error {
+					return nil // Successful validation
+				},
+			},
+			mode:    settings.RouteReplacementStrict,
+			wantErr: false,
+		},
+		{
+			name: "invalid TLS policy with failed cipher suite validation in strict mode",
+			policyIR: &BackendConfigPolicyIR{
+				ct: time.Now(),
+				tlsConfig: &envoytlsv3.UpstreamTlsContext{
+					CommonTlsContext: &envoytlsv3.CommonTlsContext{
+						TlsParams: &envoytlsv3.TlsParameters{
+							CipherSuites: []string{"BOGUS_CIPHER_SUITE_1", "INVALID_AES_256_GCM_SHA384"},
+						},
+					},
+				},
+			},
+			validator: &mockValidator{
+				validateFunc: func(ctx context.Context, config string) error {
+					return errors.New("Failed to initialize cipher suites BOGUS_CIPHER_SUITE_1:INVALID_AES_256_GCM_SHA384")
+				},
+			},
+			mode:    settings.RouteReplacementStrict,
+			wantErr: true,
+		},
+		{
+			name: "invalid TLS policy with failed ECDH curve validation in strict mode",
+			policyIR: &BackendConfigPolicyIR{
+				ct: time.Now(),
+				tlsConfig: &envoytlsv3.UpstreamTlsContext{
+					CommonTlsContext: &envoytlsv3.CommonTlsContext{
+						TlsParams: &envoytlsv3.TlsParameters{
+							EcdhCurves: []string{"invalid-curve-p256", "bogus-secp384r1"},
+						},
+					},
+				},
+			},
+			validator: &mockValidator{
+				validateFunc: func(ctx context.Context, config string) error {
+					return errors.New("Failed to initialize ECDH curves")
+				},
+			},
+			mode:    settings.RouteReplacementStrict,
+			wantErr: true,
+		},
+		{
+			name: "invalid policy but validation skipped in standard mode",
+			policyIR: &BackendConfigPolicyIR{
+				ct: time.Now(),
+				tlsConfig: &envoytlsv3.UpstreamTlsContext{
+					CommonTlsContext: &envoytlsv3.CommonTlsContext{
+						TlsParams: &envoytlsv3.TlsParameters{
+							CipherSuites: []string{"BOGUS_CIPHER_SUITE_1"},
+						},
+					},
+				},
+			},
+			validator: &mockValidator{
+				validateFunc: func(ctx context.Context, config string) error {
+					return errors.New("should not be called in standard mode")
+				},
+			},
+			mode:    settings.RouteReplacementStandard,
+			wantErr: false, // No error because validation is skipped
+		},
+		{
+			name: "policy with useHostnameForHashing uses STRICT_DNS cluster for validation",
+			policyIR: &BackendConfigPolicyIR{
+				ct: time.Now(),
+				loadBalancerConfig: &LoadBalancerConfigIR{
+					useHostnameForHashing: true,
+				},
+			},
+			validator: &mockValidator{
+				validateFunc: func(ctx context.Context, config string) error {
+					// Verify that the cluster uses STRICT_DNS when useHostnameForHashing is enabled
+					var bootstrap envoybootstrapv3.Bootstrap
+					if err := protojson.Unmarshal([]byte(config), &bootstrap); err != nil {
+						return err
+					}
+					if len(bootstrap.StaticResources.Clusters) != 1 {
+						return errors.New("expected exactly one cluster in bootstrap")
+					}
+					cluster := bootstrap.StaticResources.Clusters[0]
+					if cluster.GetType() != envoyclusterv3.Cluster_STRICT_DNS {
+						return fmt.Errorf("expected STRICT_DNS cluster type, got %v", cluster.GetType())
+					}
+					return nil // Validation passes
+				},
+			},
+			mode:    settings.RouteReplacementStrict,
+			wantErr: false,
+		},
+		{
+			name: "policy without useHostnameForHashing uses STATIC cluster for validation",
+			policyIR: &BackendConfigPolicyIR{
+				ct:             time.Now(),
+				connectTimeout: durationpb.New(10 * time.Second),
+			},
+			validator: &mockValidator{
+				validateFunc: func(ctx context.Context, config string) error {
+					// Verify that the cluster uses STATIC when useHostnameForHashing is not enabled
+					var bootstrap envoybootstrapv3.Bootstrap
+					if err := protojson.Unmarshal([]byte(config), &bootstrap); err != nil {
+						return err
+					}
+					if len(bootstrap.StaticResources.Clusters) != 1 {
+						return errors.New("expected exactly one cluster in bootstrap")
+					}
+					cluster := bootstrap.StaticResources.Clusters[0]
+					if cluster.GetType() != envoyclusterv3.Cluster_STATIC {
+						return fmt.Errorf("expected STATIC cluster type, got %v", cluster.GetType())
+					}
+					return nil // Validation passes
+				},
+			},
+			mode:    settings.RouteReplacementStrict,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateXDS(t.Context(), tt.policyIR, tt.validator, tt.mode)
+			if tt.wantErr {
+				assert.Error(t, err, "expected validation to fail but it succeeded")
+			} else {
+				assert.NoError(t, err, "expected validation to succeed but it failed: %v", err)
+			}
+		})
+	}
+}

--- a/internal/kgateway/extensions2/registry/registry.go
+++ b/internal/kgateway/extensions2/registry/registry.go
@@ -92,6 +92,6 @@ func Plugins(
 		serviceentry.NewPlugin(ctx, commoncol),
 		waypoint.NewPlugin(ctx, commoncol, waypointGatewayClassName),
 		sandwich.NewPlugin(),
-		backendconfigpolicy.NewPlugin(ctx, commoncol),
+		backendconfigpolicy.NewPlugin(ctx, commoncol, validator),
 	}
 }

--- a/internal/kgateway/proxy_syncer/backends.go
+++ b/internal/kgateway/proxy_syncer/backends.go
@@ -54,14 +54,14 @@ func NewPerClientEnvoyClusters(
 		for _, ucc := range uccs {
 			backendLogger.Debug("applying destination rules for backend", "ucc", ucc.ResourceName())
 
-			c, err := translator.TranslateBackend(kctx, ucc, backendObj)
+			c, err := translator.TranslateBackend(ctx, kctx, ucc, backendObj)
 			if c == nil {
 				continue
 			}
 			uccWithClusterRet = append(uccWithClusterRet, uccWithCluster{
+				Name:    c.GetName(),
 				Client:  ucc,
 				Cluster: c,
-				Name:    c.GetName(),
 				// pass along the error(s) indicating to consumers that this cluster is not usable
 				Error:          err,
 				ClusterVersion: utils.HashProto(c),

--- a/internal/kgateway/proxy_syncer/proxy_syncer.go
+++ b/internal/kgateway/proxy_syncer/proxy_syncer.go
@@ -238,7 +238,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 	clustersPerClient := NewPerClientEnvoyClusters(
 		ctx,
 		krtopts,
-		s.translator.GetUpstreamTranslator(),
+		s.translator.GetBackendTranslator(),
 		finalBackends,
 		s.uniqueClients,
 	)

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -2044,6 +2044,104 @@ func TestRouteReplacement(t *testing.T) {
 				return translatortest.AssertPolicyNotAccepted(t, "listener-merge-invalid-policy", "")
 			},
 		},
+		{
+			name:      "BackendConfigPolicy Missing Secret",
+			category:  "backendconfigpolicy",
+			inputFile: "invalid-missing-secret.yaml",
+			minMode:   settings.RouteReplacementStandard,
+			assertStandard: func(t *testing.T) translatortest.AssertReports {
+				return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+					// Verify that the backend policy has error status
+					policy := reporter.PolicyKey{
+						Group:     "gateway.kgateway.dev",
+						Kind:      "BackendConfigPolicy",
+						Namespace: "gwtest",
+						Name:      "invalid-backend-config-policy",
+					}
+					err := translatortest.GetPolicyStatusError(reportsMap, &policy)
+					require.Error(t, err, "BackendConfigPolicy should have error status due to missing secret")
+					require.Contains(t, err.Error(), "condition error", "Error should be about policy condition")
+				}
+			},
+			assertStrict: func(t *testing.T) translatortest.AssertReports {
+				return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+					policy := reporter.PolicyKey{
+						Group:     "gateway.kgateway.dev",
+						Kind:      "BackendConfigPolicy",
+						Namespace: "gwtest",
+						Name:      "invalid-backend-config-policy",
+					}
+					err := translatortest.GetPolicyStatusError(reportsMap, &policy)
+					require.Error(t, err, "BackendConfigPolicy should have error status due to missing secret")
+					require.Contains(t, err.Error(), "condition error", "Error should be about policy condition")
+				}
+			},
+		},
+		{
+			name:      "BackendConfigPolicy Invalid Cipher Suites",
+			category:  "backendconfigpolicy",
+			inputFile: "invalid-cipher-suites.yaml",
+			minMode:   settings.RouteReplacementStandard,
+			assertStrict: func(t *testing.T) translatortest.AssertReports {
+				return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+					err := translatortest.GetPolicyStatusError(reportsMap, &reporter.PolicyKey{
+						Group:     "gateway.kgateway.dev",
+						Kind:      "BackendConfigPolicy",
+						Namespace: "gwtest",
+						Name:      "invalid-cipher-policy",
+					})
+					require.Error(t, err)
+				}
+			},
+		},
+		{
+			name:      "BackendConfigPolicy Invalid TLS Files Non-existent",
+			category:  "backendconfigpolicy",
+			inputFile: "invalid-tlsfiles-nonexistent.yaml",
+			minMode:   settings.RouteReplacementStandard,
+			assertStandard: func(t *testing.T) translatortest.AssertReports {
+				return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+					err := translatortest.GetPolicyStatusError(reportsMap, &reporter.PolicyKey{
+						Group:     "gateway.kgateway.dev",
+						Kind:      "BackendConfigPolicy",
+						Namespace: "gwtest",
+						Name:      "invalid-tlsfiles-policy",
+					})
+					require.Error(t, err, "BackendConfigPolicy with non-existent TLS files should fail validation in strict mode")
+					require.Contains(t, err.Error(), "condition error", "Error should be about policy condition")
+				}
+			},
+			assertStrict: func(t *testing.T) translatortest.AssertReports {
+				return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+					err := translatortest.GetPolicyStatusError(reportsMap, &reporter.PolicyKey{
+						Group:     "gateway.kgateway.dev",
+						Kind:      "BackendConfigPolicy",
+						Namespace: "gwtest",
+						Name:      "invalid-tlsfiles-policy",
+					})
+					require.Error(t, err, "BackendConfigPolicy with non-existent TLS files should fail validation in strict mode")
+					require.Contains(t, err.Error(), "condition error", "Error should be about policy condition")
+				}
+			},
+		},
+		{
+			name:      "BackendConfigPolicy Invalid Outlier Detection Zero Interval",
+			category:  "backendconfigpolicy",
+			inputFile: "invalid-outlier-detection-zero-interval.yaml",
+			minMode:   settings.RouteReplacementStandard,
+			assertStrict: func(t *testing.T) translatortest.AssertReports {
+				return func(gwNN types.NamespacedName, reportsMap reports.ReportMap) {
+					err := translatortest.GetPolicyStatusError(reportsMap, &reporter.PolicyKey{
+						Group:     "gateway.kgateway.dev",
+						Kind:      "BackendConfigPolicy",
+						Namespace: "gwtest",
+						Name:      "invalid-outlier-detection-policy",
+					})
+					require.Error(t, err, "BackendConfigPolicy with zero interval outlier detection should fail validation in strict mode")
+					require.Contains(t, err.Error(), "condition error", "Error should be about policy condition")
+				}
+			},
+		},
 	}
 
 	runTest := func(t *testing.T, test routeReplacementTest, mode settings.RouteReplacementMode) {

--- a/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-cipher-suites.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-cipher-suites.yaml
@@ -1,0 +1,69 @@
+# Test case for BackendConfigPolicy with unknown cipher suites
+# This should cause Envoy to NACK the configuration due to unrecognized cipher names
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: https
+    port: 8443
+    protocol: HTTPS
+    hostname: www.example.com
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: gwtest
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: example
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test-route
+  namespace: gwtest
+spec:
+  parentRefs:
+  - name: example-gateway
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: BackendConfigPolicy
+metadata:
+  name: invalid-cipher-policy
+  namespace: gwtest
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: example-svc
+  tls:
+    insecureSkipVerify: false
+    parameters:
+      minVersion: "1.2"
+      maxVersion: "1.3"
+      # Invalid cipher suites that Envoy doesn't recognize
+      cipherSuites:
+      - "BOGUS_CIPHER_SUITE_1"
+      - "INVALID_AES_256_GCM_SHA384"
+      - "FAKE_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+      # Invalid ECDH curves
+      ecdhCurves:
+      - "invalid-curve-p256"
+      - "bogus-secp384r1"
+      - "fake-x25519"

--- a/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-missing-secret.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-missing-secret.yaml
@@ -1,0 +1,66 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: example-gateway
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+  namespace: gwtest
+  labels:
+    app: backend
+    service: backend
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+      appProtocol: https
+  selector:
+    app: backend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: example-gateway
+  hostnames:
+    - "example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend-service
+          port: 443
+---
+# BackendConfigPolicy with reference to non-existent secret - should cause validation error
+kind: BackendConfigPolicy
+apiVersion: gateway.kgateway.dev/v1alpha1
+metadata:
+  name: invalid-backend-config-policy
+  namespace: gwtest
+spec:
+  targetRefs:
+    - name: backend-service
+      group: ""
+      kind: Service
+  tls:
+    secretRef:
+      name: nonexistent-tls-secret  # This secret doesn't exist
+    sni: test.example.com

--- a/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-outlier-detection-zero-interval.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-outlier-detection-zero-interval.yaml
@@ -1,0 +1,66 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: example-gateway
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+  namespace: gwtest
+  labels:
+    app: backend
+    service: backend
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app: backend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: example-gateway
+  hostnames:
+    - "example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend-service
+          port: 80
+---
+# BackendConfigPolicy with zero interval outlier detection - should cause validation error in strict mode
+# Reproduces issue: https://github.com/kgateway-dev/kgateway/issues/12339
+kind: BackendConfigPolicy
+apiVersion: gateway.kgateway.dev/v1alpha1
+metadata:
+  name: invalid-outlier-detection-policy
+  namespace: gwtest
+spec:
+  targetRefs:
+    - name: backend-service
+      group: ""
+      kind: Service
+  outlierDetection:
+    consecutive5xx: 5
+    interval: "0s" # Invalid: 0s interval should fail Envoy validation
+    baseEjectionTime: "30s"

--- a/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-tlsfiles-nonexistent.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/route-replacement/backendconfigpolicy/invalid-tlsfiles-nonexistent.yaml
@@ -1,0 +1,70 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: example-gateway
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+  namespace: gwtest
+  labels:
+    app: backend
+    service: backend
+spec:
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+      appProtocol: https
+  selector:
+    app: backend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-route
+  namespace: gwtest
+spec:
+  parentRefs:
+    - name: example-gateway
+  hostnames:
+    - "example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend-service
+          port: 443
+---
+# BackendConfigPolicy with non-existent TLS file paths - should cause validation error in strict mode
+# Reproduces issue: https://github.com/kgateway-dev/kgateway/issues/12336
+kind: BackendConfigPolicy
+apiVersion: gateway.kgateway.dev/v1alpha1
+metadata:
+  name: invalid-tlsfiles-policy
+  namespace: gwtest
+spec:
+  targetRefs:
+    - name: backend-service
+      group: ""
+      kind: Service
+  tls:
+    files:
+      # These file paths don't exist in the proxy filesystem
+      tlsCertificate: "/nonexistent/path/to/cert.pem"
+      tlsKey: "/invalid/path/to/key.pem"
+      rootCA: "/missing/path/to/ca.pem"
+    sni: "backend.example.com"

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -1,0 +1,161 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_example-svc_80
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        tlsParams:
+          cipherSuites:
+          - BOGUS_CIPHER_SUITE_1
+          - INVALID_AES_256_GCM_SHA384
+          - FAKE_ECDHE_RSA_WITH_AES_128_CBC_SHA
+          ecdhCurves:
+          - invalid-curve-p256
+          - bogus-secp384r1
+          - fake-x25519
+          tlsMaximumProtocolVersion: TLSv1_3
+          tlsMinimumProtocolVersion: TLSv1_2
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8443
+  filterChains:
+  - filterChainMatch:
+      serverNames:
+      - www.example.com
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: https
+        statPrefix: http
+        useRemoteAddress: true
+    name: https
+  listenerFilters:
+  - name: envoy.filters.listener.tls_inspector
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+  name: listener~8443
+Routes:
+- ignorePortInHostMatching: true
+  name: https
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: https~www_example_com
+    routes:
+    - match:
+        prefix: /
+      name: https~www_example_com-route-0-httproute-test-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-cipher-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: example-svc
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -1,0 +1,138 @@
+Clusters:
+- loadAssignment:
+    clusterName: kube_gwtest_backend-service_443
+  metadata: {}
+  name: kube_gwtest_backend-service_443
+  type: STATIC
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~8080~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~example_com-route-0-httproute-backend-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_backend-service_443
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    gwtest/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-backend-config-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'failed to extract TLS data: failed to get secret nonexistent-tls-secret:
+            failed to find secret nonexistent-tls-secret: Secret "nonexistent-tls-secret"
+            not found'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: ""
+          reason: Pending
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -1,0 +1,145 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_gwtest_backend-service_80
+  outlierDetection:
+    baseEjectionTime: 30s
+    consecutive5xx: 5
+    interval: 0s
+    maxEjectionPercent: 10
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~8080~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~example_com-route-0-httproute-backend-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_backend-service_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    gwtest/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-outlier-detection-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -1,0 +1,137 @@
+Clusters:
+- loadAssignment:
+    clusterName: kube_gwtest_backend-service_443
+  metadata: {}
+  name: kube_gwtest_backend-service_443
+  type: STATIC
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~8080~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~example_com-route-0-httproute-backend-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_backend-service_443
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    gwtest/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-tlsfiles-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid certificate and key pair: tls: failed to find any PEM
+            data in certificate input'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: ""
+          reason: Pending
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -1,0 +1,144 @@
+Clusters:
+- loadAssignment:
+    clusterName: kube_gwtest_example-svc_80
+  metadata: {}
+  name: kube_gwtest_example-svc_80
+  type: STATIC
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8443
+  filterChains:
+  - filterChainMatch:
+      serverNames:
+      - www.example.com
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: https
+        statPrefix: http
+        useRemoteAddress: true
+    name: https
+  listenerFilters:
+  - name: envoy.filters.listener.tls_inspector
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+  name: listener~8443
+Routes:
+- ignorePortInHostMatching: true
+  name: https
+  virtualHosts:
+  - domains:
+    - www.example.com
+    name: https~www_example_com
+    routes:
+    - match:
+        prefix: /
+      name: https~www_example_com-route-0-httproute-test-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: https
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+  httpRoutes:
+    gwtest/test-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-cipher-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: example-svc
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Failed to initialize cipher suites BOGUS_CIPHER_SUITE_1:INVALID_AES_256_GCM_SHA384:FAKE_ECDHE_RSA_WITH_AES_128_CBC_SHA.
+            The following ciphers were rejected when tried individually: BOGUS_CIPHER_SUITE_1,
+            INVALID_AES_256_GCM_SHA384, FAKE_ECDHE_RSA_WITH_AES_128_CBC_SHA'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: ""
+          reason: Pending
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -1,0 +1,138 @@
+Clusters:
+- loadAssignment:
+    clusterName: kube_gwtest_backend-service_443
+  metadata: {}
+  name: kube_gwtest_backend-service_443
+  type: STATIC
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~8080~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~example_com-route-0-httproute-backend-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_backend-service_443
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    gwtest/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-backend-config-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'failed to extract TLS data: failed to get secret nonexistent-tls-secret:
+            failed to find secret nonexistent-tls-secret: Secret "nonexistent-tls-secret"
+            not found'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: ""
+          reason: Pending
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -1,0 +1,150 @@
+Clusters:
+- loadAssignment:
+    clusterName: kube_gwtest_backend-service_80
+  metadata: {}
+  name: kube_gwtest_backend-service_80
+  type: STATIC
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~8080~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~example_com-route-0-httproute-backend-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_backend-service_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    gwtest/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-outlier-detection-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid xds configuration: error initializing configuration '''':
+            node { id: "validation-node-id" cluster: "validation-cluster" } static_resources
+            { listeners { name: "placeholder_listener" address { socket_address {
+            address: "0.0.0.0" port_value: 8081 } } filter_chains { filters { name:
+            "envoy.filters.network.http_connection_manager" typed_config { [type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager]
+            { stat_prefix: "placeholder" route_config { virtual_hosts { name: "placeholder_vhost"
+            domains: "*" } } } } } name: "placeholder_filter_chain" } } clusters {
+            name: "test-cluster-for-validation" type: STATIC connect_timeout { seconds:
+            5 } outlier_detection { consecutive_5xx { value: 5 } interval { } base_ejection_time
+            { seconds: 30 } max_ejection_percent { value: 10 } } } } : Proto constraint
+            validation failed (BootstrapValidationError.StaticResources: embedded
+            message failed validation | caused by StaticResourcesValidationError.Clusters[0]:
+            embedded message failed validation | caused by ClusterValidationError.OutlierDetection:
+            embedded message failed validation | caused by OutlierDetectionValidationError.Interval:
+            value must be greater than 0s)'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: ""
+          reason: Pending
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -1,0 +1,137 @@
+Clusters:
+- loadAssignment:
+    clusterName: kube_gwtest_backend-service_443
+  metadata: {}
+  name: kube_gwtest_backend-service_443
+  type: STATIC
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~8080~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~example_com-route-0-httproute-backend-route-gwtest-0-0-matcher-0
+      route:
+        cluster: kube_gwtest_backend-service_443
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    gwtest/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      - lastTransitionTime: null
+        message: Gateway is accepted
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Gateway is programmed
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Listener is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Listener does not have conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Listener is programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    gwtest/backend-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Route is accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Route has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    BackendConfigPolicy/gwtest/invalid-tlsfiles-policy:
+      ancestors:
+      - ancestorRef:
+          group: ""
+          kind: Service
+          name: backend-service
+          namespace: gwtest
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid certificate and key pair: tls: failed to find any PEM
+            data in certificate input'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: ""
+          reason: Pending
+          status: "False"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/irtranslator/backend_test.go
+++ b/internal/kgateway/translator/irtranslator/backend_test.go
@@ -2,23 +2,23 @@ package irtranslator_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_upstreams_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
+	"github.com/kgateway-dev/kgateway/v2/api/settings"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/irtranslator"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	pluginsdkir "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
-
-func testInitBackend(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
-	return nil
-}
 
 func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 	var bt irtranslator.BackendTranslator
@@ -35,11 +35,13 @@ func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 	}
 	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
 		{Group: "group", Kind: "kind"}: {
-			InitEnvoyBackend: testInitBackend,
+			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+				return nil
+			},
 		},
 	}
 
-	c, err := bt.TranslateBackend(kctx, ucc, backend)
+	c, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
 	require.NoError(t, err)
 	opts := c.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
 	assert.NotNil(t, opts)
@@ -50,4 +52,198 @@ func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 	httpOpts, ok := p.(*envoy_upstreams_v3.HttpProtocolOptions)
 	assert.True(t, ok)
 	assert.NotNil(t, httpOpts.GetExplicitHttpConfig().GetHttp2ProtocolOptions())
+}
+
+// TestBackendTranslatorHandlesBackendIRErrors validates that when the Backend IR itself
+// has pre-existing errors, the translator returns a blackhole cluster and error.
+func TestBackendTranslatorHandlesBackendIRErrors(t *testing.T) {
+	// Create backend IR errors to simulate validation failures during IR construction.
+	// No attached policies needed for this test.
+	backendError1 := errors.New("invalid backend hostname")
+	backendError2 := errors.New("unsupported backend protocol")
+	backend := &ir.BackendObjectIR{
+		ObjectSource: ir.ObjectSource{
+			Group:     "core",
+			Kind:      "Service",
+			Name:      "invalid-svc",
+			Namespace: "test-ns",
+		},
+		Port:   80,
+		Errors: []error{backendError1, backendError2},
+		AttachedPolicies: pluginsdkir.AttachedPolicies{
+			Policies: map[schema.GroupKind][]pluginsdkir.PolicyAtt{},
+		},
+	}
+
+	var bt irtranslator.BackendTranslator
+	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
+		{Group: "core", Kind: "Service"}: {
+			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+				return nil
+			},
+		},
+	}
+	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{}
+
+	var ucc ir.UniqlyConnectedClient
+	var kctx krt.TestingDummyContext
+	// Validate that the backend IR errors are propagated.
+	cluster, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid backend hostname")
+	assert.Contains(t, err.Error(), "unsupported backend protocol")
+
+	// Should return a blackhole cluster when Backend IR has errors
+	assert.NotNil(t, cluster)
+	assert.Equal(t, "service_test-ns_invalid-svc_80", cluster.GetName())
+	assert.Equal(t, envoyclusterv3.Cluster_STATIC, cluster.GetType())
+	assert.Empty(t, cluster.GetLoadAssignment().GetEndpoints())
+
+	// Backend IR errors should remain in the backend
+	assert.NotEmpty(t, backend.Errors)
+	assert.Contains(t, backend.Errors, backendError1)
+	assert.Contains(t, backend.Errors, backendError2)
+}
+
+// TestBackendTranslatorPropagatesPolicyErrors validates that attached policy IR errors
+// are propagated and result in an error return with a blackhole cluster.
+func TestBackendTranslatorPropagatesPolicyErrors(t *testing.T) {
+	policyError1 := errors.New("invalid TLS certificate")
+	policyError2 := errors.New("invalid health check configuration")
+	backend := &ir.BackendObjectIR{
+		ObjectSource: ir.ObjectSource{
+			Group:     "group",
+			Kind:      "kind",
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		AttachedPolicies: pluginsdkir.AttachedPolicies{
+			Policies: map[schema.GroupKind][]pluginsdkir.PolicyAtt{
+				{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"}: {
+					{
+						GroupKind: schema.GroupKind{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"},
+						Errors:    []error{policyError1},
+					},
+				},
+				{Group: "gateway-api", Kind: "BackendTLSPolicy"}: {
+					{
+						GroupKind: schema.GroupKind{Group: "gateway-api", Kind: "BackendTLSPolicy"},
+						Errors:    []error{policyError2},
+					},
+				},
+			},
+		},
+	}
+
+	var bt irtranslator.BackendTranslator
+	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
+		{Group: "group", Kind: "kind"}: {
+			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+				return nil
+			},
+		},
+	}
+	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{
+		{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"}: {
+			Name: "BackendConfigPolicy",
+			ProcessBackend: func(ctx context.Context, polir ir.PolicyIR, backend ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
+			},
+		},
+		{Group: "gateway-api", Kind: "BackendTLSPolicy"}: {
+			Name: "BackendTLSPolicy",
+			ProcessBackend: func(ctx context.Context, polir ir.PolicyIR, backend ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
+			},
+		},
+	}
+
+	var ucc ir.UniqlyConnectedClient
+	var kctx krt.TestingDummyContext
+	cluster, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+	// Validate that the policy errors are propagated.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid TLS certificate")
+	assert.Contains(t, err.Error(), "invalid health check configuration")
+
+	// Validate that a blackhole cluster is returned when policy errors occur.
+	assert.NotNil(t, cluster)
+	assert.Equal(t, "kind_namespace_name_0", cluster.GetName())
+	assert.Equal(t, envoyclusterv3.Cluster_STATIC, cluster.GetType())
+	assert.Empty(t, cluster.GetLoadAssignment().GetEndpoints())
+
+	// Validate that policy errors are not stored in backend.Errors
+	assert.Empty(t, backend.Errors)
+}
+
+// TestBackendTranslatorHandlesXDSValidationErrors validates that when xDS validation fails
+// in strict mode, the translator returns a blackhole cluster and error.
+func TestBackendTranslatorHandlesXDSValidationErrors(t *testing.T) {
+	// Create a mock validator that always returns an error
+	mockValidator := &mockValidator{
+		validateFunc: func(ctx context.Context, config string) error {
+			return errors.New("envoy validation failed: invalid cluster configuration")
+		},
+	}
+
+	// BackendIR with no errors.
+	backend := &ir.BackendObjectIR{
+		ObjectSource: ir.ObjectSource{
+			Group:     "core",
+			Kind:      "Service",
+			Name:      "test-svc",
+			Namespace: "test-ns",
+		},
+		Port: 80,
+		// No pre-existing errors
+		Errors: nil,
+		// No attached policies that would cause errors
+		AttachedPolicies: pluginsdkir.AttachedPolicies{
+			Policies: map[schema.GroupKind][]pluginsdkir.PolicyAtt{},
+		},
+	}
+
+	var bt irtranslator.BackendTranslator
+	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
+		{Group: "core", Kind: "Service"}: {
+			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+				return nil
+			},
+		},
+	}
+	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{}
+
+	// Set up strict mode and inject the mock validator
+	bt.Mode = settings.RouteReplacementStrict
+	bt.Validator = mockValidator
+
+	var ucc ir.UniqlyConnectedClient
+	var kctx krt.TestingDummyContext
+	cluster, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+
+	// Should get an error because xDS validation failed
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "envoy validation failed")
+	assert.Contains(t, err.Error(), "invalid cluster configuration")
+
+	// Should return a blackhole cluster when xDS validation fails
+	assert.NotNil(t, cluster)
+	assert.Equal(t, "service_test-ns_test-svc_80", cluster.GetName())
+	assert.Equal(t, envoyclusterv3.Cluster_STATIC, cluster.GetType())
+	assert.Empty(t, cluster.GetLoadAssignment().GetEndpoints())
+
+	// Backend IR should remain clean (xDS errors don't modify backend.Errors)
+	assert.Empty(t, backend.Errors)
+}
+
+// mockValidator is a test implementation of validator.Validator for testing xDS validation errors
+type mockValidator struct {
+	validateFunc func(ctx context.Context, config string) error
+}
+
+var _ validator.Validator = &mockValidator{}
+
+func (m *mockValidator) Validate(ctx context.Context, config string) error {
+	if m.validateFunc != nil {
+		return m.validateFunc(ctx, config)
+	}
+	return nil
 }

--- a/internal/kgateway/translator/translator.go
+++ b/internal/kgateway/translator/translator.go
@@ -81,6 +81,8 @@ func (s *CombinedTranslator) Init(ctx context.Context) {
 		ContributedBackends: make(map[schema.GroupKind]ir.BackendInit),
 		ContributedPolicies: s.extensions.ContributesPolicies,
 		CommonCols:          s.commonCols,
+		Validator:           s.validator,
+		Mode:                s.commonCols.Settings.RouteReplacementMode,
 	}
 	for k, up := range s.extensions.ContributesBackends {
 		s.backendTranslator.ContributedBackends[k] = up.BackendInit
@@ -124,7 +126,7 @@ func (s *CombinedTranslator) buildProxy(kctx krt.HandlerContext, ctx context.Con
 	return proxy
 }
 
-func (s *CombinedTranslator) GetUpstreamTranslator() *irtranslator.BackendTranslator {
+func (s *CombinedTranslator) GetBackendTranslator() *irtranslator.BackendTranslator {
 	return s.backendTranslator
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Follow-up to the https://github.com/kgateway-dev/kgateway/pull/11939 PR that introduces RDS support to the
route config translation. This commit updates the backend
translator to additionally ensure the computed Envoy cluster
passes xDS validation when the controller is running in
strict mode.

This implies that envoy mode validate is being run twice during
a translation pass, and then per-IR event update for the
BackendConfigPolicy and TrafficPolicy plugins.

Implement xDS validation for the BackendConfigPolicy plugin to
act as a safety net between valid user configuration but invalid
xDS configuration that degrades the dataplane.

Note: While BackendTLSPolicy can contribute policy to the backend
being computed and that policy can lead to NACKs, then current
implementation needs more work and doesn't work with newer
versions of that experimental API or the stable version being
promoted in GW API 1.4.

Fixes #11766.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind feature

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
