### PR TITLE
ci: update actions

### DIFF
--- a/.github/actions/kube-conformance-tests/action.yaml
+++ b/.github/actions/kube-conformance-tests/action.yaml
@@ -34,7 +34,7 @@ runs:
       uses: ./.github/actions/prep-go-runner
 
 
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       id: kubectl
       with:
         version: ${{ inputs.kubectl-version }}

--- a/.github/actions/prep-go-runner/action.yaml
+++ b/.github/actions/prep-go-runner/action.yaml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Cancel Previous Actions
-      uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+      uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
       with:
         access_token: ${{ github.token }}
     - name: Free disk space
@@ -65,7 +65,7 @@ runs:
         docker system df -v
     - name: Set up Go
       id: setup-go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         # https://github.com/actions/setup-go/blob/main/action.yml
         go-version-file: ${{ inputs.working-directory }}/go.mod
@@ -88,13 +88,13 @@ runs:
       run: |
         echo "go-build=${{ runner.os }}-go-build-v3-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
     - name: Restore Go Build Cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: go-build-cache
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ steps.go-cache-keys.outputs.go-build }}
     - name: Cache Go Modules
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: go-mod-cache
       with:
         # https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/.github/actions/setup-k3d-cluster/action.yaml
+++ b/.github/actions/setup-k3d-cluster/action.yaml
@@ -34,7 +34,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       id: kubectl
       with:
         version: ${{ inputs.kubectl-version }}

--- a/.github/actions/setup-kind-cluster/action.yaml
+++ b/.github/actions/setup-kind-cluster/action.yaml
@@ -30,7 +30,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       id: kubectl
       with:
         version: ${{ inputs.kubectl-version }}

--- a/.github/actions/upload-artifact/action.yaml
+++ b/.github/actions/upload-artifact/action.yaml
@@ -27,7 +27,7 @@ runs:
           echo "job_id=$ts" >> $GITHUB_OUTPUT
         fi
     - name: Upload artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.name }}-${{ github.run_id }}-${{ steps.get-job-id.outputs.job_id }}
         path: ${{ inputs.path }}

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Enable auto-merge
         shell: bash
         env:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Disable auto-merge
         shell: bash
         env:

--- a/.github/workflows/build-tools.yaml
+++ b/.github/workflows/build-tools.yaml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set tags
         id: tags
@@ -63,21 +63,21 @@ jobs:
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to GHCR
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (and optionally push)
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: tools/build-tools/Dockerfile

--- a/.github/workflows/cache-eviction.yaml
+++ b/.github/workflows/cache-eviction.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cleanup Cache for PR
         # In this step we will delete the cache keys for the PR that was just closed.
         # We use a GitHub CLI extension (https://github.com/actions/gh-actions-cache).

--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prep Go Runner
         id: prep-go-runner
         uses: ./.github/actions/prep-go-runner
@@ -28,7 +28,7 @@ jobs:
           go test -run '^$' -tags e2e ./...
       - name: Save Go Build Cache
         if: success() && steps.prep-go-runner.outputs.go-build-cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key }}

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -29,9 +29,9 @@ jobs:
         test-type: [gateway-api]
         arch: ['amd64', 'arm64']
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: "./.github/workflows/.env/pr-tests/versions.env"

--- a/.github/workflows/devcontainer-smoke.yaml
+++ b/.github/workflows/devcontainer-smoke.yaml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoke-test-debug
           path: artifacts/

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,13 +24,13 @@ jobs:
     timeout-minutes: 45
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Restore envoyinit BuildKit cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/.buildx-cache-envoyinit
           key: ${{ runner.os }}-buildx-envoyinit-v1-${{ hashFiles('internal/envoy_modules/Cargo.lock', 'internal/envoy_modules/**/Cargo.toml', 'cmd/envoyinit/Dockerfile.tmpl', 'cmd/envoyinit/generate-dockerfile.sh') }}
@@ -51,7 +51,7 @@ jobs:
             mv /tmp/.buildx-cache-envoyinit-new /tmp/.buildx-cache-envoyinit
           fi
       - name: Upload shared e2e images
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-shared-images
           path: _output/e2e-images/shared-images.tar
@@ -124,19 +124,19 @@ jobs:
         version-files:
           - file: './.github/workflows/.env/pr-tests/versions.env'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       # The dotenv action is used to load key-value pairs from files.
       # In this case, the file is specified in the matrix and will contain the versions of the tools to use
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.version-files.file }}
           log-variables: true
       - name: Download shared e2e images
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: e2e-shared-images
           path: _output/e2e-images

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -25,7 +25,7 @@ jobs:
           exit 0
 
       - if: github.event_name != 'merge_group'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Sync /kind labels & enforce changelog fields
         if: github.event_name != 'merge_group'
         uses: kgateway-dev/pr-kind-labeler@f15977b7f894730fbaefcc22e2cd4c7c3d3bfcf2 # untagged main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Analyze source tree
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Lint Helm Charts
         run: make lint-kgateway-charts
 
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - run: make lint-actions
@@ -61,12 +61,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Read Rust toolchain version
         id: rust
         run: echo "channel=$(awk -F'"' '/^channel[[:space:]]*=/ {print $2}' internal/envoy_modules/rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           toolchain: ${{ steps.rust.outputs.channel }}
           components: clippy,rustfmt

--- a/.github/workflows/merge-queue-delete.yaml
+++ b/.github/workflows/merge-queue-delete.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cancel GH workflows
         # This action cancels any running builds for MQ branches which have already been deleted.

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -82,11 +82,11 @@ jobs:
             label: min_versions
         gateway-api-channel: ['experimental', 'standard']
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.ref.checkout_ref }}
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.env-versions.file }}
@@ -117,7 +117,7 @@ jobs:
             kubectl: v1.35.0
             kind: v0.31.0
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.ref.checkout_ref }}
       - uses: ./.github/actions/kube-gateway-api-load-tests
@@ -153,7 +153,7 @@ jobs:
         controllers:
           - regex: "^TestKgateway|^TestAPIValidation|^TestListenerSet|^TestCustomGWP$$|^TestRouteReplacement$$|^TestZeroDowntimeRollout$$/^TestZeroDowntimeRollout$$|^TestControlPlaneTLS$$"
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.ref.checkout_ref }}
       # v2.2.x is built against Gateway API 1.4 and refuses to start on 1.5 (#13872), so the
@@ -194,7 +194,7 @@ jobs:
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.env-versions.file }}

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -82,7 +82,7 @@ jobs:
           - linux/arm64
     steps:
       - name: Checkout branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ matrix.branch }}
@@ -145,7 +145,7 @@ jobs:
 
       - name: Run source scanner
         if: ${{ matrix.platform == 'linux/amd64' }}
-        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: |-
             --output=results.json
@@ -158,7 +158,7 @@ jobs:
 
       - name: Convert source results to SARIF
         if: ${{ matrix.platform == 'linux/amd64' }}
-        uses: google/osv-scanner-action/osv-reporter-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        uses: google/osv-scanner-action/osv-reporter-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: |-
             --output=results.sarif
@@ -168,7 +168,7 @@ jobs:
 
       - name: Upload source SARIF
         if: ${{ matrix.platform == 'linux/amd64' && !cancelled() && hashFiles('results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif
           ref: ${{ steps.metadata.outputs.ref }}
@@ -415,7 +415,7 @@ jobs:
 
       - name: Upload image SARIF
         if: ${{ !cancelled() && hashFiles('image-results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: image-results.sarif
           ref: ${{ steps.metadata.outputs.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       needs_release: ${{ steps.set_vars.outputs.needs_release }}
       previous_tag: ${{ steps.set_vars.outputs.previous_tag }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set the release related variables
@@ -135,7 +135,7 @@ jobs:
     needs: [setup, goreleaser]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Helm login to ${{ env.IMAGE_REGISTRY }}
         if: ${{ github.event_name != 'pull_request' }}
@@ -158,7 +158,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ needs.setup.outputs.needs_release == 'true' }}
         with:
           fetch-depth: 0
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload release notes
         if: ${{ needs.setup.outputs.needs_release == 'true' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-notes
           path: _output/RELEASE_NOTES.md
@@ -186,7 +186,7 @@ jobs:
     needs: [setup, release-notes]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Prep Go Runner
@@ -199,18 +199,18 @@ jobs:
 
       - name: Log into ghcr.io
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392" # v3.6.0
-      - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10.0
+      - uses: "docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3" # v4.1.0
+      - uses: "docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5" # v4.1.0
 
       - name: Download release notes
         if: ${{ needs.setup.outputs.needs_release == 'true' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-notes
           path: _output
@@ -262,7 +262,7 @@ jobs:
       matrix:
         arch: ['amd64', 'arm64']
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
 
@@ -309,7 +309,7 @@ jobs:
     if: ${{ inputs.run_load_tests }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
 

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Re-run failed jobs
         shell: bash
         env:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Install dependencies
@@ -54,7 +54,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Setup Buildx
         if: ${{ steps.validator-image.outputs.rebuild == 'true' }}
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Build validator image
         if: ${{ steps.validator-image.outputs.rebuild == 'true' }}
         env:
@@ -129,9 +129,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: tools/go.mod
       - name: Run drift tests

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Generate Code


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Update actions so they support Node.js 24
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
update GitHub Actions to support Node.js 24
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
