### PR TITLE
make status messages consistent

### DIFF
--- a/internal/kgateway/agentgatewaysyncer/status_syncer.go
+++ b/internal/kgateway/agentgatewaysyncer/status_syncer.go
@@ -454,7 +454,7 @@ func ensureBasicGatewayConditions(status *gwv1.GatewayStatus, generation int64) 
 			Type:               string(gwv1.GatewayConditionAccepted),
 			Status:             metav1.ConditionTrue,
 			Reason:             string(gwv1.GatewayReasonAccepted),
-			Message:            "Gateway is accepted by agent-gateway controller",
+			Message:            reports.GatewayAcceptedMessage,
 			ObservedGeneration: generation,
 		})
 	}
@@ -465,7 +465,7 @@ func ensureBasicGatewayConditions(status *gwv1.GatewayStatus, generation int64) 
 			Type:               string(gwv1.GatewayConditionProgrammed),
 			Status:             metav1.ConditionTrue,
 			Reason:             string(gwv1.GatewayReasonProgrammed),
-			Message:            "Gateway is programmed by agent-gateway controller",
+			Message:            reports.GatewayProgrammedMessage,
 			ObservedGeneration: generation,
 		})
 	}

--- a/internal/kgateway/controller/gw_controller.go
+++ b/internal/kgateway/controller/gw_controller.go
@@ -20,6 +20,7 @@ import (
 
 	intdeployer "github.com/kgateway-dev/kgateway/v2/internal/kgateway/deployer"
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 )
 
 const (
@@ -129,7 +130,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: gw.Generation,
 			Reason:             string(api.GatewayReasonAccepted),
-			Message:            "Gateway is accepted",
+			Message:            reports.GatewayAcceptedMessage,
 		}
 		if statusErr := r.updateGatewayStatusWithRetry(ctx, &gw, condition); statusErr != nil {
 			log.Error(statusErr, "failed to update Gateway status after retries")

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
@@ -207,7 +207,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
@@ -189,12 +189,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -202,7 +202,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -212,12 +212,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref-fakegw.yaml
@@ -207,7 +207,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
@@ -252,12 +252,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -265,7 +265,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -275,12 +275,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
@@ -270,7 +270,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gateway-ref.yaml
@@ -270,7 +270,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
@@ -207,7 +207,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
@@ -189,12 +189,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -202,7 +202,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -212,12 +212,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref-nonrootns.yaml
@@ -207,7 +207,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
@@ -279,7 +279,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
@@ -261,12 +261,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -274,7 +274,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -284,12 +284,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-gatewayclass-ref.yaml
@@ -279,7 +279,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
@@ -255,7 +255,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
@@ -255,7 +255,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-multi-service.yaml
@@ -237,12 +237,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -250,7 +250,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -260,12 +260,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -194,7 +194,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -194,7 +194,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -176,12 +176,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -189,7 +189,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -199,12 +199,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -217,12 +217,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
@@ -249,7 +249,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
@@ -249,7 +249,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/authz.yaml
@@ -231,12 +231,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -244,7 +244,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -254,12 +254,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
@@ -34,7 +34,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
@@ -16,12 +16,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -29,7 +29,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -39,12 +39,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/empty.yaml
@@ -34,7 +34,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
@@ -180,7 +180,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
@@ -180,7 +180,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-gateway.yaml
@@ -162,12 +162,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -175,7 +175,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -185,12 +185,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -203,12 +203,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -170,7 +170,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -152,12 +152,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -165,7 +165,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -175,12 +175,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -193,12 +193,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -170,7 +170,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -170,7 +170,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -152,12 +152,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -165,7 +165,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -175,12 +175,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -193,12 +193,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -170,7 +170,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
@@ -138,12 +138,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -151,7 +151,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -161,12 +161,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -179,12 +179,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-svc.yaml
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -223,7 +223,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -205,12 +205,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -218,7 +218,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -228,12 +228,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -223,7 +223,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
@@ -104,7 +104,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
@@ -86,12 +86,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -99,7 +99,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -109,12 +109,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/se-use-waypoint.yaml
@@ -104,7 +104,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
@@ -88,12 +88,12 @@ Statuses:
     infra/example-waypoint:
       conditions:
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -101,7 +101,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -111,12 +111,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
+++ b/internal/kgateway/extensions2/plugins/waypoint/testdata/output/svc-use-waypoint.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
@@ -73,12 +73,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -86,7 +86,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -96,12 +96,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -116,12 +116,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-default.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
@@ -78,12 +78,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -91,7 +91,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -101,12 +101,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -121,12 +121,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
@@ -96,7 +96,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-h2c.yaml
@@ -96,7 +96,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
@@ -93,7 +93,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
@@ -93,7 +93,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/backend-ws.yaml
@@ -75,12 +75,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -88,7 +88,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -98,12 +98,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -118,12 +118,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
@@ -61,12 +61,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,7 +74,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -84,12 +84,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,12 +104,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-default.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
@@ -66,12 +66,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,7 +79,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -89,12 +89,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -109,12 +109,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-h2c.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -106,12 +106,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backend-protocol/svc-ws.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
@@ -77,7 +77,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
@@ -77,7 +77,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-http2backend.yaml
@@ -59,12 +59,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -72,7 +72,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -82,12 +82,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
@@ -77,7 +77,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
@@ -77,7 +77,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/commonhttpprotocol-httpbackend.yaml
@@ -59,12 +59,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -72,7 +72,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -82,12 +82,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
@@ -90,7 +90,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
@@ -72,12 +72,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -85,7 +85,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -95,12 +95,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/healthcheck.yaml
@@ -90,7 +90,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
@@ -104,7 +104,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
@@ -104,7 +104,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/http2.yaml
@@ -86,12 +86,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -99,7 +99,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -109,12 +109,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
@@ -190,12 +190,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -203,7 +203,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -213,12 +213,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
@@ -208,7 +208,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-config.yaml
@@ -208,7 +208,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/lb-usehostnameforhashing.yaml
@@ -88,12 +88,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -101,7 +101,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -111,12 +111,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
@@ -69,12 +69,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,7 +82,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -92,12 +92,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
@@ -114,7 +114,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
@@ -96,12 +96,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -109,7 +109,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -119,12 +119,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -139,12 +139,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/simple-tls.yaml
@@ -114,7 +114,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
@@ -99,7 +99,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
@@ -99,7 +99,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-insecureskipverify.yaml
@@ -81,12 +81,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -94,7 +94,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -104,12 +104,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -124,12 +124,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
@@ -149,12 +149,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -162,7 +162,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -172,12 +172,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -192,12 +192,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-san.yaml
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-system-ca.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-system-ca.yaml
@@ -97,12 +97,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -110,7 +110,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -120,12 +120,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -140,12 +140,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-system-ca.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-system-ca.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-system-ca.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/tls-system-ca.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
@@ -136,7 +136,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
@@ -118,12 +118,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -131,7 +131,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -141,12 +141,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda.yaml
@@ -136,7 +136,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
@@ -69,12 +69,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -82,7 +82,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -92,12 +92,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -119,7 +119,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/backend-ref-port-error.yaml
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
@@ -61,12 +61,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,7 +74,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -84,12 +84,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,12 +104,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backends/basic.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
@@ -142,12 +142,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -155,7 +155,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -165,12 +165,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -185,12 +185,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
@@ -160,7 +160,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls-san.yaml
@@ -160,7 +160,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
@@ -154,7 +154,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
@@ -136,12 +136,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -149,7 +149,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -159,12 +159,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -179,12 +179,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tls.yaml
@@ -154,7 +154,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
@@ -61,12 +61,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,7 +74,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -84,12 +84,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,12 +104,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/custom-gateway-class.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
@@ -85,12 +85,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -98,7 +98,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -108,12 +108,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -128,12 +128,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -147,12 +147,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
@@ -103,7 +103,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic.yaml
@@ -103,7 +103,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
@@ -87,12 +87,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -100,7 +100,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -110,12 +110,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -136,7 +136,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -155,7 +155,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
@@ -105,7 +105,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_invalid_hostname.yaml
@@ -105,7 +105,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
@@ -85,12 +85,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -98,7 +98,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -108,12 +108,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -128,12 +128,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -147,12 +147,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
@@ -103,7 +103,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_match.yaml
@@ -103,7 +103,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -87,12 +87,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -100,7 +100,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -110,12 +110,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -135,7 +135,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -105,7 +105,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/basic_parentref_mismatch.yaml
@@ -105,7 +105,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
@@ -135,7 +135,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
@@ -135,7 +135,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/builtin_rule_inheritance.yaml
@@ -117,12 +117,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -130,7 +130,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -140,12 +140,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -160,12 +160,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -179,12 +179,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -198,12 +198,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -217,12 +217,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -235,12 +235,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -139,7 +139,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -121,12 +121,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -134,7 +134,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -144,12 +144,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -164,12 +164,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -188,7 +188,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/child_rule_matcher.yaml
@@ -139,7 +139,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -93,12 +93,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -106,7 +106,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -116,12 +116,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -143,7 +143,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
@@ -157,12 +157,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic1.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -93,12 +93,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -106,7 +106,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -116,12 +116,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -143,7 +143,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
@@ -157,12 +157,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -176,12 +176,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/cyclic2.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
@@ -79,12 +79,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -92,7 +92,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -102,12 +102,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -122,12 +122,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -141,12 +141,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
@@ -97,7 +97,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/discard_invalid_child_matches.yaml
@@ -97,7 +97,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
@@ -114,7 +114,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
@@ -114,7 +114,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parentref.yaml
@@ -96,12 +96,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -109,7 +109,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -119,12 +119,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -139,12 +139,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -158,12 +158,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -97,12 +97,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -110,7 +110,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -120,12 +120,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -140,12 +140,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -163,7 +163,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -182,7 +182,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
@@ -97,12 +97,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -110,7 +110,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -120,12 +120,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -140,12 +140,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -159,12 +159,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -178,12 +178,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -196,12 +196,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/label_based.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
@@ -120,7 +120,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
@@ -102,12 +102,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -115,7 +115,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -125,12 +125,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -145,12 +145,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -164,12 +164,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -183,12 +183,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -200,12 +200,12 @@ Statuses:
           namespace: default
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -219,12 +219,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multi_level_multiple_parents.yaml
@@ -120,7 +120,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
@@ -93,12 +93,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -106,7 +106,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -116,12 +116,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -136,12 +136,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -155,12 +155,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -174,12 +174,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_children.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -111,12 +111,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -124,7 +124,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -134,12 +134,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -154,12 +154,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -171,12 +171,12 @@ Statuses:
           namespace: infra
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -190,12 +190,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -209,12 +209,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -232,7 +232,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -129,7 +129,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/multiple_parents.yaml
@@ -129,7 +129,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
@@ -181,7 +181,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
@@ -163,12 +163,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -176,7 +176,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -186,12 +186,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -206,12 +206,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -225,12 +225,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -244,12 +244,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -263,12 +263,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/nested_absolute_relative.yaml
@@ -181,7 +181,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -197,12 +197,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -210,7 +210,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -220,12 +220,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -240,12 +240,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -259,12 +259,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -278,12 +278,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -296,12 +296,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -215,7 +215,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -215,7 +215,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
@@ -100,12 +100,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -113,7 +113,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -123,12 +123,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -143,12 +143,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -162,12 +162,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -181,12 +181,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
@@ -118,7 +118,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/recursive.yaml
@@ -118,7 +118,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
@@ -206,12 +206,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -219,7 +219,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -229,12 +229,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -249,12 +249,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -266,12 +266,12 @@ Statuses:
           namespace: infra
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -285,12 +285,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -302,12 +302,12 @@ Statuses:
           namespace: infra
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -321,12 +321,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -339,12 +339,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
@@ -224,7 +224,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/relative_paths.yaml
@@ -224,7 +224,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -113,12 +113,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -126,7 +126,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -136,12 +136,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -156,12 +156,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -175,12 +175,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -131,7 +131,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -131,7 +131,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -245,12 +245,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -258,7 +258,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -268,12 +268,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -288,12 +288,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -307,12 +307,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -263,7 +263,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -263,7 +263,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -125,12 +125,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -138,7 +138,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -148,12 +148,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -168,12 +168,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -187,12 +187,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -143,7 +143,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -143,7 +143,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -125,12 +125,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -138,7 +138,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -148,12 +148,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -168,12 +168,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -187,12 +187,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -143,7 +143,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -143,7 +143,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -165,7 +165,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -165,7 +165,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -147,12 +147,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -160,7 +160,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -170,12 +170,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -190,12 +190,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -209,12 +209,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -232,7 +232,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -214,12 +214,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -227,7 +227,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -237,12 +237,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -257,12 +257,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -276,12 +276,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -295,12 +295,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -232,7 +232,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -331,12 +331,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -344,7 +344,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -354,12 +354,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -374,12 +374,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -393,12 +393,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -412,12 +412,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -430,12 +430,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -449,12 +449,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -349,7 +349,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -349,7 +349,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
@@ -97,12 +97,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -110,7 +110,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -120,12 +120,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -140,12 +140,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -159,12 +159,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_route_policy.yaml
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
@@ -134,7 +134,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
@@ -134,7 +134,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/delegation/unresolved_ref.yaml
@@ -116,12 +116,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -129,7 +129,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -139,12 +139,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -159,12 +159,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -183,7 +183,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
@@ -202,7 +202,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
@@ -66,12 +66,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,7 +79,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -89,12 +89,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -109,12 +109,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/simple.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
@@ -93,7 +93,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
@@ -93,7 +93,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/dfp/tls.yaml
@@ -75,12 +75,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -88,7 +88,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -98,12 +98,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -118,12 +118,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
@@ -73,7 +73,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
@@ -73,7 +73,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse.yaml
@@ -55,12 +55,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -68,7 +68,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -78,12 +78,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -98,12 +98,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
@@ -61,12 +61,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,7 +74,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -84,12 +84,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,12 +104,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/invalid-backendref-filter.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
@@ -54,12 +54,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -67,7 +67,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -77,12 +77,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,7 +104,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/missing-ref.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
@@ -54,12 +54,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -67,7 +67,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -77,12 +77,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -103,7 +103,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/directresponse/overlapping-filters.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -138,12 +138,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -151,7 +151,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -161,12 +161,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -181,12 +181,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -200,12 +200,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -96,12 +96,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -109,7 +109,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -119,12 +119,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -144,7 +144,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -114,7 +114,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -114,7 +114,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/gateway-invalid-listener-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/gateway-invalid-listener-proxy.yaml
@@ -30,7 +30,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -40,7 +40,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/gateway-invalid-listener-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/gateway-invalid-listener-proxy.yaml
@@ -35,7 +35,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/gateway-invalid-listener-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/gateway-invalid-listener-proxy.yaml
@@ -35,7 +35,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/proxy.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -94,7 +94,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -120,7 +120,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/proxy.yaml
@@ -48,7 +48,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -56,7 +56,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -66,12 +66,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -89,7 +89,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -99,7 +99,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -115,7 +115,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -125,7 +125,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-only/proxy.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -94,7 +94,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -120,7 +120,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
@@ -88,7 +88,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -116,7 +116,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
@@ -88,7 +88,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -116,7 +116,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/gateway-per-conn-buf-lim/proxy.yaml
@@ -70,12 +70,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -83,7 +83,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -93,12 +93,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -111,7 +111,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -121,12 +121,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
@@ -66,12 +66,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,7 +79,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -89,12 +89,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -109,12 +109,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/basic-proxy.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
@@ -52,12 +52,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -65,7 +65,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -75,12 +75,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,7 +100,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
@@ -52,12 +52,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -65,7 +65,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -75,12 +75,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,7 +100,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/missing-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
@@ -103,7 +103,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
@@ -103,7 +103,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/grpc-routing/multi-backend-proxy.yaml
@@ -85,12 +85,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -98,7 +98,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -108,12 +108,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -128,12 +128,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -52,12 +52,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -65,7 +65,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -75,12 +75,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,7 +100,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
@@ -52,12 +52,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -65,7 +65,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -75,12 +75,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,7 +100,7 @@ Statuses:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-missing-backend.yaml
@@ -70,7 +70,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
@@ -136,7 +136,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
@@ -136,7 +136,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-routing-proxy.yaml
@@ -118,12 +118,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -131,7 +131,7 @@ Statuses:
       - attachedRoutes: 3
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -141,12 +141,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -161,12 +161,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -179,12 +179,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -197,12 +197,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
@@ -135,7 +135,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
@@ -117,12 +117,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -130,7 +130,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -140,12 +140,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -160,12 +160,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/http-with-header-modifier-proxy.yaml
@@ -135,7 +135,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
@@ -73,12 +73,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -86,7 +86,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -96,12 +96,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -116,12 +116,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/accept-http10.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
@@ -73,12 +73,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -86,7 +86,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -96,12 +96,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -116,12 +116,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
@@ -78,12 +78,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -91,7 +91,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -101,12 +101,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -121,12 +121,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
@@ -96,7 +96,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/default-host-for-http10.yaml
@@ -96,7 +96,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/idle-timeout.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/idle-timeout.yaml
@@ -73,12 +73,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -86,7 +86,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -96,12 +96,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -116,12 +116,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/idle-timeout.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/idle-timeout.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/idle-timeout.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/idle-timeout.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -168,7 +168,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -150,12 +150,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -163,7 +163,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -173,12 +173,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/merge.yaml
@@ -168,7 +168,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
@@ -95,7 +95,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
@@ -77,12 +77,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -90,7 +90,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -100,12 +100,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -120,12 +120,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/preserve-http1-header-case.yaml
@@ -95,7 +95,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -98,12 +98,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -111,7 +111,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -121,12 +121,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -141,12 +141,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -116,7 +116,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/route-and-pol.yaml
@@ -116,7 +116,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
@@ -61,12 +61,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,7 +74,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -84,12 +84,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,12 +104,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-absent.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-false.yaml
@@ -71,12 +71,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,7 +84,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -94,12 +94,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,12 +114,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/use-remote-addr-true.yaml
@@ -71,12 +71,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,7 +84,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -94,12 +94,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,12 +114,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
@@ -136,12 +136,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -149,7 +149,7 @@ Statuses:
       - attachedRoutes: 6
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -159,12 +159,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -179,12 +179,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -197,12 +197,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -215,12 +215,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -233,12 +233,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -251,12 +251,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -269,12 +269,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
@@ -154,7 +154,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/httproute-timeout-retry-proxy.yaml
@@ -154,7 +154,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -119,7 +119,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -147,7 +147,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -119,7 +119,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -147,7 +147,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-invalid-cert-proxy.yaml
@@ -68,7 +68,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,7 +114,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -142,7 +142,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -160,12 +160,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
@@ -73,12 +73,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -86,7 +86,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -96,12 +96,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -116,12 +116,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-listener-pol/upgrades.yaml
@@ -91,7 +91,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
@@ -152,7 +152,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -178,7 +178,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
@@ -152,7 +152,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -178,7 +178,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/https-routing-proxy.yaml
@@ -134,12 +134,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -147,7 +147,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -157,12 +157,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -173,7 +173,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -183,12 +183,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -201,12 +201,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -219,12 +219,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml
@@ -49,7 +49,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml
@@ -12,12 +12,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -31,7 +31,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -44,7 +44,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -54,7 +54,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml
@@ -49,7 +49,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml
@@ -80,7 +80,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -102,7 +102,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml
@@ -80,7 +80,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -102,7 +102,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml
@@ -43,12 +43,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -62,7 +62,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -75,7 +75,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -85,7 +85,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -97,7 +97,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -107,12 +107,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -131,7 +131,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml
@@ -49,7 +49,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml
@@ -12,12 +12,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -31,7 +31,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -44,7 +44,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -54,7 +54,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml
@@ -49,7 +49,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml
@@ -61,12 +61,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,7 +74,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -84,12 +84,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,12 +104,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -128,7 +128,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -141,7 +141,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -151,7 +151,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -146,7 +146,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -146,7 +146,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml
@@ -85,7 +85,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -139,7 +139,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml
@@ -67,7 +67,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -80,7 +80,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -90,7 +90,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -103,12 +103,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -121,12 +121,12 @@ Statuses:
     default/example-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -134,7 +134,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -144,12 +144,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml
@@ -85,7 +85,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -139,7 +139,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret-ref.yaml
@@ -50,7 +50,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret-ref.yaml
@@ -27,7 +27,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -45,7 +45,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -63,12 +63,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret-ref.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret-ref.yaml
@@ -50,7 +50,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret.yaml
@@ -52,7 +52,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret.yaml
@@ -27,7 +27,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -47,7 +47,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -65,12 +65,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-listener-invalid-secret.yaml
@@ -52,7 +52,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-mixed-listeners.yaml
@@ -109,7 +109,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -125,7 +125,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-mixed-listeners.yaml
@@ -109,7 +109,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -125,7 +125,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/https-mixed-listeners.yaml
@@ -86,7 +86,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -104,7 +104,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -120,7 +120,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -130,12 +130,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -148,12 +148,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -166,12 +166,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-listener-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-listener-no-routes.yaml
@@ -18,7 +18,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -31,7 +31,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -41,7 +41,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-listener-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-listener-no-routes.yaml
@@ -36,7 +36,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-listener-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-listener-no-routes.yaml
@@ -36,7 +36,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-mixed-listeners.yaml
@@ -42,7 +42,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -55,7 +55,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -65,7 +65,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -109,7 +109,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-mixed-listeners.yaml
@@ -60,7 +60,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tcp-mixed-listeners.yaml
@@ -60,7 +60,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-listener-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-listener-no-routes.yaml
@@ -18,7 +18,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -31,7 +31,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -41,7 +41,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-listener-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-listener-no-routes.yaml
@@ -36,7 +36,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-listener-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-listener-no-routes.yaml
@@ -36,7 +36,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-mixed-listeners.yaml
@@ -49,7 +49,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -62,7 +62,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -72,7 +72,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -83,7 +83,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -93,12 +93,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -116,7 +116,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-mixed-listeners.yaml
@@ -67,7 +67,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -88,7 +88,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-mixed-listeners.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-mixed-listeners.yaml
@@ -67,7 +67,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -88,7 +88,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-route-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-route-invalid-backend.yaml
@@ -52,7 +52,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-route-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-route-invalid-backend.yaml
@@ -34,12 +34,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -47,7 +47,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -57,12 +57,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-route-invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-route-invalid-backend.yaml
@@ -52,7 +52,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-both-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-both-no-routes.yaml
@@ -37,7 +37,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -63,7 +63,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-both-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-both-no-routes.yaml
@@ -37,7 +37,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -63,7 +63,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-both-no-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-both-no-routes.yaml
@@ -19,7 +19,7 @@ Statuses:
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -32,7 +32,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -42,7 +42,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -58,7 +58,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -68,7 +68,7 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-mixed-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-mixed-routes.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-mixed-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-mixed-routes.yaml
@@ -43,12 +43,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -56,7 +56,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -66,12 +66,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -82,7 +82,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -92,12 +92,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -115,7 +115,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-mixed-routes.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/invalid-filter-chains/tls-same-port-mixed-routes.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -196,7 +196,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -196,7 +196,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
@@ -88,12 +88,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -101,7 +101,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -111,12 +111,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -131,12 +131,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -149,12 +149,12 @@ Statuses:
     default/foo-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -162,7 +162,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -172,12 +172,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -201,12 +201,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
@@ -88,12 +88,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -101,7 +101,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -111,12 +111,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -131,12 +131,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -149,12 +149,12 @@ Statuses:
     default/foo-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -162,7 +162,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -172,12 +172,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/basic.yaml
@@ -106,7 +106,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
@@ -68,7 +68,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
@@ -50,12 +50,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -63,7 +63,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -73,12 +73,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/listener-sets/no-allowed-lis.yaml
@@ -68,7 +68,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
@@ -134,7 +134,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
@@ -116,12 +116,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -129,7 +129,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -139,12 +139,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -159,12 +159,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -177,12 +177,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/loadbalancer/hash-policies.yaml
@@ -134,7 +134,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -59,7 +59,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -41,12 +41,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -54,7 +54,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -64,12 +64,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -82,7 +82,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -92,12 +92,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -59,7 +59,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -137,7 +137,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
@@ -111,7 +111,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -137,7 +137,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
@@ -93,12 +93,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -106,7 +106,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -116,12 +116,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -132,7 +132,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -142,12 +142,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
@@ -59,7 +59,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
@@ -59,7 +59,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/no_route.yaml
@@ -41,12 +41,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -54,7 +54,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -64,12 +64,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
@@ -192,12 +192,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -205,7 +205,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -215,12 +215,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -235,12 +235,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
@@ -210,7 +210,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/gateway-cel-rbac.yaml
@@ -210,7 +210,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
@@ -394,7 +394,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
@@ -376,12 +376,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -389,7 +389,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -399,12 +399,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -419,12 +419,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/httproute-cel-rbac.yaml
@@ -394,7 +394,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
@@ -241,7 +241,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
@@ -241,7 +241,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/rbac/route-cel-rbac.yaml
@@ -223,12 +223,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -236,7 +236,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -246,12 +246,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -266,12 +266,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
@@ -170,7 +170,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -198,7 +198,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
@@ -170,7 +170,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -198,7 +198,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
@@ -152,12 +152,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -165,7 +165,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -175,12 +175,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -193,7 +193,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -203,12 +203,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -221,12 +221,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
@@ -198,7 +198,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -226,7 +226,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -254,7 +254,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
@@ -180,12 +180,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -193,7 +193,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -203,12 +203,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -221,7 +221,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -231,12 +231,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -249,7 +249,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -259,12 +259,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -277,12 +277,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
@@ -198,7 +198,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -226,7 +226,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -254,7 +254,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
@@ -223,7 +223,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -251,7 +251,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -279,7 +279,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
@@ -223,7 +223,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -251,7 +251,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -279,7 +279,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
@@ -205,12 +205,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -218,7 +218,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -228,12 +228,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -246,7 +246,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -256,12 +256,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -274,7 +274,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -284,12 +284,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -304,12 +304,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -322,12 +322,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -340,12 +340,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
@@ -99,12 +99,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -112,7 +112,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -122,12 +122,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -142,12 +142,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
@@ -117,7 +117,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
@@ -117,7 +117,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
@@ -160,7 +160,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -188,7 +188,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
@@ -142,12 +142,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -155,7 +155,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -165,12 +165,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -183,7 +183,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -193,12 +193,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -211,12 +211,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/listener-invalid-out.yaml
@@ -160,7 +160,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -188,7 +188,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
@@ -269,7 +269,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -297,7 +297,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -374,7 +374,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -403,7 +403,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
@@ -251,12 +251,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -264,7 +264,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -274,12 +274,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -292,7 +292,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -302,12 +302,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -320,12 +320,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -338,12 +338,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -356,12 +356,12 @@ Statuses:
     gwtest/test-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -379,12 +379,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -408,12 +408,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
@@ -269,7 +269,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -297,7 +297,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -374,7 +374,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -403,7 +403,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
@@ -180,7 +180,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -241,7 +241,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -270,7 +270,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
@@ -180,7 +180,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -241,7 +241,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -270,7 +270,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
@@ -162,12 +162,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -175,7 +175,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -185,12 +185,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -205,12 +205,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -223,12 +223,12 @@ Statuses:
     gwtest/test-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -236,7 +236,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -246,12 +246,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -265,7 +265,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -275,12 +275,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
@@ -162,7 +162,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -223,7 +223,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -252,7 +252,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
@@ -144,12 +144,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -157,7 +157,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -167,12 +167,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -187,12 +187,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -205,12 +205,12 @@ Statuses:
     gwtest/test-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -218,7 +218,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -228,12 +228,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -247,7 +247,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -257,12 +257,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
@@ -162,7 +162,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -223,7 +223,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -252,7 +252,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -102,7 +102,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -102,7 +102,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -84,12 +84,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -97,7 +97,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -107,12 +107,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -125,12 +125,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -57,12 +57,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,7 +70,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -80,12 +80,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,12 +100,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -66,12 +66,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -79,7 +79,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -89,12 +89,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -109,12 +109,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -84,7 +84,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -57,12 +57,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,7 +70,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -80,12 +80,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,12 +100,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -113,7 +113,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/builtin/urlrewrite-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
@@ -90,7 +90,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
@@ -72,12 +72,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -85,7 +85,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -95,12 +95,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -115,12 +115,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-header-regex-invalid-out.yaml
@@ -90,7 +90,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -113,7 +113,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-prefix-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
@@ -71,12 +71,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,7 +84,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -94,12 +94,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,12 +114,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -132,12 +132,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-path-regex-invalid-out.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -85,7 +85,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -85,7 +85,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -67,12 +67,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -80,7 +80,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -90,12 +90,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -110,12 +110,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-ai-default-value-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -112,7 +112,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/policy/policy-extension-ref-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -112,7 +112,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
@@ -115,7 +115,7 @@ Statuses:
         status: "False"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -123,7 +123,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -133,12 +133,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -151,7 +151,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -161,12 +161,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -179,12 +179,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
@@ -128,7 +128,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-invalid-out.yaml
@@ -128,7 +128,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-invalid-out.yaml
@@ -146,12 +146,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -171,12 +171,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -189,7 +189,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -199,12 +199,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -229,12 +229,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -247,12 +247,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-invalid-out.yaml
@@ -166,7 +166,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -194,7 +194,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -224,7 +224,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-invalid-out.yaml
@@ -166,7 +166,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -194,7 +194,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -224,7 +224,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-merge-invalid-out.yaml
@@ -182,7 +182,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -210,7 +210,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -238,7 +238,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-merge-invalid-out.yaml
@@ -162,12 +162,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -187,12 +187,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -205,7 +205,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -215,12 +215,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -233,7 +233,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -243,12 +243,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -263,12 +263,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -281,12 +281,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -299,12 +299,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/gateway-listener-merge-invalid-out.yaml
@@ -182,7 +182,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -210,7 +210,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -238,7 +238,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/httproute-invalid-out.yaml
@@ -71,12 +71,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -84,7 +84,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -94,12 +94,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -121,7 +121,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
@@ -106,12 +106,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -119,7 +119,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -129,12 +129,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -147,7 +147,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -157,12 +157,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -175,12 +175,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
@@ -124,7 +124,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -152,7 +152,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/listener-invalid-out.yaml
@@ -124,7 +124,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -152,7 +152,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/multi-target-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/multi-target-invalid-out.yaml
@@ -199,7 +199,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -227,7 +227,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -304,7 +304,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -335,7 +335,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/multi-target-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/multi-target-invalid-out.yaml
@@ -199,7 +199,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -227,7 +227,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -304,7 +304,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -335,7 +335,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/multi-target-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/multi-target-invalid-out.yaml
@@ -186,7 +186,7 @@ Statuses:
         status: "False"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -194,7 +194,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -204,12 +204,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -222,7 +222,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -232,12 +232,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -250,12 +250,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -268,12 +268,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -286,12 +286,12 @@ Statuses:
     gwtest/test-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -309,12 +309,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -340,12 +340,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
@@ -146,7 +146,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -209,7 +209,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -240,7 +240,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
@@ -128,12 +128,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -141,7 +141,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -151,12 +151,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -171,12 +171,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -189,12 +189,12 @@ Statuses:
     gwtest/test-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -214,12 +214,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -245,12 +245,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-invalid-out.yaml
@@ -146,7 +146,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -209,7 +209,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -240,7 +240,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-listener-invalid-out.yaml
@@ -145,7 +145,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -208,7 +208,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -237,7 +237,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-listener-invalid-out.yaml
@@ -127,12 +127,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -140,7 +140,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -150,12 +150,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -170,12 +170,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -188,12 +188,12 @@ Statuses:
     gwtest/test-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -213,12 +213,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -232,7 +232,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -242,12 +242,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/attachment/xlistenerset-listener-invalid-out.yaml
@@ -145,7 +145,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -208,7 +208,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -237,7 +237,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -82,7 +82,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -82,7 +82,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -64,12 +64,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -77,7 +77,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -87,12 +87,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -105,12 +105,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -57,12 +57,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,7 +70,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -80,12 +80,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,12 +100,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -57,12 +57,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,7 +70,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -80,12 +80,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,12 +100,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -57,12 +57,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,7 +70,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -80,12 +80,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -100,12 +100,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/request-header-modifier-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,7 +114,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/response-header-modifier-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,7 +114,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -113,7 +113,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/builtin/urlrewrite-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
@@ -54,12 +54,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -67,7 +67,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -77,12 +77,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,7 +104,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-header-regex-invalid-out.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -113,7 +113,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-prefix-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -113,7 +113,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -126,12 +126,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-path-regex-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
@@ -54,12 +54,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -67,7 +67,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -77,12 +77,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,7 +104,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-query-regex-invalid-out.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -54,12 +54,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -67,7 +67,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -77,12 +77,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -104,7 +104,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/matcher/matcher-regex-re2-unsupported-out.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-ai-default-value-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -112,7 +112,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-csrf-regex-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -112,7 +112,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extauth-extension-ref-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -112,7 +112,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-extension-ref-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -112,7 +112,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-header-template-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,7 +114,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -97,7 +97,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -79,12 +79,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -92,7 +92,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -102,12 +102,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -122,12 +122,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -97,7 +97,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-body-template-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,7 +114,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-header-template-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -114,7 +114,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
@@ -63,12 +63,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -76,7 +76,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -86,12 +86,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -113,7 +113,7 @@ Statuses:
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-transformation-malformed-template-invalid-out.yaml
@@ -81,7 +81,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
@@ -171,7 +171,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
@@ -153,12 +153,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -166,7 +166,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -176,12 +176,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -196,12 +196,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -215,12 +215,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -234,12 +234,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -253,12 +253,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -271,12 +271,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort-weighted.yaml
@@ -171,7 +171,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
@@ -135,12 +135,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -148,7 +148,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -158,12 +158,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -178,12 +178,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -196,12 +196,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
@@ -153,7 +153,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/route-sort.yaml
@@ -153,7 +153,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -183,7 +183,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -183,7 +183,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -165,12 +165,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -178,7 +178,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -188,12 +188,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -208,12 +208,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -227,12 +227,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
@@ -92,7 +92,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
@@ -92,7 +92,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/session-persistence/header.yaml
@@ -74,12 +74,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -87,7 +87,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -97,12 +97,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -117,12 +117,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -171,7 +171,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -153,12 +153,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -166,7 +166,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -176,12 +176,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -196,12 +196,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -214,12 +214,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -171,7 +171,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
@@ -54,7 +54,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
@@ -54,7 +54,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/basic-proxy.yaml
@@ -36,12 +36,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -49,7 +49,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -59,12 +59,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -82,7 +82,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
@@ -27,12 +27,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -40,7 +40,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -50,12 +50,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
@@ -45,7 +45,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
@@ -45,7 +45,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
@@ -27,12 +27,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -40,7 +40,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -50,12 +50,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
@@ -45,7 +45,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/missing-backend.yaml
@@ -45,7 +45,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
@@ -68,7 +68,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
@@ -50,12 +50,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -63,7 +63,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -73,12 +73,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -96,7 +96,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tcp-routing/multi-backend-proxy.yaml
@@ -68,7 +68,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/basic-proxy.yaml
@@ -43,12 +43,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -56,7 +56,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -66,12 +66,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -89,7 +89,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
@@ -43,12 +43,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -56,7 +56,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -66,12 +66,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
@@ -61,7 +61,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
@@ -52,7 +52,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
@@ -34,12 +34,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -47,7 +47,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -57,12 +57,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/missing-backend.yaml
@@ -52,7 +52,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
@@ -57,12 +57,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -70,7 +70,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -80,12 +80,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -103,7 +103,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/tls-routing/multi-backend-proxy.yaml
@@ -75,7 +75,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
@@ -61,12 +61,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -74,7 +74,7 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -84,12 +84,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-gateway.yaml
@@ -79,7 +79,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
@@ -161,7 +161,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -189,7 +189,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
@@ -161,7 +161,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -189,7 +189,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/buffer-route.yaml
@@ -143,12 +143,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -156,7 +156,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -166,12 +166,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -184,7 +184,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -194,12 +194,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -214,12 +214,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -232,12 +232,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -291,7 +291,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -291,7 +291,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -273,12 +273,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -286,7 +286,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -296,12 +296,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -316,12 +316,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-full-config.yaml
@@ -169,7 +169,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-full-config.yaml
@@ -151,12 +151,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -164,7 +164,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -174,12 +174,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -194,12 +194,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -212,12 +212,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-full-config.yaml
@@ -169,7 +169,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-simple.yaml
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-simple.yaml
@@ -156,7 +156,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-simple.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-simple.yaml
@@ -138,12 +138,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -151,7 +151,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -161,12 +161,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -181,12 +181,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -199,12 +199,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
@@ -458,7 +458,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -486,7 +486,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -514,7 +514,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -540,7 +540,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
@@ -458,7 +458,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -486,7 +486,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -514,7 +514,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -540,7 +540,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth.yaml
@@ -440,12 +440,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -453,7 +453,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -463,12 +463,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -481,7 +481,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -491,12 +491,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -509,7 +509,7 @@ Statuses:
       - attachedRoutes: 3
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -519,12 +519,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -535,7 +535,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -545,12 +545,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -563,12 +563,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -581,12 +581,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -599,12 +599,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -617,12 +617,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -635,12 +635,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -653,12 +653,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -671,12 +671,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
@@ -417,12 +417,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -430,7 +430,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -440,12 +440,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -460,12 +460,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
@@ -435,7 +435,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-deep-merge.yaml
@@ -435,7 +435,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
@@ -220,7 +220,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
@@ -220,7 +220,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc-full-config.yaml
@@ -202,12 +202,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -215,7 +215,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -225,12 +225,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -245,12 +245,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -263,12 +263,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
@@ -302,7 +302,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
@@ -284,12 +284,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -297,7 +297,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -307,12 +307,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -327,12 +327,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/extproc.yaml
@@ -302,7 +302,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
@@ -87,12 +87,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -100,7 +100,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -110,12 +110,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -130,12 +130,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
@@ -105,7 +105,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/generation.yaml
@@ -105,7 +105,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
@@ -290,7 +290,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -371,7 +371,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
@@ -272,12 +272,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -285,7 +285,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -295,12 +295,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -315,12 +315,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -334,12 +334,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -353,12 +353,12 @@ Statuses:
     default/ls:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -366,7 +366,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -376,12 +376,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-all.yaml
@@ -290,7 +290,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -371,7 +371,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
@@ -119,7 +119,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
@@ -101,12 +101,12 @@ Statuses:
         status: "False"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -114,7 +114,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -124,12 +124,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -144,12 +144,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-gateway.yaml
@@ -119,7 +119,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
@@ -187,7 +187,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -268,7 +268,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
@@ -187,7 +187,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted
@@ -268,7 +268,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-route.yaml
@@ -169,12 +169,12 @@ Statuses:
         status: "True"
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -182,7 +182,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -192,12 +192,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -212,12 +212,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -231,12 +231,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -250,12 +250,12 @@ Statuses:
     default/ls:
       conditions:
       - lastTransitionTime: null
-        message: ListenerSet is accepted
+        message: Successfully accepted ListenerSet
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: ListenerSet is programmed
+        message: Successfully programmed ListenerSet
         reason: Programmed
         status: "True"
         type: Programmed
@@ -263,7 +263,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -273,12 +273,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -149,12 +149,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -162,7 +162,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -172,12 +172,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -192,12 +192,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -167,7 +167,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -178,7 +178,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -178,7 +178,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -160,12 +160,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -173,7 +173,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -183,12 +183,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -203,12 +203,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -134,7 +134,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -116,12 +116,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -129,7 +129,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -139,12 +139,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -159,12 +159,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -134,7 +134,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
@@ -189,7 +189,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
@@ -171,12 +171,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -184,7 +184,7 @@ Statuses:
       - attachedRoutes: 2
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -194,12 +194,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -214,12 +214,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -232,12 +232,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
@@ -189,7 +189,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
@@ -227,7 +227,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
@@ -209,12 +209,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -222,7 +222,7 @@ Statuses:
       - attachedRoutes: 5
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -232,12 +232,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -252,12 +252,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -271,12 +271,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -289,12 +289,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -307,12 +307,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
@@ -325,12 +325,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
@@ -227,7 +227,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -203,12 +203,12 @@ Statuses:
         status: Unknown
         type: AttachedListenerSets
       - lastTransitionTime: null
-        message: Gateway is accepted
+        message: Successfully accepted Gateway
         reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
-        message: Gateway is programmed
+        message: Successfully programmed Gateway
         reason: Programmed
         status: "True"
         type: Programmed
@@ -216,7 +216,7 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: Listener is accepted
+          message: Successfully accepted Listener
           reason: Accepted
           status: "True"
           type: Accepted
@@ -226,12 +226,12 @@ Statuses:
           status: "False"
           type: Conflicted
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
         - lastTransitionTime: null
-          message: Listener is programmed
+          message: Successfully programmed Listener
           reason: Programmed
           status: "True"
           type: Programmed
@@ -246,12 +246,12 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: Route is accepted
+          message: Successfully accepted Route
           reason: Accepted
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Route has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -221,7 +221,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that listener has no conflicts
+          message: Successfully verified that Listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -221,7 +221,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: Listener does not have conflicts
+          message: Successfully verified that listener has no conflicts
           reason: NoConflicts
           status: "False"
           type: Conflicted

--- a/internal/kgateway/translator/gateway/testutils/outputs/validation/gateway-reserved-port.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/validation/gateway-reserved-port.yaml
@@ -44,7 +44,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/internal/kgateway/translator/gateway/testutils/outputs/validation/xlistenerset-reserved-port.yaml
+++ b/internal/kgateway/translator/gateway/testutils/outputs/validation/xlistenerset-reserved-port.yaml
@@ -52,7 +52,7 @@ Statuses:
           status: "False"
           type: Programmed
         - lastTransitionTime: null
-          message: Listener has valid refs
+          message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -27,7 +27,7 @@ const (
 	ListenerSetAcceptedMessage   = "Successfully accepted ListenerSet"
 	ListenerSetProgrammedMessage = "Successfully programmed ListenerSet"
 	ListenerAcceptedMessage      = "Successfully accepted Listener"
-	ListenerNoConflictsMessage   = "Listener does not have conflicts"
+	ListenerNoConflictsMessage   = "Successfully verified that listener has no conflicts"
 	ValidRefsMessage             = "Successfully resolved all references"
 	ListenerProgrammedMessage    = "Successfully programmed Listener"
 	RouteAcceptedMessage         = "Successfully accepted Route"

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -27,7 +27,7 @@ const (
 	ListenerSetAcceptedMessage   = "Successfully accepted ListenerSet"
 	ListenerSetProgrammedMessage = "Successfully programmed ListenerSet"
 	ListenerAcceptedMessage      = "Successfully accepted Listener"
-	ListenerNoConflictsMessage   = "Successfully verified that listener has no conflicts"
+	ListenerNoConflictsMessage   = "Successfully verified that Listener has no conflicts"
 	ValidRefsMessage             = "Successfully resolved all references"
 	ListenerProgrammedMessage    = "Successfully programmed Listener"
 	RouteAcceptedMessage         = "Successfully accepted Route"

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -22,16 +22,15 @@ import (
 
 // Status message constants
 const (
-	GatewayAcceptedMessage       = "Gateway is accepted"
-	GatewayProgrammedMessage     = "Gateway is programmed"
-	ListenerSetAcceptedMessage   = "ListenerSet is accepted"
-	ListenerSetProgrammedMessage = "ListenerSet is programmed"
-	ListenerAcceptedMessage      = "Listener is accepted"
+	GatewayAcceptedMessage       = "Successfully accepted Gateway"
+	GatewayProgrammedMessage     = "Successfully programmed Gateway"
+	ListenerSetAcceptedMessage   = "Successfully accepted ListenerSet"
+	ListenerSetProgrammedMessage = "Successfully programmed ListenerSet"
+	ListenerAcceptedMessage      = "Successfully accepted Listener"
 	ListenerNoConflictsMessage   = "Listener does not have conflicts"
-	ListenerValidRefsMessage     = "Listener has valid refs"
-	ListenerProgrammedMessage    = "Listener is programmed"
-	RouteAcceptedMessage         = "Route is accepted"
-	RouteValidRefsMessage        = "Route has valid refs"
+	ValidRefsMessage             = "Successfully resolved all references"
+	ListenerProgrammedMessage    = "Successfully programmed Listener"
+	RouteAcceptedMessage         = "Successfully accepted Route"
 )
 
 // TODO: refactor this struct + methods to better reflect the usage now in proxy_syncer
@@ -446,7 +445,7 @@ func addMissingListenerConditions(lisReport *ListenerReport) {
 			Type:    gwv1.ListenerConditionResolvedRefs,
 			Status:  metav1.ConditionTrue,
 			Reason:  gwv1.ListenerReasonResolvedRefs,
-			Message: ListenerValidRefsMessage,
+			Message: ValidRefsMessage,
 		})
 	}
 	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionProgrammed)); cond == nil {
@@ -476,7 +475,7 @@ func addMissingParentRefConditions(report *ParentRefReport) {
 			Type:    gwv1.RouteConditionResolvedRefs,
 			Status:  metav1.ConditionTrue,
 			Reason:  gwv1.RouteReasonResolvedRefs,
-			Message: RouteValidRefsMessage,
+			Message: ValidRefsMessage,
 		})
 	}
 }


### PR DESCRIPTION
# Description

Make positive status messages consistent by starting with "Successfully" to make it easier to tell at a glance that a gateway is healthy.

See pkg/reports/status.go

# Change Type

/kind cleanup


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
