### PR TITLE
gateway: detect reserved port usage and report status

### DIFF
--- a/internal/kgateway/deployer/gateway_parameters_test.go
+++ b/internal/kgateway/deployer/gateway_parameters_test.go
@@ -163,6 +163,13 @@ func TestShouldUseDefaultGatewayParameters(t *testing.T) {
 		},
 		Spec: api.GatewaySpec{
 			GatewayClassName: wellknown.DefaultGatewayClassName,
+			Listeners: []api.Listener{
+				{
+					Protocol: api.HTTPProtocolType,
+					Port:     80,
+					Name:     "http",
+				},
+			},
 		},
 	}
 

--- a/internal/kgateway/translator/gateway/gateway_translator_test.go
+++ b/internal/kgateway/translator/gateway/gateway_translator_test.go
@@ -1608,6 +1608,30 @@ func TestBasic(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("Gateway with reserved port should be rejected", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "validation/gateway-reserved-port.yaml",
+			outputFile: "validation/gateway-reserved-port.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "test",
+			},
+			assertReports: translatortest.AssertReportsNoOp,
+		})
+	})
+
+	t.Run("XListenerSet with reserved port should be rejected", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "validation/xlistenerset-reserved-port.yaml",
+			outputFile: "validation/xlistenerset-reserved-port.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "test",
+			},
+			assertReports: translatortest.AssertReportsNoOp,
+		})
+	})
 }
 
 func TestRouteReplacement(t *testing.T) {

--- a/internal/kgateway/translator/gateway/testutils/inputs/validation/gateway-reserved-port.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/validation/gateway-reserved-port.yaml
@@ -1,0 +1,13 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: test
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 9091 # reserved port should be rejected
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/internal/kgateway/translator/gateway/testutils/inputs/validation/xlistenerset-reserved-port.yaml
+++ b/internal/kgateway/translator/gateway/testutils/inputs/validation/xlistenerset-reserved-port.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test
+spec:
+  gatewayClassName: kgateway
+  allowedListeners:
+    namespaces:
+      from: All
+---
+apiVersion: gateway.networking.x-k8s.io/v1alpha1
+kind: XListenerSet
+metadata:
+  name: test
+spec:
+  parentRef:
+    name: test
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: http
+    protocol: TCP
+    port: 9091 # reserved port should be rejected

--- a/internal/kgateway/translator/gateway/testutils/outputs/validation/gateway-reserved-port.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/validation/gateway-reserved-port.yaml
@@ -1,0 +1,56 @@
+Clusters:
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Statuses:
+  gateways:
+    default/test:
+      conditions:
+      - lastTransitionTime: null
+        message: 'Some listeners are not programmed: http: invalid port 9091 in listener
+          Gateway/default/test/http: port is reserved'
+        reason: ListenersNotValid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ""
+        reason: Invalid
+        status: "False"
+        type: Programmed
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenerSetsNotAllowed
+        status: Unknown
+        type: AttachedListenerSets
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid port 9091 in listener Gateway/default/test/http: port
+            is reserved'
+          reason: Invalid
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: 'invalid port 9091 in listener Gateway/default/test/http: port
+            is reserved'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: 'invalid port 9091 in listener Gateway/default/test/http: port
+            is reserved'
+          reason: Invalid
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/internal/kgateway/translator/gateway/testutils/outputs/validation/xlistenerset-reserved-port.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/validation/xlistenerset-reserved-port.yaml
@@ -1,0 +1,63 @@
+Clusters:
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Statuses:
+  gateways:
+    default/test:
+      conditions:
+      - lastTransitionTime: null
+        message: No valid listeners
+        reason: ListenersNotValid
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ""
+        reason: Invalid
+        status: "False"
+        type: Programmed
+  listenerSets:
+    default/test:
+      conditions:
+      - lastTransitionTime: null
+        message: 'Some listeners are not programmed: http: invalid port 9091 in listener
+          XListenerSet/default/test/http: port is reserved'
+        reason: ListenersNotValid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: ""
+        reason: ListenersNotValid
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: 'invalid port 9091 in listener XListenerSet/default/test/http:
+            port is reserved'
+          reason: Invalid
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: 'invalid port 9091 in listener XListenerSet/default/test/http:
+            port is reserved'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: 'invalid port 9091 in listener XListenerSet/default/test/http:
+            port is reserved'
+          reason: Invalid
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: null
+          message: Listener has valid refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        name: http
+        port: 9091
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute

--- a/internal/kgateway/validate/gateway.go
+++ b/internal/kgateway/validate/gateway.go
@@ -1,0 +1,58 @@
+package validate
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
+
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+)
+
+var ErrListenerPortReserved = fmt.Errorf("port is reserved")
+
+var reservedPorts = sets.New[int32](
+	9091, // Metrics port
+)
+
+// Gateway validates the given Gateway IR. Currently, it validates the listener ports for
+// conflicts with reserved ports, and should be extended to include other validations that are
+// common to the Deployer and Translator.
+func Gateway(gw *ir.Gateway) error {
+	if gw == nil {
+		return nil
+	}
+
+	// Validate listener ports for conflicts
+	for _, l := range gw.Listeners {
+		if err := ListenerPort(l, l.Port); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ListenerPort validates that the given listener port does not conflict with reserved ports.
+func ListenerPort(listener ir.Listener, port gwv1.PortNumber) error {
+	if reservedPorts.Has(int32(port)) {
+		return fmt.Errorf("invalid port %d in listener %s/%s/%s: %w",
+			port, getListenerSourceKind(listener.Parent), kubeutils.NamespacedNameFrom(listener.Parent), listener.Name, ErrListenerPortReserved)
+	}
+	return nil
+}
+
+func getListenerSourceKind(obj client.Object) string {
+	switch obj.(type) {
+	case *gwv1.Gateway:
+		return wellknown.GatewayKind
+	case *gwxv1a1.XListenerSet:
+		return wellknown.XListenerSetKind
+	default:
+		return ""
+	}
+}

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -415,6 +415,13 @@ var _ = Describe("Deployer", func() {
 				},
 				Spec: api.GatewaySpec{
 					GatewayClassName: wellknown.DefaultGatewayClassName,
+					Listeners: []api.Listener{
+						{
+							Protocol: api.HTTPProtocolType,
+							Port:     80,
+							Name:     "http",
+						},
+					},
 				},
 			}
 
@@ -731,7 +738,6 @@ var _ = Describe("Deployer", func() {
 			Expect(*psc.RunAsGroup).To(Equal(gid))
 			Expect(*psc.FSGroup).To(Equal(fsGroup))
 		})
-
 	})
 
 	Context("special cases", func() {
@@ -753,6 +759,13 @@ var _ = Describe("Deployer", func() {
 				},
 				Spec: api.GatewaySpec{
 					GatewayClassName: wellknown.DefaultGatewayClassName,
+					Listeners: []api.Listener{
+						{
+							Protocol: api.HTTPProtocolType,
+							Port:     80,
+							Name:     "http",
+						},
+					},
 				},
 			}
 
@@ -768,6 +781,13 @@ var _ = Describe("Deployer", func() {
 				},
 				Spec: api.GatewaySpec{
 					GatewayClassName: wellknown.DefaultGatewayClassName,
+					Listeners: []api.Listener{
+						{
+							Protocol: api.HTTPProtocolType,
+							Port:     80,
+							Name:     "http",
+						},
+					},
 				},
 			}
 
@@ -2166,10 +2186,7 @@ var _ = Describe("Deployer", func() {
 				},
 				defaultGwp: defaultGatewayParams(),
 			}, &expectedOutput{
-				validationFunc: func(objs clientObjects, inp *input) error {
-					Expect(objs).NotTo(BeEmpty())
-					return nil
-				},
+				getObjsErr: deployerinternal.ErrNoValidPorts,
 			}),
 			Entry("no port offset", defaultInput(), &expectedOutput{
 				validationFunc: func(objs clientObjects, inp *input) error {
@@ -2962,7 +2979,7 @@ var _ = Describe("DeployObjs", func() {
 		ctx  = context.Background()
 	)
 
-	var getDeployer = func(fc *fakeClient) *deployer.Deployer {
+	getDeployer := func(fc *fakeClient) *deployer.Deployer {
 		chart, err := deployerinternal.LoadGatewayChart()
 		Expect(err).ToNot(HaveOccurred())
 		return deployer.NewDeployer(
@@ -3079,6 +3096,7 @@ func (f *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.O
 	}
 	return f.Client.Get(ctx, key, obj)
 }
+
 func (f *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 	if f.patchFunc != nil {
 		return f.patchFunc(ctx, obj, patch, opts...)

--- a/pkg/deployer/values_helpers.go
+++ b/pkg/deployer/values_helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/translator/listener"
+	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/validate"
 )
 
 // This file contains helper functions that generate helm values in the format needed
@@ -35,6 +36,11 @@ func GetPortsValues(gw *ir.Gateway, gwp *v1alpha1.GatewayParameters) []HelmPort 
 	for _, l := range gw.Listeners {
 		listenerPort := uint16(l.Port)
 		portName := listener.GenerateListenerName(l)
+		if err := validate.ListenerPort(l, l.Port); err != nil {
+			// skip invalid ports; statuses are handled in the translator
+			logger.Error("skipping port", "gateway", gw.ResourceName(), "error", err)
+			continue
+		}
 		gwPorts = AppendPortValue(gwPorts, listenerPort, portName, gwp)
 	}
 

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -539,6 +539,11 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 	return nil
 }
 
+// AssertReportsNoOp is a no-op assertion function. It should be used when the test does not
+// need to perform the default or custom assertions on the reports, and instead relies on the
+// statuses written to the output file
+func AssertReportsNoOp(gwNN types.NamespacedName, reportsMap reports.ReportMap) {}
+
 type SettingsOpts func(*settings.Settings)
 
 func (tc TestCase) Run(


### PR DESCRIPTION
# Description
Detects reserved port usage (currently only metrics port) on Listener/XListenerSet, report error status, and skip Gateway deployment.

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
NONE
```

# Additional Notes
Resolves #12196