### PR TITLE
Removes a TODO that was already done.

### DIFF
--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -274,8 +274,6 @@ func (k *kGatewayParameters) getGatewayParametersForGatewayClass(ctx context.Con
 	// when not OmitDefaultSecurityContext:
 	defaultGwp := deployer.GetInMemoryGatewayParameters(gwc.GetName(), k.inputs.ImageInfo, k.inputs.GatewayClassName, k.inputs.WaypointGatewayClassName, k.inputs.AgentgatewayClassName, false)
 
-	/* TODO(chandler): DLC deprecation warnings */
-
 	paramRef := gwc.Spec.ParametersRef
 	if paramRef == nil {
 		// when there is no parametersRef, just return the defaults


### PR DESCRIPTION
# Description

Commit 44a743d3c34c4542f47fe9525ac76f8e568c90f3 landed with the deprecation warning already logged by:

```
logger.Log(context.Background(), slog.LevelWarn, "the field
GatewayParameters.Spec.Kube.FloatingUserId is deprecated and will be removed in
a future release; see if OmitDefaultSecurityContext fits your needs")
```


# Change Type
/kind cleanup


# Changelog



```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
