### PR TITLE
feat: improve HTTPRoute rejection condition messages

### DIFF
--- a/pkg/kgateway/translator/gateway/gateway_translator.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator.go
@@ -79,10 +79,10 @@ func (t *translator) Translate(
 
 	for _, rErr := range routesForGw.RouteErrors {
 		reporter.Route(rErr.Route.GetSourceObject()).ParentRef(&rErr.ParentRef).SetCondition(reports.RouteCondition{
-			Type:   gwv1.RouteConditionAccepted,
-			Status: metav1.ConditionFalse,
-			Reason: rErr.Error.Reason,
-			// TODO message
+			Type:    gwv1.RouteConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  rErr.Error.Reason,
+			Message: rErr.Error.E.Error(),
 		})
 	}
 

--- a/pkg/kgateway/translator/gateway/gateway_translator.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator.go
@@ -78,11 +78,15 @@ func (t *translator) Translate(
 	}
 
 	for _, rErr := range routesForGw.RouteErrors {
+		message := string(rErr.Error.Reason)
+		if rErr.Error.E != nil {
+			message = rErr.Error.E.Error()
+		}
 		reporter.Route(rErr.Route.GetSourceObject()).ParentRef(&rErr.ParentRef).SetCondition(reports.RouteCondition{
 			Type:    gwv1.RouteConditionAccepted,
 			Status:  metav1.ConditionFalse,
 			Reason:  rErr.Error.Reason,
-			Message: rErr.Error.E.Error(),
+			Message: message,
 		})
 	}
 

--- a/pkg/kgateway/translator/gateway/status_test.go
+++ b/pkg/kgateway/translator/gateway/status_test.go
@@ -1,10 +1,15 @@
 package gateway_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
@@ -32,4 +37,41 @@ func TestStatuses(t *testing.T) {
 			settingOpt,
 		)
 	})
+}
+
+// TestRouteRejectionConditionHasMessage verifies that when an HTTPRoute is rejected
+// (e.g. its sectionName doesn't match any listener), the Accepted=False condition
+// includes a non-empty message so operators can diagnose the problem via kubectl.
+func TestRouteRejectionConditionHasMessage(t *testing.T) {
+	dir := fsutils.MustGetThisDir()
+	gwNN := types.NamespacedName{Namespace: "default", Name: "example-gateway"}
+
+	tc := translatortest.TestCase{
+		InputFiles: []string{
+			filepath.Join(dir, "testutils/inputs/status/route-rejection.yaml"),
+		},
+	}
+	scheme := translatortest.NewScheme(translatortest.ExtraConfig{}.Schemes)
+	results, err := tc.Run(t, context.Background(), scheme, translatortest.ExtraConfig{})
+	require.NoError(t, err)
+	require.Contains(t, results, gwNN)
+
+	reportsMap := results[gwNN].ReportsMap
+	routeNN := types.NamespacedName{Namespace: "default", Name: "rejected-route"}
+	routeReport := reportsMap.HTTPRoutes[routeNN]
+	require.NotNil(t, routeReport, "expected a route report for rejected-route")
+
+	// Find any Accepted=False condition across all parent refs and assert it has a message.
+	var acceptedCond *metav1.Condition
+	for _, parentReport := range routeReport.Parents {
+		for i := range parentReport.Conditions {
+			c := &parentReport.Conditions[i]
+			if c.Type == string(gwv1.RouteConditionAccepted) && c.Status == metav1.ConditionFalse {
+				acceptedCond = c
+				break
+			}
+		}
+	}
+	require.NotNil(t, acceptedCond, "expected an Accepted=False condition for the rejected route")
+	assert.NotEmpty(t, acceptedCond.Message, "Accepted=False condition must include a message explaining why the route was rejected")
 }

--- a/pkg/kgateway/translator/gateway/testutils/inputs/status/route-rejection.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/status/route-rejection.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: default
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rejected-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: example-gateway
+    sectionName: nonexistent-listener
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80


### PR DESCRIPTION
# Description

Improve HTTPRoute rejection condition messages by populating the `message` field for rejected routes instead of returning empty status messages.

This helps operators quickly understand why a route was rejected directly from the resource status.

# Change Type

/kind fix

# Changelog

```release-note
Improved HTTPRoute rejection status messages by populating condition messages for rejected routes.
```