### PR TITLE
Fix xDS TLS env var mismatch in Helm template

### DIFF
--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -139,7 +139,7 @@ spec:
               value: "true"
             {{- end }}
             {{- if .Values.controller.xds.tls.enabled }}
-            - name: KGW_XDS_TLS_ENABLED
+            - name: KGW_XDS_TLS
               value: "true"
             {{- end }}
             - name: POD_NAMESPACE

--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
             - name: KGW_ENABLE_WAYPOINT
               value: "true"
             {{- end }}
-            {{- if .Values.controller.xds.tls.enabled }}
+            {{- if and .Values.controller.xds.tls.enabled (not (and .Values.controller.extraEnv (hasKey .Values.controller.extraEnv "KGW_XDS_TLS"))) }}
             - name: KGW_XDS_TLS
               value: "true"
             {{- end }}

--- a/test/helm/testdata/kgateway/xds-tls-enabled.golden
+++ b/test/helm/testdata/kgateway/xds-tls-enabled.golden
@@ -387,7 +387,7 @@ spec:
               value: "true"
             - name: KGW_GATEWAY_CLASS_PARAMETERS_REFS
               value: "{}"
-            - name: KGW_XDS_TLS_ENABLED
+            - name: KGW_XDS_TLS
               value: "true"
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
# Description

In `v2.3.0`, enabling `controller.xds.tls.enabled` rendered `KGW_XDS_TLS_ENABLED=true` in the controller Deployment. However, the runtime settings parser (`api/settings/settings.go`) reads the `XdsTLS` field via envconfig with `split_words:"true"` under the `KGW` prefix, which maps to `KGW_XDS_TLS` — not `KGW_XDS_TLS_ENABLED`. This mismatch meant xDS TLS was silently left disabled even when correctly configured via Helm values.

This PR:
- Renames the rendered env var from `KGW_XDS_TLS_ENABLED` to `KGW_XDS_TLS` in the Helm Deployment template.
- Adds a guard to skip emitting the chart-managed `KGW_XDS_TLS` when the user already set it via `controller.extraEnv`, preventing duplicate env entries for users who applied the workaround from issue #14049.
- Updates the Helm golden fixture to match the corrected output.

## What changed
- `install/helm/kgateway/templates/deployment.yaml`: renamed env var; added dedup guard.
- `test/helm/testdata/kgateway/xds-tls-enabled.golden`: updated to expect `KGW_XDS_TLS`.

Fixes #14049
# Change Type

/kind fix

```release-note
Fix xDS TLS env var name in Helm chart: `KGW_XDS_TLS_ENABLED` is renamed to `KGW_XDS_TLS` to match the runtime settings key. Users who set `controller.xds.tls.enabled: true` will now have xDS TLS correctly enabled without requiring a manual `extraEnv` workaround.
```