### PR TITLE
[2.3] Backport xDS TLS env var Helm fix

### DIFF
--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -139,7 +139,7 @@ spec:
               value: "true"
             {{- end }}
             {{- if .Values.controller.xds.tls.enabled }}
-            - name: KGW_XDS_TLS_ENABLED
+            - name: KGW_XDS_TLS
               value: "true"
             {{- end }}
             - name: POD_NAMESPACE

--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
             - name: KGW_ENABLE_WAYPOINT
               value: "true"
             {{- end }}
-            {{- if .Values.controller.xds.tls.enabled }}
+            {{- if and .Values.controller.xds.tls.enabled (not (and .Values.controller.extraEnv (hasKey .Values.controller.extraEnv "KGW_XDS_TLS"))) }}
             - name: KGW_XDS_TLS
               value: "true"
             {{- end }}

--- a/test/helm/helm_version_test.go
+++ b/test/helm/helm_version_test.go
@@ -319,6 +319,17 @@ func TestHelmChartTemplate(t *testing.T) {
 `,
 		},
 		{
+			name: "xds-tls-enabled-extraenv-dedup",
+			valuesYAML: `controller:
+  xds:
+    tls:
+      enabled: true
+  extraEnv:
+    KGW_XDS_TLS: "true"
+    FOO: "bar"
+`,
+		},
+		{
 			name: "pdb-min-available",
 			valuesYAML: `controller:
   podDisruptionBudget:

--- a/test/helm/testdata/kgateway/xds-tls-enabled-extraenv-dedup.golden
+++ b/test/helm/testdata/kgateway/xds-tls-enabled-extraenv-dedup.golden
@@ -1,0 +1,407 @@
+---
+# Source: kgateway/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-release-kgateway
+  namespace: default
+  labels:
+    helm.sh/chart: kgateway-0.0.2
+    kgateway: kgateway
+    app.kubernetes.io/name: kgateway
+    app.kubernetes.io/instance: test-release
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: kgateway/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kgateway-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.kgateway.dev
+  resources:
+  - backendconfigpolicies
+  - backends
+  - directresponses
+  - gatewayextensions
+  - gatewayparameters
+  - httplistenerpolicies
+  - listenerpolicies
+  - trafficpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.kgateway.dev
+  resources:
+  - backendconfigpolicies/status
+  - backends/status
+  - directresponses/status
+  - gatewayextensions/status
+  - gatewayparameters/status
+  - httplistenerpolicies/status
+  - listenerpolicies/status
+  - trafficpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies
+  - gateways
+  - grpcroutes
+  - httproutes
+  - listenersets
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies/status
+  - gatewayclasses/status
+  - gateways/status
+  - grpcroutes/status
+  - httproutes/status
+  - listenersets/status
+  - tcproutes/status
+  - tlsroutes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.x-k8s.io
+  resources:
+  - xlistenersets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.x-k8s.io
+  resources:
+  - xlistenersets/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  - serviceentries
+  - workloadentries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.istio.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: kgateway/templates/serviceaccount.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kgateway-role-default
+subjects:
+- kind: ServiceAccount
+  name: test-release-kgateway
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kgateway-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: kgateway/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-release-kgateway
+  namespace: default
+  labels:
+    helm.sh/chart: kgateway-0.0.2
+    kgateway: kgateway
+    app.kubernetes.io/name: kgateway
+    app.kubernetes.io/instance: test-release
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: grpc-xds
+    protocol: TCP
+    port: 9977
+    targetPort: 9977
+  - name: health
+    protocol: TCP
+    port: 9093
+    targetPort: 9093
+  - name: metrics
+    protocol: TCP
+    port: 9092
+    targetPort: 9092
+  selector:
+    kgateway: kgateway
+    app.kubernetes.io/name: kgateway
+    app.kubernetes.io/instance: test-release
+---
+# Source: kgateway/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-release-kgateway
+  namespace: default
+  labels:
+    helm.sh/chart: kgateway-0.0.2
+    kgateway: kgateway
+    app.kubernetes.io/name: kgateway
+    app.kubernetes.io/instance: test-release
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      kgateway: kgateway
+      app.kubernetes.io/name: kgateway
+      app.kubernetes.io/instance: test-release
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "9092"
+        prometheus.io/scrape: "true"
+      labels:
+        kgateway: kgateway
+        app.kubernetes.io/name: kgateway
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/component: controller
+    spec:
+      serviceAccountName: test-release-kgateway
+      containers:
+        - name: controller
+          image: "cr.kgateway.dev/kgateway-dev/kgateway:v0.0.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9977
+              name: grpc-xds
+              protocol: TCP
+            - containerPort: 9093
+              name: health
+              protocol: TCP
+            - containerPort: 9092
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          startupProbe:
+            failureThreshold: 600
+            httpGet:
+              path: /readyz
+              port: 9093
+            initialDelaySeconds: 0
+            periodSeconds: 1
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: KGW_LOG_LEVEL
+              value: "info"
+            - name: KGW_XDS_SERVICE_NAME
+              value: test-release-kgateway
+            - name: KGW_XDS_SERVICE_PORT
+              value: "9977"
+            - name: KGW_DEFAULT_IMAGE_REGISTRY
+              value: cr.kgateway.dev/kgateway-dev
+            - name: KGW_DEFAULT_IMAGE_TAG
+              value: v0.0.1
+            - name: KGW_DEFAULT_IMAGE_PULL_POLICY
+              value: IfNotPresent
+            - name: KGW_DISCOVERY_NAMESPACE_SELECTORS
+              value: "[]"
+            - name: KGW_POLICY_MERGE
+              value: "{}"
+            - name: KGW_VALIDATION_MODE
+              value: "standard"
+            - name: FOO
+              value: "bar"
+            - name: KGW_XDS_TLS
+              value: "true"
+            - name: KGW_ENABLE_ENVOY
+              value: "true"
+            - name: KGW_GATEWAY_CLASS_PARAMETERS_REFS
+              value: "{}"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            {}
+          volumeMounts:
+            - name: xds-tls
+              mountPath: /etc/xds-tls
+              readOnly: true
+      volumes:
+        - name: xds-tls
+          secret:
+            secretName: kgateway-xds-cert

--- a/test/helm/testdata/kgateway/xds-tls-enabled.golden
+++ b/test/helm/testdata/kgateway/xds-tls-enabled.golden
@@ -387,7 +387,7 @@ spec:
               value: "true"
             - name: KGW_GATEWAY_CLASS_PARAMETERS_REFS
               value: "{}"
-            - name: KGW_XDS_TLS_ENABLED
+            - name: KGW_XDS_TLS
               value: "true"
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
# Description

Backport of #14050 to `v2.3.x`.

This backports the xDS TLS env var fix for Helm:
- Render `KGW_XDS_TLS` (instead of `KGW_XDS_TLS_ENABLED`) when `controller.xds.tls.enabled=true`.
- Keep duplicate protection to avoid rendering a second `KGW_XDS_TLS` when users already set `controller.extraEnv.KGW_XDS_TLS` as a workaround.
- Added regression test case validating the dedup behavior works correctly.

# Change Type

/kind fix

```release-note
Backport: Fix xDS TLS env var name in Helm chart for v2.3.x by using `KGW_XDS_TLS` and preventing duplicate env entries when `controller.extraEnv.KGW_XDS_TLS` is set.
```