### PR TITLE
Simplify gateway parameters generator override to 1:1 mapping

### DIFF
--- a/examples/plugin/main.go
+++ b/examples/plugin/main.go
@@ -16,12 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/ir"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/plugins"
 	"github.com/kgateway-dev/kgateway/v2/internal/kgateway/setup"
-	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	collections "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
@@ -238,10 +235,6 @@ func pluginFactory(ctx context.Context, commoncol *collections.CommonCollections
 	}
 }
 
-func extraGatewayParametersFactory(cli client.Client, inputs *deployer.Inputs) []deployer.ExtraGatewayParameters {
-	return make([]deployer.ExtraGatewayParameters, 0)
-}
-
 func main() {
 	// TODO: move setup.StartGGv2 from internal to public.
 	// Start Kgateway and provide our plugin.
@@ -251,7 +244,6 @@ func main() {
 
 	setup, _ := setup.New(
 		setup.WithExtraPlugins(pluginFactory),
-		setup.ExtraGatewayParameters(extraGatewayParametersFactory),
 	)
 	setup.Start(context.Background())
 }

--- a/internal/kgateway/controller/start.go
+++ b/internal/kgateway/controller/start.go
@@ -74,11 +74,11 @@ type StartConfig struct {
 	RestConfig *rest.Config
 	// ExtensionsFactory is the factory function which will return an extensions.K8sGatewayExtensions
 	// This is responsible for producing the extension points that this controller requires
-	ExtraPlugins           func(ctx context.Context, commoncol *collections.CommonCollections, mergeSettingsJSON string) []sdk.Plugin
-	ExtraAgwPlugins        func(ctx context.Context, agw *agwplugins.AgwCollections) []agwplugins.AgwPlugin
-	ExtraGatewayParameters func(cli client.Client, inputs *deployer.Inputs) []deployer.ExtraGatewayParameters
-	Client                 istiokube.Client
-	Validator              validator.Validator
+	ExtraPlugins                func(ctx context.Context, commoncol *collections.CommonCollections, mergeSettingsJSON string) []sdk.Plugin
+	ExtraAgwPlugins             func(ctx context.Context, agw *agwplugins.AgwCollections) []agwplugins.AgwPlugin
+	HelmValuesGeneratorOverride func(cli client.Client, inputs *deployer.Inputs) deployer.HelmValuesGenerator
+	Client                      istiokube.Client
+	Validator                   validator.Validator
 
 	AgwCollections    *agwplugins.AgwCollections
 	CommonCollections *collections.CommonCollections
@@ -327,7 +327,7 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 	}
 
 	setupLog.Info("creating base gateway controller")
-	if err := NewBaseGatewayController(ctx, gwCfg, c.cfg.ExtraGatewayParameters); err != nil {
+	if err := NewBaseGatewayController(ctx, gwCfg, c.cfg.HelmValuesGeneratorOverride); err != nil {
 		setupLog.Error(err, "unable to create gateway controller")
 		return err
 	}
@@ -349,7 +349,7 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 		if !globalSettings.EnableAgentgateway {
 			setupLog.Info("using inference extension without agentgateway is deprecated in v2.1 and will not be supported in v2.2.")
 		}
-		if err := NewBaseInferencePoolController(ctx, poolCfg, &gwCfg, c.cfg.ExtraGatewayParameters); err != nil {
+		if err := NewBaseInferencePoolController(ctx, poolCfg, &gwCfg, c.cfg.HelmValuesGeneratorOverride); err != nil {
 			setupLog.Error(err, "unable to create inferencepool controller")
 			return err
 		}

--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -28,15 +28,14 @@ func NewGatewayParameters(cli client.Client, inputs *deployer.Inputs) *GatewayPa
 		cli:               cli,
 		inputs:            inputs,
 		knownGWParameters: []client.Object{&v1alpha1.GatewayParameters{}}, // always include default GatewayParameters
-		extraHVGenerators: make(map[schema.GroupKind]deployer.HelmValuesGenerator),
 	}
 }
 
 type GatewayParameters struct {
-	cli               client.Client
-	inputs            *deployer.Inputs
-	extraHVGenerators map[schema.GroupKind]deployer.HelmValuesGenerator
-	knownGWParameters []client.Object
+	cli                         client.Client
+	inputs                      *deployer.Inputs
+	helmValuesGeneratorOverride deployer.HelmValuesGenerator
+	knownGWParameters           []client.Object
 }
 
 type kGatewayParameters struct {
@@ -44,15 +43,8 @@ type kGatewayParameters struct {
 	inputs *deployer.Inputs
 }
 
-func (gp *GatewayParameters) WithExtraGatewayParameters(params ...deployer.ExtraGatewayParameters) *GatewayParameters {
-	for _, p := range params {
-		key := schema.GroupKind{Group: p.Group, Kind: p.Kind}
-		if _, ok := gp.extraHVGenerators[key]; ok {
-			panic(fmt.Sprintf("key already exists in the map: %v", key))
-		}
-		gp.knownGWParameters = append(gp.knownGWParameters, p.Object)
-		gp.extraHVGenerators[key] = p.Generator
-	}
+func (gp *GatewayParameters) WithHelmValuesGeneratorOverride(generator deployer.HelmValuesGenerator) *GatewayParameters {
+	gp.helmValuesGeneratorOverride = generator
 	return gp
 }
 
@@ -102,38 +94,12 @@ func (gp *GatewayParameters) getHelmValuesGenerator(ctx context.Context, obj cli
 		return nil, fmt.Errorf("expected a Gateway resource, got %s", obj.GetObjectKind().GroupVersionKind().String())
 	}
 
-	ref, err := gp.getGatewayParametersGK(ctx, gw)
-	if err != nil {
-		return nil, err
-	}
-
-	if g, ok := gp.extraHVGenerators[ref]; ok {
-		slog.Debug("using custom HelmValuesGenerator for Gateway",
+	if gp.helmValuesGeneratorOverride != nil {
+		slog.Debug("using override HelmValuesGenerator for Gateway",
 			"gateway_name", gw.GetName(),
 			"gateway_namespace", gw.GetNamespace(),
 		)
-		return g, nil
-	}
-
-	// Before falling back to built-in defaults, check if ExtraGatewayParameters
-	// can handle this gateway class specifically
-	gwc, err := getGatewayClassFromGateway(ctx, gp.cli, gw)
-	if err == nil {
-		gatewayClassName := string(gwc.GetName())
-
-		// Try to find ExtraGatewayParameters for this specific gateway class
-		// This allows overriding built-in defaults for specific gateway classes
-		fallbackRef := schema.GroupKind{
-			Group: "gateway.class.kgateway.dev",
-			Kind:  gatewayClassName,
-		}
-		if g, ok := gp.extraHVGenerators[fallbackRef]; ok {
-			slog.Debug("using ExtraGatewayParameters fallback for gateway class",
-				"gateway_name", gw.GetName(),
-				"gateway_class_name", gatewayClassName,
-			)
-			return g, nil
-		}
+		return gp.helmValuesGeneratorOverride, nil
 	}
 
 	slog.Debug("using default HelmValuesGenerator for Gateway",
@@ -141,46 +107,6 @@ func (gp *GatewayParameters) getHelmValuesGenerator(ctx context.Context, obj cli
 		"gateway_namespace", gw.GetNamespace(),
 	)
 	return newKGatewayParameters(gp.cli, gp.inputs), nil
-}
-
-func (gp *GatewayParameters) getGatewayParametersGK(ctx context.Context, gw *api.Gateway) (schema.GroupKind, error) {
-	// attempt to get the GatewayParameters name from the Gateway. If we can't find it,
-	// we'll check for the default GWP for the GatewayClass.
-	if gw.Spec.Infrastructure == nil || gw.Spec.Infrastructure.ParametersRef == nil {
-		slog.Debug("no GatewayParameters found for Gateway, using default",
-			"gateway_name", gw.GetName(),
-			"gateway_namespace", gw.GetNamespace(),
-		)
-		return gp.getDefaultGatewayParametersGK(ctx, gw)
-	}
-
-	return schema.GroupKind{
-			Group: string(gw.Spec.Infrastructure.ParametersRef.Group),
-			Kind:  string(gw.Spec.Infrastructure.ParametersRef.Kind),
-		},
-		nil
-}
-
-func (gp *GatewayParameters) getDefaultGatewayParametersGK(ctx context.Context, gw *api.Gateway) (schema.GroupKind, error) {
-	gwc, err := getGatewayClassFromGateway(ctx, gp.cli, gw)
-	if err != nil {
-		return schema.GroupKind{}, err
-	}
-
-	if gwc.Spec.ParametersRef != nil {
-		return schema.GroupKind{
-				Group: string(gwc.Spec.ParametersRef.Group),
-				Kind:  string(gwc.Spec.ParametersRef.Kind),
-			},
-			nil
-	}
-
-	// For gateways without explicit parametersRef, use a default GroupKind
-	// that ExtraGatewayParameters can register for based on gateway class name
-	return schema.GroupKind{
-		Group: "default.gateway.kgateway.dev",
-		Kind:  string(gwc.GetName()), // Use gateway class name as Kind
-	}, nil
 }
 
 func newKGatewayParameters(cli client.Client, inputs *deployer.Inputs) *kGatewayParameters {

--- a/internal/kgateway/deployer/gateway_parameters_test.go
+++ b/internal/kgateway/deployer/gateway_parameters_test.go
@@ -142,7 +142,7 @@ func TestIsSelfManagedWithExtendedGatewayParameters(t *testing.T) {
 	}
 
 	gwp := NewGatewayParameters(newFakeClientWithObjs(gwc, gwParams, extraGwParams), defaultInputs(t, gwc, gw)).
-		WithExtraGatewayParameters(deployer.ExtraGatewayParameters{Group: "v1", Kind: "ConfigMap", Object: extraGwParams, Generator: &testHelmValuesGenerator{}})
+		WithHelmValuesGeneratorOverride(&testHelmValuesGenerator{})
 	selfManaged, err := gwp.IsSelfManaged(context.Background(), gw)
 	assert.NoError(t, err)
 	assert.True(t, selfManaged)
@@ -215,7 +215,7 @@ func TestShouldUseExtendedGatewayParameters(t *testing.T) {
 	}
 
 	gwp := NewGatewayParameters(newFakeClientWithObjs(gwc, gwParams, extraGwParams), defaultInputs(t, gwc, gw)).
-		WithExtraGatewayParameters(deployer.ExtraGatewayParameters{Group: "v1", Kind: "ConfigMap", Object: extraGwParams, Generator: &testHelmValuesGenerator{}})
+		WithHelmValuesGeneratorOverride(&testHelmValuesGenerator{})
 	vals, err := gwp.GetValues(context.Background(), gw)
 
 	assert.NoError(t, err)

--- a/internal/kgateway/setup/setup.go
+++ b/internal/kgateway/setup/setup.go
@@ -98,9 +98,9 @@ func WithLeaderElectionID(id string) func(*setup) {
 	}
 }
 
-func ExtraGatewayParameters(extraGatewayParameters func(cli client.Client, inputs *deployer.Inputs) []deployer.ExtraGatewayParameters) func(*setup) {
+func WithHelmValuesGeneratorOverride(helmValuesGeneratorOverride func(cli client.Client, inputs *deployer.Inputs) deployer.HelmValuesGenerator) func(*setup) {
 	return func(s *setup) {
-		s.extraGatewayParameters = extraGatewayParameters
+		s.helmValuesGeneratorOverride = helmValuesGeneratorOverride
 	}
 }
 
@@ -167,20 +167,20 @@ func WithExtraAgwPolicyStatusHandlers(handlers map[string]agwplugins.AgwPolicySt
 }
 
 type setup struct {
-	gatewayControllerName    string
-	agwControllerName        string
-	gatewayClassName         string
-	waypointClassName        string
-	agentgatewayClassName    string
-	additionalGatewayClasses map[string]*deployer.GatewayClassInfo
-	extraPlugins             func(ctx context.Context, commoncol *collections.CommonCollections, mergeSettingsJSON string) []sdk.Plugin
-	extraAgwPlugins          func(ctx context.Context, agw *agwplugins.AgwCollections) []agwplugins.AgwPlugin
-	extraGatewayParameters   func(cli client.Client, inputs *deployer.Inputs) []deployer.ExtraGatewayParameters
-	extraXDSCallbacks        xdsserver.Callbacks
-	xdsListener              net.Listener
-	agwXdsListener           net.Listener
-	restConfig               *rest.Config
-	ctrlMgrOptionsInitFunc   func(context.Context) *ctrl.Options
+	gatewayControllerName       string
+	agwControllerName           string
+	gatewayClassName            string
+	waypointClassName           string
+	agentgatewayClassName       string
+	additionalGatewayClasses    map[string]*deployer.GatewayClassInfo
+	extraPlugins                func(ctx context.Context, commoncol *collections.CommonCollections, mergeSettingsJSON string) []sdk.Plugin
+	extraAgwPlugins             func(ctx context.Context, agw *agwplugins.AgwCollections) []agwplugins.AgwPlugin
+	helmValuesGeneratorOverride func(cli client.Client, inputs *deployer.Inputs) deployer.HelmValuesGenerator
+	extraXDSCallbacks           xdsserver.Callbacks
+	xdsListener                 net.Listener
+	agwXdsListener              net.Listener
+	restConfig                  *rest.Config
+	ctrlMgrOptionsInitFunc      func(context.Context) *ctrl.Options
 	// extra controller manager config, like adding registering additional controllers
 	extraManagerConfig           []func(ctx context.Context, mgr manager.Manager, objectFilter kubetypes.DynamicObjectFilter) error
 	krtDebugger                  *krt.DebugHandler
@@ -351,7 +351,7 @@ func (s *setup) Start(ctx context.Context) error {
 		ctx, mgr, s.gatewayControllerName, s.agwControllerName, s.gatewayClassName, s.waypointClassName,
 		s.agentgatewayClassName, s.additionalGatewayClasses, setupOpts, s.restConfig,
 		istioClient, commoncol, agwCollections, uccBuilder, s.extraPlugins, s.extraAgwPlugins,
-		s.extraGatewayParameters,
+		s.helmValuesGeneratorOverride,
 		s.validator,
 		s.extraAgwPolicyStatusHandlers,
 	)
@@ -385,7 +385,7 @@ func BuildKgatewayWithConfig(
 	uccBuilder krtcollections.UniquelyConnectedClientsBulider,
 	extraPlugins func(ctx context.Context, commoncol *collections.CommonCollections, mergeSettingsJSON string) []sdk.Plugin,
 	extraAgwPlugins func(ctx context.Context, agw *agwplugins.AgwCollections) []agwplugins.AgwPlugin,
-	extraGatewayParameters func(cli client.Client, inputs *deployer.Inputs) []deployer.ExtraGatewayParameters,
+	helmValuesGeneratorOverride func(cli client.Client, inputs *deployer.Inputs) deployer.HelmValuesGenerator,
 	validator validator.Validator,
 	extraAgwPolicyStatusHandlers map[string]agwplugins.AgwPolicyStatusSyncHandler,
 ) error {
@@ -411,7 +411,7 @@ func BuildKgatewayWithConfig(
 		AdditionalGatewayClasses:     additionalGatewayClasses,
 		ExtraPlugins:                 extraPlugins,
 		ExtraAgwPlugins:              extraAgwPlugins,
-		ExtraGatewayParameters:       extraGatewayParameters,
+		HelmValuesGeneratorOverride:  helmValuesGeneratorOverride,
 		RestConfig:                   restConfig,
 		SetupOpts:                    setupOpts,
 		Client:                       kubeClient,

--- a/pkg/deployer/gateway_parameters.go
+++ b/pkg/deployer/gateway_parameters.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
@@ -25,13 +24,6 @@ type Inputs struct {
 	GatewayClassName         string
 	WaypointGatewayClassName string
 	AgentgatewayClassName    string
-}
-
-type ExtraGatewayParameters struct {
-	Group     string
-	Kind      string
-	Object    client.Object
-	Generator HelmValuesGenerator
 }
 
 // UpdateSecurityContexts updates the security contexts in the gateway parameters.

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -19,18 +19,18 @@ import (
 )
 
 type Options struct {
-	GatewayControllerName      string
-	AgentgatewayControllerName string
-	GatewayClassName           string
-	WaypointGatewayClassName   string
-	AgentgatewayClassName      string
-	AdditionalGatewayClasses   map[string]*deployer.GatewayClassInfo
-	ExtraPlugins               func(ctx context.Context, commoncol *collections.CommonCollections, mergeSettingsJSON string) []sdk.Plugin
-	ExtraAgwPlugins            func(ctx context.Context, agw *agwplugins.AgwCollections) []agwplugins.AgwPlugin
-	ExtraGatewayParameters     func(cli client.Client, inputs *deployer.Inputs) []deployer.ExtraGatewayParameters
-	ExtraXDSCallbacks          xdsserver.Callbacks
-	RestConfig                 *rest.Config
-	CtrlMgrOptions             func(context.Context) *ctrl.Options
+	GatewayControllerName       string
+	AgentgatewayControllerName  string
+	GatewayClassName            string
+	WaypointGatewayClassName    string
+	AgentgatewayClassName       string
+	AdditionalGatewayClasses    map[string]*deployer.GatewayClassInfo
+	ExtraPlugins                func(ctx context.Context, commoncol *collections.CommonCollections, mergeSettingsJSON string) []sdk.Plugin
+	ExtraAgwPlugins             func(ctx context.Context, agw *agwplugins.AgwCollections) []agwplugins.AgwPlugin
+	HelmValuesGeneratorOverride func(cli client.Client, inputs *deployer.Inputs) deployer.HelmValuesGenerator
+	ExtraXDSCallbacks           xdsserver.Callbacks
+	RestConfig                  *rest.Config
+	CtrlMgrOptions              func(context.Context) *ctrl.Options
 	// extra controller manager config, like registering additional controllers
 	ExtraManagerConfig []func(ctx context.Context, mgr manager.Manager, objectFilter kubetypes.DynamicObjectFilter) error
 	// Validator is the validator to use for the controller.
@@ -44,7 +44,7 @@ func New(opts Options) (setup.Server, error) {
 	return setup.New(
 		setup.WithExtraPlugins(opts.ExtraPlugins),
 		setup.WithExtraAgwPlugins(opts.ExtraAgwPlugins),
-		setup.ExtraGatewayParameters(opts.ExtraGatewayParameters),
+		setup.WithHelmValuesGeneratorOverride(opts.HelmValuesGeneratorOverride),
 		setup.WithGatewayControllerName(opts.GatewayControllerName),
 		setup.WithAgwControllerName(opts.AgentgatewayControllerName),
 		setup.WithGatewayClassName(opts.GatewayClassName),

--- a/test/deployer/deployer_helm.go
+++ b/test/deployer/deployer_helm.go
@@ -66,7 +66,7 @@ func (dt DeployerTester) RunHelmChartTest(
 	tt HelmTestCase,
 	scheme *runtime.Scheme,
 	dir string,
-	extraParamsFunc func(cli client.Client, inputs *pkgdeployer.Inputs) []pkgdeployer.ExtraGatewayParameters,
+	helmValuesGeneratorOverride func(cli client.Client, inputs *pkgdeployer.Inputs) pkgdeployer.HelmValuesGenerator,
 ) {
 	filePath := filepath.Join(dir, "testdata/", tt.InputFile)
 	inputFile := filePath + ".yaml"
@@ -94,8 +94,8 @@ func (dt DeployerTester) RunHelmChartTest(
 		fakeClient,
 		inputs,
 	)
-	if extraParamsFunc != nil {
-		gwParams.WithExtraGatewayParameters(extraParamsFunc(fakeClient, inputs)...)
+	if helmValuesGeneratorOverride != nil {
+		gwParams.WithHelmValuesGeneratorOverride(helmValuesGeneratorOverride(fakeClient, inputs))
 	}
 	deployer := pkgdeployer.NewDeployer(
 		dt.ControllerName,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Refactors the gateway parameters customization from a complex ExtraGatewayParameters map-based system to a simple 1:1 HelmValuesGeneratorOverride pattern.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->
/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
