### PR TITLE
fix(setup): monitor TLS cert watcher for startup failures

### DIFF
--- a/pkg/kgateway/setup/setup.go
+++ b/pkg/kgateway/setup/setup.go
@@ -313,6 +313,7 @@ func (s *setup) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		slog.Info("TLS certificate watcher enabled")
 		// certWatcher.Start() sets up file watches (polling up to 10s) then blocks
 		// in a ticker loop on success. If file watch setup fails, it returns an error
 		// immediately. We monitor for early return to catch startup failures instead

--- a/pkg/kgateway/setup/setup.go
+++ b/pkg/kgateway/setup/setup.go
@@ -313,11 +313,23 @@ func (s *setup) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		// certWatcher.Start() sets up file watches (polling up to 10s) then blocks
+		// in a ticker loop on success. If file watch setup fails, it returns an error
+		// immediately. We monitor for early return to catch startup failures instead
+		// of silently running without cert rotation.
+		certWatcherStarted := make(chan error, 1)
 		go func() {
-			if err := certWatcher.Start(ctx); err != nil {
-				slog.Error("failed to start TLS certificate watcher", "error", err)
+			certWatcherStarted <- certWatcher.Start(ctx)
+		}()
+		go func() {
+			select {
+			case err := <-certWatcherStarted:
+				// Start() returned — it only does this on failure or context cancellation.
+				if err != nil && ctx.Err() == nil {
+					slog.Error("TLS certificate watcher failed, cert rotation will not work", "error", err)
+				}
+			case <-ctx.Done():
 			}
-			slog.Info("started TLS certificate watcher")
 		}()
 	}
 


### PR DESCRIPTION
## Description

When xDS TLS is enabled, `certWatcher.Start(ctx)` was launched in a fire-and-forget goroutine. If the file watch setup failed, the error was silently logged and a misleading "started TLS certificate watcher" message was printed — giving no indication that cert rotation was broken.

This PR adds a monitor goroutine that catches early `Start()` failures and logs a clear error: `"TLS certificate watcher failed, cert rotation will not work"`. The misleading success log is also removed.

Since `certwatcher.New()` already loads the initial certificate, `GetCertificate()` works immediately — so `Start()` only needs to run in the background for ongoing file watching. The fix is intentionally non-blocking.

issue fix #13847

## Additional Notes

- `certWatcher.Start()` blocks forever on success (ticker loop), so it only returns early on failure
- The monitor goroutine also checks `ctx.Err() == nil` to avoid false alarms during normal shutdown
- No new dependencies or test changes needed — existing setup tests pass