### PR TITLE
deprecate envoy ai gateway and inf extension

### DIFF
--- a/api/settings/settings.go
+++ b/api/settings/settings.go
@@ -112,8 +112,11 @@ type Settings struct {
 	UseRustFormations bool `split_words:"true" default:"false"`
 
 	// EnableInferExt defines whether to enable/disable support for Gateway API inference extension.
+	// If enabled, EnableAgentgateway should also be set to true. Enabling inference extension without agentgateway
+	// is deprecated in v2.1 and will not be supported in v2.2.
 	EnableInferExt bool `split_words:"true"`
 	// InferExtAutoProvision defines whether to enable/disable the Gateway API inference extension deployer.
+	// Deprecated: inference extension auto-provisioning is deprecated in v2.1 and will be removed in v2.2.
 	InferExtAutoProvision bool `split_words:"true"`
 
 	// DefaultImageRegistry is the default image registry to use for the kgateway image.

--- a/api/v1alpha1/gateway_parameters_types.go
+++ b/api/v1alpha1/gateway_parameters_types.go
@@ -116,6 +116,9 @@ type KubernetesProxyConfig struct {
 	// +optional
 	Stats *StatsConfig `json:"stats,omitempty"`
 
+	// Deprecated: `aiExtension` is deprecated in v2.1 and will be removed in v2.2.
+	// Prefer to use `agentgateway` instead.
+	//
 	// Configuration for the AI extension.
 	//
 	// +optional

--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -91,9 +91,9 @@ image:
 
 # -- Configure the integration with the Gateway API Inference Extension project, which lets you use kgateway to route to AI inference workloads like LLMs that run locally in your Kubernetes cluster. Documentation for Inference Extension can be found here: https://kgateway.dev/docs/integrations/inference-extension/
 inferenceExtension:
-  # -- Enable Inference Extension.
+  # -- Enable Inference Extension. If enabled, agentgateway.enabled should also be set to true. Enabling inference extension without agentgateway is deprecated in v2.1 and will not be supported in v2.2.
   enabled: false
-  # -- Enable automatic provisioning for Inference Extension.
+  # -- Enable automatic provisioning for Inference Extension. Deprecated: this is deprecated in v2.1 and will be removed in v2.2.
   autoProvision: false
 
 # -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Kgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/operations/install/#namespace-discovery.

--- a/internal/kgateway/controller/start.go
+++ b/internal/kgateway/controller/start.go
@@ -343,7 +343,11 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 		}
 		// Enable the inference extension deployer if set.
 		if globalSettings.InferExtAutoProvision {
+			setupLog.Info("inference extension auto-provisioning is deprecated in v2.1 and will be removed in v2.2.")
 			poolCfg.InferenceExt = new(deployer.InferenceExtInfo)
+		}
+		if !globalSettings.EnableAgentgateway {
+			setupLog.Info("using inference extension without agentgateway is deprecated in v2.1 and will not be supported in v2.2.")
 		}
 		if err := NewBaseInferencePoolController(ctx, poolCfg, &gwCfg, c.cfg.ExtraGatewayParameters); err != nil {
 			setupLog.Error(err, "unable to create inferencepool controller")

--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -376,6 +376,9 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 	statsConfig := kubeProxyConfig.GetStats()
 	istioContainerConfig := istioConfig.GetIstioProxyContainer()
 	aiExtensionConfig := kubeProxyConfig.GetAiExtension()
+	if aiExtensionConfig != nil {
+		slog.Warn("GatewayParameters spec.kube.aiExtension is deprecated in v2.1 and will be removed in v2.2. Use spec.kube.agentgateway instead.")
+	}
 	agwConfig := kubeProxyConfig.GetAgentgateway()
 
 	gateway := vals.Gateway

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
+// TODO: envoy-based AI gateway is deprecated in v2.1 and will be removed in v2.2. The files in this folder (and any associated tests) can be removed in v2.2.
+
 // IR is the internal representation of an AI backend.
 type IR struct {
 	AISecret       *ir.Secret

--- a/internal/kgateway/extensions2/plugins/backend/plugin.go
+++ b/internal/kgateway/extensions2/plugins/backend/plugin.go
@@ -200,6 +200,7 @@ func buildTranslateFunc(
 				lambdaFilters:         lambdaFilters,
 			}
 		case v1alpha1.BackendTypeAI:
+			logger.Warn("Envoy-based AI Gateway is deprecated in v2.1 and will be removed in v2.2. Use agentgateway instead.")
 			backendIr.AIIr = &ai.IR{}
 			err := ai.PreprocessAIBackend(ctx, i.Spec.AI, backendIr.AIIr)
 			if err != nil {
@@ -361,6 +362,7 @@ func (p *backendPlugin) ApplyForBackend(pCtx *ir.RouteBackendContext, in ir.Http
 	backendIr := pCtx.Backend.ObjIr.(*BackendIr)
 	switch backend.Spec.Type {
 	case v1alpha1.BackendTypeAI:
+
 		err := ai.ApplyAIBackend(backendIr.AIIr, pCtx, out)
 		if err != nil {
 			return err

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/ai_policy.go
@@ -26,6 +26,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/wellknown"
 )
 
+// TODO: envoy-based AI gateway is deprecated in v2.1 and will be removed in v2.2. This file (and any associated tests) can be removed in v2.2.
+
 const (
 	contextString = `{"content":"%s","role":"%s"}`
 
@@ -112,6 +114,7 @@ func constructAI(
 	if policyCR.Spec.AI == nil {
 		return nil
 	}
+	logger.Warn("Envoy-based AI Gateway is deprecated in v2.1 and will be removed in v2.2. Use agentgateway instead.")
 
 	ir := &aiPolicyIR{}
 	// Augment with AI secrets as needed

--- a/pkg/deployer/values.go
+++ b/pkg/deployer/values.go
@@ -83,6 +83,7 @@ type HelmGateway struct {
 	Stats *HelmStatsConfig `json:"stats,omitempty"`
 
 	// AI extension values
+	// TODO: envoy-based AI gateway is deprecated in v2.1. We can remove this in v2.2.
 	AIExtension *HelmAIExtension `json:"aiExtension,omitempty"`
 
 	// agentgateway integration values

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4777,7 +4777,7 @@ func schema_kgateway_v2_api_v1alpha1_KubernetesProxyConfig(ref common.ReferenceC
 					},
 					"aiExtension": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Configuration for the AI extension.",
+							Description: "Deprecated: `aiExtension` is deprecated in v2.1 and will be removed in v2.2. Prefer to use `agentgateway` instead.\n\nConfiguration for the AI extension.",
 							Ref:         ref("github.com/kgateway-dev/kgateway/v2/api/v1alpha1.AiExtension"),
 						},
 					},


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Add deprecations notices in API and log deprecation messages for the following:
- envoy-based AI gateway
- envoy-based inference extension
- inference extension auto-provisioning

Fixes https://github.com/kgateway-dev/kgateway/issues/12372
Fixes https://github.com/kgateway-dev/kgateway/issues/10878

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind deprecation

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Deprecated Envoy-based AI Gateway, Envoy-based Inference Extension, and Inference Extension auto-provisioning.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
