### PR TITLE
fix: Avoids envoy 5xx with response flags 'NC' re: errored clusters

### DIFF
--- a/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
+++ b/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
@@ -2,7 +2,15 @@ package proxy_syncer
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"strconv"
 
+	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoyresource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 )
 
@@ -13,7 +21,7 @@ func (s *ProxyTranslator) syncXds(
 	snap := snapWrap.snap
 	proxyKey := snapWrap.proxyKey
 
-	// TODO: handle errored clusters by fetching them from the previous snapshot and using the old cluster
+	snap = s.withRestoredErroredClusters(proxyKey, snap, snapWrap.erroredClusters)
 
 	// stringifying the snapshot may be an expensive operation, so we'd like to avoid building the large
 	// string if we're not even going to log it anyway
@@ -27,4 +35,74 @@ func (s *ProxyTranslator) syncXds(
 	// a default initial fetch timeout
 	// snap.MakeConsistent()
 	s.xdsCache.SetSnapshot(ctx, proxyKey, snap)
+}
+
+func (s *ProxyTranslator) withRestoredErroredClusters(
+	proxyKey string,
+	snap *envoycache.Snapshot,
+	erroredClusters []string,
+) *envoycache.Snapshot {
+	if snap == nil || len(erroredClusters) == 0 {
+		return snap
+	}
+
+	previousSnapshot, err := s.xdsCache.GetSnapshot(proxyKey)
+	if err != nil {
+		logger.Debug("no previous xds snapshot available for errored clusters", "proxy_key", proxyKey, "error", err)
+		return snap
+	}
+	if previousSnapshot == nil {
+		logger.Debug("previous xds snapshot is nil", "proxy_key", proxyKey)
+		return snap
+	}
+
+	previousClusters := previousSnapshot.GetResourcesAndTTL(envoyresource.ClusterType)
+	if len(previousClusters) == 0 {
+		logger.Debug("previous xds snapshot has no clusters to restore", "proxy_key", proxyKey)
+		return snap
+	}
+
+	clusterResources := snap.Resources[envoycachetypes.Cluster]
+	clusterItems := make(map[string]envoycachetypes.ResourceWithTTL, len(clusterResources.Items)+len(erroredClusters))
+	maps.Copy(clusterItems, clusterResources.Items)
+
+	clusterVersionHash, err := strconv.ParseUint(clusterResources.Version, 10, 64)
+	if err != nil {
+		clusterVersionHash = utils.HashString(clusterResources.Version)
+	}
+
+	restoredClusters := make([]string, 0, len(erroredClusters))
+	for _, clusterName := range erroredClusters {
+		if _, ok := clusterItems[clusterName]; ok {
+			continue
+		}
+
+		previousCluster, ok := previousClusters[clusterName]
+		if !ok || previousCluster.Resource == nil {
+			continue
+		}
+
+		clusterItems[clusterName] = previousCluster
+		clusterVersionHash ^= utils.HashProto(previousCluster.Resource)
+		restoredClusters = append(restoredClusters, clusterName)
+	}
+	if len(restoredClusters) == 0 {
+		return snap
+	}
+
+	// Clone only the mutated cluster resource group so the KRT-produced snapshot is not rewritten.
+	clusterResources.Items = clusterItems
+	clusterResources.Version = fmt.Sprintf("%d", clusterVersionHash)
+
+	restoredSnap := *snap
+	restoredSnap.Resources[envoycachetypes.Cluster] = clusterResources
+	restoredSnap.VersionMap = nil
+
+	logger.Info(
+		"restored errored clusters from previous xds snapshot",
+		"proxy_key", proxyKey,
+		"clusters", restoredClusters,
+	)
+
+	return &restoredSnap
 }

--- a/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer_test.go
+++ b/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer_test.go
@@ -1,0 +1,138 @@
+package proxy_syncer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoyresource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+)
+
+func TestSyncXdsRestoresErroredClustersFromPreviousSnapshot(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	proxyKey := "test-proxy"
+	xdsCache := envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil)
+	translator := NewProxyTranslator(xdsCache)
+
+	healthyCluster := testCluster("cluster-a", time.Second)
+	previousErroredCluster := testCluster("cluster-b", 2*time.Second)
+	previousVersion := testClusterVersion(healthyCluster, previousErroredCluster)
+	previousSnap := testSnapshotWithClusters(previousVersion, healthyCluster, previousErroredCluster)
+	g.Expect(xdsCache.SetSnapshot(ctx, proxyKey, previousSnap)).To(gomega.Succeed())
+
+	incomingSnap := testSnapshotWithClusters(testClusterVersion(healthyCluster), healthyCluster)
+	translator.syncXds(ctx, XdsSnapWrapper{
+		snap:            incomingSnap,
+		proxyKey:        proxyKey,
+		erroredClusters: []string{"cluster-b", "cluster-missing"},
+	})
+
+	storedSnapshot, err := xdsCache.GetSnapshot(proxyKey)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	storedClusters := storedSnapshot.GetResourcesAndTTL(envoyresource.ClusterType)
+
+	g.Expect(storedClusters).To(gomega.HaveKey("cluster-a"))
+	g.Expect(storedClusters).To(gomega.HaveKey("cluster-b"))
+	g.Expect(storedClusters).NotTo(gomega.HaveKey("cluster-missing"))
+	g.Expect(proto.Equal(storedClusters["cluster-b"].Resource, previousErroredCluster)).To(gomega.BeTrue())
+	g.Expect(storedSnapshot.GetVersion(envoyresource.ClusterType)).To(gomega.Equal(previousVersion))
+
+	g.Expect(incomingSnap.Resources[envoycachetypes.Cluster].Items).NotTo(gomega.HaveKey("cluster-b"),
+		"restoring old clusters must not mutate the KRT-produced snapshot")
+}
+
+func TestSyncXdsRestoresErroredClustersAfterHealthyClusterChange(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	proxyKey := "test-proxy"
+	xdsCache := envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil)
+	translator := NewProxyTranslator(xdsCache)
+
+	previousHealthyCluster := testCluster("cluster-a", time.Second)
+	previousErroredCluster := testCluster("cluster-b", 2*time.Second)
+	previousSnap := testSnapshotWithClusters(
+		testClusterVersion(previousHealthyCluster, previousErroredCluster),
+		previousHealthyCluster,
+		previousErroredCluster,
+	)
+	g.Expect(xdsCache.SetSnapshot(ctx, proxyKey, previousSnap)).To(gomega.Succeed())
+
+	updatedHealthyCluster := testCluster("cluster-a", 3*time.Second)
+	expectedVersion := testClusterVersion(updatedHealthyCluster, previousErroredCluster)
+	incomingSnap := testSnapshotWithClusters(testClusterVersion(updatedHealthyCluster), updatedHealthyCluster)
+	translator.syncXds(ctx, XdsSnapWrapper{
+		snap:            incomingSnap,
+		proxyKey:        proxyKey,
+		erroredClusters: []string{"cluster-b"},
+	})
+
+	storedSnapshot, err := xdsCache.GetSnapshot(proxyKey)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	storedClusters := storedSnapshot.GetResourcesAndTTL(envoyresource.ClusterType)
+
+	g.Expect(proto.Equal(storedClusters["cluster-a"].Resource, updatedHealthyCluster)).To(gomega.BeTrue())
+	g.Expect(proto.Equal(storedClusters["cluster-b"].Resource, previousErroredCluster)).To(gomega.BeTrue())
+	g.Expect(storedSnapshot.GetVersion(envoyresource.ClusterType)).To(gomega.Equal(expectedVersion))
+}
+
+func TestSyncXdsDoesNotOverwriteCurrentClusterWhenRestoringErroredClusters(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+	proxyKey := "test-proxy"
+	xdsCache := envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil)
+	translator := NewProxyTranslator(xdsCache)
+
+	previousCluster := testCluster("cluster-a", time.Second)
+	g.Expect(xdsCache.SetSnapshot(ctx, proxyKey, testSnapshotWithClusters(testClusterVersion(previousCluster), previousCluster))).To(gomega.Succeed())
+
+	currentCluster := testCluster("cluster-a", 2*time.Second)
+	currentVersion := testClusterVersion(currentCluster)
+	translator.syncXds(ctx, XdsSnapWrapper{
+		snap:            testSnapshotWithClusters(currentVersion, currentCluster),
+		proxyKey:        proxyKey,
+		erroredClusters: []string{"cluster-a"},
+	})
+
+	storedSnapshot, err := xdsCache.GetSnapshot(proxyKey)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	storedClusters := storedSnapshot.GetResourcesAndTTL(envoyresource.ClusterType)
+
+	g.Expect(proto.Equal(storedClusters["cluster-a"].Resource, currentCluster)).To(gomega.BeTrue())
+	g.Expect(storedSnapshot.GetVersion(envoyresource.ClusterType)).To(gomega.Equal(currentVersion))
+}
+
+func testSnapshotWithClusters(version string, clusters ...*envoyclusterv3.Cluster) *envoycache.Snapshot {
+	resources := make([]envoycachetypes.ResourceWithTTL, 0, len(clusters))
+	for _, cluster := range clusters {
+		resources = append(resources, envoycachetypes.ResourceWithTTL{Resource: cluster})
+	}
+
+	snap := &envoycache.Snapshot{}
+	snap.Resources[envoycachetypes.Cluster] = envoycache.NewResourcesWithTTL(version, resources)
+	return snap
+}
+
+func testClusterVersion(clusters ...*envoyclusterv3.Cluster) string {
+	var hash uint64
+	for _, cluster := range clusters {
+		hash ^= utils.HashProto(cluster)
+	}
+	return fmt.Sprintf("%d", hash)
+}
+
+func testCluster(name string, connectTimeout time.Duration) *envoyclusterv3.Cluster {
+	return &envoyclusterv3.Cluster{
+		Name:           name,
+		ConnectTimeout: durationpb.New(connectTimeout),
+	}
+}

--- a/test/e2e/features/backendtls/suite.go
+++ b/test/e2e/features/backendtls/suite.go
@@ -142,6 +142,20 @@ func (s *tsuite) TestBackendTLSPolicyAndStatus() {
 		Message:            fmt.Sprintf("invalid CA certificate ref ConfigMap/ca: %s: kgateway-base/ca", backendtlspolicy.ErrConfigMapNotFound),
 		ObservedGeneration: backendTlsPolicy.Generation,
 	})
+
+	// The policy is now invalid, but Envoy should keep serving with the last good backend clusters.
+	for _, tc := range tt {
+		common.BaseGateway.Send(
+			s.T(),
+			&matchers.HttpResponse{
+				StatusCode: http.StatusOK,
+				Body:       gomega.ContainSubstring(defaults.NginxResponse),
+			},
+			curl.WithPort(80),
+			curl.WithHostHeader(tc.host),
+			curl.WithPath("/"),
+		)
+	}
 }
 
 func (s *tsuite) assertPolicyStatus(inCondition metav1.Condition) {


### PR DESCRIPTION

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Handles errored clusters by fetching them from the previous snapshot and using the old cluster.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
xDS fix: Handles errored clusters by fetching them from the previous snapshot and using the old cluster.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
