### PR TITLE
Fix access log conditional filters

### DIFF
--- a/api/v1alpha1/http_listener_policy_types.go
+++ b/api/v1alpha1/http_listener_policy_types.go
@@ -370,7 +370,7 @@ type Op string
 
 const (
 	EQ Op = "EQ" // Equal
-	GE Op = "GQ" // Greater or equal
+	GE Op = "GE" // Greater or equal
 	LE Op = "LE" // Less or equal
 )
 

--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_converter.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_converter.go
@@ -155,10 +155,14 @@ func createFileAccessLog(fileSink *v1alpha1.FileSink) (proto.Message, error) {
 			},
 		}
 	case fileSink.JsonFormat != nil:
+		jsonStruct, err := convertJsonFormat(fileSink.JsonFormat)
+		if err != nil {
+			return nil, err
+		}
 		fileCfg.AccessLogFormat = &envoyalfile.FileAccessLog_LogFormat{
 			LogFormat: &envoycorev3.SubstitutionFormatString{
 				Format: &envoycorev3.SubstitutionFormatString_JsonFormat{
-					JsonFormat: convertJsonFormat(fileSink.JsonFormat),
+					JsonFormat: jsonStruct,
 				},
 				Formatters: formatterExtensions,
 			},
@@ -194,19 +198,25 @@ func addAccessLogFilter(accessLogCfg *envoyaccesslogv3.AccessLog, filter *v1alph
 
 	switch {
 	case filter.OrFilter != nil:
-		filters, err = translateOrFilters(filter.OrFilter)
+		filters, err = translateFilters(filter.OrFilter)
 		if err != nil {
 			return err
 		}
-		accessLogCfg.GetFilter().FilterSpecifier = &envoyaccesslogv3.AccessLogFilter_OrFilter{
+		if accessLogCfg.Filter == nil {
+			accessLogCfg.Filter = &envoyaccesslogv3.AccessLogFilter{}
+		}
+		accessLogCfg.Filter.FilterSpecifier = &envoyaccesslogv3.AccessLogFilter_OrFilter{
 			OrFilter: &envoyaccesslogv3.OrFilter{Filters: filters},
 		}
 	case filter.AndFilter != nil:
-		filters, err = translateOrFilters(filter.AndFilter)
+		filters, err = translateFilters(filter.AndFilter)
 		if err != nil {
 			return err
 		}
-		accessLogCfg.GetFilter().FilterSpecifier = &envoyaccesslogv3.AccessLogFilter_AndFilter{
+		if accessLogCfg.Filter == nil {
+			accessLogCfg.Filter = &envoyaccesslogv3.AccessLogFilter{}
+		}
+		accessLogCfg.Filter.FilterSpecifier = &envoyaccesslogv3.AccessLogFilter_AndFilter{
 			AndFilter: &envoyaccesslogv3.AndFilter{Filters: filters},
 		}
 	case filter.FilterType != nil:
@@ -219,8 +229,8 @@ func addAccessLogFilter(accessLogCfg *envoyaccesslogv3.AccessLog, filter *v1alph
 	return nil
 }
 
-// translateOrFilters translates a slice of filter types
-func translateOrFilters(filters []v1alpha1.FilterType) ([]*envoyaccesslogv3.AccessLogFilter, error) {
+// translateFilters translates a slice of filter types
+func translateFilters(filters []v1alpha1.FilterType) ([]*envoyaccesslogv3.AccessLogFilter, error) {
 	result := make([]*envoyaccesslogv3.AccessLogFilter, 0, len(filters))
 	for _, filter := range filters {
 		cfg, err := translateFilter(&filter)
@@ -384,22 +394,22 @@ func createHeaderMatchSpecifier(header gwv1.HTTPHeaderMatch) *envoyroutev3.Heade
 	}
 }
 
-func convertJsonFormat(jsonFormat *runtime.RawExtension) *structpb.Struct {
+func convertJsonFormat(jsonFormat *runtime.RawExtension) (*structpb.Struct, error) {
 	if jsonFormat == nil {
-		return nil
+		return nil, nil
 	}
 
-	var formatMap map[string]interface{}
+	var formatMap map[string]any
 	if err := json.Unmarshal(jsonFormat.Raw, &formatMap); err != nil {
-		return nil
+		return nil, fmt.Errorf("invalid access log jsonFormat: %w", err)
 	}
 
 	structVal, err := structpb.NewStruct(formatMap)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("invalid access log jsonFormat: %w", err)
 	}
 
-	return structVal
+	return structVal, nil
 }
 
 func generateCommonAccessLogGrpcConfig(grpcService v1alpha1.CommonAccessLogGrpcService, grpcBackends map[string]*ir.BackendObjectIR, accessLogId int) (*envoygrpc.CommonGrpcAccessLogConfig, error) {
@@ -557,9 +567,9 @@ func toEnvoyComparisonOpType(op v1alpha1.Op) (envoyaccesslogv3.ComparisonFilter_
 	case v1alpha1.EQ:
 		return envoyaccesslogv3.ComparisonFilter_EQ, nil
 	case v1alpha1.GE:
-		return envoyaccesslogv3.ComparisonFilter_EQ, nil
+		return envoyaccesslogv3.ComparisonFilter_GE, nil
 	case v1alpha1.LE:
-		return envoyaccesslogv3.ComparisonFilter_EQ, nil
+		return envoyaccesslogv3.ComparisonFilter_LE, nil
 	default:
 		return 0, fmt.Errorf("unknown OP (%s)", op)
 	}

--- a/test/kubernetes/e2e/features/http_listener_policy/suite.go
+++ b/test/kubernetes/e2e/features/http_listener_policy/suite.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +55,7 @@ func (s *testingSuite) SetupSuite() {
 		"TestHttpListenerPolicyAllFields":    {gatewayManifest, httpRouteManifest, allFieldsManifest},
 		"TestHttpListenerPolicyServerHeader": {gatewayManifest, httpRouteManifest, serverHeaderManifest},
 		"TestPreserveHttp1HeaderCase":        {gatewayManifest, preserveHttp1HeaderCaseManifest},
+		"TestAccessLogEmittedToStdout":       {gatewayManifest, httpRouteManifest, accessLogManifest},
 	}
 }
 
@@ -168,4 +171,38 @@ func (s *testingSuite) TestPreserveHttp1HeaderCase() {
 			},
 		},
 	)
+}
+
+func (s *testingSuite) TestAccessLogEmittedToStdout() {
+	// Trigger traffic to generate an access log line
+	s.testInstallation.Assertions.AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
+			curl.WithHostHeader("example.com"),
+			curl.WithPath("/"),
+		},
+		&matchers.HttpResponse{
+			StatusCode: http.StatusOK,
+		},
+	)
+
+	// Fetch gateway pod logs and verify the access log JSON fields are present
+	pods, err := s.testInstallation.Actions.Kubectl().GetPodsInNsWithLabel(
+		s.ctx, proxyDeployment.ObjectMeta.GetNamespace(),
+		"app.kubernetes.io/name="+proxyDeployment.ObjectMeta.GetName(),
+	)
+	s.Require().NoError(err)
+	s.Require().Len(pods, 1)
+
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		logs, err := s.testInstallation.Actions.Kubectl().GetContainerLogs(s.ctx, proxyDeployment.ObjectMeta.GetNamespace(), pods[0])
+		s.Require().NoError(err)
+		// Check a few key fields configured in http-listener-policy-access-log.yaml jsonFormat
+		assert.Contains(c, logs, "\"method\":\"GET\"")
+		assert.Contains(c, logs, "\"protocol\":\"HTTP/1.1\"")
+		assert.Contains(c, logs, "\"response_code\":200")
+		assert.Contains(c, logs, "\"path\":\"/")
+	}, 30*time.Second, 200*time.Millisecond)
 }

--- a/test/kubernetes/e2e/features/http_listener_policy/testdata/http-listener-policy-access-log.yaml
+++ b/test/kubernetes/e2e/features/http_listener_policy/testdata/http-listener-policy-access-log.yaml
@@ -1,0 +1,36 @@
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: http-listener-policy-access-log
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gw
+  accessLog:
+  - fileSink:
+      path: /dev/stdout
+      jsonFormat:
+          start_time: "%START_TIME%"
+          method: "%REQ(X-ENVOY-ORIGINAL-METHOD?:METHOD)%"
+          path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+          protocol: "%PROTOCOL%"
+          response_code: "%RESPONSE_CODE%"
+          response_flags: "%RESPONSE_FLAGS%"
+          bytes_received: "%BYTES_RECEIVED%"
+          bytes_sent: "%BYTES_SENT%"
+          total_duration: "%DURATION%"
+          resp_backend_service_time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+          req_x_forwarded_for: "%REQ(X-FORWARDED-FOR)%"
+          user_agent: "%REQ(USER-AGENT)%"
+          request_id: "%REQ(X-REQUEST-ID)%"
+          authority: "%REQ(:AUTHORITY)%"
+          backendHost: "%UPSTREAM_HOST%"
+          backendCluster: "%UPSTREAM_CLUSTER%"
+    filter:
+      andFilter:
+      - notHealthCheckFilter: true
+      - statusCodeFilter:
+          op: GE
+          value: 200

--- a/test/kubernetes/e2e/features/http_listener_policy/types.go
+++ b/test/kubernetes/e2e/features/http_listener_policy/types.go
@@ -17,6 +17,7 @@ var (
 	allFieldsManifest               = filepath.Join(fsutils.MustGetThisDir(), "testdata", "http-listener-policy-all-fields.yaml")
 	serverHeaderManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata", "http-listener-policy-server-header.yaml")
 	preserveHttp1HeaderCaseManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "preserve-http1-header-case.yaml")
+	accessLogManifest               = filepath.Join(fsutils.MustGetThisDir(), "testdata", "http-listener-policy-access-log.yaml")
 
 	// When we apply the setup file, we expect resources to be created with this metadata
 	proxyObjectMeta = metav1.ObjectMeta{


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Typos in the code prevented the access log configuration from being applied when there were conditional filters with `GE` or `LE` OPs.

Also added an e2e test for the access logging in general and filters specifically.

Fixes https://github.com/kgateway-dev/kgateway/issues/12359

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
/kind bug_fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fixed no access log when specific filter conditions were added to it
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
