### PR TITLE
test: deployer helm tests dry-run outputs against real k8s API server

### DIFF
--- a/test/deployer/deployer_helm.go
+++ b/test/deployer/deployer_helm.go
@@ -1,6 +1,7 @@
 package deployer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,7 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
@@ -25,6 +29,7 @@ import (
 	internaldeployer "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/deployer"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
@@ -226,6 +231,7 @@ func (dt DeployerTester) RunHelmChartTest(
 	dir string,
 	crdDir string,
 	fakeClient apiclient.Client,
+	envTestCfg *rest.Config,
 ) {
 	filePath := filepath.Join(dir, "testdata/", tt.InputFile)
 	outputFile := filePath + "-out.yaml"
@@ -295,10 +301,83 @@ func (dt DeployerTester) RunHelmChartTest(
 	outputStr := "%s\nthe golden file, which can be refreshed via `REFRESH_GOLDEN=true go test ./test/deployer`, is\n%s"
 	assert.Empty(t, diff, outputStr, diff, outputFile)
 
+	// Hand the rendered objects to the envtest API server via dry-run Create.
+	// The API server runs the same admission/schema validation it would for a
+	// real apply, but discards the object — so this catches malformed
+	// metadata, label/annotation length limits, schema violations, etc. that
+	// the golden-file diff would otherwise let through.
+	if envTestCfg != nil {
+		validateObjectsAgainstAPIServer(t, ctx, envTestCfg, scheme, gtw.GetNamespace(), deployObjs)
+	}
+
 	// Run additional validation if provided
 	if tt.Validate != nil {
 		tt.Validate(t, string(data))
 	}
+}
+
+// validateObjectsAgainstAPIServer sends each rendered object to the API server
+// with client.DryRunAll. The server validates the object as if it were being
+// created (admission webhooks, schema, label/annotation rules, etc.) but does
+// not persist it. All errors are collected and reported together so the caller
+// sees every problem in one run rather than just the first.
+//
+// Objects whose GVK has no REST mapping in the test API server (typically
+// CRDs that weren't installed, e.g. VPA) are skipped with a log line — the
+// goal is to validate the well-known Kubernetes objects the deployer
+// produces, not to require every CRD to be present in envtest.
+//
+// Each object is converted to unstructured.Unstructured before being sent.
+// The deployer produces typed objects for some kinds (e.g. PodDisruptionBudget,
+// HorizontalPodAutoscaler) that aren't registered in the test scheme, and the
+// controller-runtime client would otherwise refuse to encode them. Converting
+// to unstructured mirrors what the API server actually receives over the wire
+// and makes this helper robust to any kind the deployer might emit.
+func validateObjectsAgainstAPIServer(
+	t *testing.T,
+	ctx context.Context,
+	cfg *rest.Config,
+	scheme *runtime.Scheme,
+	defaultNamespace string,
+	objs []client.Object,
+) {
+	t.Helper()
+
+	ctrlClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	require.NoError(t, err, "failed to create controller-runtime client for dry-run validation")
+
+	var errs []error
+	for _, obj := range objs {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		u := &unstructured.Unstructured{}
+		raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj.DeepCopyObject())
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to convert %s %s/%s to unstructured: %w",
+				gvk.Kind, obj.GetNamespace(), obj.GetName(), err))
+			continue
+		}
+		u.Object = raw
+		u.GetObjectKind().SetGroupVersionKind(gvk)
+		// Owner references carry the source Gateway's UID, which the test
+		// inputs don't populate. Dry-run admission would reject the reference
+		// as malformed; drop it — we're validating the object shape, not the
+		// owner graph.
+		u.SetOwnerReferences(nil)
+		if kubeutils.IsNamespacedGVK(gvk) && u.GetNamespace() == "" {
+			u.SetNamespace(defaultNamespace)
+		}
+
+		if err := ctrlClient.Create(ctx, u, client.DryRunAll); err != nil {
+			if meta.IsNoMatchError(err) {
+				t.Logf("skipping dry-run for %s/%s: no API server mapping (CRD not installed): %v",
+					gvk.Kind, u.GetName(), err)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("API server rejected %s %s/%s: %w",
+				gvk.Kind, u.GetNamespace(), u.GetName(), err))
+		}
+	}
+	assert.NoError(t, errors.Join(errs...), "rendered objects must pass API server validation")
 }
 
 // sanitizeOutput removes things that change often but are not relevant to the tests

--- a/test/deployer/internal_helm_test.go
+++ b/test/deployer/internal_helm_test.go
@@ -32,8 +32,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
@@ -752,9 +756,77 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 			} else {
 				client = fake.NewClient(t, objs...)
 			}
-			tester.RunHelmChartTest(t, tt, scheme, dir, crdDir, client)
+			tester.RunHelmChartTest(t, tt, scheme, dir, crdDir, client, envTestCfg)
 		})
 	}
+}
+
+// TestEnvtestRejectsLongLabelValue tests the tests -- it proves that
+// the dry-run Create validation in RunHelmChartTest works, that the
+// envtest API server actually enforces label-value length (max 63
+// characters). Without this guarantee, the dry-run step in
+// RunHelmChartTest would silently rubber- stamp malformed helm
+// output.
+func TestEnvtestRejectsLongLabelValue(t *testing.T) {
+	envTestCfg := getEnvTestConfig(t)
+	if envTestCfg == nil {
+		t.Skip("envtest is required for this test (set USE_ENVTEST=true)")
+	}
+
+	scheme := schemes.GatewayScheme()
+	ctrlClient, err := ctrlclient.New(envTestCfg, ctrlclient.Options{Scheme: scheme})
+	require.NoError(t, err, "failed to create controller-runtime client")
+
+	newDeployment := func(labelValue string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "envtest-validation-probe",
+				Namespace: "default",
+				Labels: map[string]string{
+					"validation-probe": labelValue,
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "probe"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "probe"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "probe",
+							Image: "nginx:latest",
+						}},
+					},
+				},
+			},
+		}
+	}
+
+	// Green: a 63-character label value is the documented maximum, so the API
+	// server must accept it. If this fails, our dry-run pipeline is broken or
+	// validation rules have shifted under us.
+	t.Run("accepts 63-char label value", func(t *testing.T) {
+		labelValue := strings.Repeat("a", 63)
+		require.Len(t, labelValue, 63)
+		err := ctrlClient.Create(t.Context(), newDeployment(labelValue), ctrlclient.DryRunAll)
+		assert.NoError(t, err, "envtest API server should accept a 63-character label value")
+	})
+
+	// Red: a 253-character label value violates k8s validation. If the API
+	// server lets this through, the dry-run hook in RunHelmChartTest cannot be
+	// trusted — it would silently approve malformed manifests.
+	t.Run("rejects 253-char label value", func(t *testing.T) {
+		labelValue := strings.Repeat("a", 253)
+		require.Len(t, labelValue, 253)
+		err := ctrlClient.Create(t.Context(), newDeployment(labelValue), ctrlclient.DryRunAll)
+		require.Error(t, err, "envtest API server must reject a 253-character label value; "+
+			"if this passes, the dry-run validation in RunHelmChartTest is not actually validating")
+		assert.Contains(t, err.Error(), "must be no more than 63 characters",
+			"rejection should cite the 63-character label-value limit")
+	})
 }
 
 // TestDeployerManagedResourcesHaveRBACPermissions verifies that all Kubernetes

--- a/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
+++ b/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
@@ -384,4 +384,14 @@ spec:
       - configMap:
           name: my-custom-config
         name: custom-config
+      - configMap:
+          name: gw
+        name: envoy-config
+      - name: xds-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: kgateway
+              expirationSeconds: 43200
+              path: xds-token
 status: {}

--- a/test/deployer/testdata/envoy-strategic-merge-patch.yaml
+++ b/test/deployer/testdata/envoy-strategic-merge-patch.yaml
@@ -34,6 +34,16 @@ spec:
               - name: custom-config
                 configMap:
                   name: my-custom-config
+              - name: envoy-config
+                configMap:
+                  name: gw
+              - name: xds-token
+                projected:
+                  sources:
+                    - serviceAccountToken:
+                        audience: kgateway
+                        expirationSeconds: 43200
+                        path: xds-token
             containers:
               - name: kgateway-proxy
                 volumeMounts:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Closes a gap left by #14008. That PR wired envtest into `TestRenderHelmChart` and swapped the fake `apiclient.Client` for an envtest-backed one, but `RunHelmChartTest` only used the client for KRT wiring — the helm chart's rendered output was never sent to the API server. What actually got API-server-validated were the **test inputs** (Gateway, GatewayClass, GatewayParameters fixtures) populated via `envtest.NewClient`'s `Create()` calls.

14008's framing ("If we generate a 64-character value in a 63-character-or-less field, the k8s API server will cause such a test to fail") overstates that. It is true for fields on the input fixtures. It is not true for anything the deployer renders: the rendered Deployment, Service, ConfigMap, PDB, HPA, VPA, ServiceAccount were never submitted to envtest.

This branch closes that loop:

- `RunHelmChartTest` now takes `envTestCfg *rest.Config` and, after the golden-file diff, sends every rendered object to the API server via `client.Create(ctx, obj, client.DryRunAll)`. Errors are collected and asserted together so a single run surfaces every problem rather than just the first.
- Objects are converted to `unstructured.Unstructured` before submission. The deployer's strategic-merge-patch path emits typed `*policyv1.PodDisruptionBudget` and `*autoscalingv2.HorizontalPodAutoscaler` even though those types aren't registered in `schemes.GatewayScheme()`; routing through unstructured mirrors what the API server actually receives over the wire and decouples the helper from the test scheme.
- `TestEnvtestRejectsLongLabelValue` is an explicit red-green proof: a 63-char label is accepted, a 253-char label is rejected with "must be no more than 63 characters". Without this, "the API server is validating" remains an implicit claim.

# Real bug caught while wiring this up

One fixture (`testdata/envoy-strategic-merge-patch.yaml`) was actually broken and the golden-file diff had been letting it through. The overlay used `$patch: replace` on `volumes` (wiping `envoy-config` and `xds-token`) without clearing the kgateway-proxy container's existing `volumeMounts`, leaving dangling references. The rendered Deployment is invalid.

# Change Type
/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

