### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,9 +38,9 @@ After a Pull Request is marked as `Ready for Review` it will trigger the action 
 
 ### Comments That Trigger Workflows
 - Commenting `/retest` (without any other text) on a PR will trigger the [retest](./retest.yaml) job (limited to kgateway org members only). This will re-run any failed jobs from the latest workflow runs on the PR.
-- Commenting `/merge` (without any other text) on a PR will trigger the [enable auto-merge](./automerge.yaml) job (limited to kgateway org members only). This will enable auto-merge for the PR.
+- Commenting `/merge` (without any other text) on a PR will trigger the [enable auto-merge](./auto-merge.yaml) job (limited to kgateway org members only). This will enable auto-merge for the PR.
     - Note: if all _required_ checks have passed and the PR has been approved, this will immediately add the PR to the merge queue, regardless of whether there are still outstanding/failing _non-required_ checks.
-- Commenting `/unmerge` (without any other text) on a PR will trigger the [disable auto-merge](./automerge.yaml) job (limited to kgateway org members only). This will disable auto-merge for the PR.
+- Commenting `/unmerge` (without any other text) on a PR will trigger the [disable auto-merge](./auto-merge.yaml) job (limited to kgateway org members only). This will disable auto-merge for the PR.
     - Note: this can only disable auto-merge if the PR isn't already in the merge queue. If the PR is already in the merge queue and you need to remove it, please ask a maintainer to manually remove it from the merge queue.
 
 ### Labels That Prevent Merge

--- a/devel/architecture/metrics.md
+++ b/devel/architecture/metrics.md
@@ -9,7 +9,7 @@ The [metrics](/pkg/metrics/metrics.go) package provides constructors to create m
 These constructors handle registering the metrics with a metrics registry. By default, a new empty registry is created at startup. This can be replaced with a custom registry, or a built-in registry used by controller-runtime can be enabled by using:
 * `SetRegistry(useBuiltinRegistry bool, r RegistererGatherer)`
 
-The underlying implementation is based on [github.com/prometheus/client_golang/prometheus](github.com/prometheus/client_golang/prometheus).
+The underlying implementation is based on [github.com/prometheus/client_golang/prometheus](https://github.com/prometheus/client_golang/tree/main/prometheus).
 
 ### Best practices and common patterns
 * Metrics are expected to have a namespace and subsystem defined in their options
@@ -49,7 +49,7 @@ defer func() {
 rErr := DoSomeTranslation()
 ```
 
-These `Start` methods return a function to be defered to run on completion of the event handling, allowing collection of timing and other metrics. If the `Start` method is not called, those metrics will not be collected, but there will be no failures.
+These `Start` methods return a function to be deferred to run on completion of the event handling, allowing collection of timing and other metrics. If the `Start` method is not called, those metrics will not be collected, but there will be no failures.
 
 
 ### Gathering metrics from a KRT collection

--- a/internal/envoy_modules/filters/kgateway-example-filter/README.md
+++ b/internal/envoy_modules/filters/kgateway-example-filter/README.md
@@ -2,5 +2,5 @@
 
 This is a reference skeleton filter for kgateway Envoy dynamic module.
 
-See [adding-a-filter.md](../../../../docs/guides/adding-a-filter.md) for step-by-step instructions
+See [adding-a-filter.md](../../adding-a-filter.md) for step-by-step instructions
 on how to create a new filter based on this example.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,4 +30,4 @@ _We document the historical challenges we have experienced with writing and mana
 ### Framework
 We've learned from these challenges and have introduced a framework that we believe addresses the concerns. This framework allows us to write expressive end-to-end tests that reflect the experiences of users of the product.
 
-_For more details on the end-to-end framework, see the [e2e](./e2e) package._
+_For more details on the end-to-end framework, see the [E2E framework README](./README-e2e-framework.md)._


### PR DESCRIPTION
# Description
Tiny docs papercut, nothing spicy. A few README links point at files that do not exist anymore, or at a malformed URL, so clicking them 404s.

Repro on main:
```bash
test -e docs/guides/adding-a-filter.md; echo $?
test -e .github/workflows/automerge.yaml; echo $?
test -e test/e2e/e2e; echo $?
```

Those return non-zero. This points the links at the real files and fixes one nearby typo. Follow-up to #13954.

# Change Type
/kind cleanup
/kind documentation

# Changelog
```release-note
NONE
```

# Additional Notes
Checked `git diff --check`, `make lint-actions`, and local links in the changed files.