### PR TITLE
Make Bedrock model field optional to allow user-specified models

### DIFF
--- a/api/applyconfiguration/internal/internal.go
+++ b/api/applyconfiguration/internal/internal.go
@@ -555,7 +555,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: model
       type:
         scalar: string
-      default: ""
     - name: region
       type:
         scalar: string

--- a/api/v1alpha1/ai_backend.go
+++ b/api/v1alpha1/ai_backend.go
@@ -301,9 +301,12 @@ type BedrockConfig struct {
 	// +optional
 	Auth *AwsAuth `json:"auth,omitempty"`
 
-	// The model field is the supported model id published by AWS. See <https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html>
+	// Optional: Override the model ID.
+	// If unset, the model is taken from the request.
+	// See <https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html>
+	// +optional
 	// +kubebuilder:validation:MinLength=1
-	Model string `json:"model"`
+	Model *string `json:"model,omitempty"`
 
 	// Region is the AWS region to use for the backend.
 	// Defaults to us-east-1 if not specified.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -869,6 +869,11 @@ func (in *BedrockConfig) DeepCopyInto(out *BedrockConfig) {
 		*out = new(AwsAuth)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Model != nil {
+		in, out := &in.Model, &out.Model
+		*out = new(string)
+		**out = **in
+	}
 	if in.Guardrail != nil {
 		in, out := &in.Guardrail, &out.Guardrail
 		*out = new(AWSGuardrailConfig)

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backends.yaml
@@ -180,8 +180,6 @@ spec:
                             minLength: 1
                             pattern: ^[a-z0-9-]+$
                             type: string
-                        required:
-                        - model
                         type: object
                       gemini:
                         properties:
@@ -470,8 +468,6 @@ spec:
                                     minLength: 1
                                     pattern: ^[a-z0-9-]+$
                                     type: string
-                                required:
-                                - model
                                 type: object
                               gemini:
                                 properties:

--- a/internal/kgateway/agentgatewaysyncer/backend/translate.go
+++ b/internal/kgateway/agentgatewaysyncer/backend/translate.go
@@ -157,8 +157,11 @@ func translateLLMProviderToProvider(krtctx krt.HandlerContext, llm *v1alpha1.LLM
 		}
 		auth = buildTranslatedAuthPolicy(krtctx, &llm.VertexAI.AuthToken, secrets, namespace)
 	} else if llm.Bedrock != nil {
-		model := &wrappers.StringValue{
-			Value: llm.Bedrock.Model,
+		var model *wrappers.StringValue
+		if llm.Bedrock.Model != nil {
+			model = &wrappers.StringValue{
+				Value: *llm.Bedrock.Model,
+			}
 		}
 		region := llm.Bedrock.Region
 		var guardrailIdentifier, guardrailVersion *wrappers.StringValue

--- a/internal/kgateway/agentgatewaysyncer/backend/translate_test.go
+++ b/internal/kgateway/agentgatewaysyncer/backend/translate_test.go
@@ -438,7 +438,7 @@ func TestBuildAIBackendIr(t *testing.T) {
 					AI: &v1alpha1.AIBackend{
 						LLM: &v1alpha1.LLMProvider{
 							Bedrock: &v1alpha1.BedrockConfig{
-								Model:  "anthropic.claude-3-haiku-20240307-v1:0",
+								Model:  ptr.To("anthropic.claude-3-haiku-20240307-v1:0"),
 								Region: "eu-west-1",
 								Guardrail: &v1alpha1.AWSGuardrailConfig{
 									GuardrailIdentifier: "test-guardrail",

--- a/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
+++ b/internal/kgateway/extensions2/plugins/backend/ai/ai_backend.go
@@ -209,7 +209,9 @@ func getBackendModel(provider *v1alpha1.LLMProvider, byType map[string]struct{})
 	} else if provider.Bedrock != nil {
 		// currently only supported in agentgateway
 		byType["bedrock"] = struct{}{}
-		llmModel = provider.Bedrock.Model
+		if provider.Bedrock.Model != nil {
+			llmModel = *provider.Bedrock.Model
+		}
 	}
 	return llmModel
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2007,8 +2007,7 @@ func schema_kgateway_v2_api_v1alpha1_BedrockConfig(ref common.ReferenceCallback)
 					},
 					"model": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The model field is the supported model id published by AWS. See <https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html>",
-							Default:     "",
+							Description: "Optional: Override the model ID. If unset, the model is taken from the request. See <https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html>",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2027,7 +2026,6 @@ func schema_kgateway_v2_api_v1alpha1_BedrockConfig(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"model"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
# Description

Makes the Bedrock `model` field optional in the Backend CRD, allowing users to specify any Bedrock model in their requests rather than being forced to configure a single model at the Backend level.

This aligns the kgateway API with the agentgateway data plane behavior, which already supports optional model override (uses backend model if set, otherwise uses the model from the request).

**Before:**
```yaml
spec:
  type: AI
  ai:
    llm:
      bedrock:
        model: "anthropic.claude-3-5-sonnet-20241022-v2:0"  # REQUIRED
        region: us-east-1
```

**After:**
```yaml
spec:
  type: AI
  ai:
    llm:
      bedrock:
        # model omitted - users can send any model in their requests
        region: us-east-1
```

This matches the behavior of OpenAI and Anthropic providers, which also have optional `model` fields.

# Change Type

/kind bug_fix

# Changelog

```release-note
Make Bedrock model field optional to allow user-specified models, matching OpenAI/Anthropic behavior
```

# Additional Notes

- The agentgateway data plane already handles optional model override correctly
- OpenAI and Anthropic providers already have optional model fields in kgateway
- Bedrock was incorrectly marked as required, causing users to be unable to use multiple models with a single backend
- Changes include API definition, translators, tests, and regenerated code (CRDs, deepcopy, client)