### PR TITLE
fix: clarify TLS file path error messages in BackendConfigPolicy

### DIFF
--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -1,9 +1,27 @@
 Clusters:
-- loadAssignment:
-    clusterName: kube_gwtest_backend-service_443
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
   metadata: {}
   name: kube_gwtest_backend-service_443
-  type: STATIC
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        tlsCertificates:
+        - certificateChain:
+            filename: /nonexistent/path/to/cert.pem
+          privateKey:
+            filename: /invalid/path/to/key.pem
+        validationContext:
+          trustedCa:
+            filename: /missing/path/to/ca.pem
+      sni: backend.example.com
+  type: EDS
 - connectTimeout: 5s
   metadata: {}
   name: test-backend-plugin_default_example-svc_80
@@ -124,14 +142,13 @@ Statuses:
           namespace: gwtest
         conditions:
         - lastTransitionTime: null
-          message: 'invalid certificate and key pair: tls: failed to find any PEM
-            data in certificate input'
-          reason: Invalid
-          status: "False"
+          message: Policy accepted
+          reason: Valid
+          status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: ""
-          reason: Pending
-          status: "False"
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
           type: Attached
         controllerName: kgateway.dev/kgateway

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -124,8 +124,8 @@ Statuses:
           namespace: gwtest
         conditions:
         - lastTransitionTime: null
-          message: 'invalid certificate and key pair: tls: failed to find any PEM
-            data in certificate input'
+          message: 'invalid xds configuration: error initializing configuration '''':
+            Invalid path: /missing/path/to/ca.pem'
           reason: Invalid
           status: "False"
           type: Accepted


### PR DESCRIPTION
# Description
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->
**Motivation:**  
When `BackendConfigPolicy` used file-based TLS certificates with non-existent file paths, users received misleading error messages like `failed to find any PEM data in certificate input` instead of clear file path errors. This happened because `cleanedSslKeyPair` called `tls.X509KeyPair` on file paths, treating them as PEM data rather than file references.

**What changed:**  
- Separated Secret-based and File-based TLS certificate processing using `tlsData.inlineDataSource`
- Skipped PEM validation (`cleanedSslKeyPair`) for file-based certificates, delegating file path validation to Envoy
- Introduced `buildSecretBasedCertificates` and `buildFileBasedCertificates` functions using Go’s early return pattern
- Updated test expectations for both Standard and Strict modes to reflect improved error handling

**Related issues:**  
Fixes #12336 

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
-->
/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fixed BackendConfigPolicy TLS file path error messages to show actual file path issues instead of misleading PEM parsing errors.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
**Root cause analysis:**  
`cleanedSslKeyPair` attempted to parse file paths like `/nonexistent/path/to/cert.pem` as PEM data, leading to misleading parsing errors.

**Solution approach:**  
- Secret-based (inline PEM data): Validate with `cleanedSslKeyPair`
- File-based (file paths): Pass directly to Envoy for runtime validation

**Improved error messages:**  
- Standard mode: Policy succeeds, file validation deferred to Envoy runtime  
- Strict mode: XDS validation surfaces clear errors such as `invalid xds configuration: Invalid path: /missing/path/to/ca.pem`

**Design decisions:**  
- **Why skip validation for files?**
For file-based TLS, the certificate data isn't available during policy translation - only file paths are provided. Envoy is responsible for reading these files and performing all TLS validations at runtime, including certificate/key pair validation.

If you have any feedback or suggestions for improvement, please let me know. I'd be happy to incorporate them 🙌
