### PR TITLE
Use native envoy per-route config in rustformation dynamic module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,10 @@ ENVOYINIT_SOURCES=$(call get_sources,$(ENVOYINIT_DIR))
 ENVOYINIT_OUTPUT_DIR=$(OUTPUT_DIR)/$(ENVOYINIT_DIR)
 export ENVOYINIT_IMAGE_REPO ?= envoy-wrapper
 
+RUSTFORMATIONS_DIR := internal/envoyinit/rustformations
+# find all the find under the rustformation directory but exclude the target directory
+RUSTFORMATIONS_SRC_FILES := $(shell find $(RUSTFORMATIONS_DIR) -type d -name target -prune -o -type f)
+
 $(ENVOYINIT_OUTPUT_DIR)/envoyinit-linux-$(GOARCH): $(ENVOYINIT_SOURCES)
 	$(GO_BUILD_FLAGS) GOOS=linux go build -ldflags='$(LDFLAGS)' -gcflags='$(GCFLAGS)' -o $@ ./cmd/envoyinit/...
 
@@ -404,7 +408,8 @@ $(ENVOYINIT_OUTPUT_DIR)/envoyinit-linux-$(GOARCH): $(ENVOYINIT_SOURCES)
 envoyinit: $(ENVOYINIT_OUTPUT_DIR)/envoyinit-linux-$(GOARCH)
 
 # TODO(nfuden) cheat the process for now with -r but try to find a cleaner method
-$(ENVOYINIT_OUTPUT_DIR)/Dockerfile.envoyinit: cmd/envoyinit/Dockerfile
+$(ENVOYINIT_OUTPUT_DIR)/Dockerfile.envoyinit: cmd/envoyinit/Dockerfile $(RUSTFORMATIONS_SRC_FILES)
+	echo "copying rustformations..."
 	cp  -r  internal/envoyinit/rustformations $(ENVOYINIT_OUTPUT_DIR)
 	cp $< $@
 

--- a/cmd/envoyinit/Dockerfile
+++ b/cmd/envoyinit/Dockerfile
@@ -19,8 +19,10 @@ RUN cargo fetch
 RUN rm -rf src
 
 # Then copy the rest of the source code and build the library.
-COPY ./${RUSTFORMATIONS_DIR} .
+COPY ${RUSTFORMATIONS_DIR} .
 RUN cargo zigbuild --target x86_64-unknown-linux-gnu
+# switch to this locally if you are on arm
+# RUN cargo zigbuild --target aarch64-unknown-linux-gnu
 
 # hard code amd64 for now as we only have that version of envoy-gloo
 RUN cp /build/target/x86_64-unknown-linux-gnu/debug/librust_module.so /build/amd64_librust_module.so

--- a/internal/envoyinit/rustformations/src/http_simple_mutations.rs
+++ b/internal/envoyinit/rustformations/src/http_simple_mutations.rs
@@ -8,21 +8,33 @@ use mockall::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] trait.
-///
-/// The trait corresponds to a Envoy filter chain configuration.
-
-#[derive(Serialize, Deserialize)]
-pub struct FilterConfig {
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PerRouteConfig {
     #[serde(default)]
     request_headers_setter: Vec<(String, String)>,
     #[serde(default)]
     response_headers_setter: Vec<(String, String)>,
-    route_specific: HashMap<String, String>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct PerRouteConfig {
+impl PerRouteConfig {
+    pub fn new(config: &str) -> Option<Self> {
+        let per_route_config: PerRouteConfig = match serde_json::from_str(config) {
+            Ok(cfg) => cfg,
+            Err(err) => {
+                eprintln!("Error parsing per route config: {config} {err}");
+                return None;
+            }
+        };
+        Some(per_route_config)
+    }
+}
+
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] trait.
+///
+/// The trait corresponds to a Envoy filter chain configuration.
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FilterConfig {
     #[serde(default)]
     request_headers_setter: Vec<(String, String)>,
     #[serde(default)]
@@ -40,7 +52,7 @@ impl FilterConfig {
             Ok(cfg) => cfg,
             Err(err) => {
                 // TODO(nfuden): Dont panic if there is incorrect configuration
-                eprintln!("Error parsing filter config: {err}");
+                eprintln!("Error parsing filter config: {filter_config} {err}");
                 return None;
             }
         };
@@ -86,28 +98,13 @@ impl<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter> HttpFilterConfig<EC, EHF> 
         // env.add_function("context", context);
         // env.add_function("env", env);
 
-        // attempt to unmarshal the route_specific strings into RouteSpecificConfigs
-        // TODO(nfuden): remove this once upstream allows for real route specific configs
-        let mut specific = HashMap::new();
-        for (key, value) in self.route_specific.iter() {
-            let route_specific: PerRouteConfig = match serde_json::from_str(value) {
-                Ok(cfg) => cfg,
-                Err(err) => {
-                    eprintln!("Error parsing route specific config: {err} {value}");
-                    continue;
-                }
-            };
-            specific.insert(key.clone(), route_specific);
-        }
-
         // specific.extend(self.route_specific.into_iter());
 
         Box::new(Filter {
             request_headers_setter: self.request_headers_setter.clone(),
             // request_headers_extractions: self.request_headers_extractions.clone(),
             response_headers_setter: self.response_headers_setter.clone(),
-            // clone the hashmap
-            route_specific: specific,
+            per_route_config: None,
             env,
         })
     }
@@ -140,7 +137,8 @@ fn header(state: &State, key: &str) -> String {
     let Some(header_map) = <HashMap<String, String>>::deserialize(headers.clone()).ok() else {
         return "".to_string();
     };
-    header_map.get(key).cloned().unwrap_or_default()
+    let value = header_map.get(key).cloned().unwrap_or_default();
+    return value;
 }
 
 fn request_header(state: &State, key: &str) -> String {
@@ -160,39 +158,43 @@ pub struct Filter {
     request_headers_setter: Vec<(String, String)>,
     // request_headers_extractions: Vec<(String, String)>,
     response_headers_setter: Vec<(String, String)>,
-    route_specific: HashMap<String, PerRouteConfig>,
+    per_route_config: Option<Box<PerRouteConfig>>,
     env: Environment<'static>,
 }
 
-/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`] trait.
-impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for Filter {
-    fn on_request_headers(
+impl Filter {
+    fn set_per_route_config<EHF: EnvoyHttpFilter>(
         &mut self,
         envoy_filter: &mut EHF,
-        _end_of_stream: bool,
-    ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
-        if !_end_of_stream {
-            return abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
-        }
-
-        let mut setters = self.request_headers_setter.clone();
-        // use the sub route version if appropriate as we dont have valid perroute config today
-        if !self.route_specific.is_empty() {
-            // check filter state for info
-            let route_name_data_option = envoy_filter.get_metadata_string(
-                abi::envoy_dynamic_module_type_metadata_source::Dynamic,
-                "kgateway",
-                "route",
-            );
-            if let Some(route_name_data) = route_name_data_option {
-                // if its there then we should be able to pull the data name
-                let route_name = std::str::from_utf8(route_name_data.as_slice()).unwrap();
-                let route_config = self.route_specific.get(route_name);
-                if let Some(route_config_val) = route_config {
-                    setters = route_config_val.request_headers_setter.clone();
-                }
+    ) {
+        if !self.per_route_config.is_some() {
+            if let Some(per_route_config) = envoy_filter.get_most_specific_route_config().as_ref() {
+                let per_route_config = match per_route_config.downcast_ref::<PerRouteConfig>() {
+                    Some(cfg) => cfg,
+                    None => {
+                        eprintln!("set_per_route_config: wrong per route config type: {:?}", per_route_config);
+                        return;
+                    }
+                };
+                self.per_route_config = Some(Box::new(per_route_config.clone()));
             }
         }
+    }
+
+    fn get_per_route_config(
+        &self,
+    ) -> Option<&PerRouteConfig> {
+        self.per_route_config.as_ref().map(|config| &**config)
+    }
+
+    fn transform_request_headers<EHF: EnvoyHttpFilter>(
+        &self,
+        envoy_filter: &mut EHF,
+    ) {
+        let setters = match self.get_per_route_config() {
+            Some(config) => &config.request_headers_setter,
+            None => &self.request_headers_setter,
+        };
 
         // TODO(nfuden): find someone who knows rust to see if we really need this Hash map for serialization
         let mut headers = HashMap::new();
@@ -205,11 +207,11 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for Filter {
             headers.insert(key.to_string(), value);
         }
 
-        for (key, value) in &setters {
+        for (key, value) in setters {
             let mut env = self.env.clone();
             env.add_template("temp", value).unwrap();
             let tmpl = env.get_template("temp").unwrap();
-            let rendered = tmpl.render(context!(headers => headers));
+            let rendered = tmpl.render(context!(headers => headers, request_headers => headers));
             let mut rendered_str = "".to_string();
             if let Ok(rendered_val) = rendered {
                 rendered_str = rendered_val;
@@ -218,7 +220,47 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for Filter {
             }
             envoy_filter.set_request_header(key, rendered_str.as_bytes());
         }
+    }
+}
+
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`] trait.
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for Filter {
+    fn on_request_headers(
+        &mut self,
+        envoy_filter: &mut EHF,
+        _end_of_stream: bool,
+    ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+        // TODO: need to test if we get called even if there is no transformation setting
+        //       if yes, we need to short circuit here and return Continue
+        if !_end_of_stream {
+            // TODO: this here always stop iteration to wait for the full request body,
+            //       need to support body passthrough
+            return abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
+        }
+
+        self.set_per_route_config(envoy_filter);
+        self.transform_request_headers(envoy_filter);
         abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+    }
+
+    fn on_request_body(
+        &mut self,
+        envoy_filter: &mut EHF,
+        end_of_stream: bool,
+    ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
+        // TODO: need to test if we get called even if there is no transformation setting
+        //       if yes, we need to short circuit here and return Continue
+        if !end_of_stream {
+            // TODO: Technically, we don't need to buffer the body yet as we don't support parsing the body now
+            //       but it will be coming next. This is mimicking the C++ transformation filter behavior to 
+            //       always buffer the request body by default unless passthrough is set. Will revisit and consider
+            //       if this is the desired behavior when we implement parsing the body
+            return abi::envoy_dynamic_module_type_on_http_filter_request_body_status::StopIterationAndBuffer
+        }
+
+        self.set_per_route_config(envoy_filter);
+        self.transform_request_headers(envoy_filter);
+        return abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue;
     }
 
     fn on_response_headers(
@@ -247,26 +289,13 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for Filter {
             request_headers.insert(key.to_string(), value);
         }
 
-        let mut setters = self.response_headers_setter.clone();
-        // use the sub route version if appropriate as we dont have valid perroute config today
-        if !self.route_specific.is_empty() {
-            // check filter state for info
-            let route_name_data_option = envoy_filter.get_metadata_string(
-                abi::envoy_dynamic_module_type_metadata_source::Dynamic,
-                "kgateway",
-                "route",
-            );
-            if let Some(route_name_data) = route_name_data_option {
-                // if its there then we should be able to pull the data name
-                let route_name = std::str::from_utf8(route_name_data.as_slice()).unwrap();
-                let route_config = self.route_specific.get(route_name);
-                if let Some(route_config_val) = route_config {
-                    setters = route_config_val.response_headers_setter.clone();
-                }
-            }
-        }
+        self.set_per_route_config(envoy_filter);
+        let setters = match self.get_per_route_config() {
+            Some(config) => &config.response_headers_setter,
+            None => &self.response_headers_setter,
+        };
 
-        for (key, value) in &setters {
+        for (key, value) in setters {
             let mut env = self.env.clone();
             env.add_template("temp", value).unwrap();
             let tmpl = env.get_template("temp").unwrap();
@@ -320,9 +349,12 @@ mod tests {
                 ),
             ],
             response_headers_setter: vec![("X-Bar".to_string(), "foo".to_string())],
-            route_specific: HashMap::new(),
         };
         let mut filter = filter_conf.new_http_filter(&mut envoy_config);
+
+        envoy_filter.expect_get_most_specific_route_config().returning(|| {
+            None
+        });
 
         envoy_filter.expect_get_request_headers().returning(|| {
             vec![
@@ -421,9 +453,12 @@ mod tests {
                 "{%- if true -%}supersuper{% endif %}".to_string(),
             )],
             response_headers_setter: vec![("X-Bar".to_string(), "foo".to_string())],
-            route_specific: HashMap::new(),
         };
         let mut filter = filter_conf.new_http_filter(&mut envoy_config);
+
+        envoy_filter.expect_get_most_specific_route_config().returning(|| {
+            None
+        });
 
         envoy_filter.expect_get_request_headers().returning(|| {
             vec![

--- a/internal/envoyinit/rustformations/src/lib.rs
+++ b/internal/envoyinit/rustformations/src/lib.rs
@@ -1,9 +1,10 @@
 use envoy_proxy_dynamic_modules_rust_sdk::*;
+use std::any::Any;
 
 // ALL FILTERS HERE
 mod http_simple_mutations;
 
-declare_init_functions!(init, new_http_filter_config_fn);
+declare_init_functions!(init, new_http_filter_config_fn, new_http_filter_per_route_config_fn);
 
 /// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::ProgramInitFunction`].
 ///
@@ -43,6 +44,24 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
         _ => panic!(
             "Unknown filter name: {}, known filters are {}",
             filter_name, "http_simple_mutations"
+        ),
+    }
+}
+
+fn new_http_filter_per_route_config_fn(name: &str, config: &[u8]) -> Option<Box<dyn Any>> {
+    let per_route_config = match std::str::from_utf8(config) {
+        Ok(config) => config,
+        Err(_) => {
+            eprintln!("Invalid UTF-8 in per route filter configuration");
+            return None;
+        }
+    };
+    match name {
+        "http_simple_mutations" => http_simple_mutations::PerRouteConfig::new(per_route_config)
+            .map(|config| Box::new(config) as Box<dyn Any>),
+        _ => panic!(
+            "Unknown filter name: {}, known filters are {}",
+            name, "http_simple_mutations"
         ),
     }
 }

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -2,9 +2,6 @@ package trafficpolicy
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"strconv"
 	"time"
 
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -51,7 +48,6 @@ import (
 const (
 	transformationFilterNamePrefix = "transformation"
 	rustformationFilterNamePrefix  = "dynamic_modules/simple_mutations"
-	metadataRouteTransformation    = "transformation/helper"
 	localRateLimitFilterNamePrefix = "ratelimit/local"
 	localRateLimitStatPrefix       = "http_local_rate_limiter"
 	rateLimitFilterNamePrefix      = "ratelimit"
@@ -194,18 +190,16 @@ type trafficPolicyPluginGwPass struct {
 	ir.UnimplementedProxyTranslationPass
 
 	setTransformationInChain map[string]bool // TODO(nfuden): make this multi stage
-	// TODO(nfuden): dont abuse httplevel filter in favor of route level
-	rustformationStash    map[string]string
-	listenerTransform     *transformationpb.RouteTransformations
-	localRateLimitInChain map[string]*localratelimitv3.LocalRateLimit
-	extAuthPerProvider    ProviderNeededMap
-	extProcPerProvider    ProviderNeededMap
-	rateLimitPerProvider  ProviderNeededMap
-	rbacInChain           map[string]*envoyrbacv3.RBAC
-	corsInChain           map[string]*corsv3.Cors
-	csrfInChain           map[string]*envoy_csrf_v3.CsrfPolicy
-	headerMutationInChain map[string]*header_mutationv3.HeaderMutationPerRoute
-	bufferInChain         map[string]*bufferv3.Buffer
+	listenerTransform        *transformationpb.RouteTransformations
+	localRateLimitInChain    map[string]*localratelimitv3.LocalRateLimit
+	extAuthPerProvider       ProviderNeededMap
+	extProcPerProvider       ProviderNeededMap
+	rateLimitPerProvider     ProviderNeededMap
+	rbacInChain              map[string]*envoyrbacv3.RBAC
+	corsInChain              map[string]*corsv3.Cors
+	csrfInChain              map[string]*envoy_csrf_v3.CsrfPolicy
+	headerMutationInChain    map[string]*header_mutationv3.HeaderMutationPerRoute
+	bufferInChain            map[string]*bufferv3.Buffer
 }
 
 var _ ir.ProxyTranslationPass = &trafficPolicyPluginGwPass{}
@@ -229,6 +223,9 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, me
 	registerTypes(commoncol.OurClient)
 
 	useRustformations = commoncol.Settings.UseRustFormations // stash the state of the env setup for rustformation usage
+	if useRustformations {
+		logger.Info("Transformation is using Rust Dynamic Module.")
+	}
 
 	col := krt.WrapClient(kclient.NewFiltered[*v1alpha1.TrafficPolicy](
 		commoncol.Client,
@@ -325,56 +322,6 @@ func (p *trafficPolicyPluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputR
 	policy, ok := pCtx.Policy.(*TrafficPolicy)
 	if !ok {
 		return nil
-	}
-
-	if policy.spec.rustformation != nil {
-		// TODO(nfuden): get back to this path once we have valid perroute
-		// pCtx.TypedFilterConfig.AddTypedConfig(rustformationFilterNamePrefix, policy.spec.rustformation)
-
-		// Hack around not having route level.
-		// Note this is really really bad and rather fragile due to listener draining behaviors
-		routeHash := strconv.Itoa(int(utils.HashProto(outputRoute))) //nolint:gosec // G115: hash value used as string key, truncation is acceptable
-		if p.rustformationStash == nil {
-			p.rustformationStash = make(map[string]string)
-		}
-		// encode the configuration that would be route level and stash the serialized version in a map
-		p.rustformationStash[routeHash] = string(policy.spec.rustformation.toStash)
-
-		// augment the dynamic metadata so that we can do our route hack
-		// set_dynamic_metadata filter DOES NOT have a route level configuration
-		// set_filter_state can be used but the dynamic modules cannot access it on the current version of envoy
-		// therefore use the old transformation just for rustformation
-		reqm := &transformationpb.RouteTransformations_RouteTransformation_RequestMatch{
-			RequestTransformation: &transformationpb.Transformation{
-				TransformationType: &transformationpb.Transformation_TransformationTemplate{
-					TransformationTemplate: &transformationpb.TransformationTemplate{
-						ParseBodyBehavior: transformationpb.TransformationTemplate_DontParse, // Default is to try for JSON... Its kinda nice but failure is bad...
-						DynamicMetadataValues: []*transformationpb.TransformationTemplate_DynamicMetadataValue{
-							{
-								MetadataNamespace: "kgateway",
-								Key:               "route",
-								Value: &transformationpb.InjaTemplate{
-									Text: routeHash,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		setmetaTransform := &transformationpb.RouteTransformations{
-			Transformations: []*transformationpb.RouteTransformations_RouteTransformation{
-				{
-					Match: &transformationpb.RouteTransformations_RouteTransformation_RequestMatch_{
-						RequestMatch: reqm,
-					},
-				},
-			},
-		}
-		pCtx.TypedFilterConfig.AddTypedConfig(metadataRouteTransformation, setmetaTransform)
-
-		p.setTransformationInChain[pCtx.FilterChainName] = true
 	}
 
 	if policy.spec.ai != nil {
@@ -479,49 +426,29 @@ func (p *trafficPolicyPluginGwPass) HttpFilters(fcc ir.FilterChainCommon) ([]plu
 		// ---------------
 		// | END CLASSIC |
 		// ---------------
-		// TODO(nfuden/yuvalk): how to do route level correctly probably contribute to dynamic module upstream
-		// smash together configuration
-		filterRouteHashConfig := map[string]string{}
-		topLevel, ok := p.rustformationStash[""]
-
-		if topLevel == "" {
-			topLevel = "}"
-		} else {
-			// toplevel is already formatted and at this point its quicker to rip off the { than it is so unmarshal and all}
-			topLevel = "," + topLevel[1:]
-		}
-		if ok {
-			delete(p.rustformationStash, "")
-		}
-		for k, v := range p.rustformationStash {
-			filterRouteHashConfig[k] = v
-		}
-
-		filterConfig, _ := json.Marshal(filterRouteHashConfig)
-		msg, _ := utils.MessageToAny(&wrapperspb.StringValue{
-			Value: fmt.Sprintf(`{"route_specific": %s%s`, string(filterConfig), topLevel),
+		// TODO: on the rust module side, the deserialization would fail and envoy would reject the config if
+		//       any fields are missing in the json EVEN the filter is disabled, so need this for now untill
+		//       we change the rust module to have default value
+		cfg, _ := utils.MessageToAny(&wrapperspb.StringValue{
+			Value: "{\"request_headers_setter\": [], \"response_headers_setter\": []}",
 		})
 		rustCfg := dynamicmodulesv3.DynamicModuleFilter{
 			DynamicModuleConfig: &exteniondynamicmodulev3.DynamicModuleConfig{
 				Name: "rust_module",
 			},
-			FilterName: "http_simple_mutations",
-
-			// currently we use stringvalue but we should look at using the json variant as supported in upstream
-			FilterConfig: msg,
+			FilterName:   "http_simple_mutations",
+			FilterConfig: cfg,
+		}
+		if p.listenerTransform != nil {
+			// TODO: Add the listener level transform config here?
 		}
 
-		filters = append(filters, sdkfilters.MustNewStagedFilter(rustformationFilterNamePrefix,
+		filter := sdkfilters.MustNewStagedFilter(rustformationFilterNamePrefix,
 			&rustCfg,
 			plugins.BeforeStage(plugins.AcceptedStage),
-		))
-
-		// filters = append(filters, sdkfilters.MustNewStagedFilter(setFilterStateFilterName,
-		// 	&set_filter_statev3.Config{}, plugins.AfterStage(plugins.FaultStage)))
-		filters = append(filters, sdkfilters.MustNewStagedFilter(metadataRouteTransformation,
-			&transformationpb.FilterTransformations{},
-			plugins.AfterStage(plugins.FaultStage),
-		))
+		)
+		filter.Filter.Disabled = true
+		filters = append(filters, filter)
 	}
 
 	// Add global ExtAuth disable filter when there are providers
@@ -622,7 +549,12 @@ func (p *trafficPolicyPluginGwPass) handlePolicies(
 	typedFilterConfig *ir.TypedFilterConfigMap,
 	spec trafficPolicySpecIr,
 ) {
-	p.handleTransformation(fcn, typedFilterConfig, spec.transformation)
+	if useRustformations {
+		p.handleRustTransformation(fcn, typedFilterConfig, spec.rustformation)
+	} else {
+		p.handleTransformation(fcn, typedFilterConfig, spec.transformation)
+	}
+
 	// Apply ExtAuthz configuration if present
 	// ExtAuth does not allow for most information such as destination
 	// to be set at the route level so we need to smuggle info upwards.

--- a/internal/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
+++ b/internal/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
@@ -7,6 +7,7 @@ import (
 	exteniondynamicmodulev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/dynamic_modules/v3"
 	dynamicmodulesv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_modules/v3"
 	transformationpb "github.com/solo-io/envoy-gloo/go/config/filter/http/transformation/v2"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -168,8 +169,7 @@ func toTransformFilterConfig(t *v1alpha1.TransformationPolicy) (*transformationp
 }
 
 type rustformationIR struct {
-	config  *dynamicmodulesv3.DynamicModuleFilter
-	toStash string
+	config *dynamicmodulesv3.DynamicModuleFilterPerRoute
 }
 
 var _ PolicySubIR = &rustformationIR{}
@@ -185,7 +185,7 @@ func (r *rustformationIR) Equals(other PolicySubIR) bool {
 	if r == nil || otherRustformation == nil {
 		return false
 	}
-	return proto.Equal(r.config, otherRustformation.config) && r.toStash == otherRustformation.toStash
+	return proto.Equal(r.config, otherRustformation.config)
 }
 
 func (r *rustformationIR) Validate() error {
@@ -200,18 +200,17 @@ func constructRustformation(in *v1alpha1.TrafficPolicy, out *trafficPolicySpecIr
 	if in.Spec.Transformation == nil || !useRustformations {
 		return nil
 	}
-	rustformation, toStash, err := toRustformFilterConfig(in.Spec.Transformation)
+	rustformation, err := toRustFormationPerRouteConfig(in.Spec.Transformation)
 	if err != nil {
 		return err
 	}
 	out.rustformation = &rustformationIR{
-		config:  rustformation,
-		toStash: toStash,
+		config: rustformation,
 	}
 	return nil
 }
 
-func toRustFormationPerRouteConfig(t *v1alpha1.Transform) (map[string]interface{}, bool) {
+func toRustFormationConfig(t *v1alpha1.Transform) (map[string]interface{}, bool) {
 	// if there is no transformations present then return a
 	hasTransform := false
 	rustformationConfigMap := map[string]interface{}{}
@@ -251,51 +250,51 @@ func toRustFormationPerRouteConfig(t *v1alpha1.Transform) (map[string]interface{
 	return rustformationConfigMap, hasTransform
 }
 
-// toRustformFilterConfig converts a TransformationPolicy to a RustFormation filter config.
+// toRustFormationPerRouteConfig converts a TransformationPolicy to a RustFormation per route config.
 // The shape of this function currently resembles that of the traditional API
 // Feel free to change the shape and flow of this function as needed provided there are sufficient unit tests on the configuration output.
 // The most dangerous updates here will be any switch over env variables that we are working on.s
-func toRustformFilterConfig(t *v1alpha1.TransformationPolicy) (*dynamicmodulesv3.DynamicModuleFilter, string, error) {
+func toRustFormationPerRouteConfig(t *v1alpha1.TransformationPolicy) (*dynamicmodulesv3.DynamicModuleFilterPerRoute, error) {
 	if t == nil || *t == (v1alpha1.TransformationPolicy{}) {
-		return nil, "", nil
+		return nil, nil
 	}
 	hasTransform := false
 	rustformCfgMap := map[string]interface{}{}
 
-	requestMap, hasRequestTransform := toRustFormationPerRouteConfig(t.Request)
+	requestMap, hasRequestTransform := toRustFormationConfig(t.Request)
 	hasTransform = hasTransform || hasRequestTransform
 	for k, v := range requestMap {
 		rustformCfgMap["request_"+k] = v
 	}
 
-	requestMap, hasResponseTransform := toRustFormationPerRouteConfig(t.Response)
+	requestMap, hasResponseTransform := toRustFormationConfig(t.Response)
 	hasTransform = hasTransform || hasResponseTransform
 	for k, v := range requestMap {
 		rustformCfgMap["response_"+k] = v
 	}
 
 	if !hasTransform {
-		return nil, "", nil
+		return nil, nil
 	}
 
 	rustformationJson, err := json.Marshal(rustformCfgMap)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	stringConf := string(rustformationJson)
 	filterCfg, _ := utils.MessageToAny(&wrapperspb.StringValue{
 		Value: stringConf,
 	})
-	rustCfg := &dynamicmodulesv3.DynamicModuleFilter{
+	rustCfg := &dynamicmodulesv3.DynamicModuleFilterPerRoute{
 		DynamicModuleConfig: &exteniondynamicmodulev3.DynamicModuleConfig{
 			Name: "rust_module",
 		},
-		FilterName:   "http_simple_mutations",
-		FilterConfig: filterCfg,
+		PerRouteConfigName: "http_simple_mutations",
+		FilterConfig:       filterCfg,
 	}
 
-	return rustCfg, stringConf, nil
+	return rustCfg, nil
 }
 
 func convertClassicRouteToListener(
@@ -311,8 +310,8 @@ func convertClassicRouteToListener(
 	transform := transformationpb.TransformationRule{
 		Match: &envoyroutev3.RouteMatch{
 			PathSpecifier: &envoyroutev3.RouteMatch_Prefix{
-				// match all as we arent doing submatches at this point
-				// consider attaching to a route or wiating until merging logic is done
+				// match all as we aren't doing submatches at this point
+				// consider attaching to a route or waiting until merging logic is done
 				Prefix: "/",
 			},
 		},
@@ -331,6 +330,30 @@ func (p *trafficPolicyPluginGwPass) handleTransformation(fcn string, typedFilter
 	}
 	if transform.config != nil {
 		typedFilterConfig.AddTypedConfig(transformationFilterNamePrefix, transform.config)
+		p.setTransformationInChain[fcn] = true
+	}
+}
+
+func (p *trafficPolicyPluginGwPass) handleRustTransformation(fcn string, typedFilterConfig *ir.TypedFilterConfigMap, rustTransform *rustformationIR) {
+	if rustTransform == nil {
+		return
+	}
+	if rustTransform.config != nil {
+		/*
+			anyMsg, err := utils.MessageToAny(rustTransform.config)
+			if err != nil {
+				logger.Error("failed to serialize rustformation config", "error", err)
+				return
+			}
+			typedFilterConfig.AddTypedConfig(rustformationFilterNamePrefix, anyMsg)
+		*/
+		typedFilterConfig.AddTypedConfig(rustformationFilterNamePrefix, rustTransform.config)
+		json, err := protojson.Marshal(typedFilterConfig.GetTypedConfig(rustformationFilterNamePrefix))
+		if err == nil {
+			logger.Info("rustTransform", "typed config", string(json))
+		} else {
+			logger.Error("failed to get json from rustTransform config", "error", err)
+		}
 		p.setTransformationInChain[fcn] = true
 	}
 }

--- a/test/gomega/matchers/have_http_request.go
+++ b/test/gomega/matchers/have_http_request.go
@@ -1,0 +1,240 @@
+package matchers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+var _ types.GomegaMatcher = new(HaveHttpRequestMatcher)
+
+// HaveRequestWithHeaders expects a set of headers that match the provided headers
+func HaveRequestWithHeaders(headers map[string]interface{}) types.GomegaMatcher {
+	return HaveHttpRequest(&HttpRequest{
+		Headers: headers,
+	})
+}
+
+// HaveRequestWithoutHeaders expects a request that does not contain the specified headers
+func HaveRequestWithoutHeaders(headerNames ...string) types.GomegaMatcher {
+	return HaveHttpRequest(&HttpRequest{
+		NotHeaders: headerNames,
+	})
+}
+
+// HttpRequest defines the set of properties that we can validate from an http.Request
+type HttpRequest struct {
+	// Method is the expected request method (eg GET, POST ...etc)
+	// Optional: If not provided, does not perform method validation
+	Method string
+	// Path is the expected request path (including any qs param)
+	// Optional: If not provided, does not perform path validation
+	Path string
+
+	// Body is the expected request body for an http.Request
+	// Body can be of type: {string, bytes, GomegaMatcher}
+	// Optional: If not provided, defaults to an empty string
+	// TODO: currently, the http echo service we use in our test does not
+	//       return the request body. So, this is not implemented yet and commented out
+	// Body interface{}
+
+	// Headers is the set of expected header values for an http.Request
+	// Each header can be of type: {string, GomegaMatcher}
+	// Optional: If not provided, does not perform header validation
+	Headers map[string]interface{}
+	// NotHeaders is a list of headers that should not be present in the request
+	// Optional: If not provided, does not perform header absence validation
+	NotHeaders []string
+	// Custom is a generic matcher that can be applied to validate any other properties of an http.Request
+	// Optional: If not provided, does not perform additional validation
+	Custom types.GomegaMatcher
+}
+
+func (r *HttpRequest) String() string {
+	return fmt.Sprintf("HttpRequest{Method: %s, Path: %s, Headers: %v, NotHeaders: %v, Custom: %v}",
+		r.Method, r.Path, r.Headers, r.NotHeaders, r.Custom)
+}
+
+// HaveHttpRequest returns a GomegaMatcher which validates that an http.Request contains
+// particular expected properties (method, body..etc)
+// If an expected body isn't specified, the body is not matched
+func HaveHttpRequest(expected *HttpRequest) types.GomegaMatcher {
+	expectedCustomMatcher := expected.Custom
+	if expected.Custom == nil {
+		// Default to an always accept matcher
+		expectedCustomMatcher = gstruct.Ignore()
+	}
+
+	var partialRequestMatchers []types.GomegaMatcher
+	if len(expected.Method) > 0 {
+		partialRequestMatchers = append(partialRequestMatchers, &HaveHTTPRequestHeaderWithValueMatcher{
+			Header: ":method",
+			Value:  expected.Method,
+		})
+	}
+	if len(expected.Path) > 0 {
+		partialRequestMatchers = append(partialRequestMatchers, &HaveHTTPRequestHeaderWithValueMatcher{
+			Header: ":path",
+			Value:  expected.Path,
+		})
+	}
+	for headerName, headerMatch := range expected.Headers {
+		partialRequestMatchers = append(partialRequestMatchers, &HaveHTTPRequestHeaderWithValueMatcher{
+			Header: headerName,
+			Value:  headerMatch,
+		})
+	}
+	for _, headerName := range expected.NotHeaders {
+		partialRequestMatchers = append(partialRequestMatchers, &NotHaveHTTPRequestHeaderMatcher{
+			Header: headerName,
+		})
+	}
+	partialRequestMatchers = append(partialRequestMatchers, expectedCustomMatcher)
+
+	return &HaveHttpRequestMatcher{
+		Expected:       expected,
+		requestMatcher: gomega.And(partialRequestMatchers...),
+	}
+}
+
+type HaveHttpRequestMatcher struct {
+	Expected *HttpRequest
+
+	requestMatcher types.GomegaMatcher
+}
+
+func (m *HaveHttpRequestMatcher) Match(actual interface{}) (success bool, err error) {
+	if ok, matchErr := m.requestMatcher.Match(actual); !ok {
+		return false, matchErr
+	}
+
+	return true, nil
+}
+
+func (m *HaveHttpRequestMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("%s \n%s",
+		m.requestMatcher.FailureMessage(actual),
+		informativeRequestComparison(m.Expected, actual))
+}
+
+func (m *HaveHttpRequestMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("%s \n%s",
+		m.requestMatcher.NegatedFailureMessage(actual),
+		informativeRequestComparison(m.Expected, actual))
+}
+
+// HaveHTTPRequestHeaderWithValueMatcher is a matcher that checks if a header exists and match the value in the HTTP request
+type HaveHTTPRequestHeaderWithValueMatcher struct {
+	Header string
+	Value  any
+}
+
+func (m *HaveHTTPRequestHeaderWithValueMatcher) Match(actual interface{}) (success bool, err error) {
+	request, ok := actual.(*http.Request)
+	if !ok {
+		return false, fmt.Errorf("HaveHTTPRequestHeaderWithValueMatcher expects an *http.Request, got %T", actual)
+	}
+
+	if request == nil {
+		return false, errors.New("HaveHTTPRequestHeaderWithValueMatcher matcher requires a non-nil *http.Request")
+	}
+
+	values := request.Header.Values(m.Header)
+	valuesMap := make(map[string]bool)
+	for _, value := range values {
+		valuesMap[value] = true
+	}
+
+	switch expected := m.Value.(type) {
+	case string:
+		return valuesMap[expected], nil
+	case []string:
+		for _, v := range expected {
+			if !valuesMap[v] {
+				return false, nil
+			}
+		}
+		return true, nil
+
+	default:
+		return false, errors.New("HaveHTTPRequestHeaderWithValueMatcher only supports string or []string value")
+	}
+}
+
+func (m *HaveHTTPRequestHeaderWithValueMatcher) FailureMessage(actual interface{}) string {
+	request, ok := actual.(*http.Request)
+	if !ok || request == nil {
+		return fmt.Sprintf("Expected a valid *http.Request, got %T", actual)
+	}
+
+	values := request.Header.Values(m.Header)
+	if len(values) == 0 {
+		return fmt.Sprintf("Expected HTTP request to have header '%s: %s', but it does not exist", m.Header, m.Value)
+	}
+	return fmt.Sprintf("Expected HTTP request to have header '%s: %s', but the value does not match. Actual: %v", m.Header, m.Value, values)
+}
+
+func (m *HaveHTTPRequestHeaderWithValueMatcher) NegatedFailureMessage(actual interface{}) string {
+	request, ok := actual.(*http.Request)
+	if !ok || request == nil {
+		return fmt.Sprintf("Expected a valid *http.Request, got %T", actual)
+	}
+
+	return fmt.Sprintf("Expected HTTP request to not have header '%s: %s', but it was not present", m.Header, m.Value)
+}
+
+// NotHaveHTTPRequestHeaderMatcher is a matcher that checks if a header is not present in the HTTP request
+type NotHaveHTTPRequestHeaderMatcher struct {
+	Header string
+}
+
+func (m *NotHaveHTTPRequestHeaderMatcher) Match(actual interface{}) (success bool, err error) {
+	request, ok := actual.(*http.Request)
+	if !ok {
+		return false, fmt.Errorf("NotHaveHTTPRequestHeaderMatcher expects an *http.Request, got %T", actual)
+	}
+
+	if request == nil {
+		return false, errors.New("NotHaveHTTPRequestHeaderMatcher matcher requires a non-nil *http.Request")
+	}
+
+	_, headerExists := request.Header[http.CanonicalHeaderKey(m.Header)]
+	return !headerExists, nil
+}
+
+func (m *NotHaveHTTPRequestHeaderMatcher) FailureMessage(actual interface{}) string {
+	request, ok := actual.(*http.Request)
+	if !ok || request == nil {
+		return fmt.Sprintf("Expected a valid *http.Request, got %T", actual)
+	}
+
+	return fmt.Sprintf("Expected HTTP request not to have header '%s', but it was present", m.Header)
+}
+
+func (m *NotHaveHTTPRequestHeaderMatcher) NegatedFailureMessage(actual interface{}) string {
+	request, ok := actual.(*http.Request)
+	if !ok || request == nil {
+		return fmt.Sprintf("Expected a valid *http.Request, got %T", actual)
+	}
+
+	return fmt.Sprintf("Expected HTTP request to have header '%s', but it was not present", m.Header)
+}
+
+// informativeRequestComparison returns a string which presents data to the user to help them understand why a failure occurred.
+// The HaveHttpRequestMatcher uses an And matcher, which intentionally short-circuits and only
+// logs the first failure that occurred.
+// To help developers, we print more details in this function.
+func informativeRequestComparison(expected, actual interface{}) string {
+	expectedJson, _ := json.MarshalIndent(expected, "", "  ")
+
+	request, ok := actual.(*http.Request)
+	if !ok || request == nil {
+		return fmt.Sprintf("\nexpected: %s", expectedJson)
+	}
+	return fmt.Sprintf("\nexpected: %s actual request headers: %v", expectedJson, request.Header)
+}

--- a/test/kubernetes/e2e/features/transformation/suite.go
+++ b/test/kubernetes/e2e/features/transformation/suite.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/onsi/gomega"
@@ -28,6 +29,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/tests/base"
+	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/testutils/helper"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite
@@ -40,6 +42,10 @@ var (
 	transformForBodyJsonManifest     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "transform-for-body-json.yaml")
 	transformForBodyAsStringManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "transform-for-body-as-string.yaml")
 	gatewayAttachedTransformManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "gateway-attached-transform.yaml")
+	transformForMatchPathManifest    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "transform-for-match-path.yaml")
+	transformForMatchHeaderManifest  = filepath.Join(fsutils.MustGetThisDir(), "testdata", "transform-for-match-header.yaml")
+	transformForMatchQueryManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "transform-for-match-query.yaml")
+	transformForMatchMethodManifest  = filepath.Join(fsutils.MustGetThisDir(), "testdata", "transform-for-match-method.yaml")
 
 	proxyObjectMeta = metav1.ObjectMeta{
 		Name:      "gw",
@@ -56,6 +62,10 @@ var (
 			transformForBodyJsonManifest,
 			transformForBodyAsStringManifest,
 			gatewayAttachedTransformManifest,
+			transformForMatchHeaderManifest,
+			transformForMatchMethodManifest,
+			transformForMatchPathManifest,
+			transformForMatchQueryManifest,
 		},
 	}
 
@@ -63,14 +73,289 @@ var (
 	testCases = map[string]*base.TestCase{}
 )
 
+type transformationTestCase struct {
+	name      string
+	routeName string
+	opts      []curl.Option
+	resp      *testmatchers.HttpResponse
+	req       *testmatchers.HttpRequest
+}
+
 // testingSuite is a suite of basic routing / "happy path" tests
 type testingSuite struct {
 	*base.BaseTestingSuite
+	// testcases that are common between the traditional transformation (c++) and rustformation
+	// once the rustformation is in feature parity with the trandiation transformation,
+	// they should both just use this.
+	commonTestCases []transformationTestCase
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
 		base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+		[]transformationTestCase{
+			{
+				name:      "basic-gateway-attached",
+				routeName: "gateway-attached-transform",
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusOK,
+					Headers: map[string]interface{}{
+						"response-gateway": "goodbye",
+					},
+					NotHeaders: []string{
+						"x-foo-response",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						"request-gateway": "hello",
+					},
+				},
+			},
+			{
+				name:      "basic",
+				routeName: "headers",
+				opts: []curl.Option{
+					curl.WithBody("hello"),
+				},
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusOK,
+					Headers: map[string]interface{}{
+						"x-foo-response":        "notsuper",
+						"x-foo-response-status": "200",
+					},
+					NotHeaders: []string{
+						"response-gateway",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						"x-foo-bar":  "foolen_5",
+						"x-foo-bar2": "foolen_5",
+					},
+					NotHeaders: []string{
+						// looks like the way we set up transformation targeting gateway, we are
+						// also using RouteTransformation instead of FilterTransformation and it's
+						// set , so it's set at the route table level and if there is a more specific
+						// transformation (eg in vhost or prefix match), the gateway attached transformation
+						// will not apply. Make sure it's not there.
+						"request-gateway",
+					},
+				},
+			},
+			{
+				name:      "conditional set by request header", // inja and the request_header function in use
+				routeName: "headers",
+				opts: []curl.Option{
+					curl.WithBody("hello-world"),
+					curl.WithHeader("x-add-bar", "super"),
+				},
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusOK,
+					Headers: map[string]interface{}{
+						"x-foo-response":        "supersupersuper",
+						"x-foo-response-status": "200",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						"x-foo-bar":  "foolen_11",
+						"x-foo-bar2": "foolen_11",
+					},
+					NotHeaders: []string{
+						// looks like the way we set up transformation targeting gateway, we are
+						// also using RouteTransformation instead of FilterTransformation and it's
+						// set , so it's set at the route table level and if there is a more specific
+						// transformation (eg in vhost or prefix match), the gateway attached transformation
+						// will not apply. Make sure it's not there.
+						"request-gateway",
+					},
+				},
+			},
+			{
+				// When all matching criterion are met, path match takes precedence
+				name:      "match-all",
+				routeName: "match",
+				opts: []curl.Option{
+					curl.WithHeader("foo", "bar"),
+					curl.WithPath("/path_match/index.html"),
+					curl.WithQueryParameters(map[string]string{"test": "123"}),
+				},
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusOK,
+					Headers: map[string]interface{}{
+						"x-foo-response":  "path matched",
+						"x-path-response": "matched",
+						//						"x-method-response": "matched",
+						//						"x-header-response": "matched",
+						//						"x-query-response":  "matched",
+					},
+					NotHeaders: []string{
+						"response-gateway",
+						"x-method-response",
+						"x-header-response",
+						"x-query-response",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						"x-foo-request":  "path matched",
+						"x-path-request": "matched",
+						//						"x-method-request": "matched",
+						//						"x-header-request": "matched",
+						//						"x-query-request":  "matched",
+					},
+					NotHeaders: []string{
+						"request-gateway",
+						"x-method-request",
+						"x-header-request",
+						"x-query-request",
+					},
+				},
+			},
+			{
+				// When all matching criterion are met except path, method match takes precedence
+				name:      "match-method-header-and-query",
+				routeName: "match",
+				opts: []curl.Option{
+					curl.WithHeader("foo", "bar"),
+					curl.WithPath("/index.html"),
+					curl.WithQueryParameters(map[string]string{"test": "123"}),
+				},
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusOK,
+					Headers: map[string]interface{}{
+						"x-foo-response":    "method matched",
+						"x-method-response": "matched",
+					},
+					NotHeaders: []string{
+						"response-gateway",
+						"x-path-response",
+						"x-header-response",
+						"x-query-response",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						"x-foo-request":    "method matched",
+						"x-method-request": "matched",
+					},
+					NotHeaders: []string{
+						"request-gateway",
+						"x-path-request",
+						"x-header-request",
+						"x-query-request",
+					},
+				},
+			},
+			{
+				// When all matching criterion are met except path and method, header match takes precedence
+				name:      "match-header-and-query",
+				routeName: "match",
+				opts: []curl.Option{
+					curl.WithBody("hello"),
+					curl.WithHeader("foo", "bar"),
+					curl.WithPath("/index.html"),
+					curl.WithQueryParameters(map[string]string{"test": "123"}),
+				},
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusOK,
+					Headers: map[string]interface{}{
+						"x-foo-response":    "header matched",
+						"x-header-response": "matched",
+					},
+					NotHeaders: []string{
+						"response-gateway",
+						"x-path-response",
+						"x-method-response",
+						"x-query-response",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						"x-foo-request":    "header matched",
+						"x-header-request": "matched",
+					},
+					NotHeaders: []string{
+						"request-gateway",
+						"x-path-request",
+						"x-method-request",
+						"x-query-request",
+					},
+				},
+			},
+			{
+				name:      "match-query",
+				routeName: "match",
+				opts: []curl.Option{
+					curl.WithBody("hello"),
+					curl.WithPath("/index.html"),
+					curl.WithQueryParameters(map[string]string{"test": "123"}),
+				},
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusOK,
+					Headers: map[string]interface{}{
+						"x-foo-response":   "query matched",
+						"x-query-response": "matched",
+					},
+					NotHeaders: []string{
+						"response-gateway",
+						"x-path-response",
+						"x-method-response",
+						"x-header-response",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						"x-foo-request":   "query matched",
+						"x-query-request": "matched",
+					},
+					NotHeaders: []string{
+						"request-gateway",
+						"x-path-request",
+						"x-method-request",
+						"x-header-request",
+					},
+				},
+			},
+			{
+				// Interesting Note: because when a transformation attached to the gateway is set at route-table
+				// level, when nothing match and envoy returns 404, that transformation won't ge applied neither!
+				name:      "match-none",
+				routeName: "match",
+				opts: []curl.Option{
+					curl.WithBody("hello"),
+					curl.WithPath("/index.html"),
+				},
+				resp: &testmatchers.HttpResponse{
+					StatusCode: http.StatusNotFound,
+					Headers:    map[string]interface{}{
+						//						"response-gateway": "goodbyte",
+					},
+					NotHeaders: []string{
+						"response-gateway",
+						"x-path-response",
+						"x-method-response",
+						"x-header-response",
+						"x-query-response",
+						"x-foo-response",
+					},
+				},
+				req: &testmatchers.HttpRequest{
+					Headers: map[string]interface{}{
+						//						"request-gateway": "hello",
+					},
+					NotHeaders: []string{
+						"request-gateway",
+						"x-path-request",
+						"x-method-request",
+						"x-header-request",
+						"x-foo-request",
+						"x-query-request",
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -87,55 +372,7 @@ func (s *testingSuite) TestGatewayWithTransformedRoute() {
 		s.dynamicModuleAssertion(false),
 	)
 
-	testCases := []struct {
-		name      string
-		routeName string
-		opts      []curl.Option
-		resp      *testmatchers.HttpResponse
-	}{
-		{
-			name:      "basic-gateway-attached",
-			routeName: "gateway-attached-transform",
-			resp: &testmatchers.HttpResponse{
-				StatusCode: http.StatusOK,
-				Headers: map[string]interface{}{
-					"response-gateway": "goodbye",
-				},
-				NotHeaders: []string{
-					"x-foo-response",
-				},
-			},
-		},
-		{
-			name:      "basic",
-			routeName: "headers",
-			opts: []curl.Option{
-				curl.WithBody("hello"),
-			},
-			resp: &testmatchers.HttpResponse{
-				StatusCode: http.StatusOK,
-				Headers: map[string]interface{}{
-					"x-foo-response": "notsuper",
-				},
-				NotHeaders: []string{
-					"response-gateway",
-				},
-			},
-		},
-		{
-			name:      "conditional set by request header", // inja and the request_header function in use
-			routeName: "headers",
-			opts: []curl.Option{
-				curl.WithBody("hello"),
-				curl.WithHeader("x-add-bar", "super"),
-			},
-			resp: &testmatchers.HttpResponse{
-				StatusCode: http.StatusOK,
-				Headers: map[string]interface{}{
-					"x-foo-response": "supersupersuper",
-				},
-			},
-		},
+	testCases := []transformationTestCase{
 		{
 			name:      "pull json info", // shows we parse the body as json
 			routeName: "route-for-body-json",
@@ -150,9 +387,19 @@ func (s *testingSuite) TestGatewayWithTransformedRoute() {
 					"from-incoming": "key_level_myinnervalue",
 				},
 			},
+			// Note: for this test, there is a response body transformation setup which extracts just the headers field
+			// When we create the Request Object from the echo response, we accounted for that
+			req: &testmatchers.HttpRequest{
+				Headers: map[string]interface{}{
+					"X-Transformed-Incoming": "level_myinnervalue",
+				},
+			},
 		},
 		{
-			name:      "dont pull info if we dont parse json", // shows we parse the body as json
+			// The default for Body parsing is AsString which translate to body passthrough (no buffering in envoy)
+			// For this test, the response header transformation is set to try to use the `headers` field in the response
+			// json body, because the body is never parse, so `headers` is undefine and envoy returns 400 response
+			name:      "dont pull info if we dont parse json",
 			routeName: "route-for-body",
 			opts: []curl.Option{
 				curl.WithBody(`{"mykey": {"myinnerkey": "myinnervalue"}}`),
@@ -176,17 +423,8 @@ func (s *testingSuite) TestGatewayWithTransformedRoute() {
 			},
 		},
 	}
-	for _, tc := range testCases {
-		s.TestInstallation.Assertions.AssertEventualCurlResponse(
-			s.Ctx,
-			defaults.CurlPodExecOpt,
-			append(tc.opts,
-				curl.WithHost(kubeutils.ServiceFQDN(proxyObjectMeta)),
-				curl.WithHostHeader(fmt.Sprintf("example-%s.com", tc.routeName)),
-				curl.WithPort(8080),
-			),
-			tc.resp)
-	}
+	testCases = append(testCases, s.commonTestCases...)
+	s.runTestCases((testCases))
 }
 
 func (s *testingSuite) TestGatewayRustformationsWithTransformedRoute() {
@@ -257,50 +495,32 @@ func (s *testingSuite) TestGatewayRustformationsWithTransformedRoute() {
 		s.dynamicModuleAssertion(true),
 	)
 
-	testCases := []struct {
-		name      string
-		routeName string
-		opts      []curl.Option
-		resp      *testmatchers.HttpResponse
-	}{
-		{
-			name:      "basic",
-			routeName: "headers",
-			opts: []curl.Option{
-				curl.WithBody("hello"),
-			},
-			resp: &testmatchers.HttpResponse{
-				StatusCode: http.StatusOK,
-				Headers: map[string]interface{}{
-					"x-foo-response": "notsuper",
-				},
-			},
-		},
-		{
-			name:      "conditional set by request header", // inja and the request_header function in use
-			routeName: "headers",
-			opts: []curl.Option{
-				curl.WithBody("hello"),
-				curl.WithHeader("x-add-bar", "super"),
-			},
-			resp: &testmatchers.HttpResponse{
-				StatusCode: http.StatusOK,
-				Headers: map[string]interface{}{
-					"x-foo-response": "supersupersuper",
-				},
-			},
-		},
-	}
+	testCases := []transformationTestCase{}
+	testCases = append(testCases, s.commonTestCases...)
+	s.runTestCases((testCases))
+}
+
+func (s *testingSuite) runTestCases(testCases []transformationTestCase) {
 	for _, tc := range testCases {
-		s.TestInstallation.Assertions.AssertEventualCurlResponse(
-			s.Ctx,
-			defaults.CurlPodExecOpt,
-			append(tc.opts,
-				curl.WithHost(kubeutils.ServiceFQDN(proxyObjectMeta)),
-				curl.WithHostHeader(fmt.Sprintf("example-%s.com", tc.routeName)),
-				curl.WithPort(8080),
-			),
-			tc.resp)
+		s.T().Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			resp := s.TestInstallation.Assertions.AssertEventualCurlReturnResponse(
+				s.Ctx,
+				defaults.CurlPodExecOpt,
+				append(tc.opts,
+					curl.WithHost(kubeutils.ServiceFQDN(proxyObjectMeta)),
+					curl.WithHostHeader(fmt.Sprintf("example-%s.com", tc.routeName)),
+					curl.WithPort(8080),
+				),
+				tc.resp)
+			if resp.StatusCode == http.StatusOK {
+				req, err := helper.CreateRequestFromEchoResponse(resp.Body)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(req).To(testmatchers.HaveHttpRequest(tc.req))
+			} else {
+				resp.Body.Close()
+			}
+		})
 	}
 }
 
@@ -374,8 +594,6 @@ func (s *testingSuite) dynamicModuleAssertion(shouldBeLoaded bool) func(ctx cont
 			dynamicModuleLoaded := strings.Contains(listener.String(), "dynamic_modules/")
 			if shouldBeLoaded {
 				g.Expect(dynamicModuleLoaded).To(gomega.BeTrue(), fmt.Sprintf("dynamic module not loaded: %v", listener.String()))
-				dynamicModuleRouteConfigured := strings.Contains(listener.String(), "transformation/helper")
-				g.Expect(dynamicModuleRouteConfigured).To(gomega.BeTrue(), fmt.Sprintf("dynamic module routespecific not loaded: %v", listener.String()))
 			} else {
 				g.Expect(dynamicModuleLoaded).To(gomega.BeFalse(), fmt.Sprintf("dynamic module should not be loaded: %v", listener.String()))
 			}

--- a/test/kubernetes/e2e/features/transformation/testdata/gateway.yaml
+++ b/test/kubernetes/e2e/features/transformation/testdata/gateway.yaml
@@ -27,3 +27,5 @@ spec:
       env:
         - name: RUST_BACKTRACE
           value: "1"
+      bootstrap:
+        logLevel: trace

--- a/test/kubernetes/e2e/features/transformation/testdata/transform-for-headers.yaml
+++ b/test/kubernetes/e2e/features/transformation/testdata/transform-for-headers.yaml
@@ -25,11 +25,17 @@ spec:
   transformation:
     request:
       set:
+# in request header context, both header() and request_header() refer to the same set of headers
         - name: x-foo-bar
           value: "foolen_{{header(\"content-length\")}}"
+        - name: x-foo-bar2
+          value: "foolen_{{request_header(\"content-length\")}}"
         - name: ":method"
           value: "pseudo-not-rejected!"
     response:
       set:
+# in response header context, header() refers to response headers and request_header() refer to request headers
         - name: x-foo-response
           value: "{%- if request_header(\"x-add-bar\") != \"\" -%}supersuper{{request_header(\"x-add-bar\")}}{% else %}notsuper{% endif %}"
+        - name: x-foo-response-status
+          value: "{{header(\":status\")}}"

--- a/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-header.yaml
+++ b/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-header.yaml
@@ -1,0 +1,43 @@
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-for-header-match
+spec:
+  parentRefs:
+    - name: gw
+  hostnames:
+    - "example-match.com"
+  rules:
+    - matches:
+        - headers:
+          - type: Exact
+            name: foo
+            value: bar
+      backendRefs:
+        - name: simple-svc
+          port: 8080
+      
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: example-traffic-policy-for-header-match
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route-for-header-match
+  transformation:
+    request:
+      set:
+        - name: x-foo-request
+          value: "header matched"
+        - name: x-header-request
+          value: "matched"
+    response:
+      set:
+        - name: x-foo-response
+          value: "header matched"
+        - name: x-header-response
+          value: "matched"

--- a/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-method.yaml
+++ b/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-method.yaml
@@ -1,0 +1,39 @@
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-for-method-match
+spec:
+  parentRefs:
+    - name: gw
+  hostnames:
+    - "example-match.com"
+  rules:
+    - matches:
+        - method: GET
+      backendRefs:
+        - name: simple-svc
+          port: 8080
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: example-traffic-policy-for-method-match
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route-for-method-match
+  transformation:
+    request:
+      set:
+        - name: x-foo-request
+          value: "method matched"
+        - name: x-method-request
+          value: "matched"
+    response:
+      set:
+        - name: x-foo-response
+          value: "method matched"
+        - name: x-method-response
+          value: "matched"

--- a/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-path.yaml
+++ b/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-path.yaml
@@ -1,0 +1,41 @@
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-for-path-match
+spec:
+  parentRefs:
+    - name: gw
+  hostnames:
+    - "example-match.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /path_match/
+      backendRefs:
+        - name: simple-svc
+          port: 8080
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: example-traffic-policy-for-path-match
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route-for-path-match
+  transformation:
+    request:
+      set:
+        - name: x-foo-request
+          value: "path matched"
+        - name: x-path-request
+          value: "matched"
+    response:
+      set:
+        - name: x-foo-response
+          value: "path matched"
+        - name: x-path-response
+          value: "matched"

--- a/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-query.yaml
+++ b/test/kubernetes/e2e/features/transformation/testdata/transform-for-match-query.yaml
@@ -1,0 +1,42 @@
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-for-query-match
+spec:
+  parentRefs:
+    - name: gw
+  hostnames:
+    - "example-match.com"
+  rules:
+    - matches:
+        - queryParams:
+          - type: Exact
+            name: test
+            value: "123"
+      backendRefs:
+        - name: simple-svc
+          port: 8080
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: example-traffic-policy-for-query-match
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route-for-query-match
+  transformation:
+    request:
+      set:
+        - name: x-foo-request
+          value: "query matched"
+        - name: x-query-request
+          value: "matched"
+    response:
+      set:
+        - name: x-foo-response
+          value: "query matched"
+        - name: x-query-response
+          value: "matched"

--- a/test/kubernetes/testutils/helper/http_echo.go
+++ b/test/kubernetes/testutils/helper/http_echo.go
@@ -1,0 +1,88 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+type echoResponse struct {
+	Path    string              `json:"path"`
+	Host    string              `json:"host"`
+	Method  string              `json:"method"`
+	Proto   string              `json:"proto"`
+	Headers map[string][]string `json:"headers"`
+	// other fields like namespace, ingress, service, pod ignored
+}
+
+// ToHttpRequest reconstructs an http.Request from the EchoResponse
+func (er *echoResponse) ToHttpRequest() (*http.Request, error) {
+	// Construct a URL (you may want to prepend scheme, default http://)
+	u := &url.URL{
+		Scheme: "http",
+		Host:   er.Host,
+		Path:   er.Path,
+	}
+
+	// Create a body if Content-Length > 0 (dummy body here)
+	var body io.ReadCloser
+	if cl, ok := er.Headers["Content-Length"]; ok && len(cl) > 0 && cl[0] != "0" {
+		body = io.NopCloser(bytes.NewBuffer(make([]byte, 0)))
+	}
+
+	// Build request
+	req := &http.Request{
+		Method: er.Method,
+		URL:    u,
+		Host:   er.Host,
+		Header: http.Header{},
+		Body:   body,
+		Proto:  er.Proto,
+	}
+
+	// Add headers
+	for k, v := range er.Headers {
+		for _, val := range v {
+			req.Header.Add(k, val)
+		}
+	}
+
+	return req, nil
+}
+
+func CreateRequestFromEchoResponse(r io.ReadCloser) (*http.Request, error) {
+	bytes, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	r.Close()
+
+	var response echoResponse
+	if err := json.Unmarshal(bytes, &response); err != nil {
+		return nil, err
+	}
+
+	if len(response.Headers) == 0 {
+		// Hack Alert:
+		// For a request, the headers will at least contain `:path` and `:method` and should
+		// never be empty.
+		// some transformation tests extract just the headers field from the original echo
+		// response and return that as the json body, so just try parse that as a map of key
+		// and value and put that into Headers
+		var m map[string][]string
+		if err := json.Unmarshal(bytes, &m); err != nil {
+			return nil, err
+		}
+
+		if response.Headers == nil {
+			response.Headers = make(map[string][]string)
+		}
+		for k, v := range m {
+			response.Headers[k] = v
+		}
+
+	}
+	return response.ToHttpRequest()
+}


### PR DESCRIPTION
# Description

- Unwind the route specific config hack and switch to envoy native per route config exposed by the sdk now
- Convert the http echo service response body back to http.Request and added Gomega matcher to test the request 
- Refactor the transformation testsuite to share the same testCases between the C++ transformation and Rustformation. (There are some test cases still in C++ transformation test only because we don't support parsing body yet in Rustformation)
- 

# Change Type

/kind cleanup

# Changelog

```release-note
Use native envoy per-route config in rustformation dynamic module
```

# Additional Notes

While adding more tests, found some interesting facts that we should document:
- When a TrafficPolicy with transformation is targeting the Gateway, we are using RouteTransformation instead of FilterTransformation and it's set at the route table level. So, if there is a more specific transformation targeting HttpRoute that matches vhost or path prefix ...etc, the gateway attached transformation will not applied. This can be both a surprise to some users or expected behavior to other users. So, it's good to the behavior
- If a request is not matching any routes and envoy returns 404, the transformation targeting Gateway would not apply neither.
- When there are many transformation targeting many routes with different matches like Method, Path, QueryParams, Header ...etc and if your request happens to match more than one of them, here is the precedence that determines which transformation will take place:
  - Path
  - Method
  - Header
  - Query
