### PR TITLE
fix(translator): add nil check for backend.Backend in setRouteAction

### DIFF
--- a/pkg/kgateway/translator/httproute/gateway_http_route_translator.go
+++ b/pkg/kgateway/translator/httproute/gateway_http_route_translator.go
@@ -210,13 +210,18 @@ func setRouteAction(
 			continue
 		}
 
+		if backend.Backend == nil {
+			logger.Warn("unexpected nil backend, skipping")
+			continue
+		}
+
 		if err := backend.Backend.Err; err != nil {
 			query.ProcessBackendError(err, reporter)
 			logger.Debug("error on backend upstream", "error", err)
 		}
 
 		httpBackend := ir.HttpBackend{
-			Backend:          *backend.Backend, // TODO: Nil check?
+			Backend:          *backend.Backend,
 			AttachedPolicies: backend.AttachedPolicies,
 		}
 		outputRoute.Backends = append(outputRoute.Backends, httpBackend)


### PR DESCRIPTION
## Description                                                                                                                                                                                                      
                                                            
  Fixes a potential nil pointer dereference in `setRouteAction()` at `pkg/kgateway/translator/httproute/gateway_http_route_translator.go:219`.                                                                        
                                                            
  The `HttpBackendOrDelegate.Backend` field is a pointer (`*BackendRefIR`) and can be nil. The code previously accessed `backend.Backend.Err` and dereferenced `*backend.Backend` without a nil guard, which would    
  cause the controller to panic if `Backend` was nil.       
                                                                                                                                                                                                                      
  The existing `// TODO: Nil check?` comment at line 219 confirms this was a known gap. Other code paths (e.g., `backend_variants.go:143`) already handle this condition defensively.                                 
   
  **What changed:**                                                                                                                                                                                                   
  - Added a nil check for `backend.Backend` with a warning log before accessing the field
  - Removed the resolved `// TODO: Nil check?` comment                                                                                                                                                                
                                                                                                                                                                                                                      
  While current production code paths always populate `Backend` with a non-nil pointer, this fix prevents a latent defect from becoming a crash if future code changes introduce a nil `Backend`.                     
 
## Fixes #14040 
                                                                                                                                                                                                                      
  ## Change Type                                                                                                                                                                                                      
                                                            
  /kind fix                                                                                                                                                                                                           
                                                            
  ## Changelog                                                                                                                                                                                                        
                                                            
  ```release-note                                                                                                                                                                                                     
  fix: add nil check for backend.Backend in HTTP route translator to prevent potential controller panic
                                                                                                                                                                                                                      
  Additional Notes                                                                                                                                                                                                    
                                                                                                                                                                                                                      
  - The gateway/translator test suite has a pre-existing failure unrelated to this change (confirmed by testing on clean main)                                                                                        
  - Follows the same defensive pattern used in backend_variants.go:143