### PR TITLE
Gateway Curls for Route Delegation e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,13 @@ test: ## Run all tests with ginkgo, or only run the test package at {TEST_PKG} i
 # will still have e2e tests run by Github Actions once they publish a pull
 # request.
 # CLUSTER_TYPE controls whether images are loaded via kind or k3d (default: kind)
+#
+# k3d note: under k3d, LB IPs are not host-reachable, so e2e tests use
+# GATEWAY_ADDRESS_OVERRIDE (e.g. "localhost") to direct curls to a port-forwarded
+# address. This override is honored only for the base gateway resolved by
+# common.SetupBaseGateway; multi-gateway suites that construct their own
+# common.Gateway values cannot disambiguate multiple gateways with a single env
+# var and are therefore out of scope under k3d.
 CLUSTER_TYPE ?= kind
 
 .PHONY: cluster-load-extproc-server

--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -771,6 +771,9 @@ main() {
         echo "  CLUSTER_TYPE=${CLUSTER_TYPE}"
         echo "  CLUSTER_NAME=${CLUSTER_NAME}"
         if [[ "$CLUSTER_TYPE" == "k3d" ]]; then
+            # GATEWAY_ADDRESS_OVERRIDE only affects the base gateway resolved via
+            # common.SetupBaseGateway; multi-gateway suites that construct their own
+            # common.Gateway values do not honor it and are out of scope under k3d.
             echo "  GATEWAY_ADDRESS_OVERRIDE=${GATEWAY_ADDRESS_OVERRIDE:-localhost}"
         fi
         if is_truthy PERSIST_INSTALL; then

--- a/test/e2e/common/base.go
+++ b/test/e2e/common/base.go
@@ -3,23 +3,15 @@
 package common
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"io"
-	"net"
 	"os"
 	"testing"
-	"time"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/util/assert"
-	"istio.io/istio/pkg/test/util/retry"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
-	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 )
 
 func SetupBaseConfig(ctx context.Context, t *testing.T, installation *e2e.TestInstallation, manifests ...string) {
@@ -53,108 +45,4 @@ func SetupBaseGateway(ctx context.Context, t *testing.T, installation *e2e.TestI
 	}
 }
 
-// Gateway is a curl-able handle for a Gateway resource. Address is the literal value used by
-// curl — callers populate it however they like (LB IP, in-cluster DNS, port-forward, etc.).
-// GATEWAY_ADDRESS_OVERRIDE is applied only by SetupBaseGateway; direct constructions of this type
-// do not consult it.
-type Gateway struct {
-	types.NamespacedName
-	Address string
-}
-
 var BaseGateway Gateway
-
-// Defaults for SendConsistently — mirror assertions.AssertEventuallyConsistentCurlResponse.
-const (
-	defaultConsistencyWindow = 3 * time.Second
-	defaultConsistencyPoll   = 1 * time.Second
-)
-
-// Send curls the gateway and waits until the response matches.
-func (g *Gateway) Send(t *testing.T, match *matchers.HttpResponse, opts ...curl.Option) {
-	t.Helper()
-	g.SendWithRetry(t, match, nil, opts...)
-}
-
-// SendWithRetry curls the gateway with caller-supplied retry options
-// (e.g. retry.Timeout, retry.Delay) for controlling the eventual-match behavior.
-func (g *Gateway) SendWithRetry(t *testing.T, match *matchers.HttpResponse, retryOpts []retry.Option, opts ...curl.Option) {
-	t.Helper()
-	fullOpts := g.curlOpts(opts)
-	retry.UntilSuccessOrFail(t, func() error {
-		return g.matchOnce(fullOpts, match)
-	}, retryOpts...)
-}
-
-// SendConsistently curls the gateway, waits for the response to eventually match,
-// then asserts the response continues to match over a 3s window polled every 1s.
-// Mirrors assertions.AssertEventuallyConsistentCurlResponse semantics.
-func (g *Gateway) SendConsistently(t *testing.T, match *matchers.HttpResponse, opts ...curl.Option) {
-	t.Helper()
-	g.SendConsistentlyFor(t, match, defaultConsistencyWindow, defaultConsistencyPoll, opts...)
-}
-
-// SendConsistentlyFor is SendConsistently with caller-supplied window and polling interval.
-// Any divergence within the window fails the test (no per-iteration retries).
-func (g *Gateway) SendConsistentlyFor(t *testing.T, match *matchers.HttpResponse, window, poll time.Duration, opts ...curl.Option) {
-	t.Helper()
-	if poll <= 0 {
-		t.Fatalf("SendConsistentlyFor: poll interval must be positive, got %v", poll)
-	}
-	g.Send(t, match, opts...)
-
-	fullOpts := g.curlOpts(opts)
-	windowTimer := time.NewTimer(window)
-	defer windowTimer.Stop()
-	ticker := time.NewTicker(poll)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-windowTimer.C:
-			return
-		case <-ticker.C:
-			if err := g.matchOnce(fullOpts, match); err != nil {
-				t.Fatalf("response did not consistently match within %v: %v", window, err)
-			}
-		}
-	}
-}
-
-// matchOnce executes a single curl and returns an error if the response does not match.
-// The body is buffered before matching so it can be included in failure diagnostics
-// (the underlying gomega HaveHttpResponse matcher does not print the actual body —
-// see test/gomega/matchers/have_http_response.go).
-func (g *Gateway) matchOnce(fullOpts []curl.Option, match *matchers.HttpResponse) error {
-	r, err := curl.ExecuteRequest(fullOpts...)
-	if err != nil {
-		return err
-	}
-	defer r.Body.Close()
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("reading response body: %w", err)
-	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
-
-	mm := matchers.HaveHttpResponse(match)
-	success, matchErr := mm.Match(r)
-	if matchErr != nil {
-		return matchErr
-	}
-	if !success {
-		return fmt.Errorf("%s\nactual: status=%d body=%q", mm.FailureMessage(r), r.StatusCode, string(body))
-	}
-	return nil
-}
-
-func (g *Gateway) curlOpts(opts []curl.Option) []curl.Option {
-	var hostOpt curl.Option
-	if _, _, err := net.SplitHostPort(g.Address); err == nil {
-		hostOpt = curl.WithHostPort(g.Address)
-	} else {
-		hostOpt = curl.WithHost(g.Address)
-	}
-	return append([]curl.Option{hostOpt}, opts...)
-}

--- a/test/e2e/common/base.go
+++ b/test/e2e/common/base.go
@@ -30,14 +30,20 @@ func SetupBaseConfig(ctx context.Context, t *testing.T, installation *e2e.TestIn
 	assert.NoError(t, err)
 }
 
+// SetupBaseGateway resolves the LB address for the named Gateway and stores it in BaseGateway.
+//
+// GATEWAY_ADDRESS_OVERRIDE: when set, overrides the resolved address. This exists to support
+// environments where the LB IP is not directly reachable from the host (e.g., k3d on macOS using
+// port mapping). The override is applied ONLY here — single-gateway suites that use BaseGateway
+// pick it up automatically. Suites that construct their own common.Gateway values (e.g.,
+// multi-gateway suites that need more than one address) do NOT honor the override, since a single
+// env var cannot disambiguate multiple gateways. Running such suites under k3d is out of scope.
 func SetupBaseGateway(ctx context.Context, t *testing.T, installation *e2e.TestInstallation, name types.NamespacedName) {
 	address := installation.AssertionsT(t).EventuallyGatewayAddress(
 		ctx,
 		name.Name,
 		name.Namespace,
 	)
-	// Allow overriding the gateway address for environments where the LB IP
-	// is not directly reachable from the host (e.g., k3d on macOS using port mapping).
 	if override := os.Getenv("GATEWAY_ADDRESS_OVERRIDE"); override != "" {
 		address = override
 	}
@@ -47,6 +53,10 @@ func SetupBaseGateway(ctx context.Context, t *testing.T, installation *e2e.TestI
 	}
 }
 
+// Gateway is a curl-able handle for a Gateway resource. Address is the literal value used by
+// curl — callers populate it however they like (LB IP, in-cluster DNS, port-forward, etc.).
+// GATEWAY_ADDRESS_OVERRIDE is applied only by SetupBaseGateway; direct constructions of this type
+// do not consult it.
 type Gateway struct {
 	types.NamespacedName
 	Address string

--- a/test/e2e/common/base.go
+++ b/test/e2e/common/base.go
@@ -88,18 +88,26 @@ func (g *Gateway) SendConsistently(t *testing.T, match *matchers.HttpResponse, o
 // Any divergence within the window fails the test (no per-iteration retries).
 func (g *Gateway) SendConsistentlyFor(t *testing.T, match *matchers.HttpResponse, window, poll time.Duration, opts ...curl.Option) {
 	t.Helper()
+	if poll <= 0 {
+		t.Fatalf("SendConsistentlyFor: poll interval must be positive, got %v", poll)
+	}
 	g.Send(t, match, opts...)
 
 	fullOpts := g.curlOpts(opts)
-	deadline := time.Now().Add(window)
+	windowTimer := time.NewTimer(window)
+	defer windowTimer.Stop()
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
 	for {
-		if err := g.matchOnce(fullOpts, match); err != nil {
-			t.Fatalf("response did not consistently match within %v: %v", window, err)
-		}
-		if !time.Now().Before(deadline) {
+		select {
+		case <-windowTimer.C:
 			return
+		case <-ticker.C:
+			if err := g.matchOnce(fullOpts, match); err != nil {
+				t.Fatalf("response did not consistently match within %v: %v", window, err)
+			}
 		}
-		time.Sleep(poll)
 	}
 }
 

--- a/test/e2e/common/base.go
+++ b/test/e2e/common/base.go
@@ -3,11 +3,14 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/util/assert"
@@ -51,28 +54,89 @@ type Gateway struct {
 
 var BaseGateway Gateway
 
+// Defaults for SendConsistently — mirror assertions.AssertEventuallyConsistentCurlResponse.
+const (
+	defaultConsistencyWindow = 3 * time.Second
+	defaultConsistencyPoll   = 1 * time.Second
+)
+
+// Send curls the gateway and waits until the response matches.
 func (g *Gateway) Send(t *testing.T, match *matchers.HttpResponse, opts ...curl.Option) {
+	t.Helper()
+	g.SendWithRetry(t, match, nil, opts...)
+}
+
+// SendWithRetry curls the gateway with caller-supplied retry options
+// (e.g. retry.Timeout, retry.Delay) for controlling the eventual-match behavior.
+func (g *Gateway) SendWithRetry(t *testing.T, match *matchers.HttpResponse, retryOpts []retry.Option, opts ...curl.Option) {
+	t.Helper()
+	fullOpts := g.curlOpts(opts)
+	retry.UntilSuccessOrFail(t, func() error {
+		return g.matchOnce(fullOpts, match)
+	}, retryOpts...)
+}
+
+// SendConsistently curls the gateway, waits for the response to eventually match,
+// then asserts the response continues to match over a 3s window polled every 1s.
+// Mirrors assertions.AssertEventuallyConsistentCurlResponse semantics.
+func (g *Gateway) SendConsistently(t *testing.T, match *matchers.HttpResponse, opts ...curl.Option) {
+	t.Helper()
+	g.SendConsistentlyFor(t, match, defaultConsistencyWindow, defaultConsistencyPoll, opts...)
+}
+
+// SendConsistentlyFor is SendConsistently with caller-supplied window and polling interval.
+// Any divergence within the window fails the test (no per-iteration retries).
+func (g *Gateway) SendConsistentlyFor(t *testing.T, match *matchers.HttpResponse, window, poll time.Duration, opts ...curl.Option) {
+	t.Helper()
+	g.Send(t, match, opts...)
+
+	fullOpts := g.curlOpts(opts)
+	deadline := time.Now().Add(window)
+	for {
+		if err := g.matchOnce(fullOpts, match); err != nil {
+			t.Fatalf("response did not consistently match within %v: %v", window, err)
+		}
+		if !time.Now().Before(deadline) {
+			return
+		}
+		time.Sleep(poll)
+	}
+}
+
+// matchOnce executes a single curl and returns an error if the response does not match.
+// The body is buffered before matching so it can be included in failure diagnostics
+// (the underlying gomega HaveHttpResponse matcher does not print the actual body —
+// see test/gomega/matchers/have_http_response.go).
+func (g *Gateway) matchOnce(fullOpts []curl.Option, match *matchers.HttpResponse) error {
+	r, err := curl.ExecuteRequest(fullOpts...)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("reading response body: %w", err)
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	mm := matchers.HaveHttpResponse(match)
+	success, matchErr := mm.Match(r)
+	if matchErr != nil {
+		return matchErr
+	}
+	if !success {
+		return fmt.Errorf("%s\nactual: status=%d body=%q", mm.FailureMessage(r), r.StatusCode, string(body))
+	}
+	return nil
+}
+
+func (g *Gateway) curlOpts(opts []curl.Option) []curl.Option {
 	var hostOpt curl.Option
 	if _, _, err := net.SplitHostPort(g.Address); err == nil {
 		hostOpt = curl.WithHostPort(g.Address)
 	} else {
 		hostOpt = curl.WithHost(g.Address)
 	}
-	fullOpts := append([]curl.Option{hostOpt}, opts...)
-	retry.UntilSuccessOrFail(t, func() error {
-		r, err := curl.ExecuteRequest(fullOpts...)
-		if err != nil {
-			return err
-		}
-		defer r.Body.Close()
-		mm := matchers.HaveHttpResponse(match)
-		success, err := mm.Match(r)
-		if err != nil {
-			return err
-		}
-		if !success {
-			return fmt.Errorf("match failed: %v", mm.FailureMessage(r))
-		}
-		return nil
-	})
+	return append([]curl.Option{hostOpt}, opts...)
 }

--- a/test/e2e/common/gateway.go
+++ b/test/e2e/common/gateway.go
@@ -1,0 +1,122 @@
+//go:build e2e
+
+package common
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/util/retry"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
+)
+
+// Gateway is a curl-able handle for a Gateway resource. Address is the literal value used by
+// curl — callers populate it however they like (LB IP, in-cluster DNS, port-forward, etc.).
+// GATEWAY_ADDRESS_OVERRIDE is applied only by SetupBaseGateway; direct constructions of this type
+// do not consult it.
+type Gateway struct {
+	types.NamespacedName
+	Address string
+}
+
+// Defaults for SendConsistently — mirror assertions.AssertEventuallyConsistentCurlResponse.
+const (
+	defaultConsistencyWindow = 3 * time.Second
+	defaultConsistencyPoll   = 1 * time.Second
+)
+
+// Send curls the gateway and waits until the response matches.
+func (g *Gateway) Send(t *testing.T, match *matchers.HttpResponse, opts ...curl.Option) {
+	t.Helper()
+	g.SendWithRetry(t, match, nil, opts...)
+}
+
+// SendWithRetry curls the gateway with caller-supplied retry options
+// (e.g. retry.Timeout, retry.Delay) for controlling the eventual-match behavior.
+func (g *Gateway) SendWithRetry(t *testing.T, match *matchers.HttpResponse, retryOpts []retry.Option, opts ...curl.Option) {
+	t.Helper()
+	fullOpts := g.curlOpts(opts)
+	retry.UntilSuccessOrFail(t, func() error {
+		return g.matchOnce(fullOpts, match)
+	}, retryOpts...)
+}
+
+// SendConsistently curls the gateway, waits for the response to eventually match,
+// then asserts the response continues to match over a 3s window polled every 1s.
+// Mirrors assertions.AssertEventuallyConsistentCurlResponse semantics.
+func (g *Gateway) SendConsistently(t *testing.T, match *matchers.HttpResponse, opts ...curl.Option) {
+	t.Helper()
+	g.SendConsistentlyFor(t, match, defaultConsistencyWindow, defaultConsistencyPoll, opts...)
+}
+
+// SendConsistentlyFor is SendConsistently with caller-supplied window and polling interval.
+// Any divergence within the window fails the test (no per-iteration retries).
+func (g *Gateway) SendConsistentlyFor(t *testing.T, match *matchers.HttpResponse, window, poll time.Duration, opts ...curl.Option) {
+	t.Helper()
+	if poll <= 0 {
+		t.Fatalf("SendConsistentlyFor: poll interval must be positive, got %v", poll)
+	}
+	g.Send(t, match, opts...)
+
+	fullOpts := g.curlOpts(opts)
+	windowTimer := time.NewTimer(window)
+	defer windowTimer.Stop()
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-windowTimer.C:
+			return
+		case <-ticker.C:
+			if err := g.matchOnce(fullOpts, match); err != nil {
+				t.Fatalf("response did not consistently match within %v: %v", window, err)
+			}
+		}
+	}
+}
+
+// matchOnce executes a single curl and returns an error if the response does not match.
+// The body is buffered before matching so it can be included in failure diagnostics
+// (the underlying gomega HaveHttpResponse matcher does not print the actual body —
+// see test/gomega/matchers/have_http_response.go).
+func (g *Gateway) matchOnce(fullOpts []curl.Option, match *matchers.HttpResponse) error {
+	r, err := curl.ExecuteRequest(fullOpts...)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("reading response body: %w", err)
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	mm := matchers.HaveHttpResponse(match)
+	success, matchErr := mm.Match(r)
+	if matchErr != nil {
+		return matchErr
+	}
+	if !success {
+		return fmt.Errorf("%s\nactual: status=%d body=%q", mm.FailureMessage(r), r.StatusCode, string(body))
+	}
+	return nil
+}
+
+func (g *Gateway) curlOpts(opts []curl.Option) []curl.Option {
+	var hostOpt curl.Option
+	if _, _, err := net.SplitHostPort(g.Address); err == nil {
+		hostOpt = curl.WithHostPort(g.Address)
+	} else {
+		hostOpt = curl.WithHost(g.Address)
+	}
+	return append([]curl.Option{hostOpt}, opts...)
+}

--- a/test/e2e/features/route_delegation/suite.go
+++ b/test/e2e/features/route_delegation/suite.go
@@ -87,9 +87,10 @@ func (s *testingSuite) SetupSuite() {
 	}
 }
 
-// setupTestGateway resolves the secondary gateway used only by
-// TestInvalidChildValidStandalone. Called lazily so other tests don't pay the wait.
-func (s *testingSuite) setupTestGateway() {
+// resolveTestGateway looks up the LB address for the secondary gateway used only
+// by TestInvalidChildValidStandalone. Called lazily so other tests don't pay the
+// wait — the Gateway itself is created by that test's per-test manifest.
+func (s *testingSuite) resolveTestGateway() {
 	addr := s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayAddress(s.Ctx, proxyTestMeta.Name, proxyTestMeta.Namespace)
 	s.testGateway = common.Gateway{
 		NamespacedName: types.NamespacedName{Name: proxyTestMeta.Name, Namespace: proxyTestMeta.Namespace},
@@ -201,7 +202,7 @@ func (s *testingSuite) TestMultipleParents() {
 }
 
 func (s *testingSuite) TestInvalidChildValidStandalone() {
-	s.setupTestGateway()
+	s.resolveTestGateway()
 
 	// Assert traffic to team1 route
 	s.testGateway.SendConsistently(s.T(),

--- a/test/e2e/features/route_delegation/suite.go
+++ b/test/e2e/features/route_delegation/suite.go
@@ -4,17 +4,19 @@ package route_delegation
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	. "github.com/onsi/gomega"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
-	"github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
 	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 )
@@ -23,7 +25,7 @@ var _ e2e.NewSuiteFunc = NewTestingSuite
 
 var (
 	setup = base.TestCase{
-		Manifests: []string{defaults.CurlPodManifest, commonManifest},
+		Manifests: []string{commonManifest},
 	}
 
 	testCases = map[string]*base.TestCase{
@@ -65,42 +67,64 @@ var (
 
 type testingSuite struct {
 	*base.BaseTestingSuite
+	gateway     common.Gateway
+	testGateway common.Gateway
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+	}
+}
+
+func (s *testingSuite) SetupSuite() {
+	s.BaseTestingSuite.SetupSuite()
+
+	addr := s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayAddress(s.Ctx, proxyMeta.Name, proxyMeta.Namespace)
+	s.gateway = common.Gateway{
+		NamespacedName: types.NamespacedName{Name: proxyMeta.Name, Namespace: proxyMeta.Namespace},
+		Address:        fmt.Sprintf("%s:%d", addr, gatewayPort),
+	}
+}
+
+// setupTestGateway resolves the secondary gateway used only by
+// TestInvalidChildValidStandalone. Called lazily so other tests don't pay the wait.
+func (s *testingSuite) setupTestGateway() {
+	addr := s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayAddress(s.Ctx, proxyTestMeta.Name, proxyTestMeta.Namespace)
+	s.testGateway = common.Gateway{
+		NamespacedName: types.NamespacedName{Name: proxyTestMeta.Name, Namespace: proxyTestMeta.Namespace},
+		Address:        fmt.Sprintf("%s:%d", addr, gatewayTestPort),
 	}
 }
 
 func (s *testingSuite) TestBasic() {
 	// Assert traffic to team1 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1))
 
 	// Assert traffic to team2 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)},
+		curl.WithPath(pathTeam2))
 }
 
 func (s *testingSuite) TestRecursive() {
 	// Assert traffic to team1 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1))
 
 	// Assert traffic to team2 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)},
+		curl.WithPath(pathTeam2))
 }
 
 func (s *testingSuite) TestCyclic() {
 	// Assert traffic to team1 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1))
 
 	// Assert traffic to team2 route fails with HTTP 500 as it is a cyclic route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError},
+		curl.WithPath(pathTeam2))
 
 	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPRouteStatusContainsMessage(s.Ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"cyclic reference detected", 10*time.Second, 1*time.Second)
@@ -108,12 +132,12 @@ func (s *testingSuite) TestCyclic() {
 
 func (s *testingSuite) TestInvalidChild() {
 	// Assert traffic to team1 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1))
 
 	// Assert traffic to team2 route fails with HTTP 500 as the route is invalid due to specifying a hostname on the child route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt, []curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
-		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
+	s.gateway.SendConsistently(s.T(), &testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError},
+		curl.WithPath(pathTeam2))
 
 	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPRouteStatusContainsMessage(s.Ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"spec.hostnames must be unset", 10*time.Second, 1*time.Second)
@@ -121,99 +145,84 @@ func (s *testingSuite) TestInvalidChild() {
 
 func (s *testingSuite) TestHeaderQueryMatch() {
 	// Assert traffic to team1 route with matching header and query parameters
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1),
-			curl.WithHeader("header1", "val1"),
-			curl.WithHeader("headerX", "valX"),
-			curl.WithQueryParameters(map[string]string{"query1": "val1", "queryX": "valX"}),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1),
+		curl.WithHeader("header1", "val1"),
+		curl.WithHeader("headerX", "valX"),
+		curl.WithQueryParameters(map[string]string{"query1": "val1", "queryX": "valX"}),
+	)
 
 	// Assert traffic to team2 child route fails with HTTP 404 as it does not match the parent's header and query parameters
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2),
-			curl.WithHeader("headerX", "valX"),
-			curl.WithQueryParameters(map[string]string{"queryX": "valX"}),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound},
+		curl.WithPath(pathTeam2),
+		curl.WithHeader("headerX", "valX"),
+		curl.WithQueryParameters(map[string]string{"queryX": "valX"}),
+	)
 
 	// Assert traffic to team2 parent route fails with HTTP 500 due to unresolved child route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2),
-			curl.WithHeader("header2", "val2"),
-			curl.WithQueryParameters(map[string]string{"query2": "val2"}),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError},
+		curl.WithPath(pathTeam2),
+		curl.WithHeader("header2", "val2"),
+		curl.WithQueryParameters(map[string]string{"query2": "val2"}),
+	)
 }
 
 func (s *testingSuite) TestMultipleParents() {
 	// Assert traffic to parent1.com/anything/team1
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam1),
-			curl.WithHostHeader(routeParent1Host),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1),
+		curl.WithHostHeader(routeParent1Host),
+	)
 
 	// Assert traffic to parent1.com/anything/team2
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam2),
-			curl.WithHostHeader(routeParent1Host),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)},
+		curl.WithPath(pathTeam2),
+		curl.WithHostHeader(routeParent1Host),
+	)
 
 	// Assert traffic to parent2.com/anything/team1
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam1),
-			curl.WithHostHeader(routeParent2Host),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1),
+		curl.WithHostHeader(routeParent2Host),
+	)
 
 	// Assert traffic to parent2.com/anything/team2 fails as it is not selected by parent2 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam2),
-			curl.WithHostHeader(routeParent2Host),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError},
+		curl.WithPath(pathTeam2),
+		curl.WithHostHeader(routeParent2Host),
+	)
 }
 
 func (s *testingSuite) TestInvalidChildValidStandalone() {
+	s.setupTestGateway()
+
 	// Assert traffic to team1 route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyTestHostPort),
-			curl.WithPath(pathTeam1),
-			curl.WithHostHeader(routeParentHost),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)})
+	s.testGateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam1)},
+		curl.WithPath(pathTeam1),
+		curl.WithHostHeader(routeParentHost),
+	)
 
 	// Assert traffic to team2 route on parent hostname fails with HTTP 500 as the route is invalid due to specifying a hostname on the child route
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyTestHostPort),
-			curl.WithPath(pathTeam2),
-			curl.WithHostHeader(routeParentHost),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError})
+	s.testGateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusInternalServerError},
+		curl.WithPath(pathTeam2),
+		curl.WithHostHeader(routeParentHost),
+	)
 
 	// Assert traffic to team2 route on standalone host succeeds
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyTestHostPort),
-			curl.WithPath(pathTeam2),
-			curl.WithHostHeader(routeTeam2Host),
-		},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
+	s.testGateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)},
+		curl.WithPath(pathTeam2),
+		curl.WithHostHeader(routeTeam2Host),
+	)
 
 	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPRouteStatusContainsMessage(s.Ctx, routeTeam2.Name, routeTeam2.Namespace,
 		"spec.hostnames must be unset", 10*time.Second, 1*time.Second)
@@ -234,98 +243,90 @@ func (s *testingSuite) TestMatcherInheritance() {
 		string(gwv1.RouteReasonAccepted), 10*time.Second, 1*time.Second)
 
 	// Assert traffic on parent1's prefix
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath("/anything/foo/child")},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring("/anything/foo/child")})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring("/anything/foo/child")},
+		curl.WithPath("/anything/foo/child"))
 
 	// Assert traffic on parent2's prefix
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath("/anything/baz/child")},
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring("/anything/baz/child")})
+	s.gateway.SendConsistently(s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring("/anything/baz/child")},
+		curl.WithPath("/anything/baz/child"))
 }
 
 func (s *testingSuite) TestRouteWeight() {
 	// Assert traffic to /anything path prefix is always routed to svc1
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam1)},
+	s.gateway.SendConsistently(s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
 			Body:       ContainSubstring(pathTeam1),
 			Headers: map[string]any{
 				"origin": "svc1",
 			},
-		})
+		},
+		curl.WithPath(pathTeam1))
 	// Assert traffic to /anything/team2 is also routed to svc1 since its route has higher weight
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{curl.WithHostPort(proxyHostPort), curl.WithPath(pathTeam2)},
+	s.gateway.SendConsistently(s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
 			Body:       ContainSubstring(pathTeam2),
 			Headers: map[string]any{
 				"origin": "svc1",
 			},
-		})
+		},
+		curl.WithPath(pathTeam2))
 }
 
 func (s *testingSuite) TestPolicyMerging() {
 	s.T().Skip("skipping. See https://github.com/kgateway-dev/kgateway/issues/13314 for details")
 	// Assert traffic to parent1.com/anything/team1 uses svc1's transformation policy
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam1),
-			curl.WithHostHeader(routeParent1Host),
-		},
+	s.gateway.SendConsistently(s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
 			Body:       ContainSubstring(pathTeam1),
 			Headers: map[string]any{
 				"origin": "svc1",
 			},
-		})
+		},
+		curl.WithPath(pathTeam1),
+		curl.WithHostHeader(routeParent1Host),
+	)
 
 	// Assert traffic to parent1.com/anything/team2 uses svc2's transformation policy
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam2),
-			curl.WithHostHeader(routeParent1Host),
-		},
+	s.gateway.SendConsistently(s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
 			Body:       ContainSubstring(pathTeam2),
 			Headers: map[string]any{
 				"origin": "svc2",
 			},
-		})
+		},
+		curl.WithPath(pathTeam2),
+		curl.WithHostHeader(routeParent1Host),
+	)
 
 	// Assert traffic to parent2.com/anything/team1 uses parent2's transformation policy
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam1),
-			curl.WithHostHeader(routeParent2Host),
-		},
+	s.gateway.SendConsistently(s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
 			Body:       ContainSubstring(pathTeam1),
 			Headers: map[string]any{
 				"origin": "parent2",
 			},
-		})
+		},
+		curl.WithPath(pathTeam1),
+		curl.WithHostHeader(routeParent2Host),
+	)
 
 	// Assert traffic to parent2.com/anything/team2 uses parent2's transformation policy
-	s.TestInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(s.Ctx, defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHostPort(proxyHostPort),
-			curl.WithPath(pathTeam2),
-			curl.WithHostHeader(routeParent2Host),
-		},
+	s.gateway.SendConsistently(s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
 			Body:       ContainSubstring(pathTeam2),
 			Headers: map[string]any{
 				"origin": "parent2",
 			},
-		})
+		},
+		curl.WithPath(pathTeam2),
+		curl.WithHostHeader(routeParent2Host),
+	)
 }

--- a/test/e2e/features/route_delegation/suite.go
+++ b/test/e2e/features/route_delegation/suite.go
@@ -77,6 +77,11 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	}
 }
 
+// This is a multi-gateway suite — TestInvalidChildValidStandalone creates a
+// second Gateway (proxyTestMeta) alongside the primary one. Because both gateways
+// need distinct addresses, this suite does not use common.SetupBaseGateway and
+// therefore does not honor GATEWAY_ADDRESS_OVERRIDE. Running it under k3d (where
+// LB IPs are not host-reachable) is out of scope.
 func (s *testingSuite) SetupSuite() {
 	s.BaseTestingSuite.SetupSuite()
 

--- a/test/e2e/features/route_delegation/types.go
+++ b/test/e2e/features/route_delegation/types.go
@@ -3,10 +3,8 @@
 package route_delegation
 
 import (
-	"fmt"
 	"path/filepath"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -26,8 +24,6 @@ var (
 		Name:      "http-gateway",
 		Namespace: "infra",
 	}
-	proxyService  = &corev1.Service{ObjectMeta: proxyMeta}
-	proxyHostPort = fmt.Sprintf("%s.%s.svc:%d", proxyService.Name, proxyService.Namespace, gatewayPort)
 )
 
 // ref: basic.yaml
@@ -76,9 +72,6 @@ var (
 		Name:      "http-gateway-test",
 		Namespace: "infra",
 	}
-	proxyTestService = &corev1.Service{ObjectMeta: proxyTestMeta}
-
-	proxyTestHostPort = fmt.Sprintf("%s.%s.svc:%d", proxyTestService.Name, proxyTestService.Namespace, gatewayTestPort)
 
 	routeParentHost = "parent.com"
 	routeTeam2Host  = "team2.com"


### PR DESCRIPTION
# Description

* Update route delegation tests to use Gateway for curl instead of Curl Pod
* Add gateway Curl helpers:
  * SendWithRetry - allows defining the retry options used with the existing `retry.UntilSuccessOrFail` call
  * SendConsistently - replacement for `AssertEventuallyConsistentCurlResponse`. Waits until the assertion is true, then validates it remains true. Hard-codes settings to match behavior of `AssertEventuallyConsistentCurlResponse`
  * SendConsistentlyFor - `SendConsistently` that allows configuration of the window and polling interval

# Change Type


```
/kind cleanup
```


# Changelog


```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
