### PR TITLE
[v2.3.x] bump alpine base image (#14051)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ BUG_REPORT_DIR := $(TEST_ASSET_DIR)/bug_report
 $(BUG_REPORT_DIR):
 	mkdir -p $(BUG_REPORT_DIR)
 
-# Base Alpine image used for all containers. Exported for use in goreleaser.yaml.
-export ALPINE_BASE_IMAGE ?= alpine:3.17.6
+# Base Alpine image used for SDS and dummy-idp containers. Exported for use in goreleaser.yaml.
+export ALPINE_BASE_IMAGE ?= alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 GO_VERSION := $(shell cat go.mod | grep -E '^go' | awk '{print $$2}')
 GOTOOLCHAIN ?= go$(GO_VERSION)


### PR DESCRIPTION
(cherry picked from commit bc725c62de1efc096c10e9e66f4889767638a594)
# Description

bump alpine base image 

# Change Type

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
bump alpine base image used to build images
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
