### PR TITLE
Remove `omitReplicas`

### DIFF
--- a/api/applyconfiguration/api/v1alpha1/proxydeployment.go
+++ b/api/applyconfiguration/api/v1alpha1/proxydeployment.go
@@ -9,9 +9,8 @@ import (
 // ProxyDeploymentApplyConfiguration represents a declarative configuration of the ProxyDeployment type for use
 // with apply.
 type ProxyDeploymentApplyConfiguration struct {
-	Replicas     *int32                 `json:"replicas,omitempty"`
-	OmitReplicas *bool                  `json:"omitReplicas,omitempty"`
-	Strategy     *v1.DeploymentStrategy `json:"strategy,omitempty"`
+	Replicas *int32                 `json:"replicas,omitempty"`
+	Strategy *v1.DeploymentStrategy `json:"strategy,omitempty"`
 }
 
 // ProxyDeploymentApplyConfiguration constructs a declarative configuration of the ProxyDeployment type for use with
@@ -25,14 +24,6 @@ func ProxyDeployment() *ProxyDeploymentApplyConfiguration {
 // If called multiple times, the Replicas field is set to the value of the last call.
 func (b *ProxyDeploymentApplyConfiguration) WithReplicas(value int32) *ProxyDeploymentApplyConfiguration {
 	b.Replicas = &value
-	return b
-}
-
-// WithOmitReplicas sets the OmitReplicas field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the OmitReplicas field is set to the value of the last call.
-func (b *ProxyDeploymentApplyConfiguration) WithOmitReplicas(value bool) *ProxyDeploymentApplyConfiguration {
-	b.OmitReplicas = &value
 	return b
 }
 

--- a/api/applyconfiguration/api/v1alpha1/proxydeployment.go
+++ b/api/applyconfiguration/api/v1alpha1/proxydeployment.go
@@ -9,7 +9,7 @@ import (
 // ProxyDeploymentApplyConfiguration represents a declarative configuration of the ProxyDeployment type for use
 // with apply.
 type ProxyDeploymentApplyConfiguration struct {
-	Replicas *int32                 `json:"replicas,omitempty"`
+	Replicas *uint32                `json:"replicas,omitempty"`
 	Strategy *v1.DeploymentStrategy `json:"strategy,omitempty"`
 }
 
@@ -22,7 +22,7 @@ func ProxyDeployment() *ProxyDeploymentApplyConfiguration {
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Replicas field is set to the value of the last call.
-func (b *ProxyDeploymentApplyConfiguration) WithReplicas(value int32) *ProxyDeploymentApplyConfiguration {
+func (b *ProxyDeploymentApplyConfiguration) WithReplicas(value uint32) *ProxyDeploymentApplyConfiguration {
 	b.Replicas = &value
 	return b
 }

--- a/api/applyconfiguration/internal/internal.go
+++ b/api/applyconfiguration/internal/internal.go
@@ -2109,9 +2109,6 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: com.github.kgateway-dev.kgateway.v2.api.v1alpha1.ProxyDeployment
   map:
     fields:
-    - name: omitReplicas
-      type:
-        scalar: boolean
     - name: replicas
       type:
         scalar: numeric

--- a/api/v1alpha1/gateway_parameters_types.go
+++ b/api/v1alpha1/gateway_parameters_types.go
@@ -237,17 +237,15 @@ func (in *KubernetesProxyConfig) GetOmitDefaultSecurityContext() *bool {
 }
 
 // ProxyDeployment configures the Proxy deployment in Kubernetes.
-// +kubebuilder:validation:AtMostOneOf=replicas;omitReplicas
 type ProxyDeployment struct {
-	// The number of desired pods. Defaults to 1.
+	// The number of desired pods.
+	// If omitted, behavior will be managed by the K8s control plane, and will default to 1.
+	// If you are using an HPA, make sure to not explicitly define this.
+	// K8s reference: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas
 	//
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	Replicas *int32 `json:"replicas,omitempty"`
-
-	// If true, replicas will not be set in the deployment (allowing HPA to control scaling)
-	// +optional
-	OmitReplicas *bool `json:"omitReplicas,omitempty"`
 
 	// The deployment strategy to use to replace existing pods with new
 	// ones. The Kubernetes default is a RollingUpdate with 25% maxUnavailable,
@@ -271,13 +269,6 @@ func (in *ProxyDeployment) GetReplicas() *int32 {
 		return nil
 	}
 	return in.Replicas
-}
-
-func (in *ProxyDeployment) GetOmitReplicas() *bool {
-	if in == nil {
-		return nil
-	}
-	return in.OmitReplicas
 }
 
 func (in *ProxyDeployment) GetStrategy() *appsv1.DeploymentStrategy {

--- a/api/v1alpha1/gateway_parameters_types.go
+++ b/api/v1alpha1/gateway_parameters_types.go
@@ -245,7 +245,7 @@ type ProxyDeployment struct {
 	//
 	// +optional
 	// +kubebuilder:validation:Minimum=1
-	Replicas *int32 `json:"replicas,omitempty"`
+	Replicas *uint32 `json:"replicas,omitempty"`
 
 	// The deployment strategy to use to replace existing pods with new
 	// ones. The Kubernetes default is a RollingUpdate with 25% maxUnavailable,
@@ -264,7 +264,7 @@ type ProxyDeployment struct {
 	Strategy *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
 }
 
-func (in *ProxyDeployment) GetReplicas() *int32 {
+func (in *ProxyDeployment) GetReplicas() *uint32 {
 	if in == nil {
 		return nil
 	}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3864,7 +3864,7 @@ func (in *ProxyDeployment) DeepCopyInto(out *ProxyDeployment) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		*out = new(int32)
+		*out = new(uint32)
 		**out = **in
 	}
 	if in.Strategy != nil {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3867,11 +3867,6 @@ func (in *ProxyDeployment) DeepCopyInto(out *ProxyDeployment) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.OmitReplicas != nil {
-		in, out := &in.OmitReplicas, &out.OmitReplicas
-		*out = new(bool)
-		**out = **in
-	}
 	if in.Strategy != nil {
 		in, out := &in.Strategy, &out.Strategy
 		*out = new(appsv1.DeploymentStrategy)

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayparameters.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayparameters.yaml
@@ -519,8 +519,6 @@ spec:
                     type: object
                   deployment:
                     properties:
-                      omitReplicas:
-                        type: boolean
                       replicas:
                         format: int32
                         minimum: 1
@@ -544,11 +542,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                    x-kubernetes-validations:
-                    - message: at most one of the fields in [replicas omitReplicas]
-                        may be set
-                      rule: '[has(self.replicas),has(self.omitReplicas)].filter(x,x==true).size()
-                        <= 1'
                   envoyContainer:
                     properties:
                       bootstrap:

--- a/internal/kgateway/controller/gw_controller_test.go
+++ b/internal/kgateway/controller/gw_controller_test.go
@@ -122,7 +122,7 @@ var _ = Describe("GwController", func() {
 				Spec: v1alpha1.GatewayParametersSpec{
 					Kube: &v1alpha1.KubernetesProxyConfig{
 						Deployment: &v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](2),
+							Replicas: ptr.To[uint32](2),
 						},
 					},
 				},

--- a/internal/kgateway/deployer/gateway_parameters.go
+++ b/internal/kgateway/deployer/gateway_parameters.go
@@ -108,6 +108,7 @@ func (gp *GatewayParameters) getHelmValuesGenerator(ctx context.Context, obj cli
 	}
 
 	if g, ok := gp.extraHVGenerators[ref]; ok {
+		// TODO: log the generator used...
 		slog.Debug("using custom HelmValuesGenerator for Gateway",
 			"gateway_name", gw.GetName(),
 			"gateway_namespace", gw.GetNamespace(),
@@ -393,15 +394,11 @@ func (k *kGatewayParameters) getValues(gw *api.Gateway, gwParam *v1alpha1.Gatewa
 	agwConfig := kubeProxyConfig.GetAgentgateway()
 
 	gateway := vals.Gateway
+
 	// deployment values
-	if deployConfig.GetOmitReplicas() != nil && *deployConfig.GetOmitReplicas() {
-		// Don't set replica count - let HPA (if applied) handle it
-		gateway.ReplicaCount = nil
-	} else {
-		// Use the specified replica count
-		if deployConfig.GetReplicas() != nil {
-			gateway.ReplicaCount = pointer.Uint32(uint32(*deployConfig.GetReplicas())) // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
-		}
+	// Use the specified replica count only if it's explicitly set
+	if deployConfig.GetReplicas() != nil {
+		gateway.ReplicaCount = pointer.Uint32(uint32(*deployConfig.GetReplicas())) // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
 	}
 	gateway.Strategy = deployConfig.GetStrategy()
 

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2742,7 +2742,7 @@ var _ = Describe("Deployer", func() {
 					return nil
 				},
 			}),
-			Entry("Replicas is not set", &input{
+			Entry("Replicas is not set (default)", &input{
 				dInputs: defaultDeployerInputs(),
 				gw:      defaultGateway(),
 				defaultGwp: &gw2_v1alpha1.GatewayParameters{
@@ -2757,9 +2757,7 @@ var _ = Describe("Deployer", func() {
 					},
 					Spec: gw2_v1alpha1.GatewayParametersSpec{
 						Kube: &gw2_v1alpha1.KubernetesProxyConfig{
-							Deployment: &gw2_v1alpha1.ProxyDeployment{
-								Replicas: nil,
-							},
+							Deployment: &gw2_v1alpha1.ProxyDeployment{},
 						},
 					},
 				},
@@ -2768,7 +2766,7 @@ var _ = Describe("Deployer", func() {
 				validationFunc: func(objs clientObjects, inp *input) error {
 					deployment := objs.findDeployment(defaultNamespace, defaultServiceName)
 					Expect(deployment).NotTo(BeNil())
-					Expect(deployment.Spec.Replicas).To(BeNil())
+					Expect(*deployment.Spec.Replicas).To(BeNil())
 					return nil
 				},
 			}),
@@ -2799,35 +2797,6 @@ var _ = Describe("Deployer", func() {
 					deployment := objs.findDeployment(defaultNamespace, defaultServiceName)
 					Expect(deployment).NotTo(BeNil())
 					Expect(*deployment.Spec.Replicas).To(Equal(int32(3)))
-					return nil
-				},
-			}),
-			//TODO: remove this test
-			Entry("replicas and omitReplicas aren't set (default)", &input{
-				dInputs: defaultDeployerInputs(),
-				gw:      defaultGateway(),
-				defaultGwp: &gw2_v1alpha1.GatewayParameters{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       wellknown.GatewayParametersGVK.Kind,
-						APIVersion: gw2_v1alpha1.GroupVersion.String(),
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      wellknown.DefaultGatewayParametersName,
-						Namespace: defaultNamespace,
-						UID:       "1237",
-					},
-					Spec: gw2_v1alpha1.GatewayParametersSpec{
-						Kube: &gw2_v1alpha1.KubernetesProxyConfig{
-							Deployment: &gw2_v1alpha1.ProxyDeployment{},
-						},
-					},
-				},
-				overrideGwp: &gw2_v1alpha1.GatewayParameters{},
-			}, &expectedOutput{
-				validationFunc: func(objs clientObjects, inp *input) error {
-					deployment := objs.findDeployment(defaultNamespace, defaultServiceName)
-					Expect(deployment).NotTo(BeNil())
-					Expect(*deployment.Spec.Replicas).To(Equal(int32(1))) // default replicas is 1
 					return nil
 				},
 			}),

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Deployer", func() {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](2),
+							Replicas: ptr.To[uint32](2),
 						},
 						EnvoyContainer: &gw2_v1alpha1.EnvoyContainer{
 							Bootstrap: &gw2_v1alpha1.EnvoyBootstrap{
@@ -1640,7 +1640,7 @@ var _ = Describe("Deployer", func() {
 					Spec: gw2_v1alpha1.GatewayParametersSpec{
 						Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 							Deployment: &gw2_v1alpha1.ProxyDeployment{
-								Replicas: ptr.To[int32](3),
+								Replicas: ptr.To[uint32](3),
 							},
 							EnvoyContainer: &gw2_v1alpha1.EnvoyContainer{
 								Bootstrap: &gw2_v1alpha1.EnvoyBootstrap{
@@ -1705,7 +1705,7 @@ var _ = Describe("Deployer", func() {
 					Spec: gw2_v1alpha1.GatewayParametersSpec{
 						Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 							Deployment: &gw2_v1alpha1.ProxyDeployment{
-								Replicas: ptr.To[int32](3),
+								Replicas: ptr.To[uint32](3),
 							},
 							EnvoyContainer: &gw2_v1alpha1.EnvoyContainer{
 								Bootstrap: &gw2_v1alpha1.EnvoyBootstrap{
@@ -2788,7 +2788,7 @@ var _ = Describe("Deployer", func() {
 					Spec: gw2_v1alpha1.GatewayParametersSpec{
 						Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 							Deployment: &gw2_v1alpha1.ProxyDeployment{
-								Replicas: ptr.To[int32](3),
+								Replicas: ptr.To[uint32](3),
 							},
 						},
 					},
@@ -3059,7 +3059,7 @@ func fullyDefinedGatewayParameters(name, namespace string) *gw2_v1alpha1.Gateway
 		Spec: gw2_v1alpha1.GatewayParametersSpec{
 			Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 				Deployment: &gw2_v1alpha1.ProxyDeployment{
-					Replicas: ptr.To[int32](3),
+					Replicas: ptr.To[uint32](3),
 				},
 				EnvoyContainer: &gw2_v1alpha1.EnvoyContainer{
 					Bootstrap: &gw2_v1alpha1.EnvoyBootstrap{

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2742,7 +2742,7 @@ var _ = Describe("Deployer", func() {
 					return nil
 				},
 			}),
-			Entry("OmitReplicas is true", &input{
+			Entry("Replicas is not set", &input{
 				dInputs: defaultDeployerInputs(),
 				gw:      defaultGateway(),
 				defaultGwp: &gw2_v1alpha1.GatewayParameters{
@@ -2758,7 +2758,7 @@ var _ = Describe("Deployer", func() {
 					Spec: gw2_v1alpha1.GatewayParametersSpec{
 						Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 							Deployment: &gw2_v1alpha1.ProxyDeployment{
-								OmitReplicas: ptr.To(true),
+								Replicas: nil,
 							},
 						},
 					},
@@ -2802,6 +2802,7 @@ var _ = Describe("Deployer", func() {
 					return nil
 				},
 			}),
+			//TODO: remove this test
 			Entry("replicas and omitReplicas aren't set (default)", &input{
 				dInputs: defaultDeployerInputs(),
 				gw:      defaultGateway(),

--- a/pkg/deployer/gateway_parameters.go
+++ b/pkg/deployer/gateway_parameters.go
@@ -203,10 +203,6 @@ func defaultGatewayParameters(imageInfo *ImageInfo, omitDefaultSecurityContext b
 		Spec: v1alpha1.GatewayParametersSpec{
 			SelfManaged: nil,
 			Kube: &v1alpha1.KubernetesProxyConfig{
-				Deployment: &v1alpha1.ProxyDeployment{
-					Replicas:     ptr.To[int32](1),
-					OmitReplicas: ptr.To(false),
-				},
 				Service: &v1alpha1.Service{
 					Type: (*corev1.ServiceType)(ptr.To(string(corev1.ServiceTypeLoadBalancer))),
 				},

--- a/pkg/deployer/merge.go
+++ b/pkg/deployer/merge.go
@@ -702,19 +702,7 @@ func deepMergeDeployment(dst, src *v1alpha1.ProxyDeployment) *v1alpha1.ProxyDepl
 		return src
 	}
 
-	// Handle AtMostOneOf constraint for replicas and omitReplicas
-	// If src has either field set, it takes precedence and we clear the other field
-	if src.GetReplicas() != nil {
-		dst.Replicas = src.GetReplicas()
-		dst.OmitReplicas = nil // Clear omitReplicas when replicas is set
-	} else if src.GetOmitReplicas() != nil {
-		dst.OmitReplicas = src.GetOmitReplicas()
-		dst.Replicas = nil // Clear replicas when omitReplicas is set
-	} else {
-		// src has neither field set, keep dst as is
-		// (dst.Replicas and dst.OmitReplicas remain unchanged)
-	}
-
+	dst.Replicas = MergePointers(dst.GetReplicas(), src.GetReplicas())
 	dst.Strategy = MergePointers(dst.Strategy, src.Strategy)
 
 	return dst

--- a/pkg/deployer/merge_test.go
+++ b/pkg/deployer/merge_test.go
@@ -48,7 +48,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](5),
+							Replicas: ptr.To[uint32](5),
 						},
 					},
 				},
@@ -57,7 +57,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](5),
+							Replicas: ptr.To[uint32](5),
 						},
 					},
 				},
@@ -69,7 +69,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](2),
+							Replicas: ptr.To[uint32](2),
 						},
 					},
 				},
@@ -78,7 +78,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](3),
+							Replicas: ptr.To[uint32](3),
 						},
 					},
 				},
@@ -87,7 +87,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](3),
+							Replicas: ptr.To[uint32](3),
 						},
 					},
 				},
@@ -99,7 +99,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](2),
+							Replicas: ptr.To[uint32](2),
 						},
 					},
 				},
@@ -113,7 +113,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](2),
+							Replicas: ptr.To[uint32](2),
 						},
 					},
 				},

--- a/pkg/deployer/merge_test.go
+++ b/pkg/deployer/merge_test.go
@@ -38,14 +38,10 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 			},
 		},
 		{
-			name: "should override kube deployment replicas",
+			name: "should override kube deployment replicas by default",
 			dst: &gw2_v1alpha1.GatewayParameters{
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
-					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
-						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							Replicas: ptr.To[int32](2),
-						},
-					},
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{},
 				},
 			},
 			src: &gw2_v1alpha1.GatewayParameters{
@@ -68,7 +64,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 			},
 		},
 		{
-			name: "should override kube deployment omitReplicas",
+			name: "should override kube deployment replicas if explicit",
 			dst: &gw2_v1alpha1.GatewayParameters{
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
@@ -82,7 +78,7 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							OmitReplicas: ptr.To(true),
+							Replicas: ptr.To[int32](3),
 						},
 					},
 				},
@@ -91,7 +87,33 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 				Spec: gw2_v1alpha1.GatewayParametersSpec{
 					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
 						Deployment: &gw2_v1alpha1.ProxyDeployment{
-							OmitReplicas: ptr.To(true),
+							Replicas: ptr.To[int32](3),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should not override kube deployment replicas if src is nil",
+			dst: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
+						Deployment: &gw2_v1alpha1.ProxyDeployment{
+							Replicas: ptr.To[int32](2),
+						},
+					},
+				},
+			},
+			src: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{},
+				},
+			},
+			want: &gw2_v1alpha1.GatewayParameters{
+				Spec: gw2_v1alpha1.GatewayParametersSpec{
+					Kube: &gw2_v1alpha1.KubernetesProxyConfig{
+						Deployment: &gw2_v1alpha1.ProxyDeployment{
+							Replicas: ptr.To[int32](2),
 						},
 					},
 				},

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -6411,16 +6411,9 @@ func schema_kgateway_v2_api_v1alpha1_ProxyDeployment(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The number of desired pods. Defaults to 1.",
+							Description: "The number of desired pods. If omitted, behavior will be managed by the K8s control plane, and will default to 1. If you are using an HPA, make sure to not explicitly define this. K8s reference: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas",
 							Type:        []string{"integer"},
 							Format:      "int32",
-						},
-					},
-					"omitReplicas": {
-						SchemaProps: spec.SchemaProps{
-							Description: "If true, replicas will not be set in the deployment (allowing HPA to control scaling)",
-							Type:        []string{"boolean"},
-							Format:      "",
 						},
 					},
 					"strategy": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -6413,7 +6413,7 @@ func schema_kgateway_v2_api_v1alpha1_ProxyDeployment(ref common.ReferenceCallbac
 						SchemaProps: spec.SchemaProps{
 							Description: "The number of desired pods. If omitted, behavior will be managed by the K8s control plane, and will default to 1. If you are using an HPA, make sure to not explicitly define this. K8s reference: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas",
 							Type:        []string{"integer"},
-							Format:      "int32",
+							Format:      "int64",
 						},
 					},
 					"strategy": {

--- a/test/deployer/deployer_helm.go
+++ b/test/deployer/deployer_helm.go
@@ -137,7 +137,7 @@ func (dt DeployerTester) RunHelmChartTest(
 	validateYAML(t, outputFile, data)
 
 	diff := cmp.Diff(data, got)
-	assert.Empty(t, diff, diff, tt)
+	assert.Empty(t, diff, diff)
 }
 
 func DefaultDeployerInputs(dt DeployerTester, commonCols *collections.CommonCollections) *pkgdeployer.Inputs {

--- a/test/deployer/internal_helm_test.go
+++ b/test/deployer/internal_helm_test.go
@@ -15,6 +15,10 @@ func TestRenderHelmChart(t *testing.T) {
 			InputFile: "base-gateway",
 		},
 		{
+			Name:      "gateway with replicas GWP via GWC",
+			InputFile: "gwc-with-replicas",
+		},
+		{
 			Name:      "gwparams with omitDefaultSecurityContext",
 			InputFile: "omit-default-security-context",
 		},

--- a/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-out.yaml
+++ b/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-out.yaml
@@ -74,7 +74,6 @@ metadata:
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: gw

--- a/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-ref-gwp-on-gw-out.yaml
+++ b/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-ref-gwp-on-gw-out.yaml
@@ -74,7 +74,6 @@ metadata:
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: gw

--- a/test/deployer/testdata/agentgateway-out.yaml
+++ b/test/deployer/testdata/agentgateway-out.yaml
@@ -74,7 +74,6 @@ metadata:
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: gw

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -246,7 +246,6 @@ metadata:
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: gw

--- a/test/deployer/testdata/gwc-with-replicas-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-out.yaml
@@ -1,0 +1,343 @@
+---
+# Source: kgateway-proxy/templates/gateway/proxy-deployment.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: false
+---
+# Source: kgateway-proxy/templates/gateway/proxy-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
+    app.kubernetes.io/managed-by: Helm
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address: { address: 127.0.0.1, port_value: 19000 }
+    layered_runtime:
+      layers:
+      - name: static_layer
+        static_layer:
+          envoy.restart_features.use_eds_cache_for_ads: true
+      - name: admin_layer
+        admin_layer: {}
+    node:
+      cluster: gw.default
+      metadata:
+        role: kgateway-kube-gateway-api~default~gw
+    static_resources:
+      listeners:
+      - name: readiness_listener
+        address:
+          socket_address: { address: 0.0.0.0, port_value: 8082 }
+        filter_chains:
+          - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: AUTO
+                route_config:
+                  name: main_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            path: "/ready"
+                            headers:
+                              - name: ":method"
+                                string_match:
+                                  exact: GET
+                          route:
+                            cluster: admin_port_cluster
+                http_filters:
+                  - name: envoy.filters.http.health_check
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                      pass_through_mode: false
+                      headers:
+                      - name: ":path"
+                        string_match:
+                          exact: "/envoy-hc"
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      - name: prometheus_listener
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 9091
+        filter_chains:
+          - filters:
+              - name: envoy.filters.network.http_connection_manager
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  codec_type: AUTO
+                  stat_prefix: prometheus
+                  route_config:
+                    name: prometheus_route
+                    virtual_hosts:
+                      - name: prometheus_host
+                        domains:
+                          - "*"
+                        routes:
+                          - match:
+                              path: "/ready"
+                              headers:
+                                - name: ":method"
+                                  string_match:
+                                    exact: GET
+                            route:
+                              cluster: admin_port_cluster
+                          - match:
+                              prefix: "/metrics"
+                              headers:
+                                - name: ":method"
+                                  string_match:
+                                    exact: GET
+                            route:
+                              prefix_rewrite: /stats/prometheus?usedonly
+                              cluster: admin_port_cluster
+                          - match:
+                              prefix: "/stats"
+                              headers:
+                                - name: ":method"
+                                  string_match:
+                                    exact: GET
+                            route:
+                              prefix_rewrite: /stats
+                              cluster: admin_port_cluster
+                  http_filters:
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router 
+      clusters:
+        - name: xds_cluster
+          alt_stat_name: xds_cluster
+          connect_timeout: 5.000s
+          load_assignment:
+            cluster_name: xds_cluster
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: xds.cluster.local
+                      port_value: 9977
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+              http_filters:
+              - name: transform
+                typed_config:
+                  "@type": type.googleapis.com/envoy.api.v2.filter.http.FilterTransformations
+                  transformations:
+                  - match:
+                      prefix: "/"
+                    route_transformations:
+                      request_transformation:
+                        transformation_template:
+                          headers:
+                            authorization: {"text": 'Bearer {{ "{{ trim(data_source(\"token\")) -}}" }}'}
+                          passthrough: {}
+                          data_sources:
+                            token:
+                              filename: "/var/run/secrets/tokens/xds-token"
+                              watched_directory:
+                                path: "/var/run/secrets/tokens"
+              - name: envoy.filters.http.upstream_codec
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec
+          upstream_connection_options:
+            tcp_keepalive:
+              keepalive_time: 10
+          type: STRICT_DNS
+          respect_dns_ttl: true
+        - name: admin_port_cluster
+          connect_timeout: 5.000s
+          type: STATIC
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: admin_port_cluster
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 19000 
+    dynamic_resources:
+      ads_config:
+        transport_api_version: V3
+        api_type: GRPC
+        rate_limit_settings: {}
+        grpc_services:
+        - envoy_grpc:
+            cluster_name: xds_cluster
+      cds_config:
+        resource_api_version: V3
+        ads: {}
+      lds_config:
+        resource_api_version: V3
+        ads: {}
+---
+# Source: kgateway-proxy/templates/gateway/proxy-deployment.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: LoadBalancer
+  ports:
+  - name: listener-8080
+    protocol: TCP
+    targetPort: 8080
+    port: 8080
+  selector:
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+---
+# Source: kgateway-proxy/templates/gateway/proxy-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gw
+  labels:
+    kgateway: kube-gateway
+    helm.sh/chart: kgateway-proxy-1.0.0-ci1
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/instance: gw
+    gateway.networking.k8s.io/gateway-name: gw
+    app.kubernetes.io/version: "1.0.0-ci1"
+    gateway.networking.k8s.io/gateway-class-name: kgateway
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gw
+      app.kubernetes.io/instance: gw
+      gateway.networking.k8s.io/gateway-name: gw
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9091"
+        prometheus.io/scrape: "true"
+      labels:
+        kgateway: kube-gateway
+        app.kubernetes.io/name: gw
+        app.kubernetes.io/instance: gw
+        gateway.networking.k8s.io/gateway-name: gw
+        gateway.networking.k8s.io/gateway-class-name: kgateway
+    spec:
+      serviceAccountName: gw
+      containers:
+      - name: kgateway-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10101
+        args:
+        - "--disable-hot-restart"
+        - "--service-node"
+        - $(POD_NAME).$(POD_NAMESPACE)
+        - "--log-level"
+        - "info"
+        image: "ghcr.io/envoy-wrapper:v2.1.0-dev"
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+        - name: xds-token
+          mountPath: /var/run/secrets/tokens
+          readOnly: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ENVOY_UID
+          value: "0" 
+        ports:
+        - name: listener-8080
+          protocol: TCP
+          containerPort: 8080
+        - name: http-monitoring
+          containerPort: 9091
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /ready
+            port: 8082
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - wget --post-data "" -O /dev/null 127.0.0.1:19000/healthcheck/fail; sleep 10   
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: xds-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: kgateway
+              expirationSeconds: 43200
+              path: xds-token
+      - configMap:
+          name: gw
+        name: envoy-config

--- a/test/deployer/testdata/gwc-with-replicas.yaml
+++ b/test/deployer/testdata/gwc-with-replicas.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kgateway
+spec:
+  controllerName: kgateway.dev/kgateway
+  description: Standard class for managing Gateway API ingress traffic.
+  parametersRef:
+    group: gateway.kgateway.dev
+    kind: GatewayParameters
+    name: gw-params
+    namespace: default
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: gw-params
+  namespace: default
+spec:
+  kube:
+    deployment:
+      replicas: 2
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: gw
+  namespace: default
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -246,7 +246,6 @@ metadata:
     gateway.networking.k8s.io/gateway-class-name: kgateway
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: gw

--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -173,7 +173,7 @@ func (s *testingSuite) TestProvisionResourcesUpdatedWithValidParameters() {
 
 	// modify the number of replicas in the GatewayParameters
 	s.patchGatewayParameters(gwParamsDefaultObjectMeta, func(parameters *v1alpha1.GatewayParameters) {
-		parameters.Spec.Kube.Deployment.Replicas = ptr.To[int32](2)
+		parameters.Spec.Kube.Deployment.Replicas = ptr.To[uint32](2)
 	})
 
 	// the GatewayParameters modification should cause the deployer to re-run and update the
@@ -262,7 +262,7 @@ func (s *testingSuite) TestProvisionResourcesNotUpdatedWithInvalidParameters() {
 		}
 
 		// This is valid, but should be ignored, because another part of this patch is invalid
-		parameters.Spec.Kube.Deployment.Replicas = ptr.To[int32](2)
+		parameters.Spec.Kube.Deployment.Replicas = ptr.To[uint32](2)
 	})
 
 	// We keep checking for some amount of time (30s) to account for the time it might take for

--- a/test/kubernetes/e2e/tests/api_validation_test.go
+++ b/test/kubernetes/e2e/tests/api_validation_test.go
@@ -603,46 +603,6 @@ spec:
 			wantErrors: []string{"maxRequestSize must be greater than 0 and less than 4Gi"},
 		},
 		{
-			name: "ProxyDeployment: enforce ExactlyOneOf for replicas and omitReplicas",
-			input: `---
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: GatewayParameters
-metadata:
-  name: test-proxy-deployment
-spec:
-  kube:
-    deployment:
-      replicas: 3
-      omitReplicas: true
-`,
-			wantErrors: []string{"at most one of the fields in [replicas omitReplicas] may be set"},
-		},
-		{
-			name: "ProxyDeployment: neither replicas nor omitReplicas set (should pass)",
-			input: `---
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: GatewayParameters
-metadata:
-  name: test-proxy-deployment-empty
-spec:
-  kube:
-    deployment: {}
-`,
-		},
-		{
-			name: "ProxyDeployment: only replicas set (should pass)",
-			input: `---
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: GatewayParameters
-metadata:
-  name: test-proxy-deployment-replicas-only
-spec:
-  kube:
-    deployment:
-      replicas: 3
-`,
-		},
-		{
 			name: "ProxyDeployment: Strategy is fully fleshed out",
 			input: `---
 apiVersion: gateway.kgateway.dev/v1alpha1
@@ -714,19 +674,6 @@ spec:
     deployment:
       strategy:
         type: SomeStrategemIntroducedInTheFuture
-`,
-		},
-		{
-			name: "ProxyDeployment: only omitReplicas set (should pass)",
-			input: `---
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: GatewayParameters
-metadata:
-  name: test-proxy-deployment-omit-only
-spec:
-  kube:
-    deployment:
-      omitReplicas: true
 `,
 		},
 		{


### PR DESCRIPTION
# Description

Related to:
* https://github.com/kgateway-dev/kgateway/issues/10697

We had originally solved the need for allowing users to deploy their own HPA alongside the provisioned proxy `Deployment` by adding an API field to explicitly not render the `replicas` count (implemented in https://github.com/kgateway-dev/kgateway/pull/12045).

However, there is an easier way to do this, by only rendering `replicas` in the `Deployment` if explicitly needed, otherwise omitting it and letting K8s manage the replica count. The default behavior is `1` replica in this case, but it still can be controlled by an HPA, for example.

# Change Type
```
/kind breaking_change
```

# Changelog
```release-note
Remove `omitReplicas` from `GatewayParameters`. This is only an internal break for previous betas/RC versions
```
