### PR TITLE
refactor: remove SupportedVersion condition from GatewayClass status

### DIFF
--- a/internal/kgateway/controller/controller.go
+++ b/internal/kgateway/controller/controller.go
@@ -537,15 +537,6 @@ func (r *controllerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		Message:            "GatewayClass accepted by kgateway controller",
 	})
 
-	// TODO: This should actually check the version of the CRDs in the cluster to be 100% sure
-	meta.SetStatusCondition(&gwclass.Status.Conditions, metav1.Condition{
-		Type:               string(apiv1.GatewayClassConditionStatusSupportedVersion),
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: gwclass.Generation,
-		Reason:             string(apiv1.GatewayClassReasonSupportedVersion),
-		Message:            "Gateway API version supported by kgateway controller",
-	})
-
 	if err := r.cli.Status().Update(ctx, gwclass); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/kgateway/controller/gatewayclass_controller_test.go
+++ b/internal/kgateway/controller/gatewayclass_controller_test.go
@@ -65,21 +65,5 @@ var _ = Describe("GatewayClass Status Controller", func() {
 				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring(`accepted by kgateway controller`)),
 			))
 		})
-
-		It("should set the SupportedVersion=True condition type", func() {
-			Eventually(func() (*metav1.Condition, error) {
-				gc := &apiv1.GatewayClass{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{Name: gatewayClassName}, gc); err != nil {
-					return nil, err
-				}
-				return meta.FindStatusCondition(gc.Status.Conditions, string(apiv1.GatewayClassConditionStatusSupportedVersion)), nil
-			}, timeout, interval).Should(And(
-				Not(BeNil()),
-				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(string(apiv1.GatewayClassConditionStatusSupportedVersion))),
-				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
-				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(string(apiv1.GatewayClassReasonSupportedVersion))),
-				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring(`supported by kgateway controller`)),
-			))
-		})
 	})
 })


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

**Motivation:** 
The controller currently sets the `SupportedVersion` condition on `GatewayClass` status, always marking it as `true`. This is misleading because it does not validate actual Gateway API CRDs, and upstream discussions ([kubernetes-sigs/gateway-api#3494](https://github.com/kubernetes-sigs/gateway-api/issues/3494)) indicate that this condition may never be required. Removing it avoids exposing inaccurate status information.

**What changed:**
- Removed the `SupportedVersion` condition logic from the GatewayClass reconciler in `controller.go`
- Removed the test case for `SupportedVersion=True` condition in `gatewayclass_controller_test.go` 

**Related issues:**
Fixes #12319 

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Removed the `SupportedVersion` status condition from GatewayClass.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
NONE