### PR TITLE
complete set of reserved ports

### DIFF
--- a/internal/kgateway/validate/gateway.go
+++ b/internal/kgateway/validate/gateway.go
@@ -16,7 +16,9 @@ import (
 var ErrListenerPortReserved = fmt.Errorf("port is reserved")
 
 var reservedPorts = sets.New[int32](
-	9091, // Metrics port
+	9091,  // Metrics port
+	8082,  // Readiness port
+	19000, // Envoy admin port
 )
 
 // Gateway validates the given Gateway IR. Currently, it validates the listener ports for


### PR DESCRIPTION
# Description

follow up to https://github.com/kgateway-dev/kgateway/pull/12382

We additionally reserve port 8082 (readiness) and 19000 (envoy admin). These are hardcoded in internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml

# Change Type

/kind bug_fix


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
