### PR TITLE
*: Remove ctx parameter from ProxyTranslationPass methods

### DIFF
--- a/examples/plugin/main.go
+++ b/examples/plugin/main.go
@@ -168,7 +168,7 @@ type ourPolicyPass struct {
 }
 
 // ApplyForRoute is called when a an HTTPRouteRule is being translated to an envoy route.
-func (s *ourPolicyPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteContext, out *envoyroutev3.Route) error {
+func (s *ourPolicyPass) ApplyForRoute(pCtx *ir.RouteContext, out *envoyroutev3.Route) error {
 	// get our policy IR. Kgateway used the targetRef to attach the policy to the HTTPRoute. and now as it
 	// translates the HTTPRoute to xDS, it calls our plugin and passes the policy for the plugin's translation pass to do the
 	// policy to xDS translation.
@@ -192,7 +192,7 @@ func (s *ourPolicyPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteContext
 	return nil
 }
 
-func (s *ourPolicyPass) HttpFilters(ctx context.Context, fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
+func (s *ourPolicyPass) HttpFilters(fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
 	if !s.filterNeeded[fc.FilterChainName] {
 		return nil, nil
 	}
@@ -226,7 +226,7 @@ func pluginFactory(ctx context.Context, commoncol *collections.CommonCollections
 			ContributesPolicies: sdk.ContributesPolicies{
 				configMapGK: sdk.PolicyPlugin{
 					Name: "metadataPolicy",
-					NewGatewayTranslationPass: func(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+					NewGatewayTranslationPass: func(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
 						// Return a fresh new translation pass
 						return &ourPolicyPass{}
 					},

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_resources.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_resources.go
@@ -1,8 +1,6 @@
 package ai
 
 import (
-	"context"
-
 	"log/slog"
 	"os"
 	"strconv"
@@ -24,7 +22,7 @@ const (
 	waitFilterName        = "io.kgateway.wait"
 )
 
-func GetAIAdditionalResources(ctx context.Context) []*envoyclusterv3.Cluster {
+func GetAIAdditionalResources() []*envoyclusterv3.Cluster {
 	// This env var can be used to test the ext-proc filter locally.
 	// On linux this should be set to `172.17.0.1` and on mac to `host.docker.internal`
 	// Note: Mac doesn't work yet because it needs to be a DNS cluster

--- a/internal/kgateway/extensions2/plugins/backend/plugin.go
+++ b/internal/kgateway/extensions2/plugins/backend/plugin.go
@@ -348,7 +348,7 @@ type backendPlugin struct {
 
 var _ ir.ProxyTranslationPass = &backendPlugin{}
 
-func newPlug(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+func newPlug(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
 	return &backendPlugin{}
 }
 
@@ -356,7 +356,7 @@ func (p *backendPlugin) Name() string {
 	return ExtensionName
 }
 
-func (p *backendPlugin) ApplyForBackend(ctx context.Context, pCtx *ir.RouteBackendContext, in ir.HttpBackend, out *envoyroutev3.Route) error {
+func (p *backendPlugin) ApplyForBackend(pCtx *ir.RouteBackendContext, in ir.HttpBackend, out *envoyroutev3.Route) error {
 	backend := pCtx.Backend.Obj.(*v1alpha1.Backend)
 	backendIr := pCtx.Backend.ObjIr.(*BackendIr)
 	switch backend.Spec.Type {
@@ -393,7 +393,7 @@ func (p *backendPlugin) ApplyForBackend(ctx context.Context, pCtx *ir.RouteBacke
 // called 1 time per listener
 // if a plugin emits new filters, they must be with a plugin unique name.
 // any filter returned from route config must be disabled, so it doesnt impact other routes.
-func (p *backendPlugin) HttpFilters(ctx context.Context, fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
+func (p *backendPlugin) HttpFilters(fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
 	result := []plugins.StagedHttpFilter{}
 
 	var errs []error
@@ -413,10 +413,10 @@ func (p *backendPlugin) HttpFilters(ctx context.Context, fc ir.FilterChainCommon
 }
 
 // called 1 time (per envoy proxy). replaces GeneratedResources
-func (p *backendPlugin) ResourcesToAdd(ctx context.Context) ir.Resources {
+func (p *backendPlugin) ResourcesToAdd() ir.Resources {
 	var additionalClusters []*envoyclusterv3.Cluster
 	if len(p.aiGatewayEnabled) > 0 {
-		aiClusters := ai.GetAIAdditionalResources(ctx)
+		aiClusters := ai.GetAIAdditionalResources()
 		additionalClusters = append(additionalClusters, aiClusters...)
 	}
 	return ir.Resources{

--- a/internal/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
+++ b/internal/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/client/clientset/versioned"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	pluginsdkir "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
 
@@ -99,14 +100,14 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 	}
 }
 
-func NewGatewayTranslationPass(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+func NewGatewayTranslationPass(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
 	return &directResponsePluginGwPass{
 		reporter: reporter,
 	}
 }
 
 // called one or more times per route rule
-func (p *directResponsePluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteContext, outputRoute *envoyroutev3.Route) error {
+func (p *directResponsePluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputRoute *envoyroutev3.Route) error {
 	dr, ok := pCtx.Policy.(*directResponse)
 	if !ok {
 		return fmt.Errorf("internal error: expected *directResponse, got %T", pCtx.Policy)
@@ -142,9 +143,8 @@ func (p *directResponsePluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir
 }
 
 func (p *directResponsePluginGwPass) ApplyForRouteBackend(
-	ctx context.Context,
-	policy ir.PolicyIR,
-	pCtx *ir.RouteBackendContext,
+	policy pluginsdkir.PolicyIR,
+	pCtx *pluginsdkir.RouteBackendContext,
 ) error {
 	return ir.ErrNotAttachable
 }

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
@@ -30,12 +30,12 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/plugins"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/utils"
-	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
-
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/client/clientset/versioned"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	pluginsdkir "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/policy"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	pluginsdkutils "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/utils"
@@ -274,7 +274,7 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 	}
 }
 
-func NewGatewayTranslationPass(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+func NewGatewayTranslationPass(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
 	return &httpListenerPolicyPluginGwPass{
 		reporter: reporter,
 	}
@@ -285,8 +285,7 @@ func (p *httpListenerPolicyPluginGwPass) Name() string {
 }
 
 func (p *httpListenerPolicyPluginGwPass) ApplyHCM(
-	ctx context.Context,
-	pCtx *ir.HcmContext,
+	pCtx *pluginsdkir.HcmContext,
 	out *envoy_hcm.HttpConnectionManager,
 ) error {
 	policy, ok := pCtx.Policy.(*httpListenerPolicy)
@@ -375,7 +374,7 @@ func (p *httpListenerPolicyPluginGwPass) ApplyHCM(
 	return nil
 }
 
-func (p *httpListenerPolicyPluginGwPass) HttpFilters(ctx context.Context, fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
+func (p *httpListenerPolicyPluginGwPass) HttpFilters(fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
 	if p.healthCheckPolicy == nil {
 		return nil, nil
 	}
@@ -395,8 +394,7 @@ func (p *httpListenerPolicyPluginGwPass) HttpFilters(ctx context.Context, fc ir.
 }
 
 func (p *httpListenerPolicyPluginGwPass) ApplyListenerPlugin(
-	ctx context.Context,
-	pCtx *ir.ListenerContext,
+	pCtx *pluginsdkir.ListenerContext,
 	out *envoylistenerv3.Listener,
 ) {
 	policy, ok := pCtx.Policy.(*httpListenerPolicy)

--- a/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/plugin.go
+++ b/internal/kgateway/extensions2/plugins/inferenceextension/endpointpicker/plugin.go
@@ -76,7 +76,7 @@ func NewPlugin(ctx context.Context, commonCols *collections.CommonCollections) *
 			wellknown.InferencePoolGVK.GroupKind(): {
 				Name:     poolGroupKindName,
 				Policies: p.policies,
-				NewGatewayTranslationPass: func(ctx context.Context, t ir.GwTranslationCtx, r reporter.Reporter) ir.ProxyTranslationPass {
+				NewGatewayTranslationPass: func(t ir.GwTranslationCtx, r reporter.Reporter) ir.ProxyTranslationPass {
 					return newEndpointPickerPass(r, p.podIndex)
 				},
 			},
@@ -169,7 +169,6 @@ func (p *endpointPickerPass) Name() string {
 
 // ApplyForBackend updates the Envoy route for each InferencePool-backed HTTPRoute.
 func (p *endpointPickerPass) ApplyForBackend(
-	ctx context.Context,
 	pCtx *ir.RouteBackendContext,
 	in ir.HttpBackend,
 	out *envoyroutev3.Route,
@@ -272,7 +271,7 @@ func (p *endpointPickerPass) ApplyForBackend(
 }
 
 // HttpFilters returns one ext_proc filter, using the well-known filter name.
-func (p *endpointPickerPass) HttpFilters(ctx context.Context, fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
+func (p *endpointPickerPass) HttpFilters(fc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
 	if p == nil || len(p.usedPools) == 0 {
 		return nil, nil
 	}
@@ -354,7 +353,7 @@ func (p *endpointPickerPass) HttpFilters(ctx context.Context, fc ir.FilterChainC
 }
 
 // ResourcesToAdd returns the ext_proc clusters for all used InferencePools.
-func (p *endpointPickerPass) ResourcesToAdd(ctx context.Context) ir.Resources {
+func (p *endpointPickerPass) ResourcesToAdd() ir.Resources {
 	if p == nil || len(p.usedPools) == 0 {
 		return ir.Resources{}
 	}

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/auto_host_rewrite_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/auto_host_rewrite_test.go
@@ -1,7 +1,6 @@
 package trafficpolicy
 
 import (
-	"context"
 	"testing"
 
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -99,7 +98,6 @@ func TestAutoHostRewriteIREquals(t *testing.T) {
 }
 
 func TestApplyForRoute_SetsRouteActionFlag(t *testing.T) {
-	ctx := context.Background()
 	plugin := &trafficPolicyPluginGwPass{}
 
 	t.Run("autoHostRewrite true → RouteAction flag set", func(t *testing.T) {
@@ -118,7 +116,7 @@ func TestApplyForRoute_SetsRouteActionFlag(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, plugin.ApplyForRoute(ctx, pCtx, out))
+		require.NoError(t, plugin.ApplyForRoute(pCtx, out))
 
 		ra := out.GetRoute()
 		require.NotNil(t, ra)
@@ -135,7 +133,7 @@ func TestApplyForRoute_SetsRouteActionFlag(t *testing.T) {
 			Action: &envoyroutev3.Route_Route{Route: &envoyroutev3.RouteAction{}},
 		}
 
-		require.NoError(t, plugin.ApplyForRoute(ctx, pCtx, out))
+		require.NoError(t, plugin.ApplyForRoute(pCtx, out))
 
 		ra := out.GetRoute()
 		require.NotNil(t, ra)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy_test.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/extauth_policy_test.go
@@ -1,7 +1,6 @@
 package trafficpolicy
 
 import (
-	"context"
 	"testing"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -159,7 +158,6 @@ func TestApplyForRoute(t *testing.T) {
 	t.Run("applies ext auth configuration to route", func(t *testing.T) {
 		// Setup
 		plugin := &trafficPolicyPluginGwPass{}
-		ctx := context.Background()
 		policy := &TrafficPolicy{
 			spec: trafficPolicySpecIr{
 				extAuth: &extAuthIR{
@@ -183,7 +181,7 @@ func TestApplyForRoute(t *testing.T) {
 		outputRoute := &envoyroutev3.Route{}
 
 		// Execute
-		err := plugin.ApplyForRoute(ctx, pCtx, outputRoute)
+		err := plugin.ApplyForRoute(pCtx, outputRoute)
 
 		// Verify
 		require.NoError(t, err)
@@ -196,7 +194,6 @@ func TestApplyForRoute(t *testing.T) {
 	t.Run("handles nil ext auth configuration", func(t *testing.T) {
 		// Setup
 		plugin := &trafficPolicyPluginGwPass{}
-		ctx := context.Background()
 		policy := &TrafficPolicy{
 			spec: trafficPolicySpecIr{
 				extAuth: nil,
@@ -208,7 +205,7 @@ func TestApplyForRoute(t *testing.T) {
 		outputRoute := &envoyroutev3.Route{}
 
 		// Execute
-		err := plugin.ApplyForRoute(ctx, pCtx, outputRoute)
+		err := plugin.ApplyForRoute(pCtx, outputRoute)
 
 		// Verify
 		require.NoError(t, err)
@@ -237,13 +234,12 @@ func TestHttpFilters(t *testing.T) {
 				},
 			},
 		}
-		ctx := context.Background()
 		fcc := ir.FilterChainCommon{
 			FilterChainName: "test-filter-chain",
 		}
 
 		// Execute
-		filters, err := plugin.HttpFilters(ctx, fcc)
+		filters, err := plugin.HttpFilters(fcc)
 
 		// Verify
 		require.NoError(t, err)
@@ -257,7 +253,6 @@ func TestExtAuthPolicyPlugin(t *testing.T) {
 	t.Run("applies ext auth configuration to route", func(t *testing.T) {
 		// Setup
 		plugin := &trafficPolicyPluginGwPass{}
-		ctx := context.Background()
 		policy := &TrafficPolicy{
 			spec: trafficPolicySpecIr{
 				extAuth: &extAuthIR{
@@ -284,7 +279,7 @@ func TestExtAuthPolicyPlugin(t *testing.T) {
 		outputRoute := &envoyroutev3.Route{}
 
 		// Execute
-		err := plugin.ApplyForRoute(ctx, pCtx, outputRoute)
+		err := plugin.ApplyForRoute(pCtx, outputRoute)
 
 		// Verify
 		require.NoError(t, err)
@@ -298,7 +293,6 @@ func TestExtAuthPolicyPlugin(t *testing.T) {
 	t.Run("handles disabled ext auth configuration", func(t *testing.T) {
 		// Setup
 		plugin := &trafficPolicyPluginGwPass{}
-		ctx := context.Background()
 		policy := &TrafficPolicy{
 			spec: trafficPolicySpecIr{
 				extAuth: &extAuthIR{
@@ -312,7 +306,7 @@ func TestExtAuthPolicyPlugin(t *testing.T) {
 		outputRoute := &envoyroutev3.Route{}
 
 		// Execute
-		err := plugin.ApplyForRoute(ctx, pCtx, outputRoute)
+		err := plugin.ApplyForRoute(pCtx, outputRoute)
 
 		// Verify
 		require.NoError(t, err)

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -41,6 +41,7 @@ import (
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	sdkfilters "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/filters"
+	pluginsdkir "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/policy"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	pluginsdkutils "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/utils"
@@ -283,7 +284,7 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, me
 	}
 }
 
-func NewGatewayTranslationPass(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+func NewGatewayTranslationPass(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
 	return &trafficPolicyPluginGwPass{
 		reporter:                 reporter,
 		setTransformationInChain: make(map[string]bool),
@@ -295,8 +296,7 @@ func (p *TrafficPolicy) Name() string {
 }
 
 func (p *trafficPolicyPluginGwPass) ApplyRouteConfigPlugin(
-	ctx context.Context,
-	pCtx *ir.RouteConfigContext,
+	pCtx *pluginsdkir.RouteConfigContext,
 	out *envoyroutev3.RouteConfiguration,
 ) {
 	policy, ok := pCtx.Policy.(*TrafficPolicy)
@@ -308,8 +308,7 @@ func (p *trafficPolicyPluginGwPass) ApplyRouteConfigPlugin(
 }
 
 func (p *trafficPolicyPluginGwPass) ApplyVhostPlugin(
-	ctx context.Context,
-	pCtx *ir.VirtualHostContext,
+	pCtx *pluginsdkir.VirtualHostContext,
 	out *envoyroutev3.VirtualHost,
 ) {
 	policy, ok := pCtx.Policy.(*TrafficPolicy)
@@ -322,7 +321,7 @@ func (p *trafficPolicyPluginGwPass) ApplyVhostPlugin(
 }
 
 // called 0 or more times
-func (p *trafficPolicyPluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteContext, outputRoute *envoyroutev3.Route) error {
+func (p *trafficPolicyPluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputRoute *envoyroutev3.Route) error {
 	policy, ok := pCtx.Policy.(*TrafficPolicy)
 	if !ok {
 		return nil
@@ -414,9 +413,8 @@ func (p *trafficPolicyPluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.
 }
 
 func (p *trafficPolicyPluginGwPass) ApplyForRouteBackend(
-	ctx context.Context,
-	policy ir.PolicyIR,
-	pCtx *ir.RouteBackendContext,
+	policy pluginsdkir.PolicyIR,
+	pCtx *pluginsdkir.RouteBackendContext,
 ) error {
 	rtPolicy, ok := policy.(*TrafficPolicy)
 	if !ok {
@@ -435,7 +433,7 @@ func (p *trafficPolicyPluginGwPass) ApplyForRouteBackend(
 // called 1 time per listener
 // if a plugin emits new filters, they must be with a plugin unique name.
 // any filter returned from route config must be disabled, so it doesnt impact other routes.
-func (p *trafficPolicyPluginGwPass) HttpFilters(ctx context.Context, fcc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
+func (p *trafficPolicyPluginGwPass) HttpFilters(fcc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
 	filters := []plugins.StagedHttpFilter{}
 
 	// Add global ExtProc disable filter when there are providers

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/validate.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/validate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/api/settings"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
+	pluginsdkir "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 	"github.com/kgateway-dev/kgateway/v2/pkg/xds/bootstrap"
 )
@@ -36,8 +37,8 @@ func validateXDS(ctx context.Context, p *TrafficPolicy, v validator.Validator) e
 	// use a fake translation pass to ensure we have the desired typed filter config
 	// on the placeholder vhost.
 	typedPerFilterConfig := ir.TypedFilterConfigMap(map[string]proto.Message{})
-	fakePass := NewGatewayTranslationPass(ctx, ir.GwTranslationCtx{}, nil)
-	if err := fakePass.ApplyForRoute(ctx, &ir.RouteContext{
+	fakePass := NewGatewayTranslationPass(ir.GwTranslationCtx{}, nil)
+	if err := fakePass.ApplyForRoute(&pluginsdkir.RouteContext{
 		Policy:            p,
 		TypedFilterConfig: typedPerFilterConfig,
 	}, nil); err != nil {

--- a/internal/kgateway/krtcollections/builtin.go
+++ b/internal/kgateway/krtcollections/builtin.go
@@ -104,12 +104,12 @@ type builtinPluginGwPass struct {
 	needStatefulSession map[string]bool
 }
 
-func (p *builtinPluginGwPass) ApplyForBackend(ctx context.Context, pCtx *ir.RouteBackendContext, in ir.HttpBackend, out *envoyroutev3.Route) error {
+func (p *builtinPluginGwPass) ApplyForBackend(pCtx *pluginsdkir.RouteBackendContext, in pluginsdkir.HttpBackend, out *envoyroutev3.Route) error {
 	// no op
 	return nil
 }
 
-func (p *builtinPluginGwPass) ApplyHCM(ctx context.Context, pCtx *ir.HcmContext, out *envoyhttp.HttpConnectionManager) error {
+func (p *builtinPluginGwPass) ApplyHCM(pCtx *pluginsdkir.HcmContext, out *envoyhttp.HttpConnectionManager) error {
 	// no-op
 	return nil
 }
@@ -563,7 +563,7 @@ func toEnvoyPercentage(percentage float64) *envoytype.FractionalPercent {
 	}
 }
 
-func NewGatewayTranslationPass(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+func NewGatewayTranslationPass(tctx pluginsdkir.GwTranslationCtx, reporter reporter.Reporter) pluginsdkir.ProxyTranslationPass {
 	return &builtinPluginGwPass{
 		reporter:            reporter,
 		hasCorsPolicy:       make(map[string]bool),
@@ -581,7 +581,7 @@ func (p *builtinPlugin) Name() string {
 // and may override the current policy on the output route if pCtx.InheritedPolicyPriority allows it
 // Currently, ApplyForRoute is invoked per policy in order of priority from highest(child route policies)
 // to lowest(parent route policies).
-func (p *builtinPluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteContext, outputRoute *envoyroutev3.Route) error {
+func (p *builtinPluginGwPass) ApplyForRoute(pCtx *pluginsdkir.RouteContext, outputRoute *envoyroutev3.Route) error {
 	pol, ok := pCtx.Policy.(*builtinPlugin)
 	if !ok {
 		return nil
@@ -605,9 +605,8 @@ func (p *builtinPluginGwPass) ApplyForRoute(ctx context.Context, pCtx *ir.RouteC
 }
 
 func (p *builtinPluginGwPass) ApplyForRouteBackend(
-	ctx context.Context,
-	policy ir.PolicyIR,
-	pCtx *ir.RouteBackendContext,
+	policy pluginsdkir.PolicyIR,
+	pCtx *pluginsdkir.RouteBackendContext,
 ) error {
 	inPolicy, ok := policy.(*builtinPlugin)
 	if !ok {
@@ -634,7 +633,7 @@ func (p *builtinPluginGwPass) ApplyForRouteBackend(
 	return nil
 }
 
-func (p *builtinPluginGwPass) HttpFilters(ctx context.Context, fcc ir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
+func (p *builtinPluginGwPass) HttpFilters(fcc pluginsdkir.FilterChainCommon) ([]plugins.StagedHttpFilter, error) {
 	builtinStaged := []plugins.StagedHttpFilter{}
 
 	// If there is a cors policy for route rule or backendRef, add the cors http filter to the chain

--- a/internal/kgateway/translator/irtranslator/fc.go
+++ b/internal/kgateway/translator/irtranslator/fc.go
@@ -138,7 +138,7 @@ func (n *filterChainTranslator) computeCustomFilters(
 	var networkFilters []plugins.StagedNetworkFilter
 	// Process the network filters.
 	for _, plug := range n.pluginPass {
-		stagedFilters, err := plug.NetworkFilters(ctx)
+		stagedFilters, err := plug.NetworkFilters()
 		if err != nil {
 			listenerReporter.SetCondition(sdkreporter.ListenerCondition{
 				Type:    gwv1.ListenerConditionProgrammed,
@@ -221,7 +221,7 @@ func (h *hcmNetworkFilterTranslator) computeNetworkFilters(ctx context.Context, 
 				Policy:  pol.PolicyIr,
 				Gateway: h.gateway,
 			}
-			if err := pass.ApplyHCM(ctx, pctx, httpConnectionManager); err != nil {
+			if err := pass.ApplyHCM(pctx, httpConnectionManager); err != nil {
 				h.listenerReporter.SetCondition(sdkreporter.ListenerCondition{
 					Type:    gwv1.ListenerConditionProgrammed,
 					Reason:  gwv1.ListenerReasonInvalid,
@@ -276,7 +276,7 @@ func (h *hcmNetworkFilterTranslator) computeHttpFilters(ctx context.Context, l i
 
 	// run the HttpFilter Plugins
 	for _, plug := range h.pluginPass {
-		stagedFilters, err := plug.HttpFilters(ctx, l.FilterChainCommon)
+		stagedFilters, err := plug.HttpFilters(l.FilterChainCommon)
 		if err != nil {
 			// what to do with errors here? ignore the listener??
 			h.listenerReporter.SetCondition(sdkreporter.ListenerCondition{

--- a/internal/kgateway/translator/irtranslator/fc_test.go
+++ b/internal/kgateway/translator/irtranslator/fc_test.go
@@ -34,7 +34,7 @@ type addFilters struct {
 	ir.UnimplementedProxyTranslationPass
 }
 
-func (a addFilters) NetworkFilters(ctx context.Context) ([]plugins.StagedNetworkFilter, error) {
+func (a addFilters) NetworkFilters() ([]plugins.StagedNetworkFilter, error) {
 	return []plugins.StagedNetworkFilter{
 		{
 			Filter: &envoylistenerv3.Filter{Name: testPluginFilterName},
@@ -51,7 +51,7 @@ func TestFilterChains(t *testing.T) {
 		// it will be necessary; leaving it here to save time debugging after a refactor
 		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
 			addFiltersGK: {
-				NewGatewayTranslationPass: func(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+				NewGatewayTranslationPass: func(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
 					return addFilters{}
 				},
 			},

--- a/internal/kgateway/translator/irtranslator/gateway.go
+++ b/internal/kgateway/translator/irtranslator/gateway.go
@@ -59,7 +59,7 @@ func (t *Translator) Translate(ctx context.Context, gw ir.GatewayIR, reporter sd
 
 	for _, c := range pass {
 		if c != nil {
-			r := c.ResourcesToAdd(ctx)
+			r := c.ResourcesToAdd()
 			res.ExtraClusters = append(res.ExtraClusters, r.Clusters...)
 		}
 	}
@@ -222,7 +222,7 @@ func (t *Translator) runListenerPlugins(
 					Name:      gwv1.ObjectName(gw.SourceObject.GetName()),
 				},
 			}
-			pass.ApplyListenerPlugin(ctx, pctx, out)
+			pass.ApplyListenerPlugin(pctx, out)
 		}
 		out.Metadata = addMergeOriginsToFilterMetadata(gk, mergeOrigins, out.GetMetadata())
 		reportPolicyAttachmentStatus(reporter, l.PolicyAncestorRef, mergeOrigins, pols...)
@@ -235,7 +235,7 @@ func (t *Translator) newPass(reporter sdkreporter.Reporter) TranslationPassPlugi
 		if v.NewGatewayTranslationPass == nil {
 			continue
 		}
-		tp := v.NewGatewayTranslationPass(context.TODO(), ir.GwTranslationCtx{}, reporter)
+		tp := v.NewGatewayTranslationPass(ir.GwTranslationCtx{}, reporter)
 		if tp != nil {
 			ret[k] = &TranslationPass{
 				ProxyTranslationPass: tp,

--- a/internal/kgateway/translator/irtranslator/route.go
+++ b/internal/kgateway/translator/irtranslator/route.go
@@ -91,7 +91,7 @@ func (h *httpRouteConfigurationTranslator) ComputeRouteConfiguration(
 				errs = append(errs, pol.Errors...)
 				continue
 			}
-			pass.ApplyRouteConfigPlugin(ctx, &ir.RouteConfigContext{
+			pass.ApplyRouteConfigPlugin(&ir.RouteConfigContext{
 				FilterChainName:   h.fc.FilterChainName,
 				TypedFilterConfig: typedPerFilterConfigRoute,
 				Policy:            pol.PolicyIr,
@@ -365,7 +365,7 @@ func (h *httpRouteConfigurationTranslator) runVhostPlugins(
 				FilterChainName:   h.fc.FilterChainName,
 				GatewayContext:    ir.GatewayContext{GatewayClassName: h.gw.GatewayClassName()},
 			}
-			pass.ApplyVhostPlugin(ctx, pctx, out)
+			pass.ApplyVhostPlugin(pctx, out)
 		}
 		out.Metadata = addMergeOriginsToFilterMetadata(gk, mergeOrigins, out.GetMetadata())
 		reportPolicyAttachmentStatus(h.reporter, h.listener.PolicyAncestorRef, mergeOrigins, pols...)
@@ -433,7 +433,7 @@ func (h *httpRouteConfigurationTranslator) runRoutePlugins(
 			}
 
 			pctx.Policy = pol.PolicyIr
-			err := pass.ApplyForRoute(ctx, pctx, out)
+			err := pass.ApplyForRoute(pctx, out)
 			if err != nil {
 				errs = append(errs, err)
 			}
@@ -468,7 +468,7 @@ func (h *httpRouteConfigurationTranslator) runBackendPolicies(ctx context.Contex
 		policies, _ := mergePolicies(pass, pols)
 		for _, pol := range policies {
 			// Policy on extension ref
-			err := pass.ApplyForRouteBackend(ctx, pol.PolicyIr, pCtx)
+			err := pass.ApplyForRouteBackend(pol.PolicyIr, pCtx)
 			if err != nil {
 				errs = append(errs, err)
 			}
@@ -482,7 +482,7 @@ func (h *httpRouteConfigurationTranslator) runBackend(ctx context.Context, in ir
 	if in.Backend.BackendObject != nil {
 		backendPass := h.pluginPass[in.Backend.BackendObject.GetGroupKind()]
 		if backendPass != nil {
-			err := backendPass.ApplyForBackend(ctx, pCtx, in, outRoute)
+			err := backendPass.ApplyForBackend(pCtx, in, outRoute)
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/pkg/plugins/gwextbase/base.go
+++ b/pkg/plugins/gwextbase/base.go
@@ -43,8 +43,8 @@ func NewTrafficPolicyConstructor(
 	return trafficpolicy.NewTrafficPolicyConstructor(ctx, commoncol)
 }
 
-func NewGatewayTranslationPass(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
-	return trafficpolicy.NewGatewayTranslationPass(ctx, tctx, reporter)
+func NewGatewayTranslationPass(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass {
+	return trafficpolicy.NewGatewayTranslationPass(tctx, reporter)
 }
 
 // ResolveExtGrpcService resolves a gateway extension gRPC service by looking up the backend reference

--- a/pkg/pluginsdk/types.go
+++ b/pkg/pluginsdk/types.go
@@ -48,7 +48,7 @@ type (
 
 type PolicyPlugin struct {
 	Name                      string
-	NewGatewayTranslationPass func(ctx context.Context, tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass
+	NewGatewayTranslationPass func(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass
 
 	// Backend processing for envoy proxy
 	ProcessBackend            ProcessBackend


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Fixes #12212. Removes the no longer needed context.Context parameter for methods that implement a proxy translation pass. This was previously needed for logging before we migrated away from contextutils in favor of the slog logging library we maintain in-tree.


# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
