### PR TITLE
Add test coverage for filters in the HLP access log

### DIFF
--- a/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_listener_plugin_test.go
+++ b/internal/kgateway/extensions2/plugins/httplistenerpolicy/access_logging_listener_plugin_test.go
@@ -1274,6 +1274,133 @@ func TestConvertJsonFormat_EdgeCases(t *testing.T) {
 	})
 }
 
+func TestAccessLogFilters(t *testing.T) {
+	type verifyFn func(t *testing.T, got *envoyaccesslogv3.AccessLog)
+
+	headerExact := gwv1.HeaderMatchExact
+
+	tests := []struct {
+		name     string
+		alFilter *v1alpha1.AccessLogFilter
+		verify   verifyFn
+	}{
+		{
+			name:     "StatusCode GE 400",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{StatusCodeFilter: (*v1alpha1.StatusCodeFilter)(&v1alpha1.ComparisonFilter{Op: v1alpha1.GE, Value: 400})}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				sc := got.GetFilter().GetStatusCodeFilter()
+				require.NotNil(t, sc)
+				require.NotNil(t, sc.Comparison)
+				assert.Equal(t, envoyaccesslogv3.ComparisonFilter_GE, sc.Comparison.Op)
+				assert.Equal(t, uint32(400), sc.GetComparison().GetValue().GetDefaultValue())
+			},
+		},
+		{
+			name:     "Duration LE 10",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{DurationFilter: (*v1alpha1.DurationFilter)(&v1alpha1.ComparisonFilter{Op: v1alpha1.LE, Value: 10})}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				df := got.GetFilter().GetDurationFilter()
+				require.NotNil(t, df)
+				require.NotNil(t, df.Comparison)
+				assert.Equal(t, envoyaccesslogv3.ComparisonFilter_LE, df.Comparison.Op)
+				assert.Equal(t, uint32(10), df.GetComparison().GetValue().GetDefaultValue())
+			},
+		},
+		{
+			name:     "NotHealthCheck",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{NotHealthCheckFilter: true}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				require.NotNil(t, got.GetFilter().GetNotHealthCheckFilter())
+			},
+		},
+		{
+			name:     "Traceable",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{TraceableFilter: true}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				require.NotNil(t, got.GetFilter().GetTraceableFilter())
+			},
+		},
+		{
+			name:     "Header Exact",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{HeaderFilter: &v1alpha1.HeaderFilter{Header: gwv1.HTTPHeaderMatch{Type: &headerExact, Name: gwv1.HTTPHeaderName("x-test"), Value: "val"}}}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				hf := got.GetFilter().GetHeaderFilter()
+				require.NotNil(t, hf)
+				require.NotNil(t, hf.Header)
+				assert.Equal(t, "x-test", hf.Header.GetName())
+				sm := hf.Header.GetStringMatch()
+				require.NotNil(t, sm)
+				assert.Equal(t, "val", sm.GetExact())
+			},
+		},
+		{
+			name:     "ResponseFlag UH",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{ResponseFlagFilter: &v1alpha1.ResponseFlagFilter{Flags: []string{"UH"}}}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				rf := got.GetFilter().GetResponseFlagFilter()
+				require.NotNil(t, rf)
+				assert.Contains(t, rf.Flags, "UH")
+			},
+		},
+		{
+			name:     "GrpcStatus NOT_FOUND",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{GrpcStatusFilter: &v1alpha1.GrpcStatusFilter{Statuses: []v1alpha1.GrpcStatus{v1alpha1.NOT_FOUND}}}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				gs := got.GetFilter().GetGrpcStatusFilter()
+				require.NotNil(t, gs)
+				require.Len(t, gs.Statuses, 1)
+				assert.Equal(t, envoyaccesslogv3.GrpcStatusFilter_NOT_FOUND, gs.Statuses[0])
+			},
+		},
+		{
+			name:     "CEL",
+			alFilter: &v1alpha1.AccessLogFilter{FilterType: &v1alpha1.FilterType{CELFilter: &v1alpha1.CELFilter{Match: "response.code >= 400"}}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				ext := got.GetFilter().GetExtensionFilter()
+				require.NotNil(t, ext)
+				assert.Equal(t, wellknown.CELExtensionFilter, ext.GetName())
+			},
+		},
+		{
+			name:     "And NotHealthCheck && Traceable",
+			alFilter: &v1alpha1.AccessLogFilter{AndFilter: []v1alpha1.FilterType{{NotHealthCheckFilter: true}, {TraceableFilter: true}}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				and := got.GetFilter().GetAndFilter()
+				require.NotNil(t, and)
+				require.Len(t, and.Filters, 2)
+				assert.NotNil(t, and.Filters[0].GetNotHealthCheckFilter())
+				assert.NotNil(t, and.Filters[1].GetTraceableFilter())
+			},
+		},
+		{
+			name:     "Or Header || ResponseFlag",
+			alFilter: &v1alpha1.AccessLogFilter{OrFilter: []v1alpha1.FilterType{{HeaderFilter: &v1alpha1.HeaderFilter{Header: gwv1.HTTPHeaderMatch{Type: &headerExact, Name: gwv1.HTTPHeaderName("x-test"), Value: "val"}}}, {ResponseFlagFilter: &v1alpha1.ResponseFlagFilter{Flags: []string{"UH"}}}}},
+			verify: func(t *testing.T, got *envoyaccesslogv3.AccessLog) {
+				orf := got.GetFilter().GetOrFilter()
+				require.NotNil(t, orf)
+				require.Len(t, orf.Filters, 2)
+				assert.NotNil(t, orf.Filters[0].GetHeaderFilter())
+				assert.NotNil(t, orf.Filters[1].GetResponseFlagFilter())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgs, err := translateAccessLogs([]v1alpha1.AccessLog{{
+				FileSink: &v1alpha1.FileSink{Path: "/dev/stdout"},
+				Filter:   tc.alFilter,
+			}}, nil)
+			require.NoError(t, err)
+			got, err := generateAccessLogConfig(&ir.HcmContext{Gateway: pluginsdkir.GatewayIR{SourceObject: &pluginsdkir.Gateway{ObjectSource: pluginsdkir.ObjectSource{Name: "gw", Namespace: "default"}}}}, []v1alpha1.AccessLog{{Filter: tc.alFilter, FileSink: &v1alpha1.FileSink{Path: "/dev/stdout"}}}, cfgs)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			require.NotNil(t, got[0].GetFilter())
+			tc.verify(t, got[0])
+		})
+	}
+}
+
 // Helper function to handle MessageToAny error in test cases
 func mustMessageToAny(t *testing.T, msg proto.Message) *anypb.Any {
 	a, err := utils.MessageToAny(msg)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Extra tests for the access log filters in the HTTPListenerPolicy and their translation.

"Fixes" https://github.com/kgateway-dev/kgateway/pull/12457#pullrequestreview-3285618826

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
