### PR TITLE
agentgateway: disable a2a tests run in the suite due flakiness

### DIFF
--- a/test/kubernetes/e2e/tests/agent_gateway_tests.go
+++ b/test/kubernetes/e2e/tests/agent_gateway_tests.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/agentgateway"
-	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/agentgateway/a2a"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/agentgateway/extauth"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/agentgateway/mcp"
 	"github.com/kgateway-dev/kgateway/v2/test/kubernetes/e2e/features/agentgateway/rbac"
@@ -15,7 +14,8 @@ import (
 
 func AgentgatewaySuiteRunner() e2e.SuiteRunner {
 	agentgatewaySuiteRunner := e2e.NewSuiteRunner(false)
-	agentgatewaySuiteRunner.Register("A2A", a2a.NewTestingSuite)
+	// TODO: re-enable A2A tests once the image is smaller
+	// agentgatewaySuiteRunner.Register("A2A", a2a.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("BackendTLSPolicy", backendtls.NewAgentgatewayTestingSuite)
 	agentgatewaySuiteRunner.Register("BasicRouting", agentgateway.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("Extauth", extauth.NewTestingSuite)


### PR DESCRIPTION
# Description

A concise explanation of the change. You may include:
- **Related issues:** https://github.com/kgateway-dev/kgateway/issues/12537

# Change Type

```
/kind flake
```

# Changelog

```release-note
NONE
```
