### PR TITLE
fix: always rendering volumemounts in proxy-deployment

### DIFF
--- a/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
+++ b/internal/kgateway/helm/kgateway/templates/gateway/proxy-deployment.yaml
@@ -314,8 +314,8 @@ spec:
         {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
-        volumeMounts:
 {{- if or $gateway.aiExtension.stats $gateway.aiExtension.tracing }}
+        volumeMounts:
           - mountPath: /var/run/ai-otel-config
             name: ai-otel-config
 {{- end }}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

This fixes an issue where the volumemounts were rendered in the proxy deployment when no volume mounts are defined

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

Select one or more of the following by including the corresponding slash-command:
```
/kind bug_fix
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix a bug where the volumeMounts were rendered in the proxy deployment when no volume mounts are defined
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
