### PR TITLE
fix: Add certs to config builder for strict validation

### DIFF
--- a/pkg/envoyinit/run.go
+++ b/pkg/envoyinit/run.go
@@ -38,7 +38,7 @@ func RunEnvoy(envoyExecutable, inputPath, outputPath string) {
 		log.Fatalf("initializer failed: %v", err)
 	}
 
-	caPath, err := getOSRootFilePath()
+	caPath, err := GetOSRootFilePath()
 	if err != nil {
 		log.Printf("Failed to get a supported OS CA certificate path: %v", err)
 	}
@@ -129,10 +129,10 @@ func getAndTransformConfig(inputFile string) (string, error) {
 	return buffer.String(), nil
 }
 
-// getOSRootFilePath returns the first file path detected from a list of known CA certificate file paths.
+// GetOSRootFilePath returns the first file path detected from a list of known CA certificate file paths.
 // If none of the known CA certificate files are found, a warning in printed and an empty string is returned.
 // Based on https://github.com/istio/istio/blob/d43c77c71df0150fa904d74bf6520d9e37180a1c/pkg/security/security.go#L463
-func getOSRootFilePath() (string, error) {
+func GetOSRootFilePath() (string, error) {
 	// Get and store the OS CA certificate path for Linux systems
 	// Source of CA File Paths: https://golang.org/src/crypto/x509/root_linux.go
 	certFiles := []string{

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-outlier-detection-zero-interval-out.yaml
@@ -135,8 +135,10 @@ Statuses:
             { } } } } } } name: "placeholder_filter_chain" } } clusters { name: "test-cluster-for-validation"
             type: STATIC connect_timeout { seconds: 5 } outlier_detection { consecutive_5xx
             { value: 5 } interval { } base_ejection_time { seconds: 30 } max_ejection_percent
-            { value: 10 } } } } : Proto constraint validation failed (BootstrapValidationError.StaticResources:
-            embedded message failed validation | caused by StaticResourcesValidationError.Clusters[0]:
+            { value: 10 } } } secrets { name: "SYSTEM_CA_CERT" validation_context
+            { trusted_ca { filename: "/etc/ssl/cert.pem" } } } } : Proto constraint
+            validation failed (BootstrapValidationError.StaticResources: embedded
+            message failed validation | caused by StaticResourcesValidationError.Clusters[0]:
             embedded message failed validation | caused by ClusterValidationError.OutlierDetection:
             embedded message failed validation | caused by OutlierDetectionValidationError.Interval:
             value must be greater than 0s)'

--- a/pkg/xds/bootstrap/builder.go
+++ b/pkg/xds/bootstrap/builder.go
@@ -10,15 +10,22 @@ import (
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoyhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoywellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/proto"
 
+	envoyinit_utils "github.com/kgateway-dev/kgateway/v2/internal/envoyinit/pkg/utils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/envoyinit"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
+var logger = logging.New("configbuilder")
+
 // ConfigBuilder helps construct a partial bootstrap config for validation.
 type ConfigBuilder struct {
+	caPath        string
 	filterConfigs ir.TypedFilterConfigMap
 	routes        []*envoyroutev3.Route
 	clusters      []*envoyclusterv3.Cluster
@@ -27,7 +34,13 @@ type ConfigBuilder struct {
 
 // New creates a new ConfigBuilder.
 func New() *ConfigBuilder {
+	caPath, err := envoyinit.GetOSRootFilePath()
+	if err != nil {
+		logger.Error("Failed to get a supported OS CA certificate path", "error", err)
+	}
+
 	return &ConfigBuilder{
+		caPath:        caPath,
 		filterConfigs: make(ir.TypedFilterConfigMap),
 	}
 }
@@ -98,6 +111,19 @@ func (b *ConfigBuilder) Build() (*envoybootstrapv3.Bootstrap, error) {
 	}
 
 	staticResources := &envoybootstrapv3.Bootstrap_StaticResources{
+		Secrets: []*envoytlsv3.Secret{{
+			Name: envoyinit_utils.SystemCaSecretName,
+			Type: &envoytlsv3.Secret_ValidationContext{
+				ValidationContext: &envoytlsv3.CertificateValidationContext{
+					TrustedCa: &envoycorev3.DataSource{
+						Specifier: &envoycorev3.DataSource_Filename{
+							Filename: b.caPath,
+						},
+					},
+				},
+			},
+		}},
+
 		Listeners: []*envoylistenerv3.Listener{{
 			Name: "placeholder_listener",
 			Address: &envoycorev3.Address{

--- a/pkg/xds/bootstrap/builder.go
+++ b/pkg/xds/bootstrap/builder.go
@@ -36,7 +36,7 @@ type ConfigBuilder struct {
 func New() *ConfigBuilder {
 	caPath, err := envoyinit.GetOSRootFilePath()
 	if err != nil {
-		logger.Error("Failed to get a supported OS CA certificate path", "error", err)
+		logger.Error("failed to get a supported OS CA certificate path", "error", err)
 	}
 
 	return &ConfigBuilder{

--- a/pkg/xds/bootstrap/builder.go
+++ b/pkg/xds/bootstrap/builder.go
@@ -111,19 +111,6 @@ func (b *ConfigBuilder) Build() (*envoybootstrapv3.Bootstrap, error) {
 	}
 
 	staticResources := &envoybootstrapv3.Bootstrap_StaticResources{
-		Secrets: []*envoytlsv3.Secret{{
-			Name: envoyinit_utils.SystemCaSecretName,
-			Type: &envoytlsv3.Secret_ValidationContext{
-				ValidationContext: &envoytlsv3.CertificateValidationContext{
-					TrustedCa: &envoycorev3.DataSource{
-						Specifier: &envoycorev3.DataSource_Filename{
-							Filename: b.caPath,
-						},
-					},
-				},
-			},
-		}},
-
 		Listeners: []*envoylistenerv3.Listener{{
 			Name: "placeholder_listener",
 			Address: &envoycorev3.Address{
@@ -147,6 +134,20 @@ func (b *ConfigBuilder) Build() (*envoybootstrapv3.Bootstrap, error) {
 	}
 	if len(b.clusters) > 0 {
 		staticResources.Clusters = b.clusters
+	}
+	if b.caPath != "" {
+		staticResources.Secrets = []*envoytlsv3.Secret{{
+			Name: envoyinit_utils.SystemCaSecretName,
+			Type: &envoytlsv3.Secret_ValidationContext{
+				ValidationContext: &envoytlsv3.CertificateValidationContext{
+					TrustedCa: &envoycorev3.DataSource{
+						Specifier: &envoycorev3.DataSource_Filename{
+							Filename: b.caPath,
+						},
+					},
+				},
+			},
+		}}
 	}
 
 	return &envoybootstrapv3.Bootstrap{


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
This PR updates the strict Envoy validation bootstrap generation to include a system CA certificate secret, and exposes the OS CA bundle path helper so it can be reused outside the envoyinit runtime.

This should suffice since kgateway only supports the System cert pool right now
https://github.com/kgateway-dev/kgateway/blob/e6fac1824d1c4035c30072394acb9e60143528f6/api/v1alpha1/kgateway/backend_config_policy_types.go#L298-L302

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix a bug in strict validation of backends
```

