### PR TITLE
[v2.2.x] fix: strict validation for BackendConfigPolicy system CA TLS

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate_test.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
+	eiutils "github.com/kgateway-dev/kgateway/v2/internal/envoyinit/pkg/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
 
@@ -137,6 +138,42 @@ func TestBackendConfigPolicyXDSValidation(t *testing.T) {
 						return fmt.Errorf("expected STRICT_DNS cluster type, got %v", cluster.GetType())
 					}
 					return nil // Validation passes
+				},
+			},
+			mode:    apisettings.ValidationStrict,
+			wantErr: false,
+		},
+		{
+			name: "policy with system CA adds validation secret to bootstrap",
+			policyIR: &BackendConfigPolicyIR{
+				ct: time.Now(),
+				tlsConfig: &envoytlsv3.UpstreamTlsContext{
+					CommonTlsContext: &envoytlsv3.CommonTlsContext{
+						ValidationContextType: &envoytlsv3.CommonTlsContext_CombinedValidationContext{
+							CombinedValidationContext: &envoytlsv3.CommonTlsContext_CombinedCertificateValidationContext{
+								DefaultValidationContext: &envoytlsv3.CertificateValidationContext{},
+								ValidationContextSdsSecretConfig: &envoytlsv3.SdsSecretConfig{
+									Name: eiutils.SystemCaSecretName,
+								},
+							},
+						},
+					},
+				},
+			},
+			validator: &mockValidator{
+				validateFunc: func(ctx context.Context, config *envoybootstrapv3.Bootstrap) error {
+					secrets := config.GetStaticResources().GetSecrets()
+					if len(secrets) != 1 {
+						return fmt.Errorf("expected exactly one secret in bootstrap, got %d", len(secrets))
+					}
+					secret := secrets[0]
+					if secret.GetName() != eiutils.SystemCaSecretName {
+						return fmt.Errorf("expected secret name %q, got %q", eiutils.SystemCaSecretName, secret.GetName())
+					}
+					if secret.GetValidationContext().GetTrustedCa().GetInlineString() == "" {
+						return errors.New("expected placeholder CA cert in validation secret")
+					}
+					return nil
 				},
 			},
 			mode:    apisettings.ValidationStrict,

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate_test.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate_test.go
@@ -161,8 +161,12 @@ func TestBackendConfigPolicyXDSValidation(t *testing.T) {
 				},
 			},
 			validator: &mockValidator{
-				validateFunc: func(ctx context.Context, config *envoybootstrapv3.Bootstrap) error {
-					secrets := config.GetStaticResources().GetSecrets()
+				validateFunc: func(ctx context.Context, config string) error {
+					var bootstrap envoybootstrapv3.Bootstrap
+					if err := protojson.Unmarshal([]byte(config), &bootstrap); err != nil {
+						return fmt.Errorf("failed to unmarshal bootstrap config: %w", err)
+					}
+					secrets := bootstrap.GetStaticResources().GetSecrets()
 					if len(secrets) != 1 {
 						return fmt.Errorf("expected exactly one secret in bootstrap, got %d", len(secrets))
 					}

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -1558,6 +1558,19 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("Backend Config Policy with system ca TLS in strict mode", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "backendconfigpolicy/tls-system-ca.yaml",
+			outputFile: "backendconfigpolicy/tls-system-ca.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		}, func(s *apisettings.Settings) {
+			s.ValidationMode = apisettings.ValidationStrict
+		})
+	})
+
 	t.Run("Backend Config Policy with Circuit Breakers minimal", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFile:  "backendconfigpolicy/circuitbreakers-minimal.yaml",

--- a/pkg/xds/bootstrap/builder.go
+++ b/pkg/xds/bootstrap/builder.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"slices"
 
 	envoybootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -10,18 +11,40 @@ import (
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoyhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoywellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/proto"
 
+	eiutils "github.com/kgateway-dev/kgateway/v2/internal/envoyinit/pkg/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
+
+const systemCAValidationPlaceholderCert = `-----BEGIN CERTIFICATE-----
+MIIC9jCCAd4CCQDziJBJLFeNxDANBgkqhkiG9w0BAQsFADA8MScwJQYDVQQDDB5r
+Z2F0ZXdheS1zeXN0ZW0tY2EtcGxhY2Vob2xkZXIxETAPBgNVBAoMCGtnYXRld2F5
+MCAXDTI2MDUxODEyNDMzOFoYDzIxMjYwNTE5MTI0MzM4WjA8MScwJQYDVQQDDB5r
+Z2F0ZXdheS1zeXN0ZW0tY2EtcGxhY2Vob2xkZXIxETAPBgNVBAoMCGtnYXRld2F5
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyIhEq9QW2+mRxrKC7cdG
+hIyQYNepOdkdFmlA8Aj7e06Rw+qrZ/nt0b8UFyavbgYASa4zRcVOFoFz/bOeQ+AO
+1jqYCIrPZFByuKMZMoXowqzMU/NJxFvjVWEtFCAWa5+Saf/IiKrVT3ra+lFd+oIy
+/P8jO05wMRoNO2ZrT+Jc5AH6JQ7bV8mk5k35TUO1JkCjONpW/IgGgBIyeglpXU2a
+J2is4EewbOOuPnmhmSTHR4Sf3y8aa18AXDbEIfuCJtQSJm5dEGI2Kr1DsQQLqklK
+tw5kG2z4z43G0jCf/H04TzUyrIO5c/Q6bzkpawHLWVyqfQpPLZ7taQLjqZ9zs/rR
+6QIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQC9huFeWp+0nPEor2BK5zVVzBz4FSdX
+oIZv7rbZY4OMZaJd9Z6y07aj/YM0kx66YqoIe5X0kA4NDLe8VST6kYecugQ6HeIL
+B70kEZlc8X5q4xjOj/t0EJOsmP0hZK+6aNvjr6x1rm0fWvwFUbNvLK0SKkVq/urI
+FwD8n0mhM0tkPjpsVMnhx7NO98dwKASAPk/eBdQHP3L4nNAt+eOp042OeRmQOyOx
+FHW4vPA/rQpONzRjk0fch5/sMDzspQsf/EQpl++MT9X3QC0mCf1z8T2qzjn72SJ7
+yitqAQ59a80qeeQ8i3nAI5clnJtfDYwZV6gIO72hygBWWE5FMjWzGPCE
+-----END CERTIFICATE-----`
 
 // ConfigBuilder helps construct a partial bootstrap config for validation.
 type ConfigBuilder struct {
 	filterConfigs ir.TypedFilterConfigMap
 	routes        []*envoyroutev3.Route
 	clusters      []*envoyclusterv3.Cluster
+	secrets       []*envoytlsv3.Secret
 	httpFilters   []*envoy_extensions_filters_network_http_connection_manager_v3.HttpFilter
 }
 
@@ -46,6 +69,67 @@ func (b *ConfigBuilder) AddRoute(route *envoyroutev3.Route) {
 // AddCluster adds a cluster to the builder.
 func (b *ConfigBuilder) AddCluster(cluster *envoyclusterv3.Cluster) {
 	b.clusters = append(b.clusters, cluster)
+}
+
+// AddSecret adds a static secret to the bootstrap.
+func (b *ConfigBuilder) AddSecret(secret *envoytlsv3.Secret) {
+	b.secrets = append(b.secrets, secret)
+}
+
+// SystemCAValidationSecretPlaceholder returns a secret with a placeholder CA certificate.
+// This is used so that strict validation won't erroneously fail for backend TLS configs that reference system CA certificates,
+// that would otherwise be missing in the validation bootstrap config.
+func SystemCAValidationSecretPlaceholder() *envoytlsv3.Secret {
+	return &envoytlsv3.Secret{
+		Name: eiutils.SystemCaSecretName,
+		Type: &envoytlsv3.Secret_ValidationContext{
+			ValidationContext: &envoytlsv3.CertificateValidationContext{
+				TrustedCa: &envoycorev3.DataSource{
+					Specifier: &envoycorev3.DataSource_InlineString{
+						InlineString: systemCAValidationPlaceholderCert,
+					},
+				},
+			},
+		},
+	}
+}
+
+func ClusterReferencesSystemCASecret(cluster *envoyclusterv3.Cluster) bool {
+	if cluster == nil || cluster.GetTransportSocket() == nil || cluster.GetTransportSocket().GetTypedConfig() == nil {
+		return false
+	}
+
+	upstreamTLS := &envoytlsv3.UpstreamTlsContext{}
+	if err := cluster.GetTransportSocket().GetTypedConfig().UnmarshalTo(upstreamTLS); err != nil {
+		return false
+	}
+
+	commonTLS := upstreamTLS.GetCommonTlsContext()
+	if commonTLS == nil {
+		return false
+	}
+
+	switch validation := commonTLS.GetValidationContextType().(type) {
+	case *envoytlsv3.CommonTlsContext_CombinedValidationContext:
+		return validation.CombinedValidationContext.GetValidationContextSdsSecretConfig().GetName() == eiutils.SystemCaSecretName
+	case *envoytlsv3.CommonTlsContext_ValidationContextSdsSecretConfig:
+		return validation.ValidationContextSdsSecretConfig.GetName() == eiutils.SystemCaSecretName
+	default:
+		return false
+	}
+}
+
+func clustersReferenceSystemCASecret(clusters []*envoyclusterv3.Cluster) bool {
+	return slices.ContainsFunc(clusters, ClusterReferencesSystemCASecret)
+}
+
+func hasSecretNamed(secrets []*envoytlsv3.Secret, name string) bool {
+	for _, secret := range secrets {
+		if secret != nil && secret.GetName() == name {
+			return true
+		}
+	}
+	return false
 }
 
 // AddHttpFilter adds an HTTP filter to the HCM filter chain.
@@ -121,6 +205,12 @@ func (b *ConfigBuilder) Build() (*envoybootstrapv3.Bootstrap, error) {
 	}
 	if len(b.clusters) > 0 {
 		staticResources.Clusters = b.clusters
+	}
+	if len(b.secrets) > 0 {
+		staticResources.Secrets = append(staticResources.Secrets, b.secrets...)
+	}
+	if clustersReferenceSystemCASecret(b.clusters) && !hasSecretNamed(staticResources.GetSecrets(), eiutils.SystemCaSecretName) {
+		staticResources.Secrets = append(staticResources.Secrets, SystemCAValidationSecretPlaceholder())
 	}
 
 	return &envoybootstrapv3.Bootstrap{

--- a/pkg/xds/bootstrap/builder_test.go
+++ b/pkg/xds/bootstrap/builder_test.go
@@ -7,9 +7,14 @@ import (
 
 	envoybootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/google/go-cmp/cmp"
+
+	eiutils "github.com/kgateway-dev/kgateway/v2/internal/envoyinit/pkg/utils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 )
 
 func TestConfigBuilder_Build(t *testing.T) {
@@ -100,6 +105,90 @@ func TestConfigBuilder_Build(t *testing.T) {
 				}
 				if clusters[0].GetName() != "test_cluster_2" {
 					t.Fatalf("expected cluster name 'test_cluster_2', got %q", clusters[0].GetName())
+				}
+			},
+		},
+		{
+			name: "with secret",
+			setup: func(b *ConfigBuilder) {
+				b.AddSecret(&envoytlsv3.Secret{Name: "test_secret"})
+			},
+			validate: func(t *testing.T, got *envoybootstrapv3.Bootstrap) {
+				secrets := got.GetStaticResources().GetSecrets()
+				if len(secrets) != 1 {
+					t.Fatalf("expected 1 secret, got %d", len(secrets))
+				}
+				if secrets[0].GetName() != "test_secret" {
+					t.Fatalf("expected secret name 'test_secret', got %q", secrets[0].GetName())
+				}
+			},
+		},
+		{
+			name: "auto-adds system ca placeholder secret when cluster references it",
+			setup: func(b *ConfigBuilder) {
+				tlsContextAny, err := utils.MessageToAny(&envoytlsv3.UpstreamTlsContext{
+					CommonTlsContext: &envoytlsv3.CommonTlsContext{
+						ValidationContextType: &envoytlsv3.CommonTlsContext_ValidationContextSdsSecretConfig{
+							ValidationContextSdsSecretConfig: &envoytlsv3.SdsSecretConfig{
+								Name: eiutils.SystemCaSecretName,
+							},
+						},
+					},
+				})
+				if err != nil {
+					t.Fatalf("failed to marshal tls context: %v", err)
+				}
+				b.AddCluster(&envoyclusterv3.Cluster{
+					Name: "test_cluster_system_ca",
+					TransportSocket: &envoycorev3.TransportSocket{
+						ConfigType: &envoycorev3.TransportSocket_TypedConfig{
+							TypedConfig: tlsContextAny,
+						},
+					},
+				})
+			},
+			validate: func(t *testing.T, got *envoybootstrapv3.Bootstrap) {
+				secrets := got.GetStaticResources().GetSecrets()
+				if len(secrets) != 1 {
+					t.Fatalf("expected 1 secret, got %d", len(secrets))
+				}
+				if secrets[0].GetName() != eiutils.SystemCaSecretName {
+					t.Fatalf("expected secret name %q, got %q", eiutils.SystemCaSecretName, secrets[0].GetName())
+				}
+			},
+		},
+		{
+			name: "does not duplicate provided system ca secret",
+			setup: func(b *ConfigBuilder) {
+				tlsContextAny, err := utils.MessageToAny(&envoytlsv3.UpstreamTlsContext{
+					CommonTlsContext: &envoytlsv3.CommonTlsContext{
+						ValidationContextType: &envoytlsv3.CommonTlsContext_ValidationContextSdsSecretConfig{
+							ValidationContextSdsSecretConfig: &envoytlsv3.SdsSecretConfig{
+								Name: eiutils.SystemCaSecretName,
+							},
+						},
+					},
+				})
+				if err != nil {
+					t.Fatalf("failed to marshal tls context: %v", err)
+				}
+				b.AddCluster(&envoyclusterv3.Cluster{
+					Name: "test_cluster_system_ca_existing_secret",
+					TransportSocket: &envoycorev3.TransportSocket{
+						ConfigType: &envoycorev3.TransportSocket_TypedConfig{
+							TypedConfig: tlsContextAny,
+						},
+					},
+				})
+				b.AddSecret(&envoytlsv3.Secret{Name: eiutils.SystemCaSecretName})
+			},
+			validate: func(t *testing.T, got *envoybootstrapv3.Bootstrap) {
+				secrets := got.GetStaticResources().GetSecrets()
+				if len(secrets) != 1 {
+					t.Fatalf("expected 1 secret, got %d", len(secrets))
+				}
+				if secrets[0].GetName() != eiutils.SystemCaSecretName {
+					t.Fatalf("expected secret name %q, got %q", eiutils.SystemCaSecretName, secrets[0].GetName())
 				}
 			},
 		},


### PR DESCRIPTION
# Description
Backports #14037 to `v2.2.x` so strict BackendConfigPolicy validation no longer fails when backend TLS uses `tls.wellKnownCACertificates: System`. The backport teaches the validation bootstrap builder to inject a placeholder system CA secret only when a cluster references that SDS secret, adds focused coverage for both bootstrap construction and strict validation, and includes a small test-only compatibility adjustment because `v2.2.x` still validates JSON strings instead of bootstrap protos.

# Change Type
/kind fix

# Changelog
```release-note
Fix strict BackendConfigPolicy validation when backend TLS uses well-known system CA certificates.
```

# Additional Notes
- Backported from `62c94e66b0045d96d8b00526f78ba02f39567f89`
