### PR TITLE
bump envoy-gloo to v1.34.6-patch3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 # ATTENTION: when updating to a new major version of Envoy, check if
 # universal header validation has been enabled and if so, we expect
 # failures in `test/e2e/header_validation_test.go`.
-export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.34.6-patch1
+export ENVOY_IMAGE ?= quay.io/solo-io/envoy-gloo:1.34.6-patch3
 export LDFLAGS := -X 'github.com/kgateway-dev/kgateway/v2/internal/version.Version=$(VERSION)'
 export GCFLAGS ?=
 


### PR DESCRIPTION
# Description

- bumped envoy gloo to v1.34.6-patch3. This is an update to the transformation filter in envoy-gloo, no upstream envoy change is brought in.
- envoy-gloo release note: https://github.com/solo-io/envoy-gloo/releases/tag/v1.34.6-patch3

# Change Type

/kind cleanup

# Changelog

```release-note
None
```
