### PR TITLE
Report BackendTLSPolicy status for TCP filters

### DIFF
--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -30,7 +30,9 @@ import (
 )
 
 type translatorTestCase struct {
+	// TODO(#14069): Replace inputFile with inputFiles across this test suite.
 	inputFile  string
+	inputFiles []string
 	outputFile string
 	gwNN       types.NamespacedName
 }
@@ -54,7 +56,14 @@ func TestBasic(t *testing.T) {
 				s.EnableAuthMetadata = true
 			},
 		}, settingOpts...)
-		inputFiles := []string{filepath.Join(dir, "testutils/inputs/", in.inputFile)}
+		inputs := in.inputFiles
+		if len(inputs) == 0 {
+			inputs = []string{in.inputFile}
+		}
+		inputFiles := make([]string, 0, len(inputs))
+		for _, input := range inputs {
+			inputFiles = append(inputFiles, filepath.Join(dir, "testutils/inputs/", input))
+		}
 		expectedProxyFile := filepath.Join(dir, "testutils/outputs/", in.outputFile)
 		translatortest.TestTranslation(t, ctx, inputFiles, expectedProxyFile, in.gwNN, settingOpts...)
 	}
@@ -1199,6 +1208,20 @@ func TestBasic(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFile:  "backendtlspolicy/tls-section-name.yaml",
 			outputFile: "backendtlspolicy/tls-section-name.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("Backend TLS Policy with terminated TLSRoute", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{
+				"tls-routing/tls-terminate.yaml",
+				"backendtlspolicy/tlsroute-terminated.yaml",
+			},
+			outputFile: "backendtlspolicy/tlsroute-terminated.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",

--- a/pkg/kgateway/translator/gateway/testutils/inputs/backendtlspolicy/tlsroute-terminated.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/backendtlspolicy/tlsroute-terminated.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: tlsroute-backend-tls
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: example-tls-svc
+  validation:
+    hostname: "example.com"
+    wellKnownCACertificates: System

--- a/pkg/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tlsroute-terminated.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tlsroute-terminated.yaml
@@ -1,0 +1,147 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_example-tls-svc_443
+  transportSocket:
+    name: envoy.transport_sockets.tls
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      commonTlsContext:
+        combinedValidationContext:
+          defaultValidationContext:
+            matchTypedSubjectAltNames:
+            - matcher:
+                exact: example.com
+              sanType: DNS
+          validationContextSdsSecretConfig:
+            name: SYSTEM_CA_CERT
+      sni: example.com
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8443
+  filterChains:
+  - filterChainMatch:
+      serverNames:
+      - example.com
+    filters:
+    - name: envoy.filters.network.tcp_proxy
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+        cluster: kube_default_example-tls-svc_443
+        statPrefix: listener~8443-default.example-tls-route-rule-0
+    name: listener~8443-default.example-tls-route-rule-0
+    transportSocket:
+      name: envoy.transport_sockets.tls
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        commonTlsContext:
+          tlsCertificates:
+          - certificateChain:
+              inlineBytes: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREVENDQWZXZ0F3SUJBZ0lVTkdyRWplRmNzelJjWmdnYW1FNWNXZ0lZQkkwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZqRVVNQklHQTFVRUF3d0xaWGhoYlhCc1pTNWpiMjB3SGhjTk1qWXdNakU1TVRFeU1ERTBXaGNOTXpZdwpNakUzTVRFeU1ERTBXakFXTVJRd0VnWURWUVFEREF0bGVHRnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMQURGRFNKU2NZQzJMcmx6YVk3NmpxVERsTHZiVW9jY21yNmJabFEKSUJDRW5XQ1VnTHhDcmoyWUVuWVhjOThYd1h0MVkvSmdHN2Y0TUcrbTZMVTkvR0pNWjROVG5JV2l3NTVEY3FSKwpyWElwbGZHaUswYXhDZy9IREkwQ1dLRHgzQk12OGsvM3M2MFljbit5bUhTd29RZm5PWDU4RzgzR1BhYW9OclNtCkNJU1JvcXA2VUx2NnFkSERVeDBuanBFRlo1c2NFb09OWjBxTUhmYnNvL2h6Q3Byc0ZHTkNvcFgzWUdBQjFyTVQKcHdWWkRTSmg4K1A4QWxPZE16VkJyWWF2MFp4bVdMcmd3Y3FYTzNuT1RYTVZ1TWpocmVMSFcxZlNJOWZ5QWU5QgpaQ3dSSmJZNXBsd2t4RVNrUXRhb2YvZFdTM2ZnaHEvSC9keEk0bU9EN2diL2taRUNBd0VBQWFOVE1GRXdIUVlEClZSME9CQllFRkVwWnh2enVDR05pWk9XNUd1TkIwL3hwMWRiN01COEdBMVVkSXdRWU1CYUFGRXBaeHZ6dUNHTmkKWk9XNUd1TkIwL3hwMWRiN01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQgpBS0V5WWs0YURaTW1iWmRKYmpFM1M4aGMrUGlrT0ZCaGtVY3Q2aG05bjhhM3pUcHN6S21YVU9Nd3p4VjhZNDBDCjc2Z0lSL1BNT3BoQUpTWkNXQmYzTndLenl0Z0lMZUFhRFFVWXFYbVpTaHRYeDMvU3I4c0szblYxREZ0NnZTaGMKSWdTK1dTZ2xhZU5aVWJwb1VZSDZuUWpXaDlYYVJBbmdudXEweEJLM1FUeVoxUHRzZE5seW5PWVdqR2JLc3pvNgpuNHJLOSs1WERjL3lMQlduT2ZxU28zQTRiOWI3d0VyeThCV2VBRGhvREJ2YXRvQmZ1NkVNYzBvV251VVQ0UEdiCmhVVW5xSFJiT2hVcVZFemlRZDZqajlDejdKWTRBZnhHYitQclNVYnBNdjV6ZllNZXFDY21MOW5vUEVpckxUV0gKUktCVWFyTTJjMGFQTktUZFJvTEtqaE09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+            privateKey:
+              inlineBytes: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRQ3dBeFEwaVVuR0F0aTYKNWMybU8rbzZrdzVTNzIxS0hISnErbTJaVUNBUWhKMWdsSUM4UXE0OW1CSjJGM1BmRjhGN2RXUHlZQnUzK0RCdgpwdWkxUGZ4aVRHZURVNXlGb3NPZVEzS2tmcTF5S1pYeG9pdEdzUW9QeHd5TkFsaWc4ZHdUTC9KUDk3T3RHSEovCnNwaDBzS0VINXpsK2ZCdk54ajJtcURhMHBnaUVrYUtxZWxDNytxblJ3MU1kSjQ2UkJXZWJIQktEaldkS2pCMzIKN0tQNGN3cWE3QlJqUXFLVjkyQmdBZGF6RTZjRldRMGlZZlBqL0FKVG5UTTFRYTJHcjlHY1psaTY0TUhLbHp0NQp6azF6RmJqSTRhM2l4MXRYMGlQWDhnSHZRV1FzRVNXMk9hWmNKTVJFcEVMV3FILzNWa3QzNElhdngvM2NTT0pqCmcrNEcvNUdSQWdNQkFBRUNnZ0VBS0s0ZGZtTDRyUTQ5WHp6N3dkNzVMTjZPSWZiNmNIV1FzRTcvQTc4MEdmMDgKam5Ua0tCN1ZQS0VvS3lrU2U4NTJ4bjBFUTZHWTVuVXpaS3JVQUFlNmpGR1NYeFQxQ1NIc1NtaldWMVI3Ni9YVwpsUWxoTFM1LzM5T21mL1M1M1VEcEYzb3VhL01aRVBta2hRVVhIV2t4WHEwL2FZOXZzYWlPMlRUcHArano4UWVCCnZVb1czWlhEUjZTVkVTdFVwblRQOFh1ZzRvelRTcGdFZG1ScFlmR0FqcytDL3lRcjZmUFEyRmxONWhNRm4zSVAKa0Zna3p1SjlWd0dQK25DZ0VxUlhwR0kyMWJlZkFENzJUQ3p2NW9tODhrUjZsdGhJa0xINWdzVjBnbVFDN2J1YgpMM3NrTHdUMXBHTHZBditweUdRZVFOVnJSU1Q2dUc4alJlZWpMS3FLVFFLQmdRRGIzRXJ2NjhKcFZnUnpXSldwClRURDdCL3FLRFFGSEttQVl1VTVpM25odEZKWkJ6blF1NFA4YXVkelRWNk94RWloTFdkUGo3aUJCcG1JbGIyTy8KazJleE5QY3FnOXN6QVB4UzdzdmN5bmpQN2ZwM3hHVVNKWndTYlI5Nm5QS0tZeTBiOCt2WXUrU1VpSUczMFN6awoxQk13SWlWb3g4OE8zK3c5NkNxUzk4UEJkd0tCZ1FETThhVjJqYmh1ZjMvOWdEL0xHeExWT0pESlR6Q1RRKzNvCmdJTzlpYTRMaitacUNZNVVHWkhBK1J2M2hTSXY4a2g4WVlPbUV5MDZqdjhTZ1ZLd3FhTU1vbXZkUGtPNWUxWkgKN2h6OWhWQVJ2UlVpU2M0S1BYbWVOUXM2RWNtM1FwNnh6ZlhKemJxZmtDNjQwd25xbXdIMWxDczhqaHI1ZVc2VQpWek1CZ3o5SE53S0JnSFlBNDd1bjl6MmdMRjFZYzJOZUNlY0NYa2RRT1pwZnRSb3dBMUZ2aElWUFltSkprL1JCClVNcWdiVlNGbWxjRW50bnFpWjZ4aFdDWEUrQnh5OERjTmZCWHREMStiZDBQTDE2M3luVmp1cm9uU2FLVXA0YTQKNXU3QTRQOW5VNHBSTnJubERuWFNTeG9wdGkzWnVGWE5PY3RBMklGSGxPdXY1ZFZJVWVsMXoveDdBb0dBUjBMdgpDZDRWZHphV1JvdEZvMVh5b25sY3Z1THVQUWF0dnQ2UThHTGpSZG52Z0lkNkdmd2FGa09JV2ZUTkFtYjRsV2RDCjQ0aGZmYkVqT0VnSGZLNC9wN0VDV0pmQjdNamFJNERFUzlNREdHZnE1VlZNYzNzVXd0SW02VFl1TWE3VWgzYmEKTkNWNDh1cXJsRkN0YmdvZ0VFaEpFSEZKSjkzMWVWY293U25sNHRrQ2dZQS84RmptR1E0NXZhOVQ1cDN1K1VqcQpPVzk5U1ZwR1hLS0c5MFJyelNoRHF5cDBpTTgvQzF3Y0FyWjFzc3p3QWx3QjNkUEJScmhadkNZYVh6NlNDczh1CmljOG5naUNneWV1WW05T1AzU1dKNk1VSU5Ha0pVbEJWOHlJRlI4R3FYN1NLVE5EUWZUNEw5K0xYd2VHYkF3WlMKNVUwd2N6ZG1IWW5lR1ZUa2dvQncxZz09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+          tlsParams: {}
+  listenerFilters:
+  - name: envoy.filters.listener.tls_inspector
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+  name: listener~8443
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: tls
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute
+  policies:
+    BackendTLSPolicy/default/tlsroute-backend-tls:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        controllerName: kgateway.dev/kgateway
+  tlsRoutes:
+    default/example-tls-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -374,8 +374,8 @@ func sortHttpFilters(filters filters.StagedHttpFilterList) []*envoyhttp.HttpFilt
 	return sortedFilters
 }
 
-func (h *filterChainTranslator) computeTcpFilters(l ir.TcpIR, reporter sdkreporter.ListenerReporter) []*envoylistenerv3.Filter {
-	networkFilters := sortNetworkFilters(h.computeCustomFilters(l.CustomNetworkFilters, reporter))
+func (h *filterChainTranslator) computeTcpFilters(l ir.TcpIR, listenerReporter sdkreporter.ListenerReporter) []*envoylistenerv3.Filter {
+	networkFilters := sortNetworkFilters(h.computeCustomFilters(l.CustomNetworkFilters, listenerReporter))
 
 	cfg := &envoytcp.TcpProxy{
 		StatPrefix: l.FilterChainName,

--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -380,9 +380,11 @@ func (h *filterChainTranslator) computeTcpFilters(l ir.TcpIR, reporter sdkreport
 	cfg := &envoytcp.TcpProxy{
 		StatPrefix: l.FilterChainName,
 	}
-	// TODO(#13908): Emit BackendTLSPolicy Gateway-ancestor status for TCP/TLS
-	// BackendRefs here, matching the HTTP/GRPC path in route.go. This is
-	// primarily needed for terminated TLSRoute backends on the shared path.
+	if h.reporter != nil {
+		for _, backend := range l.BackendRefs {
+			reportBackendObjectPolicyStatus(h.reporter, h.listener.PolicyAncestorRef, h.pluginPass, backend.BackendObject)
+		}
+	}
 	if len(l.BackendRefs) == 1 {
 		cfg.ClusterSpecifier = &envoytcp.TcpProxy_Cluster{
 			Cluster: l.BackendRefs[0].ClusterName,

--- a/pkg/kgateway/translator/irtranslator/gateway.go
+++ b/pkg/kgateway/translator/irtranslator/gateway.go
@@ -176,6 +176,7 @@ func (t *Translator) ComputeListener(
 	fct := filterChainTranslator{
 		listener:   lis,
 		gateway:    gw,
+		reporter:   reporter,
 		pluginPass: pass,
 	}
 

--- a/pkg/kgateway/translator/irtranslator/policy.go
+++ b/pkg/kgateway/translator/irtranslator/policy.go
@@ -126,8 +126,6 @@ func reportBackendObjectPolicyStatus(
 	pluginPass TranslationPassPlugins,
 	backend *ir.BackendObjectIR,
 ) {
-	// TODO(#13908): Wire this helper into the shared TCP/TLS filter-chain path so
-	// terminated TLSRoute backends report BackendTLSPolicy Gateway ancestors too.
 	if backend == nil {
 		return
 	}

--- a/test/e2e/features/backendtls/suite.go
+++ b/test/e2e/features/backendtls/suite.go
@@ -135,7 +135,7 @@ func (s *tsuite) TestBackendTLSPolicyAndStatus() {
 		Type:               string(gwv1.BackendTLSPolicyConditionResolvedRefs),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(gwv1.BackendTLSPolicyReasonResolvedRefs),
-		Message:            "Resolved all references",
+		Message:            resolvedAllReferencesMsg,
 		ObservedGeneration: backendTlsPolicy.Generation,
 	})
 
@@ -170,7 +170,7 @@ func (s *tsuite) TestBackendTLSPolicyStatusForTerminatedTLSRoute() {
 		Type:    string(gwv1.BackendTLSPolicyConditionResolvedRefs),
 		Status:  metav1.ConditionTrue,
 		Reason:  string(gwv1.BackendTLSPolicyReasonResolvedRefs),
-		Message: "Resolved all references",
+		Message: resolvedAllReferencesMsg,
 	})
 }
 
@@ -199,30 +199,32 @@ func (s *tsuite) assertPolicyStatusForPolicy(
 
 		g.Expect(ancestor.Conditions).To(gomega.HaveLen(2), "ancestor conditions wasn't length of 2")
 		cond := meta.FindStatusCondition(ancestor.Conditions, inCondition.Type)
-		if inCondition.ObservedGeneration == 0 {
-			inCondition.ObservedGeneration = tlsPol.Generation
+		expectedObservedGeneration := inCondition.ObservedGeneration
+		if expectedObservedGeneration == 0 {
+			expectedObservedGeneration = tlsPol.Generation
 		}
 		g.Expect(cond).NotTo(gomega.BeNil(), "policy should have expected condition")
 		g.Expect(cond.Status).To(gomega.Equal(inCondition.Status), "policy condition should have expected status")
 		g.Expect(cond.Reason).To(gomega.Equal(inCondition.Reason), "policy reason should match")
 		g.Expect(cond.Message).To(gomega.Equal(inCondition.Message))
-		g.Expect(cond.ObservedGeneration).To(gomega.Equal(inCondition.ObservedGeneration))
+		g.Expect(cond.ObservedGeneration).To(gomega.Equal(expectedObservedGeneration))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
 }
 
-func gatewayParentReference(meta metav1.ObjectMeta) gwv1.ParentReference {
-	namespace := gwv1.Namespace(meta.Namespace)
+func gatewayParentReference(objMeta metav1.ObjectMeta) gwv1.ParentReference {
+	namespace := gwv1.Namespace(objMeta.Namespace)
 	return gwv1.ParentReference{
 		Group:     &gatewayGroup,
 		Kind:      &gatewayKind,
 		Namespace: &namespace,
-		Name:      gwv1.ObjectName(meta.Name),
+		Name:      gwv1.ObjectName(objMeta.Name),
 	}
 }
 
 const (
-	kgatewayControllerName = "kgateway.dev/kgateway"
-	otherControllerName    = "other-controller.example.com/controller"
+	resolvedAllReferencesMsg = "Resolved all references"
+	kgatewayControllerName   = "kgateway.dev/kgateway"
+	otherControllerName      = "other-controller.example.com/controller"
 )
 
 // TestBackendTLSPolicyClearStaleStatus verifies that stale status is cleared when targetRef becomes invalid

--- a/test/e2e/features/backendtls/suite.go
+++ b/test/e2e/features/backendtls/suite.go
@@ -31,6 +31,7 @@ import (
 var (
 	configMapManifest                     = filepath.Join(fsutils.MustGetThisDir(), "testdata/configmap.yaml")
 	backendTLSPolicyMissingTargetManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata/missing-target.yaml")
+	terminatedTLSRouteManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata/terminated-tlsroute.yaml")
 
 	backendTlsPolicy = &gwv1.BackendTLSPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -40,6 +41,16 @@ var (
 	}
 	gatewayMeta = metav1.ObjectMeta{
 		Name:      "gateway",
+		Namespace: "kgateway-base",
+	}
+	terminatedTLSRoutePolicy = &gwv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tlsroute-backend-tls",
+			Namespace: "kgateway-base",
+		},
+	}
+	terminatedTLSRouteGatewayMeta = metav1.ObjectMeta{
+		Name:      "tlsroute-gateway",
 		Namespace: "kgateway-base",
 	}
 	gatewayGroup = gwv1.Group(gwv1.GroupVersion.Group)
@@ -54,6 +65,10 @@ var (
 	// test cases
 	testCases = map[string]*base.TestCase{
 		"TestBackendTLSPolicyAndStatus": {},
+		"TestBackendTLSPolicyStatusForTerminatedTLSRoute": {
+			Manifests:       []string{terminatedTLSRouteManifest},
+			MinGwApiVersion: base.GwApiRequireTlsRoutes,
+		},
 	}
 )
 
@@ -144,34 +159,65 @@ func (s *tsuite) TestBackendTLSPolicyAndStatus() {
 	})
 }
 
+func (s *tsuite) TestBackendTLSPolicyStatusForTerminatedTLSRoute() {
+	s.assertPolicyStatusForPolicy(terminatedTLSRoutePolicy, terminatedTLSRouteGatewayMeta, metav1.Condition{
+		Type:    string(gwv1.PolicyConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gwv1.PolicyReasonAccepted),
+		Message: reports.PolicyAcceptedMsg,
+	})
+	s.assertPolicyStatusForPolicy(terminatedTLSRoutePolicy, terminatedTLSRouteGatewayMeta, metav1.Condition{
+		Type:    string(gwv1.BackendTLSPolicyConditionResolvedRefs),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gwv1.BackendTLSPolicyReasonResolvedRefs),
+		Message: "Resolved all references",
+	})
+}
+
 func (s *tsuite) assertPolicyStatus(inCondition metav1.Condition) {
+	s.assertPolicyStatusForPolicy(backendTlsPolicy, gatewayMeta, inCondition)
+}
+
+func (s *tsuite) assertPolicyStatusForPolicy(
+	policy *gwv1.BackendTLSPolicy,
+	ancestorMeta metav1.ObjectMeta,
+	inCondition metav1.Condition,
+) {
 	currentTimeout, pollingInterval := helpers.GetTimeouts()
 	p := s.TestInstallation.AssertionsT(s.T())
 	p.Gomega.Eventually(func(g gomega.Gomega) {
 		tlsPol := &gwv1.BackendTLSPolicy{}
-		objKey := client.ObjectKeyFromObject(backendTlsPolicy)
+		objKey := client.ObjectKeyFromObject(policy)
 		err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx, objKey, tlsPol)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get BackendTLSPolicy %s", objKey)
 
 		g.Expect(tlsPol.Status.Ancestors).To(gomega.HaveLen(1), "ancestors didn't have length of 1")
 
-		expectedRef := gwv1.ParentReference{
-			Group:     &gatewayGroup,
-			Kind:      &gatewayKind,
-			Namespace: new(gwv1.Namespace(gatewayMeta.Namespace)),
-			Name:      gwv1.ObjectName(gatewayMeta.Name),
-		}
+		expectedRef := gatewayParentReference(ancestorMeta)
 		ancestor := tlsPol.Status.Ancestors[0]
 		g.Expect(ancestor.AncestorRef).To(gomega.BeEquivalentTo(expectedRef))
 
 		g.Expect(ancestor.Conditions).To(gomega.HaveLen(2), "ancestor conditions wasn't length of 2")
 		cond := meta.FindStatusCondition(ancestor.Conditions, inCondition.Type)
+		if inCondition.ObservedGeneration == 0 {
+			inCondition.ObservedGeneration = tlsPol.Generation
+		}
 		g.Expect(cond).NotTo(gomega.BeNil(), "policy should have expected condition")
 		g.Expect(cond.Status).To(gomega.Equal(inCondition.Status), "policy condition should have expected status")
 		g.Expect(cond.Reason).To(gomega.Equal(inCondition.Reason), "policy reason should match")
 		g.Expect(cond.Message).To(gomega.Equal(inCondition.Message))
 		g.Expect(cond.ObservedGeneration).To(gomega.Equal(inCondition.ObservedGeneration))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
+}
+
+func gatewayParentReference(meta metav1.ObjectMeta) gwv1.ParentReference {
+	namespace := gwv1.Namespace(meta.Namespace)
+	return gwv1.ParentReference{
+		Group:     &gatewayGroup,
+		Kind:      &gatewayKind,
+		Namespace: &namespace,
+		Name:      gwv1.ObjectName(meta.Name),
+	}
 }
 
 const (
@@ -219,12 +265,7 @@ func (s *tsuite) addAncestorStatus(policyName, policyNamespace, controllerName s
 
 		// Add fake ancestor status
 		fakeStatus := gwv1.PolicyAncestorStatus{
-			AncestorRef: gwv1.ParentReference{
-				Group:     &gatewayGroup,
-				Kind:      &gatewayKind,
-				Namespace: new(gwv1.Namespace(gatewayMeta.Namespace)),
-				Name:      gwv1.ObjectName(gatewayMeta.Name),
-			},
+			AncestorRef:    gatewayParentReference(gatewayMeta),
 			ControllerName: gwv1.GatewayController(controllerName),
 			Conditions: []metav1.Condition{
 				{

--- a/test/e2e/features/backendtls/testdata/terminated-tlsroute.yaml
+++ b/test/e2e/features/backendtls/testdata/terminated-tlsroute.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-tlsroute
+  namespace: kgateway-base
+spec:
+  selector:
+    app.kubernetes.io/name: nginx
+  ports:
+  - protocol: TCP
+    port: 8443
+    targetPort: https-web-svc
+    name: https
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: tlsroute-gateway
+  namespace: kgateway-base
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: tls
+    protocol: TLS
+    port: 8443
+    hostname: example.com
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: certs
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - kind: TLSRoute
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-backend-tls
+  namespace: kgateway-base
+spec:
+  parentRefs:
+  - name: tlsroute-gateway
+    sectionName: tls
+  hostnames:
+  - example.com
+  rules:
+  - backendRefs:
+    - name: nginx-tlsroute
+      port: 8443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: tlsroute-backend-tls
+  namespace: kgateway-base
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: nginx-tlsroute
+  validation:
+    hostname: example.com
+    wellKnownCACertificates: System


### PR DESCRIPTION
# Description

BackendTLSPolicy status is now reported for Gateway ancestors on the shared TCP filter-chain translation path, covering TCPRoute and terminated TLSRoute backends.

Changes:
- Wire the reporter into filter-chain translation and report backend object policy status for TCP backends.
- Add translator coverage for terminated TLSRoute.
- Add e2e status coverage for a terminated TLSRoute BackendTLSPolicy.

Fixes: #13908

# Change Type

/kind fix

# Changelog

```release-note
Fixed BackendTLSPolicy status reporting for TCPRoute and terminated TLSRoute backends.
```

# Additional Notes

TCPRoute shares the same TCP filter-chain translation path as terminated TLSRoute, so the implementation applies to both.