### PR TITLE
bump: Bumps Istio proxy from 1.22.0 to 1.29.2

### DIFF
--- a/.github/workflows/.env/nightly-tests/max_versions.env
+++ b/.github/workflows/.env/nightly-tests/max_versions.env
@@ -1,5 +1,5 @@
 node_version='v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f'
 kubectl_version='v1.35.0'
 kind_version='v0.31.0'
-istio_version='1.25.2'
+istio_version='1.29.2'
 cluster_type='kind'

--- a/.github/workflows/.env/pr-tests/versions.env
+++ b/.github/workflows/.env/pr-tests/versions.env
@@ -1,7 +1,6 @@
 node_version='v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f'
 kubectl_version='v1.35.0'
-# this is critical for the waypoint tests for minimal of 1.25.1,
-# but we might want to look into testing what
-# we can with older istio versions to ensure compat.
-istio_version='1.25.2'
+# Waypoint coverage requires at least 1.25.1; this default tracks the
+# latest supported Istio patch used by autoMtls.
+istio_version='1.29.2'
 cluster_type='kind'

--- a/pkg/deployer/gateway_parameters.go
+++ b/pkg/deployer/gateway_parameters.go
@@ -12,6 +12,9 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 )
 
+// DefaultIstioProxyImageTag is the default Istio proxyv2 image tag used for auto mTLS cert-agent sidecars.
+const DefaultIstioProxyImageTag = "1.29.2"
+
 // Inputs is the set of options used to configure gateway/inference pool deployment.
 type Inputs struct {
 	Dev                      bool
@@ -220,7 +223,7 @@ func defaultGatewayParameters(imageInfo *ImageInfo, omitDefaultSecurityContext b
 						Image: &kgateway.Image{
 							Registry:   new("docker.io/istio"),
 							Repository: new("proxyv2"),
-							Tag:        new("1.22.0"),
+							Tag:        new(DefaultIstioProxyImageTag),
 							PullPolicy: (*corev1.PullPolicy)(new(imageInfo.PullPolicy)),
 						},
 						LogLevel:              new("warning"),

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -493,7 +493,7 @@ spec:
               fieldPath: metadata.namespace
         - name: DISABLE_ENVOY
           value: "true"
-        image: docker.io/istio/docker.io/istio/proxyv2:1.22.0
+        image: docker.io/istio/docker.io/istio/proxyv2:1.29.2
         name: istio-proxy
         resources: {}
         volumeMounts:

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -493,7 +493,7 @@ spec:
               fieldPath: metadata.namespace
         - name: DISABLE_ENVOY
           value: "true"
-        image: docker.io/istio/docker.io/istio/proxyv2:1.29.2
+        image: docker.io/istio/proxyv2:1.29.2
         name: istio-proxy
         resources: {}
         volumeMounts:

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar.yaml
@@ -34,7 +34,8 @@ spec:
     istio:
       istioProxyContainer:
         image:
-          repository: docker.io/istio/proxyv2
+          registry: docker.io/istio
+          repository: proxyv2
           tag: 1.29.2
         istioDiscoveryAddress: istiod.istio-system.svc:15012
         istioMetaMeshId: cluster.local

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar.yaml
@@ -35,7 +35,7 @@ spec:
       istioProxyContainer:
         image:
           repository: docker.io/istio/proxyv2
-          tag: 1.22.0
+          tag: 1.29.2
         istioDiscoveryAddress: istiod.istio-system.svc:15012
         istioMetaMeshId: cluster.local
         istioMetaClusterId: Kubernetes

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -481,7 +481,7 @@ spec:
               fieldPath: metadata.namespace
         - name: DISABLE_ENVOY
           value: "true"
-        image: docker.io/istio/proxyv2:1.22.0
+        image: docker.io/istio/proxyv2:1.29.2
         name: istio-proxy
         resources: {}
         volumeMounts:

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -490,7 +490,7 @@ spec:
               fieldPath: metadata.namespace
         - name: DISABLE_ENVOY
           value: "true"
-        image: docker.io/istio/proxyv2:1.22.0
+        image: docker.io/istio/proxyv2:1.29.2
         name: istio-proxy
         resources: {}
         volumeMounts:

--- a/test/e2e/testutils/runtime/istio_version.go
+++ b/test/e2e/testutils/runtime/istio_version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	IstioVersionEnv     = "ISTIO_VERSION"
-	DefaultIstioVersion = "1.25.1"
+	DefaultIstioVersion = "1.29.2"
 )
 
 // ShouldSkipIstioVersion reports whether the current Istio version (from ISTIO_VERSION env)

--- a/tools/build-tools/version_drift_test.go
+++ b/tools/build-tools/version_drift_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -136,6 +137,26 @@ func TestIstioVersionDefaultsDoNotDrift(t *testing.T) {
 	}
 }
 
+func TestEnvoyVersionTracksIstioVersion(t *testing.T) {
+	t.Parallel()
+
+	rootDir := repoRoot(t)
+
+	deployerPath := filepath.Join(rootDir, "pkg", "deployer", "gateway_parameters.go")
+	makefilePath := filepath.Join(rootDir, "Makefile")
+
+	istioMajor, istioMinor := majorMinorVersion(t, goStringConst(t, deployerPath, "DefaultIstioProxyImageTag"))
+	envoyImage := makeVarValue(t, makefilePath, "ENVOY_IMAGE")
+	envoyMajor, envoyMinor := majorMinorVersion(t, imageTag(t, envoyImage))
+
+	if envoyMajor != istioMajor || envoyMinor != istioMinor+8 {
+		t.Fatalf(
+			"Envoy and Istio versions must remain aligned; see issue 14011 for details: Envoy %d.%d should match Istio %d.%d plus 0.8",
+			envoyMajor, envoyMinor, istioMajor, istioMinor,
+		)
+	}
+}
+
 func repoRoot(t *testing.T) string {
 	t.Helper()
 
@@ -197,4 +218,50 @@ func envValue(t *testing.T, path, name string) string {
 		t.Fatalf("could not find env value %s in %s", name, path)
 	}
 	return string(match[1])
+}
+
+func makeVarValue(t *testing.T, path, name string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	pattern := regexp.MustCompile(`(?m)^(?:export\s+)?` + regexp.QuoteMeta(name) + `\s*(?:\?=|=)\s*(\S+)\s*$`)
+	match := pattern.FindSubmatch(data)
+	if match == nil {
+		t.Fatalf("could not find Makefile variable %s in %s", name, path)
+	}
+	return string(match[1])
+}
+
+func imageTag(t *testing.T, image string) string {
+	t.Helper()
+
+	_, tag, ok := strings.Cut(image[strings.LastIndex(image, "/")+1:], ":")
+	if !ok {
+		t.Fatalf("image %q has no tag", image)
+	}
+	return tag
+}
+
+func majorMinorVersion(t *testing.T, version string) (int, int) {
+	t.Helper()
+
+	version = strings.TrimPrefix(version, "v")
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		t.Fatalf("version %q does not include major and minor components", version)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		t.Fatalf("parse major version from %q: %v", version, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatalf("parse minor version from %q: %v", version, err)
+	}
+	return major, minor
 }

--- a/tools/build-tools/version_drift_test.go
+++ b/tools/build-tools/version_drift_test.go
@@ -1,10 +1,12 @@
 package buildtools
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +84,58 @@ func TestToolsGoModVersionMatchesRoot(t *testing.T) {
 	}
 }
 
+func TestIstioVersionDefaultsDoNotDrift(t *testing.T) {
+	t.Parallel()
+
+	rootDir := repoRoot(t)
+
+	deployerPath := filepath.Join(rootDir, "pkg", "deployer", "gateway_parameters.go")
+	prTestVersionsPath := filepath.Join(rootDir, ".github", "workflows", ".env", "pr-tests", "versions.env")
+	nightlyMaxVersionsPath := filepath.Join(rootDir, ".github", "workflows", ".env", "nightly-tests", "max_versions.env")
+	e2eRuntimePath := filepath.Join(rootDir, "test", "e2e", "testutils", "runtime", "istio_version.go")
+
+	deployerTag := goStringConst(t, deployerPath, "DefaultIstioProxyImageTag")
+	prTestVersion := envValue(t, prTestVersionsPath, "istio_version")
+	nightlyMaxVersion := envValue(t, nightlyMaxVersionsPath, "istio_version")
+	e2eDefaultVersion := goStringConst(t, e2eRuntimePath, "DefaultIstioVersion")
+
+	for name, version := range map[string]string{
+		"PR test istio_version":     prTestVersion,
+		"nightly max istio_version": nightlyMaxVersion,
+		"e2e DefaultIstioVersion":   e2eDefaultVersion,
+	} {
+		if version != deployerTag {
+			t.Errorf(
+				"%s = %q, want %q to match deployer DefaultIstioProxyImageTag",
+				name, version, deployerTag,
+			)
+		}
+	}
+
+	staleProxyTag := "proxyv2:" + "1.22.0"
+	testdataDir := filepath.Join(rootDir, "test", "deployer", "testdata")
+	err := filepath.WalkDir(testdataDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "-out.yaml") {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(data), staleProxyTag) {
+			t.Errorf("%s contains stale Istio proxy image tag %q", path, staleProxyTag)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", testdataDir, err)
+	}
+}
+
 func repoRoot(t *testing.T) string {
 	t.Helper()
 
@@ -111,4 +165,36 @@ func repoRoot(t *testing.T) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func goStringConst(t *testing.T, path, name string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	pattern := regexp.MustCompile(`(?m)^\s*(?:const\s+)?` + regexp.QuoteMeta(name) + `\s*=\s*"([^"]+)"\s*$`)
+	match := pattern.FindSubmatch(data)
+	if match == nil {
+		t.Fatalf("could not find string constant %s in %s", name, path)
+	}
+	return string(match[1])
+}
+
+func envValue(t *testing.T, path, name string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	pattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `='([^']+)'\s*$`)
+	match := pattern.FindSubmatch(data)
+	if match == nil {
+		t.Fatalf("could not find env value %s in %s", name, path)
+	}
+	return string(match[1])
 }

--- a/tools/build-tools/version_drift_test.go
+++ b/tools/build-tools/version_drift_test.go
@@ -113,7 +113,7 @@ func TestIstioVersionDefaultsDoNotDrift(t *testing.T) {
 		}
 	}
 
-	staleProxyTag := "proxyv2:" + "1.22.0"
+	proxyV2TagPattern := regexp.MustCompile(`proxyv2:([A-Za-z0-9._-]+)`)
 	testdataDir := filepath.Join(rootDir, "test", "deployer", "testdata")
 	err := filepath.WalkDir(testdataDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -127,8 +127,11 @@ func TestIstioVersionDefaultsDoNotDrift(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(string(data), staleProxyTag) {
-			t.Errorf("%s contains stale Istio proxy image tag %q", path, staleProxyTag)
+		for _, match := range proxyV2TagPattern.FindAllSubmatch(data, -1) {
+			tag := string(match[1])
+			if tag != deployerTag {
+				t.Errorf("%s contains Istio proxy image tag %q, want %q", path, tag, deployerTag)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Bumps Istio proxy from 1.22.0 to 1.29.2

Includes version drift test for a brighter future.

# Change Type
/kind bump

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Default Istio proxy version bumped.
```

# Additional Notes

For #14011

<!--
Any extra context or edge cases for reviewers.
-->
