### PR TITLE
bump envoy-gloo to v1.35.2-patch4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ export VERSION
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
 # Note: When bumping this version, update the version in pkg/validator/validator.go as well.
-export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.35.2-patch1
+export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.35.2-patch4
 export LDFLAGS := -X 'github.com/kgateway-dev/kgateway/v2/internal/version.Version=$(VERSION)'
 export GCFLAGS ?=
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -13,7 +13,7 @@ import (
 var (
 	defaultEnvoyPath = "/usr/local/bin/envoy"
 	// TODO(tim): avoid hardcoding the envoy image version in multiple places.
-	defaultEnvoyImage = "quay.io/solo-io/envoy-gloo:1.35.2-patch1"
+	defaultEnvoyImage = "quay.io/solo-io/envoy-gloo:1.35.2-patch4"
 )
 
 // ErrInvalidXDS is returned when Envoy rejects the supplied YAML.

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -238,7 +238,7 @@ func TestExtractEnvoyError(t *testing.T) {
 		},
 		{
 			name: "docker pull logs present",
-			input: `Unable to find image 'quay.io/solo-io/envoy-gloo:1.35.2-patch1' locally
+			input: `Unable to find image 'quay.io/solo-io/envoy-gloo:1.35.2-patch4' locally
 1.35.2-patch1: Pulling from solo-io/envoy-gloo
 f90c8eb4724c: Pulling fs layer
 9f37c34398c2: Pulling fs layer
@@ -257,16 +257,16 @@ f90c8eb4724c: Pull complete
 1cc4dfe322cb: Pull complete
 e800bbdc2f77: Pull complete
 Digest: sha256:98c645568997299a1c4301e6077a1d2f566bb20828c0739e6c4177a821524dad
-Status: Downloaded newer image for quay.io/solo-io/envoy-gloo:1.35.2-patch1
+Status: Downloaded newer image for quay.io/solo-io/envoy-gloo:1.35.2-patch4
 error initializing configuration '': invalid named capture group: (?<=foo)bar`,
 			expected: "error initializing configuration '': invalid named capture group: (?<=foo)bar",
 		},
 		{
 			name: "docker pull logs with multi-line error",
-			input: `Unable to find image 'quay.io/solo-io/envoy-gloo:1.35.2-patch1' locally
+			input: `Unable to find image 'quay.io/solo-io/envoy-gloo:1.35.2-patch4' locally
 1.35.2-patch1: Pulling from solo-io/envoy-gloo
 f90c8eb4724c: Pull complete
-Status: Downloaded newer image for quay.io/solo-io/envoy-gloo:1.35.2-patch1
+Status: Downloaded newer image for quay.io/solo-io/envoy-gloo:1.35.2-patch4
 error initializing configuration '': missing ]:
   at line 42 in filter configuration
   regex validation failed`,


### PR DESCRIPTION
# Description

- bumped envoy gloo to v1.35.2-patch4. This is an update to the transformation filter in envoy-gloo, no upstream envoy change is brought in. 
- envoy-gloo release note: https://github.com/solo-io/envoy-gloo/releases/tag/v1.35.2-patch4

# Change Type
/kind cleanup

# Changelog

```release-note
NONE
```
