### PR TITLE
ci: add workflow to sync kind/ingress-nginx issues to ingress2gateway

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,3 +45,5 @@ After a Pull Request is marked as `Ready for Review` it will trigger the action 
 
 ### Labels That Prevent Merge
 The [check-labels](./check-labels.yaml) workflow will block a PR from merging if the PR contains a `do-not-merge*` or `work in progress` label. These labels can be added to a PR to prevent accidental merges.
+### sync-ingress-nginx 
+ 

--- a/.github/workflows/sync-ingress-nginx-issues.yaml
+++ b/.github/workflows/sync-ingress-nginx-issues.yaml
@@ -1,0 +1,283 @@
+# Syncs issues labeled with `kind/ingress-nginx` from this repo to kgateway-dev/ingress2gateway.
+# This ensures that ingress-nginx migration issues are tracked in the ingress2gateway repo
+# even after the feature has been implemented upstream.
+#
+# Required secret: KGATEWAY_CI_TOKEN
+#   A GitHub Personal Access Token (classic or fine-grained) with the following permissions
+#   on the kgateway-dev/ingress2gateway repo:
+#     - issues: write  (to create/update issues)
+#     - metadata: read
+name: Sync ingress-nginx Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - closed
+      - deleted
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: print actions without creating/updating issues"
+        required: false
+        default: "false"
+
+permissions:
+  issues: read
+
+env:
+  TARGET_REPO: kgateway-dev/ingress2gateway
+  SYNC_LABEL: kind/ingress-nginx
+  # Label applied to synced issues in the target repo so they can be identified.
+  SYNCED_LABEL: synced/kgateway
+  DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+
+jobs:
+  sync-issue:
+    name: Sync Issue to ingress2gateway
+    runs-on: ubuntu-22.04
+    # Only run when the issue has the sync label, or when a label event may have added/removed it,
+    # or when triggered manually.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.issue.labels.*.name, 'kind/ingress-nginx') ||
+      github.event.label.name == 'kind/ingress-nginx'
+    steps:
+      - name: Sync issue
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ secrets.KGATEWAY_CI_TOKEN }}
+        with:
+          github-token: ${{ secrets.KGATEWAY_CI_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const [targetOwner, targetRepo] = process.env.TARGET_REPO.split('/');
+            const syncLabel    = process.env.SYNC_LABEL;
+            const syncedLabel  = process.env.SYNCED_LABEL;
+            const dryRun       = process.env.DRY_RUN === 'true';
+            const eventName    = context.eventName;
+
+           
+            // Helper: log what would happen in dry-run mode
+           
+            function dryLog(action, payload) {
+              console.log(`[DRY RUN] ${action}:`, JSON.stringify(payload, null, 2));
+            }
+
+            // 
+            // Helper: ensure the synced label exists in the target repo
+            // 
+            async function ensureSyncedLabel() {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: targetOwner,
+                  repo: targetRepo,
+                  name: syncedLabel,
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  console.log(`Creating label "${syncedLabel}" in ${targetOwner}/${targetRepo}`);
+                  if (!dryRun) {
+                    await github.rest.issues.createLabel({
+                      owner: targetOwner,
+                      repo: targetRepo,
+                      name: syncedLabel,
+                      color: '0075ca',
+                      description: `Synced from ${owner}/${repo}`,
+                    });
+                  } else {
+                    dryLog('createLabel', { name: syncedLabel });
+                  }
+                } else {
+                  throw e;
+                }
+              }
+            }
+
+            // 
+            // Helper: find an already-synced issue in the target repo by
+            // searching for the canonical source URL embedded in the body.
+            // 
+            async function findSyncedIssue(sourceHtmlUrl) {
+              // Search in body using the GitHub issues search API
+              const query = `repo:${targetOwner}/${targetRepo} "${sourceHtmlUrl}" in:body is:issue`;
+              const result = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 5 });
+              const match = result.data.items.find(i =>
+                i.body && i.body.includes(sourceHtmlUrl) && !i.pull_request
+              );
+              return match || null;
+            }
+
+            // 
+            // Helper: build the body for the synced issue
+            // 
+            function buildBody(sourceIssue) {
+              const sourceUrl  = sourceIssue.html_url;
+              const sourceRepo = `${owner}/${repo}`;
+              const header = [
+                `> [!NOTE]`,
+                `> This issue was automatically synced from [${sourceRepo}#${sourceIssue.number}](${sourceUrl}).`,
+                `> Please track and discuss this issue in the source repo. Changes here may be overwritten.`,
+                ``,
+                `---`,
+                ``,
+              ].join('\n');
+              return header + (sourceIssue.body || '_No description provided._');
+            }
+
+            // 
+            // Helper: collect labels to forward (skip labels that are internal
+            // to the source repo, keep kind/* labels and the synced marker).
+            // 
+              const forwardedPrefixes = ['kind/', 'priority/', 'area/'];
+              const labels = sourceIssue.labels
+                .map(l => l.name)
+                .filter(name => forwardedPrefixes.some(p => name.startsWith(p)));
+              labels.push(syncedLabel);
+              return [...new Set(labels)];
+            }
+
+            //
+            // Main logic
+            // 
+
+            // For workflow_dispatch: iterate over all open issues with the label
+            if (eventName === 'workflow_dispatch') {
+              console.log(`workflow_dispatch: scanning all open issues labeled "${syncLabel}" in ${owner}/${repo}`);
+              await ensureSyncedLabel();
+
+              let page = 1;
+              while (true) {
+                const { data: issues } = await github.rest.issues.listForRepo({
+                  owner, repo,
+                  labels: syncLabel,
+                  state: 'open',
+                  per_page: 100,
+                  page,
+                });
+                if (issues.length === 0) break;
+
+                for (const issue of issues) {
+                  if (issue.pull_request) continue; // skip PRs
+                  const existing = await findSyncedIssue(issue.html_url);
+                  const title    = `[kgateway#${issue.number}] ${issue.title}`;
+                  const body     = buildBody(issue);
+                  const labels   = buildLabels(issue);
+
+                  if (!existing) {
+                    console.log(`Creating synced issue for source #${issue.number}`);
+                    if (!dryRun) {
+                      await github.rest.issues.create({
+                        owner: targetOwner, repo: targetRepo,
+                        title, body, labels,
+                      });
+                    } else {
+                      dryLog('createIssue', { title, labels });
+                    }
+                  } else {
+                    console.log(`Updating existing synced issue #${existing.number} for source #${issue.number}`);
+                    if (!dryRun) {
+                      await github.rest.issues.update({
+                        owner: targetOwner, repo: targetRepo,
+                        issue_number: existing.number,
+                        title, body, labels,
+                        state: issue.state,
+                      });
+                    } else {
+                      dryLog('updateIssue', { number: existing.number, title, labels, state: issue.state });
+                    }
+                  }
+                }
+                page++;
+              }
+              return;
+            }
+
+            // For issue events: act on the single issue from the event payload
+            const sourceIssue = context.payload.issue;
+            if (!sourceIssue) {
+              console.log('No issue found in payload, skipping.');
+              return;
+            }
+
+            // Skip pull requests (GitHub reports some PR events as issue events)
+            if (sourceIssue.pull_request) {
+              console.log('Payload is a pull request, skipping.');
+              return;
+            }
+
+            const hasLabel = sourceIssue.labels.some(l => l.name === syncLabel);
+
+            await ensureSyncedLabel();
+
+            const existing = await findSyncedIssue(sourceIssue.html_url);
+            const title    = `[kgateway#${sourceIssue.number}] ${sourceIssue.title}`;
+            const body     = buildBody(sourceIssue);
+            const labels   = buildLabels(sourceIssue);
+
+            // Issue was deleted in source: close the synced copy if it exists
+            if (context.payload.action === 'deleted') {
+              if (existing) {
+                console.log(`Source issue deleted — closing synced issue #${existing.number}`);
+                if (!dryRun) {
+                  await github.rest.issues.update({
+                    owner: targetOwner, repo: targetRepo,
+                    issue_number: existing.number,
+                    state: 'closed',
+                    body: existing.body + '\n\n> The source issue was deleted.',
+                  });
+                } else {
+                  dryLog('closeDeletedIssue', { number: existing.number });
+                }
+              }
+              return;
+            }
+
+            // Label was removed and the issue no longer carries the sync label:
+            // close the synced copy if it exists.
+            if (!hasLabel) {
+              if (existing) {
+                console.log(`Label removed — closing synced issue #${existing.number}`);
+                if (!dryRun) {
+                  await github.rest.issues.update({
+                    owner: targetOwner, repo: targetRepo,
+                    issue_number: existing.number,
+                    state: 'closed',
+                    body: existing.body +
+                      `\n\n> The \`${syncLabel}\` label was removed from the source issue. This synced copy has been closed.`,
+                  });
+                } else {
+                  dryLog('closeDueToLabelRemoval', { number: existing.number });
+                }
+              }
+              return;
+            }
+
+            // Issue has the label — create or update the synced copy
+            if (!existing) {
+              console.log(`Creating synced issue for source #${sourceIssue.number}`);
+              if (!dryRun) {
+                await github.rest.issues.create({
+                  owner: targetOwner, repo: targetRepo,
+                  title, body, labels,
+                });
+              } else {
+                dryLog('createIssue', { title, labels });
+              }
+            } else {
+              console.log(`Updating synced issue #${existing.number} for source #${sourceIssue.number}`);
+              if (!dryRun) {
+                await github.rest.issues.update({
+                  owner: targetOwner, repo: targetRepo,
+                  issue_number: existing.number,
+                  title, body, labels,
+                  state: sourceIssue.state,
+                });
+              } else {
+                dryLog('updateIssue', { number: existing.number, title, labels, state: sourceIssue.state });
+              }
+            }

--- a/.github/workflows/sync-ingress-nginx-issues.yaml
+++ b/.github/workflows/sync-ingress-nginx-issues.yaml
@@ -25,6 +25,10 @@ on:
         description: "Dry run: print actions without creating/updating issues"
         required: false
         default: "false"
+        
+concurrency:
+  group: sync-ingress-nginx-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   issues: read
@@ -44,6 +48,7 @@ jobs:
     # or when triggered manually.
     # Note: env context is not available in job-level if conditions in GitHub Actions.
     # The label value is hardcoded here intentionally — update in sync with env.SYNC_LABEL if changed.
+    # NOTE: Must match env.SYNC_label below (envnot available in job level if conditions)
     if: |
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.issue.labels.*.name, 'kind/ingress-nginx') ||
@@ -125,12 +130,9 @@ jobs:
             // Helper: collect labels to forward (skip labels that are internal
             // to the source repo, keep kind/* labels and the synced marker).
             function buildLabels(sourceIssue) {
-              const forwardedPrefixes = ['kind/', 'priority/', 'area/'];
-              const labels = sourceIssue.labels
-                .map(l => l.name)
-                .filter(name => forwardedPrefixes.some(p => name.startsWith(p)));
-              labels.push(syncedLabel);
-              return [...new Set(labels)];
+              // onlly apply the synced label to avoid validation issues in the target repo, and to make it easy to find synced issues.
+              //when label dont exist in target repo, the issue update will fail, so we only apply the synced label.
+              return [syncedLabel];
             }
 
             // ------------------------------------------------------------------
@@ -169,7 +171,7 @@ jobs:
                 const { data: issues } = await github.rest.issues.listForRepo({
                   owner, repo,
                   labels: syncLabel,
-                  state: 'open',
+                  state: 'all',
                   per_page: 100,
                   page,
                 });
@@ -295,3 +297,4 @@ jobs:
                 dryLog('updateIssue', { number: existing.number, title, labels, state: sourceIssue.state });
               }
             }
+              

--- a/.github/workflows/sync-ingress-nginx-issues.yaml
+++ b/.github/workflows/sync-ingress-nginx-issues.yaml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-22.04
     # Only run when the issue has the sync label, or when a label event may have added/removed it,
     # or when triggered manually.
+    # Note: env context is not available in job-level if conditions in GitHub Actions.
+    # The label value is hardcoded here intentionally — update in sync with env.SYNC_LABEL if changed.
     if: |
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.issue.labels.*.name, 'kind/ingress-nginx') ||
@@ -61,16 +63,12 @@ jobs:
             const dryRun       = process.env.DRY_RUN === 'true';
             const eventName    = context.eventName;
 
-           
             // Helper: log what would happen in dry-run mode
-           
             function dryLog(action, payload) {
               console.log(`[DRY RUN] ${action}:`, JSON.stringify(payload, null, 2));
             }
 
-            // 
             // Helper: ensure the synced label exists in the target repo
-            // 
             async function ensureSyncedLabel() {
               try {
                 await github.rest.issues.getLabel({
@@ -98,12 +96,9 @@ jobs:
               }
             }
 
-            // 
             // Helper: find an already-synced issue in the target repo by
             // searching for the canonical source URL embedded in the body.
-            // 
             async function findSyncedIssue(sourceHtmlUrl) {
-              // Search in body using the GitHub issues search API
               const query = `repo:${targetOwner}/${targetRepo} "${sourceHtmlUrl}" in:body is:issue`;
               const result = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 5 });
               const match = result.data.items.find(i =>
@@ -112,9 +107,7 @@ jobs:
               return match || null;
             }
 
-            // 
             // Helper: build the body for the synced issue
-            // 
             function buildBody(sourceIssue) {
               const sourceUrl  = sourceIssue.html_url;
               const sourceRepo = `${owner}/${repo}`;
@@ -129,10 +122,9 @@ jobs:
               return header + (sourceIssue.body || '_No description provided._');
             }
 
-            // 
             // Helper: collect labels to forward (skip labels that are internal
             // to the source repo, keep kind/* labels and the synced marker).
-            // 
+            function buildLabels(sourceIssue) {
               const forwardedPrefixes = ['kind/', 'priority/', 'area/'];
               const labels = sourceIssue.labels
                 .map(l => l.name)
@@ -141,14 +133,36 @@ jobs:
               return [...new Set(labels)];
             }
 
-            //
+            // ------------------------------------------------------------------
             // Main logic
-            // 
+            // ------------------------------------------------------------------
 
             // For workflow_dispatch: iterate over all open issues with the label
             if (eventName === 'workflow_dispatch') {
               console.log(`workflow_dispatch: scanning all open issues labeled "${syncLabel}" in ${owner}/${repo}`);
               await ensureSyncedLabel();
+
+              // Build a lookup map of source URL -> synced issue upfront to avoid
+              // per-issue Search API calls, which are slow and hit rate limits on large backlogs.
+              const syncedIssueMap = new Map();
+              let syncedPage = 1;
+              while (true) {
+                const { data: syncedIssues } = await github.rest.issues.listForRepo({
+                  owner: targetOwner, repo: targetRepo,
+                  labels: syncedLabel,
+                  state: 'all',
+                  per_page: 100,
+                  page: syncedPage,
+                });
+                if (syncedIssues.length === 0) break;
+                for (const si of syncedIssues) {
+                  if (si.pull_request || !si.body) continue;
+                  const match = si.body.match(/https:\/\/github\.com\/[^\s)]+\/issues\/\d+/);
+                  if (match) syncedIssueMap.set(match[0], si);
+                }
+                syncedPage++;
+              }
+              console.log(`Built lookup map with ${syncedIssueMap.size} already-synced issues.`);
 
               let page = 1;
               while (true) {
@@ -163,7 +177,7 @@ jobs:
 
                 for (const issue of issues) {
                   if (issue.pull_request) continue; // skip PRs
-                  const existing = await findSyncedIssue(issue.html_url);
+                  const existing = syncedIssueMap.get(issue.html_url) || null;
                   const title    = `[kgateway#${issue.number}] ${issue.title}`;
                   const body     = buildBody(issue);
                   const labels   = buildLabels(issue);


### PR DESCRIPTION
# Description 

Issues labeled `kind/ingress-nginx` in this repo need to be tracked in kgateway-dev/ingress2gateway to ensure continued support for automated ingress-nginx migrations after the feature is implemented.
added a GitHub Actions workflow (.github/workflows/sync-ingress-nginx-issues.yaml) that listens on issue events and syncs any issue labeled kind/ingress-nginx to kgateway-dev/ingress2gateway. It handles create, update, close, label removal, and deletion. A workflow_dispatch trigger is included for backfilling existing issues.
Related issues:

Fixes #13637 

# Change Type
/kind feature

# Changelog
```release-note
NONE
```
# Additional Notes

Requires KGATEWAY_CI_TOKEN to have issues: write on kgateway-dev/ingress2gateway. The secret is already used by labeler.yaml 
