### PR TITLE
feat: add ArgoCD health checks for gateway.kgateway.dev resources

### DIFF
--- a/hack/argocd/README.md
+++ b/hack/argocd/README.md
@@ -1,0 +1,35 @@
+# ArgoCD Health Checks for kgateway
+
+This directory contains ArgoCD health check customizations for `gateway.kgateway.dev` resources. These health checks are implemented as Lua scripts and can be contributed to the [argoproj/argo-cd](https://github.com/argoproj/argo-cd) repository under `resource_customizations/`.
+
+## Patterns
+
+### Pattern 1: Standard Kubernetes Conditions
+Used by: `Backend`, `GatewayExtension`
+Checks the `status.conditions[]` field for an `Accepted` condition.
+
+### Pattern 2: Gateway API Policy Attachment
+Used by: `TrafficPolicy`, `ListenerPolicy`, `BackendConfigPolicy`, `HTTPListenerPolicy`
+Checks the `status.ancestors[].conditions[]` field. The resource is considered healthy only if at least one ancestor is present and all ancestors have accepted the policy.
+
+### Pattern 3: No Status
+Used by: `DirectResponse`, `GatewayParameters`
+Always returns `Healthy` as long as the resource exists. For `GatewayParameters`, status is currently unimplemented in the CRD.
+
+## How to use
+
+To use these health checks in your ArgoCD installation, you can add them to the `argocd-cm` ConfigMap:
+
+```yaml
+data:
+  resource.customizations: |
+    gateway.kgateway.dev/Backend:
+      health.lua: |
+        <content of Backend/health.lua>
+    gateway.kgateway.dev/TrafficPolicy:
+      health.lua: |
+        <content of TrafficPolicy/health.lua>
+    ...
+```
+
+The health check scripts are located in `resource_customizations/gateway.kgateway.dev/`.

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/Backend/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/Backend/health.lua
@@ -1,0 +1,18 @@
+local hs = { status = "Progressing", message = "Waiting for resource to be accepted" }
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  for i, condition in ipairs(obj.status.conditions) do
+    if condition.type == "Accepted" then
+      if condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = condition.message
+        return hs
+      end
+      if condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = condition.message
+        return hs
+      end
+    end
+  end
+end
+return hs

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/BackendConfigPolicy/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/BackendConfigPolicy/health.lua
@@ -1,0 +1,37 @@
+local hs = { status = "Progressing", message = "Waiting for policy to be accepted by ancestors" }
+if obj.status ~= nil and obj.status.ancestors ~= nil and #obj.status.ancestors > 0 then
+  local all_accepted = true
+  local any_rejected = false
+  local message = ""
+  for i, ancestor in ipairs(obj.status.ancestors) do
+    local accepted = false
+    if ancestor.conditions ~= nil then
+      for j, condition in ipairs(ancestor.conditions) do
+        if condition.type == "Accepted" then
+          if condition.status == "True" then
+            accepted = true
+          elseif condition.status == "False" then
+            any_rejected = true
+            message = "Rejected by ancestor: " .. (condition.message or "unknown reason")
+          end
+        end
+      end
+    end
+    if not accepted then
+      all_accepted = false
+    end
+  end
+  
+  if any_rejected then
+    hs.status = "Degraded"
+    hs.message = message
+    return hs
+  end
+  
+  if all_accepted then
+    hs.status = "Healthy"
+    hs.message = "Policy accepted by all ancestors"
+    return hs
+  end
+end
+return hs

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/DirectResponse/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/DirectResponse/health.lua
@@ -1,0 +1,2 @@
+local hs = { status = "Healthy", message = "Resource exists" }
+return hs

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/GatewayExtension/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/GatewayExtension/health.lua
@@ -1,0 +1,18 @@
+local hs = { status = "Progressing", message = "Waiting for resource to be accepted" }
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  for i, condition in ipairs(obj.status.conditions) do
+    if condition.type == "Accepted" then
+      if condition.status == "True" then
+        hs.status = "Healthy"
+        hs.message = condition.message
+        return hs
+      end
+      if condition.status == "False" then
+        hs.status = "Degraded"
+        hs.message = condition.message
+        return hs
+      end
+    end
+  end
+end
+return hs

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/GatewayParameters/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/GatewayParameters/health.lua
@@ -1,0 +1,21 @@
+local hs = { status = "Progressing", message = "Waiting for resource to be accepted" }
+if obj.status == nil or obj.status.conditions == nil then
+  hs.status = "Healthy"
+  hs.message = "Resource exists (status not implemented)"
+  return hs
+end
+for i, condition in ipairs(obj.status.conditions) do
+  if condition.type == "Accepted" then
+    if condition.status == "True" then
+      hs.status = "Healthy"
+      hs.message = condition.message
+      return hs
+    end
+    if condition.status == "False" then
+      hs.status = "Degraded"
+      hs.message = condition.message
+      return hs
+    end
+  end
+end
+return hs

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/HTTPListenerPolicy/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/HTTPListenerPolicy/health.lua
@@ -1,0 +1,37 @@
+local hs = { status = "Progressing", message = "Waiting for policy to be accepted by ancestors" }
+if obj.status ~= nil and obj.status.ancestors ~= nil and #obj.status.ancestors > 0 then
+  local all_accepted = true
+  local any_rejected = false
+  local message = ""
+  for i, ancestor in ipairs(obj.status.ancestors) do
+    local accepted = false
+    if ancestor.conditions ~= nil then
+      for j, condition in ipairs(ancestor.conditions) do
+        if condition.type == "Accepted" then
+          if condition.status == "True" then
+            accepted = true
+          elseif condition.status == "False" then
+            any_rejected = true
+            message = "Rejected by ancestor: " .. (condition.message or "unknown reason")
+          end
+        end
+      end
+    end
+    if not accepted then
+      all_accepted = false
+    end
+  end
+  
+  if any_rejected then
+    hs.status = "Degraded"
+    hs.message = message
+    return hs
+  end
+  
+  if all_accepted then
+    hs.status = "Healthy"
+    hs.message = "Policy accepted by all ancestors"
+    return hs
+  end
+end
+return hs

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/ListenerPolicy/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/ListenerPolicy/health.lua
@@ -1,0 +1,37 @@
+local hs = { status = "Progressing", message = "Waiting for policy to be accepted by ancestors" }
+if obj.status ~= nil and obj.status.ancestors ~= nil and #obj.status.ancestors > 0 then
+  local all_accepted = true
+  local any_rejected = false
+  local message = ""
+  for i, ancestor in ipairs(obj.status.ancestors) do
+    local accepted = false
+    if ancestor.conditions ~= nil then
+      for j, condition in ipairs(ancestor.conditions) do
+        if condition.type == "Accepted" then
+          if condition.status == "True" then
+            accepted = true
+          elseif condition.status == "False" then
+            any_rejected = true
+            message = "Rejected by ancestor: " .. (condition.message or "unknown reason")
+          end
+        end
+      end
+    end
+    if not accepted then
+      all_accepted = false
+    end
+  end
+  
+  if any_rejected then
+    hs.status = "Degraded"
+    hs.message = message
+    return hs
+  end
+  
+  if all_accepted then
+    hs.status = "Healthy"
+    hs.message = "Policy accepted by all ancestors"
+    return hs
+  end
+end
+return hs

--- a/hack/argocd/resource_customizations/gateway.kgateway.dev/TrafficPolicy/health.lua
+++ b/hack/argocd/resource_customizations/gateway.kgateway.dev/TrafficPolicy/health.lua
@@ -1,0 +1,37 @@
+local hs = { status = "Progressing", message = "Waiting for policy to be accepted by ancestors" }
+if obj.status ~= nil and obj.status.ancestors ~= nil and #obj.status.ancestors > 0 then
+  local all_accepted = true
+  local any_rejected = false
+  local message = ""
+  for i, ancestor in ipairs(obj.status.ancestors) do
+    local accepted = false
+    if ancestor.conditions ~= nil then
+      for j, condition in ipairs(ancestor.conditions) do
+        if condition.type == "Accepted" then
+          if condition.status == "True" then
+            accepted = true
+          elseif condition.status == "False" then
+            any_rejected = true
+            message = "Rejected by ancestor: " .. (condition.message or "unknown reason")
+          end
+        end
+      end
+    end
+    if not accepted then
+      all_accepted = false
+    end
+  end
+  
+  if any_rejected then
+    hs.status = "Degraded"
+    hs.message = message
+    return hs
+  end
+  
+  if all_accepted then
+    hs.status = "Healthy"
+    hs.message = "Policy accepted by all ancestors"
+    return hs
+  end
+end
+return hs


### PR DESCRIPTION
# Description

This PR adds ArgoCD health check customizations for all `gateway.kgateway.dev` resources, as requested in issue #13871.

### Status Patterns Implemented:
- **Pattern 1 (Standard conditions)**: Backend, GatewayExtension (Healthy when `Accepted` is `True`).
- - **Pattern 2 (Policy Attachment)**: TrafficPolicy, ListenerPolicy, BackendConfigPolicy, HTTPListenerPolicy (Healthy when accepted by all ancestors; now requires at least one ancestor to be Healthy).
- - **Pattern 3 (No Status / Default Healthy)**: DirectResponse, GatewayParameters (Default to Healthy).
Contributes health check definitions to `hack/argocd/` which can be shared with the ArgoCD community.

# Change Type

/kind feature

# Changelog

```release-note
Add ArgoCD health check Lua scripts for gateway.kgateway.dev resources.
```
