### PR TITLE
fix: Merge probeHandler to ensure only one action is returned

### DIFF
--- a/pkg/deployer/merge.go
+++ b/pkg/deployer/merge.go
@@ -330,6 +330,19 @@ func deepMergeProbe(dst, src *corev1.Probe) *corev1.Probe {
 }
 
 func deepMergeProbeHandler(dst, src corev1.ProbeHandler) corev1.ProbeHandler {
+	srcHasExecAction := src.Exec != nil
+	srcHasHTTPGetAction := src.HTTPGet != nil
+	srcHasTCPSocketAction := src.TCPSocket != nil
+	srcHasGRPCAction := src.GRPC != nil
+	srcHasAction := srcHasExecAction || srcHasHTTPGetAction || srcHasTCPSocketAction || srcHasGRPCAction
+	if srcHasAction {
+		// Reset the dest so it does not conflict with the src Action as there should only be one Action defined per probe
+		dst.Exec = nil
+		dst.HTTPGet = nil
+		dst.TCPSocket = nil
+		dst.GRPC = nil
+	}
+	// kube-builder validation ensures that the src has only one action
 	dst.Exec = deepMergeExecAction(dst.Exec, src.Exec)
 	dst.HTTPGet = deepMergeHTTPGetAction(dst.HTTPGet, src.HTTPGet)
 	dst.TCPSocket = deepMergeTCPSocketAction(dst.TCPSocket, src.TCPSocket)

--- a/pkg/deployer/merge_test.go
+++ b/pkg/deployer/merge_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	gw2_v1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
@@ -225,6 +227,92 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				assert.Equal(t, expectedMap, got.Spec.Kube.Service.ExtraAnnotations)
 				assert.Equal(t, expectedMap, got.Spec.Kube.ServiceAccount.ExtraLabels)
 				assert.Equal(t, expectedMap, got.Spec.Kube.ServiceAccount.ExtraAnnotations)
+			},
+		},
+		{
+			name: "should have only one probeHandler action",
+			dst: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
+						PodTemplate: &gw2_v1alpha1.Pod{
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"exec", "command"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			src: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
+						PodTemplate: &gw2_v1alpha1.Pod{
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromString("8080"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
+						PodTemplate: &gw2_v1alpha1.Pod{
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromString("8080"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should merge the default probeHandler action if none specified",
+			dst: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
+						PodTemplate: &gw2_v1alpha1.Pod{
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"exec", "command"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			src: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{},
+				},
+			},
+			want: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
+						PodTemplate: &gw2_v1alpha1.Pod{
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"exec", "command"},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Fixes an issue where a dst && src have different probe actions, resulting in an invalid podTemplate with multiple probe actions

```
spec.template.spec.containers[0].readinessProbe.httpGet: Forbidden: may not specify more than 1 handler type]
```

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type


Select one or more of the following by including the corresponding slash-command:
```
/kind bug_fix
```


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fixes a bug where a user-defined GatewayParameters has a different probe from the default one, resulting in an invalid podTemplate with multiple probe actions for the given probe
```


