### PR TITLE
fix: TestControlPlaneTLS can now detect the 14049 bug

### DIFF
--- a/test/e2e/features/tls/testdata/gateway.yaml
+++ b/test/e2e/features/tls/testdata/gateway.yaml
@@ -1,10 +1,47 @@
 ---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: gw-xds-wiretap
+spec:
+  kube:
+    deployment:
+      replicas: 1
+    deploymentOverlay:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: xds-wiretap
+                image: nicolaka/netshoot:v0.14@sha256:7f08c4aff13ff61a35d30e30c5c1ea8396eac6ab4ce19fd02d5a4b3b5d0d09a2
+                imagePullPolicy: IfNotPresent
+                command:
+                  - sh
+                  - -c
+                  - "trap : TERM INT; sleep infinity & wait"
+                securityContext:
+                  privileged: true
+                  runAsNonRoot: false
+                  runAsUser: 0
+                resources:
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                  limits:
+                    cpu: 100m
+                    memory: 128Mi
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gw
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: gw-xds-wiretap
   listeners:
     - name: http
       protocol: HTTP

--- a/test/e2e/features/tls/testdata/gateway.yaml
+++ b/test/e2e/features/tls/testdata/gateway.yaml
@@ -20,9 +20,12 @@ spec:
                   - -c
                   - "trap : TERM INT; sleep infinity & wait"
                 securityContext:
-                  privileged: true
                   runAsNonRoot: false
                   runAsUser: 0
+                  capabilities:
+                    add:
+                      - NET_ADMIN
+                      - NET_RAW
                 resources:
                   requests:
                     cpu: 10m

--- a/test/e2e/tests/tls_test.go
+++ b/test/e2e/tests/tls_test.go
@@ -11,12 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	"github.com/onsi/gomega"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"

--- a/test/e2e/tests/tls_test.go
+++ b/test/e2e/tests/tls_test.go
@@ -9,15 +9,19 @@ import (
 	"path/filepath"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/tls"
 	. "github.com/kgateway-dev/kgateway/v2/test/e2e/tests"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/install"
+	"github.com/kgateway-dev/kgateway/v2/test/helpers"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
@@ -78,6 +82,13 @@ func TestControlPlaneTLS(t *testing.T) {
 		testInstallation.UninstallKgateway(cleanupCtx, t)
 	})
 	testInstallation.InstallKgatewayFromLocalChart(t.Context(), t)
+	testInstallation.AssertionsT(t).EventuallyPodContainerContainsEnvVar(
+		t.Context(),
+		installNs,
+		metav1.ListOptions{LabelSelector: testdefaults.KGatewayPodLabel},
+		helpers.KgatewayContainerName,
+		corev1.EnvVar{Name: "KGW_XDS_TLS", Value: "true"},
+	)
 
 	gatewayManifest := filepath.Join(fsutils.MustGetThisDir(), "../features/tls/testdata", "gateway.yaml")
 	common.SetupBaseConfig(t.Context(), t, testInstallation, gatewayManifest)

--- a/test/e2e/tests/tls_test.go
+++ b/test/e2e/tests/tls_test.go
@@ -133,6 +133,20 @@ func assertXDSWireTrafficIsEncrypted(ctx context.Context, t *testing.T, testInst
 
 	proxyPod := getReadyProxyPod(ctx, t, testInstallation)
 	startXDSCapture(ctx, t, testInstallation, proxyPod)
+	testutils.Cleanup(t, func() {
+		// Best-effort: if a t.Fatalf between start and stopXDSCapture left tcpdump
+		// running, kill it now and surface the log so early failures aren't blind.
+		stdout, _, _ := testInstallation.Actions.Kubectl().Execute(
+			context.Background(),
+			"exec", "-n", proxyPod.Namespace, proxyPod.Name,
+			"-c", xdsWiretapContainer, "--",
+			"sh", "-c",
+			fmt.Sprintf("if [ -s %[1]s ]; then kill -INT $(cat %[1]s) 2>/dev/null || true; fi; cat %[2]s 2>/dev/null || true", xdsWiretapPID, xdsWiretapLog),
+		)
+		if t.Failed() && stdout != "" {
+			t.Logf("xDS wiretap tcpdump log on failure:\n%s", stdout)
+		}
+	})
 
 	markerHost := fmt.Sprintf("xds-wire-%d.example.com", time.Now().UnixNano())
 	markerRoute := xdsWireProbeRouteManifest(markerHost)

--- a/test/e2e/tests/tls_test.go
+++ b/test/e2e/tests/tls_test.go
@@ -3,26 +3,41 @@
 package tests_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/threadsafe"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
 	testdefaults "github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/tls"
 	. "github.com/kgateway-dev/kgateway/v2/test/e2e/tests"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/install"
-	"github.com/kgateway-dev/kgateway/v2/test/helpers"
+	"github.com/kgateway-dev/kgateway/v2/test/envoyutils/admincli"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
+)
+
+const (
+	xdsWiretapContainer = "xds-wiretap"
+	xdsWiretapPcap      = "/tmp/xds.pcap"
+	xdsWiretapLog       = "/tmp/xds-tcpdump.log"
+	xdsWiretapPID       = "/tmp/xds-tcpdump.pid"
+	xdsWireProbeRoute   = "xds-wire-probe"
 )
 
 // TestControlPlaneTLS tests the TLS control plane integration functionality.
@@ -82,16 +97,9 @@ func TestControlPlaneTLS(t *testing.T) {
 		testInstallation.UninstallKgateway(cleanupCtx, t)
 	})
 	testInstallation.InstallKgatewayFromLocalChart(t.Context(), t)
-	testInstallation.AssertionsT(t).EventuallyPodContainerContainsEnvVar(
-		t.Context(),
-		installNs,
-		metav1.ListOptions{LabelSelector: testdefaults.KGatewayPodLabel},
-		helpers.KgatewayContainerName,
-		corev1.EnvVar{Name: "KGW_XDS_TLS", Value: "true"},
-	)
 
 	gatewayManifest := filepath.Join(fsutils.MustGetThisDir(), "../features/tls/testdata", "gateway.yaml")
-	common.SetupBaseConfig(t.Context(), t, testInstallation, gatewayManifest)
+	common.SetupBaseConfig(t.Context(), t, testInstallation, testdefaults.HttpbinManifest, gatewayManifest)
 	testutils.Cleanup(t, func() {
 		_ = testInstallation.ClusterContext.IstioClient.DeleteYAMLFiles("", gatewayManifest)
 	})
@@ -99,6 +107,8 @@ func TestControlPlaneTLS(t *testing.T) {
 		Namespace: "default",
 		Name:      "gw",
 	})
+
+	assertXDSWireTrafficIsEncrypted(t.Context(), t, testInstallation)
 
 	TLSSuiteRunner().Run(t.Context(), t, testInstallation)
 }
@@ -109,4 +119,207 @@ kind: Namespace
 metadata:
   name: %s
 `, ns)
+}
+
+func assertXDSWireTrafficIsEncrypted(ctx context.Context, t *testing.T, testInstallation *e2e.TestInstallation) {
+	t.Helper()
+
+	testInstallation.AssertionsT(t).EventuallyPodsRunning(ctx, "default", metav1.ListOptions{
+		LabelSelector: testdefaults.HttpbinLabelSelector,
+	})
+	testInstallation.AssertionsT(t).EventuallyReadyReplicas(ctx, metav1.ObjectMeta{
+		Name:      "gw",
+		Namespace: "default",
+	}, gomega.Equal(1), 120*time.Second, 500*time.Millisecond)
+
+	proxyPod := getReadyProxyPod(ctx, t, testInstallation)
+	startXDSCapture(ctx, t, testInstallation, proxyPod)
+
+	markerHost := fmt.Sprintf("xds-wire-%d.example.com", time.Now().UnixNano())
+	markerRoute := xdsWireProbeRouteManifest(markerHost)
+	testutils.Cleanup(t, func() {
+		_ = testInstallation.Actions.Kubectl().Delete(context.Background(), []byte(markerRoute))
+	})
+	if err := testInstallation.Actions.Kubectl().Apply(ctx, []byte(markerRoute)); err != nil {
+		t.Fatalf("failed to apply xDS wire probe route: %v", err)
+	}
+	testInstallation.AssertionsT(t).EventuallyHTTPRouteCondition(
+		ctx,
+		xdsWireProbeRoute,
+		"default",
+		gwv1.RouteConditionAccepted,
+		metav1.ConditionTrue,
+	)
+	assertEnvoyReceivedRouteHost(ctx, t, testInstallation, markerHost)
+
+	capture, tcpdumpLog := stopXDSCapture(ctx, t, testInstallation, proxyPod)
+	if len(capture) <= 24 {
+		t.Fatalf("xDS packet capture did not contain packet payloads; tcpdump log:\n%s", tcpdumpLog)
+	}
+	assertXDSCaptureDoesNotContainPlaintext(t, capture, markerHost, tcpdumpLog)
+}
+
+func assertEnvoyReceivedRouteHost(ctx context.Context, t *testing.T, testInstallation *e2e.TestInstallation, markerHost string) {
+	t.Helper()
+
+	testInstallation.AssertionsT(t).AssertEnvoyAdminApi(
+		ctx,
+		metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		func(ctx context.Context, adminClient *admincli.Client) {
+			testInstallation.AssertionsT(t).Gomega.Eventually(func(g gomega.Gomega) {
+				var configDump threadsafe.Buffer
+				err := adminClient.ConfigDumpCmd(ctx, map[string]string{
+					"resource": "dynamic_route_configs",
+				}).WithStdout(&configDump).Run().Cause()
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "can get Envoy route config dump")
+				g.Expect(configDump.String()).To(gomega.ContainSubstring(markerHost), "Envoy should receive the marked route over xDS")
+			}).
+				WithContext(ctx).
+				WithTimeout(30 * time.Second).
+				WithPolling(500 * time.Millisecond).
+				Should(gomega.Succeed())
+		},
+	)
+}
+
+func getReadyProxyPod(ctx context.Context, t *testing.T, testInstallation *e2e.TestInstallation) *corev1.Pod {
+	t.Helper()
+
+	var proxyPod *corev1.Pod
+	testInstallation.AssertionsT(t).Gomega.Eventually(func(g gomega.Gomega) {
+		var readyProxyPod *corev1.Pod
+		pods, err := testInstallation.ClusterContext.Clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+			LabelSelector: testdefaults.WellKnownAppLabel + "=gw",
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to list proxy pods")
+		g.Expect(pods.Items).NotTo(gomega.BeEmpty(), "expected a proxy pod")
+
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Status.Phase != corev1.PodRunning || !podContainerReady(pod, xdsWiretapContainer) {
+				continue
+			}
+			readyProxyPod = pod.DeepCopy()
+			break
+		}
+		g.Expect(readyProxyPod).NotTo(gomega.BeNil(), "expected a running proxy pod with a ready xDS wiretap sidecar")
+		proxyPod = readyProxyPod
+	}).
+		WithContext(ctx).
+		WithTimeout(60 * time.Second).
+		WithPolling(500 * time.Millisecond).
+		Should(gomega.Succeed())
+
+	return proxyPod
+}
+
+func podContainerReady(pod *corev1.Pod, containerName string) bool {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.Ready
+		}
+	}
+	return false
+}
+
+func startXDSCapture(ctx context.Context, t *testing.T, testInstallation *e2e.TestInstallation, proxyPod *corev1.Pod) {
+	t.Helper()
+
+	filter := fmt.Sprintf("tcp port %d and (((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)", wellknown.DefaultXdsPort)
+	script := fmt.Sprintf(
+		"rm -f %[1]s %[2]s %[3]s; nohup tcpdump -U -i any -s 0 -w %[1]s '%[4]s' >%[2]s 2>&1 & echo $! >%[3]s",
+		xdsWiretapPcap,
+		xdsWiretapLog,
+		xdsWiretapPID,
+		filter,
+	)
+	execWiretap(ctx, t, testInstallation, proxyPod, script)
+
+	testInstallation.AssertionsT(t).Gomega.Eventually(func(g gomega.Gomega) {
+		out := execWiretap(ctx, t, testInstallation, proxyPod, fmt.Sprintf("cat %s 2>/dev/null || true", xdsWiretapLog))
+		g.Expect(out).To(gomega.ContainSubstring("listening on"), "tcpdump should be listening before the route update")
+	}).
+		WithContext(ctx).
+		WithTimeout(10 * time.Second).
+		WithPolling(200 * time.Millisecond).
+		Should(gomega.Succeed())
+}
+
+func stopXDSCapture(ctx context.Context, t *testing.T, testInstallation *e2e.TestInstallation, proxyPod *corev1.Pod) ([]byte, string) {
+	t.Helper()
+
+	stopScript := fmt.Sprintf(
+		"if [ -s %[1]s ]; then kill -INT $(cat %[1]s) 2>/dev/null || true; fi; sleep 1; cat %[2]s 2>/dev/null || true",
+		xdsWiretapPID,
+		xdsWiretapLog,
+	)
+	tcpdumpLog := execWiretap(ctx, t, testInstallation, proxyPod, stopScript)
+	capture := execWiretap(ctx, t, testInstallation, proxyPod, fmt.Sprintf("cat %s", xdsWiretapPcap))
+
+	return []byte(capture), tcpdumpLog
+}
+
+func execWiretap(ctx context.Context, t *testing.T, testInstallation *e2e.TestInstallation, proxyPod *corev1.Pod, script string) string {
+	t.Helper()
+
+	stdout, stderr, err := testInstallation.Actions.Kubectl().Execute(
+		ctx,
+		"exec",
+		"-n",
+		proxyPod.Namespace,
+		proxyPod.Name,
+		"-c",
+		xdsWiretapContainer,
+		"--",
+		"sh",
+		"-c",
+		script,
+	)
+	if err != nil {
+		t.Fatalf("failed to execute wiretap command %q: %v\nstdout:\n%s\nstderr:\n%s", script, err, stdout, stderr)
+	}
+	return stdout
+}
+
+func assertXDSCaptureDoesNotContainPlaintext(t *testing.T, capture []byte, markerHost string, tcpdumpLog string) {
+	t.Helper()
+
+	for _, plaintext := range [][]byte{
+		[]byte(markerHost),
+		[]byte("type.googleapis.com/envoy."),
+		[]byte("envoy.config."),
+		[]byte("StreamAggregatedResources"),
+		[]byte("PRI * HTTP/2.0"),
+	} {
+		if bytes.Contains(capture, plaintext) {
+			t.Fatalf(
+				"xDS packet capture contained plaintext %q; xDS traffic between the proxy and controller is not encrypted\npcap size: %d bytes\ntcpdump log:\n%s",
+				string(plaintext),
+				len(capture),
+				tcpdumpLog,
+			)
+		}
+	}
+}
+
+func xdsWireProbeRouteManifest(host string) string {
+	return fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: %s
+  namespace: default
+spec:
+  parentRefs:
+    - name: gw
+  hostnames:
+    - %q
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: httpbin
+          port: 8000
+`, xdsWireProbeRoute, host)
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
TestControlPlaneTLS taps the wire. If you revert #14050, this test fails.
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

 Part of #14049 
<!--
Any extra context or edge cases for reviewers.
-->
