### PR TITLE
test: waypoint e2e curl wall-clock optimization

### DIFF
--- a/test/e2e/features/waypoint/cases_attachment.go
+++ b/test/e2e/features/waypoint/cases_attachment.go
@@ -52,14 +52,14 @@ func (s *testingSuite) TestServiceAttached() {
 		s.useWaypointLabelForTest("svc", "svc-a", testNamespace)
 
 		// only svc-a should through the waypoint
-		s.assertCurlService(fromCurl, "svc-a", testNamespace, hasEnvoy)
+		s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasEnvoy)
 		s.assertCurlService(fromCurl, "svc-b", testNamespace, noEnvoy)
 	})
 	s.Run("istio ServiceEntry", func() {
 		s.useWaypointLabelForTest("serviceentry", "se-a", testNamespace)
 
 		// only se-a should through the waypoint
-		s.assertCurlHost(fromCurl, "se-a.serviceentry.com", hasEnvoy)
+		s.assertStableCurlHost(fromCurl, "se-a.serviceentry.com", hasEnvoy)
 		s.assertCurlHost(fromCurl, "se-b.serviceentry.com", noEnvoy)
 	})
 }
@@ -69,12 +69,12 @@ func (s *testingSuite) TestNamespaceAttached() {
 
 	s.Run("kube Service", func() {
 		// everything goes through the waypoint
-		s.assertCurlService(fromCurl, "svc-a", testNamespace, hasEnvoy)
+		s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasEnvoy)
 		s.assertCurlService(fromCurl, "svc-b", testNamespace, hasEnvoy)
 	})
 	s.Run("istio ServiceEntry", func() {
 		// including ServiceEntry
-		s.assertCurlHost(fromCurl, "se-a.serviceentry.com", hasEnvoy)
+		s.assertStableCurlHost(fromCurl, "se-a.serviceentry.com", hasEnvoy)
 		s.assertCurlHost(fromCurl, "se-b.serviceentry.com", hasEnvoy)
 	})
 }

--- a/test/e2e/features/waypoint/cases_authz.go
+++ b/test/e2e/features/waypoint/cases_authz.go
@@ -24,7 +24,7 @@ func (s *testingSuite) TestAuthzNoCurlSvcB() {
 	s.applyOrFail("authz-deny-notcurl-svc-b.yaml", testNamespace)
 
 	// ensure waypoint attachment, and all requests fromCurl succeed
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, hasEnvoy)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasEnvoy)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, hasEnvoy)
 
 	// ensure authz is only applied to svc-a
@@ -37,7 +37,7 @@ func (s *testingSuite) TestAuthzGatewayClassRef() {
 	s.applyOrFail("authz-gatewayclass-ref.yaml", "istio-system")
 
 	// Verify waypoint attachment
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, isForbidden)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, isForbidden)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, isForbidden)
 
 	// Verify that policy applies to all services for notcurl
@@ -50,7 +50,7 @@ func (s *testingSuite) TestAuthzGatewayRef() {
 	s.applyOrFail("authz-gateway-ref.yaml", testNamespace)
 
 	// Verify waypoint attachment
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, isForbidden)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, isForbidden)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, isForbidden)
 
 	// Verify that policy applies to all services for notcurl
@@ -63,7 +63,7 @@ func (s *testingSuite) TestAuthzMultiService() {
 	s.applyOrFail("authz-multi-service.yaml", testNamespace)
 
 	// Verify waypoint attachment
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, isForbidden)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, isForbidden)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, isForbidden)
 
 	// Verify that policy applies to all services for notcurl
@@ -110,6 +110,10 @@ func (s *testingSuite) TestAuthzComplexRule() {
 					}
 
 					s.T().Run(key, func(t *testing.T) {
+						if from.name == "curl" && svc == "svc-a" && method == "GET" && path == "" {
+							s.assertStableCurlGeneric(from.opts, svc, method, path, expected)
+							return
+						}
 						s.assertCurlGeneric(from.opts, svc, method, path, expected)
 					})
 				}
@@ -123,7 +127,7 @@ func (s *testingSuite) TestAuthzServiceEntry() {
 	s.applyOrFail("authz-serviceentry.yaml", testNamespace)
 
 	// ensure waypoint attachment, and all requests fromCurl succeed
-	s.assertCurlHost(fromCurl, "se-a.serviceentry.com", hasEnvoy)
+	s.assertStableCurlHost(fromCurl, "se-a.serviceentry.com", hasEnvoy)
 	s.assertCurlHost(fromCurl, "se-b.serviceentry.com", isForbidden)
 
 	// ensure authz is only applied to svc-a

--- a/test/e2e/features/waypoint/cases_httproute.go
+++ b/test/e2e/features/waypoint/cases_httproute.go
@@ -33,7 +33,7 @@ func (s *testingSuite) TestServiceEntryHostnameHTTPRoute() {
 	s.applyOrFail("httproute-hostname.yaml", testNamespace)
 
 	// svc-a has the parent ref, so only have the route there
-	s.assertCurlHost(fromCurl, "se-a.serviceentry.com", hasHTTPRoute)
+	s.assertStableCurlHost(fromCurl, "se-a.serviceentry.com", hasHTTPRoute)
 	s.assertCurlHost(fromCurl, "se-b.serviceentry.com", noHTTPRoute)
 }
 
@@ -42,7 +42,7 @@ func (s *testingSuite) TestServiceEntryObjectHTTPRoute() {
 	s.applyOrFail("httproute-serviceentry.yaml", testNamespace)
 
 	// svc-a has the parent ref, so only have the route there
-	s.assertCurlHost(fromCurl, "se-a.serviceentry.com", hasHTTPRoute)
+	s.assertStableCurlHost(fromCurl, "se-a.serviceentry.com", hasHTTPRoute)
 	s.assertCurlHost(fromCurl, "se-b.serviceentry.com", noHTTPRoute)
 }
 
@@ -51,7 +51,7 @@ func (s *testingSuite) TestServiceHTTPRoute() {
 	s.applyOrFail("httproute-svc.yaml", testNamespace)
 
 	// svc-a has the parent ref, so only have the route there
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, noHTTPRoute)
 }
 
@@ -60,6 +60,6 @@ func (s *testingSuite) TestGatewayHTTPRoute() {
 	s.applyOrFail("httproute-gw.yaml", testNamespace)
 
 	// both get the route since we parent to the Gateway
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, hasHTTPRoute)
 }

--- a/test/e2e/features/waypoint/cases_ingress.go
+++ b/test/e2e/features/waypoint/cases_ingress.go
@@ -18,12 +18,12 @@ func (s *testingSuite) TestIngressHTTPRouteWithoutLabel() {
 
 	// verifying first the in-mesh traffic
 	// svc-a has the parent ref, so only have the route there
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, noHTTPRoute)
 
 	// verifying the ingress traffic does not go through waypoint because
 	// the ingress-use-waypoint label is not set
-	s.assertCurlInner(fromCurl, kubeutils.ServiceFQDN(metav1.ObjectMeta{
+	s.assertStableCurlInner(fromCurl, kubeutils.ServiceFQDN(metav1.ObjectMeta{
 		Name:      "gw",
 		Namespace: testNamespace,
 	}), "example.com", noHTTPRoute, "GET")
@@ -37,7 +37,7 @@ func (s *testingSuite) TestIngressHTTPRouteServiceLabel() {
 
 	// verifying first the in-mesh traffic
 	// svc-a has the parent ref, so only have the route there
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, noHTTPRoute)
 
 	// verifying the ingress traffic goes through waypoint
@@ -48,7 +48,7 @@ func (s *testingSuite) TestIngressHTTPRouteServiceLabel() {
 		// istio.io/ingress-use-waypoint=true
 		expected = noHTTPRoute
 	}
-	s.assertCurlInner(fromCurl, kubeutils.ServiceFQDN(metav1.ObjectMeta{
+	s.assertStableCurlInner(fromCurl, kubeutils.ServiceFQDN(metav1.ObjectMeta{
 		Name:      "gw",
 		Namespace: testNamespace,
 	}), "example.com", expected, "GET")
@@ -62,7 +62,7 @@ func (s *testingSuite) TestIngressHTTPRouteNamespaceLabel() {
 
 	// verifying first the in-mesh traffic
 	// svc-a has the parent ref, so only have the route there
-	s.assertCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
+	s.assertStableCurlService(fromCurl, "svc-a", testNamespace, hasHTTPRoute)
 	s.assertCurlService(fromCurl, "svc-b", testNamespace, noHTTPRoute)
 
 	// verifying the ingress traffic goes through waypoint
@@ -73,7 +73,7 @@ func (s *testingSuite) TestIngressHTTPRouteNamespaceLabel() {
 		// istio.io/ingress-use-waypoint=true
 		expected = noHTTPRoute
 	}
-	s.assertCurlInner(fromCurl, kubeutils.ServiceFQDN(metav1.ObjectMeta{
+	s.assertStableCurlInner(fromCurl, kubeutils.ServiceFQDN(metav1.ObjectMeta{
 		Name:      "gw",
 		Namespace: testNamespace,
 	}), "example.com", expected, "GET")

--- a/test/e2e/features/waypoint/curl_helper.go
+++ b/test/e2e/features/waypoint/curl_helper.go
@@ -27,6 +27,15 @@ func (s *testingSuite) assertCurlService(
 	s.assertCurlInner(from, fqdn(svcName, svcNs), "", matchers, "GET", path...)
 }
 
+func (s *testingSuite) assertStableCurlService(
+	from kubectl.PodExecOptions,
+	svcName, svcNs string, //nolint:unparam // current callers all use "svc-a"/testNamespace, but kept parameterized to match the non-stable variant
+	matchers matchers.HttpResponse,
+	path ...string, //nolint:unparam // The variadic params might cause false positive
+) {
+	s.assertStableCurlInner(from, fqdn(svcName, svcNs), "", matchers, "GET", path...)
+}
+
 // assertCurlServicePost is a helper function to assert a POST request to a service
 func (s *testingSuite) assertCurlServicePost(
 	from kubectl.PodExecOptions,
@@ -50,6 +59,15 @@ func (s *testingSuite) assertCurlHost(
 	s.assertCurlInner(from, targetHost, "", matchers, "GET", path...)
 }
 
+func (s *testingSuite) assertStableCurlHost(
+	from kubectl.PodExecOptions,
+	targetHost string, //nolint:unparam // current callers all use "se-a.serviceentry.com", but kept parameterized to match the non-stable variant
+	matchers matchers.HttpResponse,
+	path ...string, //nolint:unparam // The variadic params might cause false positive
+) {
+	s.assertStableCurlInner(from, targetHost, "", matchers, "GET", path...)
+}
+
 // assertCurlHostPost is a helper function to assert a POST request to a host
 func (s *testingSuite) assertCurlHostPost(
 	from kubectl.PodExecOptions,
@@ -63,11 +81,54 @@ func (s *testingSuite) assertCurlHostPost(
 func (s *testingSuite) assertCurlInner(
 	from kubectl.PodExecOptions,
 	targetHost string,
+	hostHeader string, //nolint:unparam // hostHeader is wired through buildCurlOptions for future use; current callers all pass ""
+	matchers matchers.HttpResponse,
+	method string,
+	path ...string,
+) {
+	curlOpts := buildCurlOptions(targetHost, hostHeader, method, path...)
+
+	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
+		s.ctx,
+		from,
+		curlOpts,
+		&matchers,
+	)
+}
+
+func (s *testingSuite) assertStableCurlInner(
+	from kubectl.PodExecOptions,
+	targetHost string,
 	hostHeader string,
 	matchers matchers.HttpResponse,
 	method string,
 	path ...string,
 ) {
+	curlOpts := buildCurlOptions(targetHost, hostHeader, method, path...)
+
+	// Waypoint dataplane startup can briefly return the right response before
+	// becoming stable, especially around AuthorizationPolicy setup.
+	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
+		s.ctx,
+		from,
+		curlOpts,
+		&matchers,
+		time.Minute,
+	)
+	s.testInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(
+		s.ctx,
+		from,
+		curlOpts,
+		&matchers,
+	)
+}
+
+func buildCurlOptions(
+	targetHost string,
+	hostHeader string,
+	method string,
+	path ...string,
+) []curl.Option {
 	curlOpts := []curl.Option{
 		curl.WithHost(targetHost),
 		curl.WithPort(testAppPort),
@@ -86,22 +147,7 @@ func (s *testingSuite) assertCurlInner(
 		curlOpts = append(curlOpts, curl.WithPath(path[0]))
 	}
 
-	// wait for 1 good response
-	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
-		s.ctx,
-		from,
-		curlOpts,
-		&matchers,
-		time.Minute,
-	)
-
-	// then ensure it's consistently working
-	s.testInstallation.AssertionsT(s.T()).AssertEventuallyConsistentCurlResponse(
-		s.ctx,
-		from,
-		curlOpts,
-		&matchers,
-	)
+	return curlOpts
 }
 
 // assertCurlGeneric is added to unify testing of mutlivalued iterating tests
@@ -111,4 +157,12 @@ func (s *testingSuite) assertCurlGeneric(
 	expected matchers.HttpResponse,
 ) {
 	s.assertCurlInner(from, fqdn(svc, testNamespace), "", expected, method, path)
+}
+
+func (s *testingSuite) assertStableCurlGeneric(
+	from kubectl.PodExecOptions,
+	svc, method, path string,
+	expected matchers.HttpResponse,
+) {
+	s.assertStableCurlInner(from, fqdn(svc, testNamespace), "", expected, method, path)
 }


### PR DESCRIPTION
# Description
Reduces waypoint e2e suite runtime by avoiding redundant stability checks.

This e2e test is part of why its shard is often the slowest. Let's avoid some 3000ms curl-based assertions that don't really improve testing.

Every `assertCurl*` helper in the waypoint suite did two things back to back:

1. `AssertEventualCurlResponse` — poll until one good response (1m timeout).
2. `AssertEventuallyConsistentCurlResponse` — keep polling to confirm the response stays good.

Step 2 is intentionally slow — it's the "stay good for N seconds" guard against the waypoint dataplane briefly returning the right response before AuthorizationPolicy / EDS / etc. fully reconcile. It runs for ~3s per call, and most test cases issue 2–4 curls.

This PR splits the helper in two:

- `assertStableCurl*` — does both phases (the original behavior).
- `assertCurl*` — does only phase 1.

Each test case now uses `assertStableCurl*` for its first curl and the lighter `assertCurl*` for subsequent ones. Once stability has been observed once in a test, the waypoint isn't going to spontaneously destabilize mid-case — the race conditions step 2 guards against have already settled.

The deflake guard is preserved at the highest-risk point (the first curl, right after manifests are applied); it's just not paid redundantly on every follow-up assertion.

/kind cleanup

```release-note
NONE
```

# Additional Notes

No production code changes — test helpers only. Estimated wall-clock savings: ~3s per non-first curl across the waypoint suite (~25 curls total, ~15 of them non-first).
