### PR TITLE
chore: AGENTS.md changes to improve PR description drafting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,18 +210,33 @@ Gateway API version is in `go.mod` and CRD install URL in Makefile (`CONFORMANCE
 
 ### PR Body Structure
 
-Every PR must include these sections:
+Every PR body must use this Markdown structure. Use heading lines exactly as shown, not bold labels or alternate heading levels:
 
-1. **Description** - Explain motivation, what changed, and link issues (`Fixes #123`)
+````markdown
+# Description
 
-2. **Change Type** - Include one or more `/kind` commands in the PR body:
-   - `/kind feature`, `/kind fix`, `/kind cleanup`, `/kind documentation`
-   - `/kind breaking_change`, `/kind deprecation`, `/kind design`
-   - `/kind bump`, `/kind flake`, `/kind install`
+Explain the motivation, what changed, and related issues such as `Fixes #123`.
 
-3. **Changelog** - A fenced code block with `release-note` as the language identifier containing the release note text, or `NONE` if not user-facing
+# Change Type
 
-4. **Additional Notes** (optional) - Extra context for reviewers
+/kind fix
+
+Replace `/kind fix` with the applicable `/kind` command or commands.
+
+# Changelog
+
+```release-note
+NONE
+```
+
+# Additional Notes
+
+Add reviewer context or edge cases. Delete this section if it does not apply.
+````
+
+When returning a PR body in chat, wrap the entire PR body in a four-backtick `markdown` fence so nested triple-backtick blocks, especially the `release-note` block, render and copy correctly.
+
+Allowed `/kind` commands are: `/kind feature`, `/kind fix`, `/kind cleanup`, `/kind documentation`, `/kind breaking_change`, `/kind deprecation`, `/kind design`, `/kind bump`, `/kind flake`, and `/kind install`.
 
 ## Style
 


### PR DESCRIPTION
# Description
Tested with Codex CLI and GPT-5.5.

The PR template itself is not in this repository, and this is obviously very coupled to the PR template. It would be slow to have the agent go fetch the template.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
