### PR TITLE
deployer: add new standard `gateway-class-name` label

### DIFF
--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -331,6 +331,7 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 			Name:             &gw.Name,
 			GatewayName:      &gw.Name,
 			GatewayNamespace: &gw.Namespace,
+			GatewayClassName: ptr.To(string(gw.Spec.GatewayClassName)),
 			Ports:            ports,
 			Xds: &deployer.HelmXds{
 				// The xds host/port MUST map to the Service definition for the Control Plane

--- a/internal/kgateway/helm/kgateway/templates/_helpers.tpl
+++ b/internal/kgateway/helm/kgateway/templates/_helpers.tpl
@@ -52,8 +52,15 @@ helm.sh/chart: {{ include "kgateway.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+gateway.networking.k8s.io/gateway-class-name: {{ .Values.gateway.gatewayClassName }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{- define "kgateway.gateway.podLabels" -}}
+{{ include "kgateway.gateway.selectorLabels" . }}
+gateway.networking.k8s.io/gateway-class-name: {{ .Values.gateway.gatewayClassName }}
+{{- end }}
+
 
 {{/*
 Selector labels

--- a/internal/kgateway/helm/kgateway/templates/gateway/agent-gateway-deployment.yaml
+++ b/internal/kgateway/helm/kgateway/templates/gateway/agent-gateway-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "kgateway.gateway.selectorLabels" . | nindent 8 }}
+        {{- include "kgateway.gateway.podLabels" . | nindent 8 }}
         {{- with $gateway.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
+++ b/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end}}
       labels:
         {{- include "kgateway.gateway.constLabels" . | nindent 8 }}
-        {{- include "kgateway.gateway.selectorLabels" . | nindent 8 }}
+        {{- include "kgateway.gateway.podLabels" . | nindent 8 }}
         {{- with $gateway.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/internal/kgateway/wellknown/controller.go
+++ b/internal/kgateway/wellknown/controller.go
@@ -29,6 +29,9 @@ const (
 	// GatewayNameLabel is a label on GW pods to indicate the name of the gateway
 	// they are associated with.
 	GatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
+	// GatewayClassNameLabel is a label on GW pods to indicate the name of the GatewayClass
+	// they are associated with.
+	GatewayClassNameLabel = "gateway.networking.k8s.io/gateway-class-name"
 
 	// LeaderElectionID is the name of the lease that leader election will use for holding the leader lock.
 	LeaderElectionID = "kgateway"

--- a/pkg/deployer/values.go
+++ b/pkg/deployer/values.go
@@ -20,6 +20,7 @@ type HelmGateway struct {
 	Name             *string `json:"name,omitempty"`
 	GatewayName      *string `json:"gatewayName,omitempty"`
 	GatewayNamespace *string `json:"gatewayNamespace,omitempty"`
+	GatewayClassName *string `json:"gatewayClassName,omitempty"`
 	NameOverride     *string `json:"nameOverride,omitempty"`
 	FullnameOverride *string `json:"fullnameOverride,omitempty"`
 

--- a/test/deployer/testdata/agentgateway-out.yaml
+++ b/test/deployer/testdata/agentgateway-out.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
     app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
 ---
@@ -26,6 +27,7 @@ metadata:
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
     app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -43,6 +45,7 @@ metadata:
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
     app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
     app.kubernetes.io/managed-by: Helm
 spec:
   type: LoadBalancer
@@ -69,6 +72,7 @@ metadata:
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
     app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -84,6 +88,7 @@ spec:
         app.kubernetes.io/name: gw
         app.kubernetes.io/instance: gw
         gateway.networking.k8s.io/gateway-name: gw
+        gateway.networking.k8s.io/gateway-class-name: agentgateway
     spec:
       serviceAccountName: gw
       securityContext:

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -6,11 +6,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
 ---
@@ -22,11 +22,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 data:
   envoy.yaml: |
@@ -210,11 +210,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
   type: LoadBalancer
@@ -235,11 +235,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -259,6 +259,7 @@ spec:
         app.kubernetes.io/name: gw
         app.kubernetes.io/instance: gw
         gateway.networking.k8s.io/gateway-name: gw
+        gateway.networking.k8s.io/gateway-class-name: kgateway
     spec:
       serviceAccountName: gw
       containers:

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -6,10 +6,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
@@ -22,10 +23,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 data:
@@ -210,10 +212,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -235,10 +238,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -6,11 +6,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
 ---
@@ -22,11 +22,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 data:
   envoy.yaml: |
@@ -210,11 +210,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
   type: LoadBalancer
@@ -235,11 +235,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    helm.sh/chart: kgateway-proxy
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
-    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -259,6 +259,7 @@ spec:
         app.kubernetes.io/name: gw
         app.kubernetes.io/instance: gw
         gateway.networking.k8s.io/gateway-name: gw
+        gateway.networking.k8s.io/gateway-class-name: kgateway
     spec:
       serviceAccountName: gw
       containers:

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -6,10 +6,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
@@ -22,10 +23,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 data:
@@ -210,10 +212,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -235,10 +238,11 @@ metadata:
   name: gw
   labels:
     kgateway: kube-gateway
-    helm.sh/chart: kgateway-proxy
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
     app.kubernetes.io/name: gw
     app.kubernetes.io/instance: gw
     gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:


### PR DESCRIPTION
# Description
This was added upstream. The primary purpose is to be able to identify all pods owned by kgateway for things like monitoring etc

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

/kind new_feature

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
The new `gateway.networking.k8s.io/gateway-class-name` label is added to all resources created by Kgateway to represent which `GatewayClass` was responsible for creating the resource.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
