### PR TITLE
feat: introduce flake.nix as an alternative to dev containers

### DIFF
--- a/.starship.toml
+++ b/.starship.toml
@@ -1,0 +1,81 @@
+format = """
+$directory\
+$git_branch\
+$git_status\
+$golang\
+$rust\
+$kubernetes\
+$helm\
+$docker_context\
+$buf\
+$nix_shell\
+$line_break\
+$character"""
+
+[directory]
+truncation_length = 3
+truncate_to_repo = true
+style = "bold cyan"
+
+[git_branch]
+format = "on [$symbol$branch(:$remote_branch)]($style) "
+symbol = " "
+style = "bold purple"
+
+[git_status]
+format = '([$all_status$ahead_behind]($style) )'
+style = "bold red"
+
+[golang]
+format = "[$symbol($version)]($style) "
+symbol = " "
+style = "bold cyan"
+detect_files = ["go.mod"]
+
+[rust]
+format = "[$symbol($version)]($style) "
+symbol = " "
+style = "bold red"
+detect_files = ["Cargo.toml"]
+
+[kubernetes]
+disabled = false
+format = "[$symbol$context( \\($namespace\\))]($style) "
+symbol = " "
+style = "bold blue"
+detect_files = []
+detect_extensions = []
+detect_folders = []
+# Show when KUBECONFIG is set
+detect_env_vars = ["KUBECONFIG"]
+
+[helm]
+format = "[$symbol($version)]($style) "
+symbol = " "
+style = "bold white"
+detect_files = ["Chart.yaml", "helmfile.yaml"]
+detect_folders = ["charts"]
+
+[docker_context]
+format = "[$symbol$context]($style) "
+symbol = " "
+style = "blue"
+only_with_files = false
+disabled = true
+
+[buf]
+format = "[$symbol($version)]($style) "
+symbol = " "
+style = "bold blue"
+detect_files = ["buf.yaml", "buf.gen.yaml", "buf.work.yaml"]
+
+[nix_shell]
+format = "via [$symbol$state]($style) "
+symbol = " "
+style = "bold blue"
+impure_msg = "nix"
+pure_msg = "nix pure"
+
+[character]
+success_symbol = "[->](bold green)"
+error_symbol = "[->](bold red)"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774273680,
+        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774321696,
+        "narHash": "sha256-g18xMjMNla/nsF5XyQCNyWmtb2UlZpkY0XE8KinIXAA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "49a67e6894d4cb782842ee6faa466aa90c92812d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "kgateway development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        # Rust toolchain for internal/envoyinit/rustformations
+        rustToolchain = pkgs.rust-bin.stable."1.86.0".default.override {
+          extensions = [ "rustfmt" "clippy" ];
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Prompt
+            starship
+
+            # Go (pinned to match go.mod: go 1.26.x)
+            go_1_26
+
+            # Rust (for internal/envoyinit/rustformations)
+            rustToolchain
+
+            # Kubernetes tooling
+            kubectl
+            kind
+            kubernetes-helm
+            tilt
+
+            # Protobuf
+            protobuf
+            buf
+
+            # Code generation & build
+            gnumake
+            gcc
+            pkg-config
+
+            # CLI utilities
+            yq-go
+            jq
+            curl
+            wget
+            git
+            unzip
+
+            # Container tooling
+            docker-client
+
+            # Linting GitHub Actions (also available via `go tool actionlint`)
+            actionlint
+          ];
+
+          shellHook = ''
+            export STARSHIP_CONFIG="$PWD/.starship.toml"
+            if [ -n "$BASH_VERSION" ]; then
+              eval "$(starship init bash 2>/dev/null)"
+            elif [ -n "$ZSH_VERSION" ]; then
+              eval "$(starship init zsh 2>/dev/null)"
+            else
+              case "$SHELL" in
+                *zsh) eval "$(starship init zsh 2>/dev/null)" ;;
+                *)    eval "$(starship init bash 2>/dev/null)" ;;
+              esac
+            fi
+
+            echo "kgateway dev shell"
+            echo "  Go:      $(go version)"
+            echo "  Rust:    $(rustc --version)"
+            echo "  kubectl: $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
+            echo "  Helm:    $(helm version --short)"
+            echo "  Kind:    $(kind version)"
+            echo ""
+            echo "Run 'make help' to see available targets."
+
+            # Most Go CLI tools (controller-gen, ginkgo, golangci-lint, etc.)
+            # are managed via go.mod and invoked with 'go tool <name>'.
+            # No need to install them separately.
+          '';
+
+          # Ensure go tool dependencies resolve correctly
+          env = {
+            GO111MODULE = "on";
+            GOTOOLCHAIN = "local";
+          };
+        };
+      });
+}


### PR DESCRIPTION
# Description

Adds [Nix flake](https://nixos.wiki/wiki/Flakes) support as a lightweight, reproducible alternative to dev containers for setting up the kgateway development environment.

## Changes

- **`flake.nix`** — Nix dev shell providing Go (1.26.x), Rust (1.86.0), kubectl, Helm, Kind, Tilt, protobuf/buf, actionlint, and other development tools
- **`flake.lock`** — Pinned Nix dependencies for reproducible builds
- **`.starship.toml`** — Shell prompt configuration showing branch, Go version, k8s context

## Usage

```bash
nix develop
make help
```

Nix provides a declarative, reproducible dev environment that works across Linux and macOS without requiring Docker or a container runtime. This is additive and does not affect the existing dev container workflow.

## Testing

- `make run` — Kind cluster creation, image build, Helm deploy ✅
- `make test` — All 58 test suites pass ✅

# Change Type

/kind feature

# Changelog

```release-note
NONE
```

# Additional Notes

Go CLI tools (controller-gen, ginkgo, golangci-lint, etc.) are managed via `go.mod` and invoked with `go tool <name>` as usual — no additional installation needed.