### PR TITLE
test: use inputFiles in gateway translator cases

### DIFF
--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 type translatorTestCase struct {
-	inputFile  string
+	inputFiles []string
 	outputFile string
 	gwNN       types.NamespacedName
 }
@@ -54,14 +54,17 @@ func TestBasic(t *testing.T) {
 				s.EnableAuthMetadata = true
 			},
 		}, settingOpts...)
-		inputFiles := []string{filepath.Join(dir, "testutils/inputs/", in.inputFile)}
+		inputFiles := make([]string, 0, len(in.inputFiles))
+		for _, inputFile := range in.inputFiles {
+			inputFiles = append(inputFiles, filepath.Join(dir, "testutils/inputs/", inputFile))
+		}
 		expectedProxyFile := filepath.Join(dir, "testutils/outputs/", in.outputFile)
 		translatortest.TestTranslation(t, ctx, inputFiles, expectedProxyFile, in.gwNN, settingOpts...)
 	}
 
 	t.Run("gateway with no routes should not add empty filter chain", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/gateway.yaml",
+			inputFiles: []string{"gateway-only/gateway.yaml"},
 			outputFile: "gateway-only/proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -72,7 +75,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with no valid listeners should report correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/gateway-invalid-listener.yaml",
+			inputFiles: []string{"gateway-only/gateway-invalid-listener.yaml"},
 			outputFile: "gateway-only/gateway-invalid-listener-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -83,7 +86,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with TLS listener with TLS options", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/tls-options.yaml",
+			inputFiles: []string{"gateway-only/tls-options.yaml"},
 			outputFile: "gateway-only/tls-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -94,7 +97,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with TLS listener with multiple TLS certificates", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/tls-multiple-certificates.yaml",
+			inputFiles: []string{"gateway-only/tls-multiple-certificates.yaml"},
 			outputFile: "gateway-only/tls-multiple-certificates.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -105,7 +108,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with FrontendTLSConfig", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "frontendtlsconfig/basic.yaml",
+			inputFiles: []string{"frontendtlsconfig/basic.yaml"},
 			outputFile: "frontendtlsconfig/basic.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -116,7 +119,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("frontendtlsconfig with verify subject alt names missing ca certificate", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "frontendtlsconfig/verify-subject-alt-names-missing-ca.yaml",
+			inputFiles: []string{"frontendtlsconfig/verify-subject-alt-names-missing-ca.yaml"},
 			outputFile: "frontendtlsconfig/verify-subject-alt-names-missing-ca.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -127,7 +130,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("frontendtlsconfig with invalid conditions", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "frontendtlsconfig/invalid-conditions.yaml",
+			inputFiles: []string{"frontendtlsconfig/invalid-conditions.yaml"},
 			outputFile: "frontendtlsconfig/invalid-conditions.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -138,7 +141,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with per connection buffer limit", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-per-conn-buf-lim/gateway.yaml",
+			inputFiles: []string{"gateway-per-conn-buf-lim/gateway.yaml"},
 			outputFile: "gateway-per-conn-buf-lim/proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -149,7 +152,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing/basic.yaml",
+			inputFiles: []string{"http-routing/basic.yaml"},
 			outputFile: "http-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -160,7 +163,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with custom class", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "custom-gateway-class",
+			inputFiles: []string{"custom-gateway-class"},
 			outputFile: "custom-gateway-class.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -171,7 +174,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("https gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-routing/gateway.yaml",
+			inputFiles: []string{"https-routing/gateway.yaml"},
 			outputFile: "https-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -182,7 +185,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("https gateway with invalid certificate ref", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-routing/invalid-cert.yaml",
+			inputFiles: []string{"https-routing/invalid-cert.yaml"},
 			outputFile: "https-invalid-cert-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -193,7 +196,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with multiple listeners on the same port", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "multiple-listeners-http-routing",
+			inputFiles: []string{"multiple-listeners-http-routing"},
 			outputFile: "multiple-listeners-http-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -204,7 +207,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("https gateway with multiple listeners on the same port", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "multiple-listeners-https-routing",
+			inputFiles: []string{"multiple-listeners-https-routing"},
 			outputFile: "multiple-listeners-https-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -215,7 +218,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with multiple routing rules and HeaderModifier filter", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-with-header-modifier",
+			inputFiles: []string{"http-with-header-modifier"},
 			outputFile: "http-with-header-modifier-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -226,7 +229,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway API route sorting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "route-sort.yaml",
+			inputFiles: []string{"route-sort.yaml"},
 			outputFile: "route-sort.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -237,7 +240,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("weight based route sorting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "route-sort-weighted.yaml",
+			inputFiles: []string{"route-sort-weighted.yaml"},
 			outputFile: "route-sort-weighted.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -250,7 +253,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("httproute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing-missing-backend",
+			inputFiles: []string{"http-routing-missing-backend"},
 			outputFile: "http-routing-missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -261,7 +264,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("httproute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing-invalid-backend",
+			inputFiles: []string{"http-routing-invalid-backend"},
 			outputFile: "http-routing-invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -272,7 +275,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("httproute with backend port error reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/backend-ref-port-error.yaml",
+			inputFiles: []string{"backends/backend-ref-port-error.yaml"},
 			outputFile: "backends/backend-ref-port-error.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -283,7 +286,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy merging", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/merge.yaml",
+			inputFiles: []string{"traffic-policy/merge.yaml"},
 			outputFile: "traffic-policy/merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -294,7 +297,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with targetSelectors", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/label_based.yaml",
+			inputFiles: []string{"traffic-policy/label_based.yaml"},
 			outputFile: "traffic-policy/label_based.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -305,7 +308,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with targetSelectors and global policy attachment", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/label_based.yaml",
+			inputFiles: []string{"traffic-policy/label_based.yaml"},
 			outputFile: "traffic-policy/label_based_global_policy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -319,7 +322,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy gRPC ExtAuth different attachment points", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-grpc.yaml",
+			inputFiles: []string{"traffic-policy/extauth-grpc.yaml"},
 			outputFile: "traffic-policy/extauth-grpc.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -330,7 +333,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy HTTP ExtAuth different attachment points", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-http.yaml",
+			inputFiles: []string{"traffic-policy/extauth-http.yaml"},
 			outputFile: "traffic-policy/extauth-http.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -342,7 +345,7 @@ func TestBasic(t *testing.T) {
 	// test the default and fully configured values for gRPC ExtAuth
 	t.Run("TrafficPolicy gRPC ExtAuth Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-grpc-full-config.yaml",
+			inputFiles: []string{"traffic-policy/extauth-grpc-full-config.yaml"},
 			outputFile: "traffic-policy/extauth-grpc-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -354,7 +357,7 @@ func TestBasic(t *testing.T) {
 	// test the default and fully configured values for HTTP ExtAuth
 	t.Run("TrafficPolicy HTTP ExtAuth Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-http-full-config.yaml",
+			inputFiles: []string{"traffic-policy/extauth-http-full-config.yaml"},
 			outputFile: "traffic-policy/extauth-http-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -365,7 +368,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtAuth with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/extauth-cross-namespace.yaml"},
 			outputFile: "traffic-policy/extauth-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -376,7 +379,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-route.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-route.yaml"},
 			outputFile: "traffic-policy/api-key-auth-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -387,7 +390,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-httproute.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-httproute.yaml"},
 			outputFile: "traffic-policy/api-key-auth-httproute.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -398,7 +401,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-gateway.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-gateway.yaml"},
 			outputFile: "traffic-policy/api-key-auth-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -409,7 +412,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication route override gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-override.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-override.yaml"},
 			outputFile: "traffic-policy/api-key-auth-override.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -420,7 +423,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication route override gateway with sectionName", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-override-section.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-override-section.yaml"},
 			outputFile: "traffic-policy/api-key-auth-override-section.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -431,7 +434,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretRef", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-secretref.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-secretref.yaml"},
 			outputFile: "traffic-policy/api-key-auth-secretref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -442,7 +445,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretRef and ReferenceGrant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-secretref-with-refgrant.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-secretref-with-refgrant.yaml"},
 			outputFile: "traffic-policy/api-key-auth-secretref-with-refgrant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -453,7 +456,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretSelector and ReferenceGrant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-selector-with-refgrant.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-selector-with-refgrant.yaml"},
 			outputFile: "traffic-policy/api-key-auth-selector-with-refgrant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -464,7 +467,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretSelector no matching secrets", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-selector-no-matching-secret.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-selector-no-matching-secret.yaml"},
 			outputFile: "traffic-policy/api-key-auth-selector-no-matching-secret.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -475,7 +478,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fail open rate limiting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fail-open",
+			inputFiles: []string{"traffic-policy/fail-open"},
 			outputFile: "traffic-policy/fail-open.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -486,7 +489,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with rate limiting for extension ref", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/filter-extension-ref",
+			inputFiles: []string{"traffic-policy/filter-extension-ref"},
 			outputFile: "traffic-policy/filter-extension-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -497,7 +500,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with rate limiting on gateway section attachment", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/gateway-section-attachment",
+			inputFiles: []string{"traffic-policy/gateway-section-attachment"},
 			outputFile: "traffic-policy/gateway-section-attachment.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -508,7 +511,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth with inline users at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/inline-users-route.yaml",
+			inputFiles: []string{"basic-auth/inline-users-route.yaml"},
 			outputFile: "basic-auth/inline-users-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -519,7 +522,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth with secret reference", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/secret-ref.yaml",
+			inputFiles: []string{"basic-auth/secret-ref.yaml"},
 			outputFile: "basic-auth/secret-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -530,7 +533,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth at gateway level with route override", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/gateway-with-route-override.yaml",
+			inputFiles: []string{"basic-auth/gateway-with-route-override.yaml"},
 			outputFile: "basic-auth/gateway-with-route-override.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -541,7 +544,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth disabled at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/route-disable.yaml",
+			inputFiles: []string{"basic-auth/route-disable.yaml"},
 			outputFile: "basic-auth/route-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -552,7 +555,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with local rate limiting configurable percentage", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/local-rate-limit-configurable-percentage.yaml",
+			inputFiles: []string{"traffic-policy/local-rate-limit-configurable-percentage.yaml"},
 			outputFile: "traffic-policy/local-rate-limit-configurable-percentage.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -563,7 +566,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with local and global rate limiting combined", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/local-and-global-combined",
+			inputFiles: []string{"traffic-policy/local-and-global-combined"},
 			outputFile: "traffic-policy/local-and-global-combined.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -574,7 +577,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with multi-dimensional rate limiting descriptors", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/multi-dimensional-descriptors",
+			inputFiles: []string{"traffic-policy/multi-dimensional-descriptors"},
 			outputFile: "traffic-policy/multi-dimensional-descriptors.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -585,7 +588,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with multiple descriptors OR rate limiting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/multiple-descriptors-or",
+			inputFiles: []string{"traffic-policy/multiple-descriptors-or"},
 			outputFile: "traffic-policy/multiple-descriptors-or.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -596,7 +599,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with multiple headers single descriptor rate limiting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/multiple-headers-single-descriptor",
+			inputFiles: []string{"traffic-policy/multiple-headers-single-descriptor"},
 			outputFile: "traffic-policy/multiple-headers-single-descriptor.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -607,7 +610,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with rate limiting on route section attachment", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-section-attachment",
+			inputFiles: []string{"traffic-policy/route-section-attachment"},
 			outputFile: "traffic-policy/route-section-attachment.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -618,7 +621,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc different attachment points", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc.yaml",
+			inputFiles: []string{"traffic-policy/extproc.yaml"},
 			outputFile: "traffic-policy/extproc.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -629,7 +632,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-full-config.yaml",
+			inputFiles: []string{"traffic-policy/extproc-full-config.yaml"},
 			outputFile: "traffic-policy/extproc-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -640,7 +643,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/extproc-cross-namespace.yaml"},
 			outputFile: "traffic-policy/extproc-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -651,7 +654,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtAuth deep merge", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-deep-merge.yaml",
+			inputFiles: []string{"traffic-policy/extauth-deep-merge.yaml"},
 			outputFile: "traffic-policy/extauth-deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -665,7 +668,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc deep merge", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-deep-merge.yaml",
+			inputFiles: []string{"traffic-policy/extproc-deep-merge.yaml"},
 			outputFile: "traffic-policy/extproc-deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -679,7 +682,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc with overrides", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-overrides.yaml",
+			inputFiles: []string{"traffic-policy/extproc-overrides.yaml"},
 			outputFile: "traffic-policy/extproc-overrides.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -690,7 +693,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy Transformation deep merge", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/transformation-deep-merge.yaml",
+			inputFiles: []string{"traffic-policy/transformation-deep-merge.yaml"},
 			outputFile: "traffic-policy/transformation-deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -704,7 +707,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy Transformation skip body buffering", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/transformation-skip-body-buffering.yaml",
+			inputFiles: []string{"traffic-policy/transformation-skip-body-buffering.yaml"},
 			outputFile: "traffic-policy/transformation-skip-body-buffering.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -715,7 +718,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy transformation set metadata", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/transformation-set-metadata.yaml",
+			inputFiles: []string{"traffic-policy/transformation-set-metadata.yaml"},
 			outputFile: "traffic-policy/transformation-set-metadata.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -726,7 +729,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Load balancer with hash policies", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "loadbalancer/hash-policies.yaml",
+			inputFiles: []string{"loadbalancer/hash-policies.yaml"},
 			outputFile: "loadbalancer/hash-policies.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -737,7 +740,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with buffer attached to gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/buffer-gateway.yaml",
+			inputFiles: []string{"traffic-policy/buffer-gateway.yaml"},
 			outputFile: "traffic-policy/buffer-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -748,7 +751,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with buffer attached to route", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/buffer-route.yaml",
+			inputFiles: []string{"traffic-policy/buffer-route.yaml"},
 			outputFile: "traffic-policy/buffer-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -759,7 +762,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fault injection attached to route", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fault-injection-route.yaml",
+			inputFiles: []string{"traffic-policy/fault-injection-route.yaml"},
 			outputFile: "traffic-policy/fault-injection-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -770,7 +773,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fault injection attached to gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fault-injection-gateway.yaml",
+			inputFiles: []string{"traffic-policy/fault-injection-gateway.yaml"},
 			outputFile: "traffic-policy/fault-injection-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -781,7 +784,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fault injection disable overriding gateway policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fault-injection-disable.yaml",
+			inputFiles: []string{"traffic-policy/fault-injection-disable.yaml"},
 			outputFile: "traffic-policy/fault-injection-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -792,7 +795,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers attached to gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-gateway.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-gateway.yaml"},
 			outputFile: "traffic-policy/header-modifiers-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -803,7 +806,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers attached to routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-route.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-route.yaml"},
 			outputFile: "traffic-policy/header-modifiers-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -814,7 +817,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers attached to routes listenerset and gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-all.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-all.yaml"},
 			outputFile: "traffic-policy/header-modifiers-all.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -824,7 +827,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("TrafficPolicy with header modifiers from secret (same namespace)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -835,7 +838,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (cross namespace with ReferenceGrant)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-cross-namespace.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -846,7 +849,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (cross namespace, no ReferenceGrant)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -857,7 +860,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (policy and secret in different namespace from Gateway)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-policy-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-policy-cross-namespace.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-policy-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -868,7 +871,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (key/name defaulting)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-key-defaulting.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-key-defaulting.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-key-defaulting.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -879,7 +882,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (all keys)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-all-keys.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-all-keys.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-all-keys.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -890,7 +893,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with compression Policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/compression-route.yaml",
+			inputFiles: []string{"traffic-policy/compression-route.yaml"},
 			outputFile: "traffic-policy/compression-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -900,7 +903,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("TrafficPolicy with decompression Policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/decompression-route.yaml",
+			inputFiles: []string{"traffic-policy/decompression-route.yaml"},
 			outputFile: "traffic-policy/decompression-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -911,7 +914,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with url rewrite", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/url-rewrite.yaml",
+			inputFiles: []string{"traffic-policy/url-rewrite.yaml"},
 			outputFile: "traffic-policy/url-rewrite.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -922,7 +925,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with route tracing sampling overrides", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-tracing-sampling.yaml",
+			inputFiles: []string{"traffic-policy/route-tracing-sampling.yaml"},
 			outputFile: "traffic-policy/route-tracing-sampling.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -933,7 +936,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with route tracing disabled", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-tracing-disable.yaml",
+			inputFiles: []string{"traffic-policy/route-tracing-disable.yaml"},
 			outputFile: "traffic-policy/route-tracing-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -944,7 +947,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with route tracing custom tags", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-tracing-custom-tags.yaml",
+			inputFiles: []string{"traffic-policy/route-tracing-custom-tags.yaml"},
 			outputFile: "traffic-policy/route-tracing-custom-tags.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -955,7 +958,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcp gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/basic.yaml",
+			inputFiles: []string{"tcp-routing/basic.yaml"},
 			outputFile: "tcp-routing/basic-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -966,7 +969,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcproute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/missing-backend.yaml",
+			inputFiles: []string{"tcp-routing/missing-backend.yaml"},
 			outputFile: "tcp-routing/missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -977,7 +980,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcproute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/invalid-backend.yaml",
+			inputFiles: []string{"tcp-routing/invalid-backend.yaml"},
 			outputFile: "tcp-routing/invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -988,7 +991,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcp gateway with multiple backend services", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/multi-backend.yaml",
+			inputFiles: []string{"tcp-routing/multi-backend.yaml"},
 			outputFile: "tcp-routing/multi-backend-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -999,7 +1002,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with tcproute", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/tls.yaml",
+			inputFiles: []string{"tcp-routing/tls.yaml"},
 			outputFile: "tcp-routing/tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1010,7 +1013,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway serving multiple certificates with tcproute", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/tls-multiple-certificates.yaml",
+			inputFiles: []string{"tcp-routing/tls-multiple-certificates.yaml"},
 			outputFile: "tcp-routing/tls-multiple-certificates.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1021,7 +1024,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/basic.yaml",
+			inputFiles: []string{"tls-routing/basic.yaml"},
 			outputFile: "tls-routing/basic-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1032,7 +1035,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tlsroute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/missing-backend.yaml",
+			inputFiles: []string{"tls-routing/missing-backend.yaml"},
 			outputFile: "tls-routing/missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1043,7 +1046,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tlsroute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/invalid-backend.yaml",
+			inputFiles: []string{"tls-routing/invalid-backend.yaml"},
 			outputFile: "tls-routing/invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1054,7 +1057,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with multiple backend services", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/multi-backend.yaml",
+			inputFiles: []string{"tls-routing/multi-backend.yaml"},
 			outputFile: "tls-routing/multi-backend-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1065,7 +1068,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with TLSRoute and TLS termination", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/tls-terminate.yaml",
+			inputFiles: []string{"tls-routing/tls-terminate.yaml"},
 			outputFile: "tls-routing/tls-terminate-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1076,7 +1079,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpc gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/basic.yaml",
+			inputFiles: []string{"grpc-routing/basic.yaml"},
 			outputFile: "grpc-routing/basic-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1087,7 +1090,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpcroute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/missing-backend.yaml",
+			inputFiles: []string{"grpc-routing/missing-backend.yaml"},
 			outputFile: "grpc-routing/missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1098,7 +1101,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpcroute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/invalid-backend.yaml",
+			inputFiles: []string{"grpc-routing/invalid-backend.yaml"},
 			outputFile: "grpc-routing/invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1109,7 +1112,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpc gateway with multiple backend services", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/multi-backend.yaml",
+			inputFiles: []string{"grpc-routing/multi-backend.yaml"},
 			outputFile: "grpc-routing/multi-backend-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1120,7 +1123,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpc route with https listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/https-listener.yaml",
+			inputFiles: []string{"grpc-routing/https-listener.yaml"},
 			outputFile: "grpc-routing/https-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1131,7 +1134,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic service backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/basic.yaml",
+			inputFiles: []string{"backends/basic.yaml"},
 			outputFile: "backends/basic.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1142,7 +1145,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("AWS Lambda backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/aws_lambda.yaml",
+			inputFiles: []string{"backends/aws_lambda.yaml"},
 			outputFile: "backends/aws_lambda.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1153,7 +1156,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("GCP backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/gcp_backend.yaml",
+			inputFiles: []string{"backends/gcp_backend.yaml"},
 			outputFile: "backends/gcp_backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1164,7 +1167,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DFP Backend with TLS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "dfp/tls.yaml",
+			inputFiles: []string{"dfp/tls.yaml"},
 			outputFile: "dfp/tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1175,7 +1178,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DFP Backend with simple", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "dfp/simple.yaml",
+			inputFiles: []string{"dfp/simple.yaml"},
 			outputFile: "dfp/simple.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1186,7 +1189,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/tls.yaml",
+			inputFiles: []string{"backendtlspolicy/tls.yaml"},
 			outputFile: "backendtlspolicy/tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1197,7 +1200,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy with sectionName", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/tls-section-name.yaml",
+			inputFiles: []string{"backendtlspolicy/tls-section-name.yaml"},
 			outputFile: "backendtlspolicy/tls-section-name.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1208,7 +1211,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy with SAN", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/tls-san.yaml",
+			inputFiles: []string{"backendtlspolicy/tls-san.yaml"},
 			outputFile: "backendtlspolicy/tls-san.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1219,7 +1222,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy conflict resolution", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/conflict-resolution.yaml",
+			inputFiles: []string{"backendtlspolicy/conflict-resolution.yaml"},
 			outputFile: "backendtlspolicy/conflict-resolution.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1230,7 +1233,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy with Gateway backend client certificate", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/gateway-client-certificate.yaml",
+			inputFiles: []string{"backendtlspolicy/gateway-client-certificate.yaml"},
 			outputFile: "backendtlspolicy/gateway-client-certificate.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1241,7 +1244,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Proxy with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "edge-cases/no_route.yaml",
+			inputFiles: []string{"edge-cases/no_route.yaml"},
 			outputFile: "no_route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1252,7 +1255,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Direct response", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/manifest.yaml",
+			inputFiles: []string{"directresponse/manifest.yaml"},
 			outputFile: "directresponse.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1263,7 +1266,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with missing reference reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/missing-ref.yaml",
+			inputFiles: []string{"directresponse/missing-ref.yaml"},
 			outputFile: "directresponse/missing-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1274,7 +1277,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with overlapping filters reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/overlapping-filters.yaml",
+			inputFiles: []string{"directresponse/overlapping-filters.yaml"},
 			outputFile: "directresponse/overlapping-filters.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1285,7 +1288,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with invalid backendRef filter reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/invalid-backendref-filter.yaml",
+			inputFiles: []string{"directresponse/invalid-backendref-filter.yaml"},
 			outputFile: "directresponse/invalid-backendref-filter.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1296,7 +1299,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with text body format", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/body-format-text.yaml",
+			inputFiles: []string{"directresponse/body-format-text.yaml"},
 			outputFile: "directresponse/body-format-text.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1307,7 +1310,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with JSON body format", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/body-format-json.yaml",
+			inputFiles: []string{"directresponse/body-format-json.yaml"},
 			outputFile: "directresponse/body-format-json.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1318,7 +1321,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with content type in body format", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/body-format-content-type.yaml",
+			inputFiles: []string{"directresponse/body-format-content-type.yaml"},
 			outputFile: "directresponse/body-format-content-type.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1329,7 +1332,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPRoutes with builtin timeout and retry", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httproute-timeout-retry/builtin.yaml",
+			inputFiles: []string{"httproute-timeout-retry/builtin.yaml"},
 			outputFile: "httproute-timeout-retry-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1340,7 +1343,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy timeout and retry", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/timeout-retry.yaml",
+			inputFiles: []string{"traffic-policy/timeout-retry.yaml"},
 			outputFile: "traffic-policy/timeout-retry.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1351,7 +1354,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy timeout attached to GRPCRoute", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/grpcroute-timeout.yaml",
+			inputFiles: []string{"traffic-policy/grpcroute-timeout.yaml"},
 			outputFile: "traffic-policy/grpcroute-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1362,7 +1365,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy timeout targeting Gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/timeout-gateway.yaml",
+			inputFiles: []string{"traffic-policy/timeout-gateway.yaml"},
 			outputFile: "traffic-policy/timeout-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1372,7 +1375,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("http gateway with session persistence (cookie)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "session-persistence/cookie.yaml",
+			inputFiles: []string{"session-persistence/cookie.yaml"},
 			outputFile: "session-persistence/cookie.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1383,7 +1386,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with session persistence (header)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "session-persistence/header.yaml",
+			inputFiles: []string{"session-persistence/header.yaml"},
 			outputFile: "session-persistence/header.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1394,7 +1397,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with upgrades", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-listener-pol/upgrades.yaml",
+			inputFiles: []string{"https-listener-pol/upgrades.yaml"},
 			outputFile: "https-listener-pol/upgrades.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1405,7 +1408,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with healthCheck", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/route-and-pol.yaml",
+			inputFiles: []string{"httplistenerpolicy/route-and-pol.yaml"},
 			outputFile: "httplistenerpolicy/route-and-pol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1416,7 +1419,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with idleTimeout", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/idle-timeout.yaml",
+			inputFiles: []string{"httplistenerpolicy/idle-timeout.yaml"},
 			outputFile: "httplistenerpolicy/idle-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1427,7 +1430,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with http2ProtocolOptions", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/http2-protocol-options.yaml",
+			inputFiles: []string{"httplistenerpolicy/http2-protocol-options.yaml"},
 			outputFile: "httplistenerpolicy/http2-protocol-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1438,7 +1441,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with preserveHttp1HeaderCase", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/preserve-http1-header-case.yaml",
+			inputFiles: []string{"httplistenerpolicy/preserve-http1-header-case.yaml"},
 			outputFile: "httplistenerpolicy/preserve-http1-header-case.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1449,7 +1452,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with useRemoteAddress absent", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/use-remote-addr-absent.yaml",
+			inputFiles: []string{"httplistenerpolicy/use-remote-addr-absent.yaml"},
 			outputFile: "httplistenerpolicy/use-remote-addr-absent.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1460,7 +1463,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with useRemoteAddress true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/use-remote-addr-true.yaml",
+			inputFiles: []string{"httplistenerpolicy/use-remote-addr-true.yaml"},
 			outputFile: "httplistenerpolicy/use-remote-addr-true.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1471,7 +1474,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with useRemoteAddress false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/use-remote-addr-false.yaml",
+			inputFiles: []string{"httplistenerpolicy/use-remote-addr-false.yaml"},
 			outputFile: "httplistenerpolicy/use-remote-addr-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1482,7 +1485,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with preserveExternalRequestId true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/preserve-external-request-id.yaml",
+			inputFiles: []string{"httplistenerpolicy/preserve-external-request-id.yaml"},
 			outputFile: "httplistenerpolicy/preserve-external-request-id.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1493,7 +1496,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with generateRequestId false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/generate-request-id-false.yaml",
+			inputFiles: []string{"httplistenerpolicy/generate-request-id-false.yaml"},
 			outputFile: "httplistenerpolicy/generate-request-id-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1504,7 +1507,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/accept-http10.yaml",
+			inputFiles: []string{"httplistenerpolicy/accept-http10.yaml"},
 			outputFile: "httplistenerpolicy/accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1515,7 +1518,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with defaultHostForHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/default-host-for-http10.yaml",
+			inputFiles: []string{"httplistenerpolicy/default-host-for-http10.yaml"},
 			outputFile: "httplistenerpolicy/default-host-for-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1526,7 +1529,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with defaultHostForHttp10 and no acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml",
+			inputFiles: []string{"httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml"},
 			outputFile: "httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1537,7 +1540,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy merging", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/merge.yaml",
+			inputFiles: []string{"httplistenerpolicy/merge.yaml"},
 			outputFile: "httplistenerpolicy/merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1548,7 +1551,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with early header mutations (add/set/remove)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/early-header-mutation.yaml",
+			inputFiles: []string{"httplistenerpolicy/early-header-mutation.yaml"},
 			outputFile: "httplistenerpolicy/early-header-mutation.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1559,7 +1562,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with forwardClientCertDetails (mode defaulted)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/forward-client-cert-details.yaml",
+			inputFiles: []string{"httplistenerpolicy/forward-client-cert-details.yaml"},
 			outputFile: "httplistenerpolicy/forward-client-cert-details.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1570,7 +1573,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with uuidRequestIdConfig defaults", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/request-id-config-defaults.yaml",
+			inputFiles: []string{"httplistenerpolicy/request-id-config-defaults.yaml"},
 			outputFile: "httplistenerpolicy/request-id-config-defaults.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1581,7 +1584,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with uuidRequestIdConfig explicit false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/request-id-config-explicit.yaml",
+			inputFiles: []string{"httplistenerpolicy/request-id-config-explicit.yaml"},
 			outputFile: "httplistenerpolicy/request-id-config-explicit.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1592,7 +1595,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with uuidRequestIdConfig mixed values", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/request-id-config-mixed.yaml",
+			inputFiles: []string{"httplistenerpolicy/request-id-config-mixed.yaml"},
 			outputFile: "httplistenerpolicy/request-id-config-mixed.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1603,7 +1606,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with upgrades", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-listener-pol/upgrades.yaml",
+			inputFiles: []string{"https-listener-pol/upgrades.yaml"},
 			outputFile: "https-listener-pol/upgrades.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1614,7 +1617,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with healthCheck", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/route-and-pol.yaml",
+			inputFiles: []string{"listener-policy-http/route-and-pol.yaml"},
 			outputFile: "listener-policy-http/route-and-pol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1625,7 +1628,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with idleTimeout", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/idle-timeout.yaml",
+			inputFiles: []string{"listener-policy-http/idle-timeout.yaml"},
 			outputFile: "listener-policy-http/idle-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1636,7 +1639,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with http2ProtocolOptions", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/http2-protocol-options.yaml",
+			inputFiles: []string{"listener-policy-http/http2-protocol-options.yaml"},
 			outputFile: "listener-policy-http/http2-protocol-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1647,7 +1650,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with tcpKeepalive", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/tcp-keepalive.yaml",
+			inputFiles: []string{"listener-policy-http/tcp-keepalive.yaml"},
 			outputFile: "listener-policy-http/tcp-keepalive.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1658,7 +1661,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with preserveHttp1HeaderCase", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/preserve-http1-header-case.yaml",
+			inputFiles: []string{"listener-policy-http/preserve-http1-header-case.yaml"},
 			outputFile: "listener-policy-http/preserve-http1-header-case.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1669,7 +1672,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with useRemoteAddress absent", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/use-remote-addr-absent.yaml",
+			inputFiles: []string{"listener-policy-http/use-remote-addr-absent.yaml"},
 			outputFile: "listener-policy-http/use-remote-addr-absent.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1680,7 +1683,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with useRemoteAddress true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/use-remote-addr-true.yaml",
+			inputFiles: []string{"listener-policy-http/use-remote-addr-true.yaml"},
 			outputFile: "listener-policy-http/use-remote-addr-true.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1691,7 +1694,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with useRemoteAddress false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/use-remote-addr-false.yaml",
+			inputFiles: []string{"listener-policy-http/use-remote-addr-false.yaml"},
 			outputFile: "listener-policy-http/use-remote-addr-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1702,7 +1705,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with skipXFFAppend absent", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/skip-xff-append-absent.yaml",
+			inputFiles: []string{"listener-policy-http/skip-xff-append-absent.yaml"},
 			outputFile: "listener-policy-http/skip-xff-append-absent.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1713,7 +1716,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with skipXFFAppend true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/skip-xff-append-true.yaml",
+			inputFiles: []string{"listener-policy-http/skip-xff-append-true.yaml"},
 			outputFile: "listener-policy-http/skip-xff-append-true.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1724,7 +1727,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with skipXFFAppend false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/skip-xff-append-false.yaml",
+			inputFiles: []string{"listener-policy-http/skip-xff-append-false.yaml"},
 			outputFile: "listener-policy-http/skip-xff-append-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1735,7 +1738,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffNumTrustedHops", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-num-trusted-hops.yaml",
+			inputFiles: []string{"listener-policy-http/xff-num-trusted-hops.yaml"},
 			outputFile: "listener-policy-http/xff-num-trusted-hops.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1746,7 +1749,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffNumTrustedHops and useRemoteAddress false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-num-trusted-hops-extension.yaml",
+			inputFiles: []string{"listener-policy-http/xff-num-trusted-hops-extension.yaml"},
 			outputFile: "listener-policy-http/xff-num-trusted-hops-extension.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1757,7 +1760,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffTrustedCIDRs", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-trusted-cidrs.yaml",
+			inputFiles: []string{"listener-policy-http/xff-trusted-cidrs.yaml"},
 			outputFile: "listener-policy-http/xff-trusted-cidrs.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1768,7 +1771,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffTrustedCIDRs and skipXFFAppend false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-trusted-cidrs-no-skip-append.yaml",
+			inputFiles: []string{"listener-policy-http/xff-trusted-cidrs-no-skip-append.yaml"},
 			outputFile: "listener-policy-http/xff-trusted-cidrs-no-skip-append.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1779,7 +1782,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/accept-http10.yaml",
+			inputFiles: []string{"listener-policy-http/accept-http10.yaml"},
 			outputFile: "listener-policy-http/accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1790,7 +1793,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with defaultHostForHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/default-host-for-http10.yaml",
+			inputFiles: []string{"listener-policy-http/default-host-for-http10.yaml"},
 			outputFile: "listener-policy-http/default-host-for-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1801,7 +1804,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with defaultHostForHttp10 and no acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/default-host-for-http10-without-accept-http10.yaml",
+			inputFiles: []string{"listener-policy-http/default-host-for-http10-without-accept-http10.yaml"},
 			outputFile: "listener-policy-http/default-host-for-http10-without-accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1812,7 +1815,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy merging", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/merge.yaml",
+			inputFiles: []string{"listener-policy-http/merge.yaml"},
 			outputFile: "listener-policy-http/merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1823,7 +1826,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with early header mutations (add/set/remove)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/early-header-mutation.yaml",
+			inputFiles: []string{"listener-policy-http/early-header-mutation.yaml"},
 			outputFile: "listener-policy-http/early-header-mutation.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1834,7 +1837,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with forwardClientCertDetails (AppendForward)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/forward-client-cert-details.yaml",
+			inputFiles: []string{"listener-policy-http/forward-client-cert-details.yaml"},
 			outputFile: "listener-policy-http/forward-client-cert-details.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1845,7 +1848,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestHeadersKb", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-request-headers-kb.yaml",
+			inputFiles: []string{"listener-policy-http/max-request-headers-kb.yaml"},
 			outputFile: "listener-policy-http/max-request-headers-kb.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1856,7 +1859,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestsPerConnection", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1867,7 +1870,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestsPerConnection set to zero", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection-zero.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection-zero.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection-zero.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1878,7 +1881,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestsPerConnection and idleTimeout", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection-with-idle-timeout.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection-with-idle-timeout.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection-with-idle-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1889,7 +1892,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy maxRequestsPerConnection merge conflict", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection-merge-conflict.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection-merge-conflict.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection-merge-conflict.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1900,7 +1903,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with stripHostPortMode AnyPort", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/strip-host-port-any-port.yaml",
+			inputFiles: []string{"listener-policy-http/strip-host-port-any-port.yaml"},
 			outputFile: "listener-policy-http/strip-host-port-any-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1911,7 +1914,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with stripHostPortMode MatchingPort", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/strip-host-port-matching-port.yaml",
+			inputFiles: []string{"listener-policy-http/strip-host-port-matching-port.yaml"},
 			outputFile: "listener-policy-http/strip-host-port-matching-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1922,7 +1925,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with uuidRequestIdConfig explicit false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/request-id-config-explicit.yaml",
+			inputFiles: []string{"listener-policy-http/request-id-config-explicit.yaml"},
 			outputFile: "listener-policy-http/request-id-config-explicit.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1933,7 +1936,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with uuidRequestIdConfig defaults", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/request-id-config-defaults.yaml",
+			inputFiles: []string{"listener-policy-http/request-id-config-defaults.yaml"},
 			outputFile: "listener-policy-http/request-id-config-defaults.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1944,7 +1947,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with uuidRequestIdConfig mixed values", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/request-id-config-mixed.yaml",
+			inputFiles: []string{"listener-policy-http/request-id-config-mixed.yaml"},
 			outputFile: "listener-policy-http/request-id-config-mixed.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1955,7 +1958,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Service with appProtocol=kubernetes.io/h2c", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/svc-h2c.yaml",
+			inputFiles: []string{"backend-protocol/svc-h2c.yaml"},
 			outputFile: "backend-protocol/svc-h2c.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1966,7 +1969,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with opentelemetry attributes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/opentelemetry.yaml",
+			inputFiles: []string{"listener-policy-http/opentelemetry.yaml"},
 			outputFile: "listener-policy-http/opentelemetry.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1977,7 +1980,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with runtime filter", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/runtime-filter.yaml",
+			inputFiles: []string{"listener-policy-http/runtime-filter.yaml"},
 			outputFile: "listener-policy-http/runtime-filter.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1988,7 +1991,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Service with appProtocol=kubernetes.io/ws", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/svc-ws.yaml",
+			inputFiles: []string{"backend-protocol/svc-ws.yaml"},
 			outputFile: "backend-protocol/svc-ws.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1999,7 +2002,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Service with appProtocol=anything", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/svc-default.yaml",
+			inputFiles: []string{"backend-protocol/svc-default.yaml"},
 			outputFile: "backend-protocol/svc-default.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2010,7 +2013,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Static Backend with appProtocol=kubernetes.io/h2c", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/backend-h2c.yaml",
+			inputFiles: []string{"backend-protocol/backend-h2c.yaml"},
 			outputFile: "backend-protocol/backend-h2c.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2021,7 +2024,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Static Backend with appProtocol=kubernetes.io/ws", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/backend-ws.yaml",
+			inputFiles: []string{"backend-protocol/backend-ws.yaml"},
 			outputFile: "backend-protocol/backend-ws.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2032,7 +2035,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Static Backend with no appProtocol", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/backend-default.yaml",
+			inputFiles: []string{"backend-protocol/backend-default.yaml"},
 			outputFile: "backend-protocol/backend-default.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2043,7 +2046,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with LB Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/lb-config.yaml",
+			inputFiles: []string{"backendconfigpolicy/lb-config.yaml"},
 			outputFile: "backendconfigpolicy/lb-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2054,7 +2057,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with LB UseHostnameForHashing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/lb-usehostnameforhashing.yaml",
+			inputFiles: []string{"backendconfigpolicy/lb-usehostnameforhashing.yaml"},
 			outputFile: "backendconfigpolicy/lb-usehostnameforhashing.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2065,7 +2068,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with DNS settings", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/dns.yaml",
+			inputFiles: []string{"backendconfigpolicy/dns.yaml"},
 			outputFile: "backendconfigpolicy/dns.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2076,7 +2079,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Health Check", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/healthcheck.yaml",
+			inputFiles: []string{"backendconfigpolicy/healthcheck.yaml"},
 			outputFile: "backendconfigpolicy/healthcheck.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2087,7 +2090,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with OutlierDetection", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/outlierdetection.yaml",
+			inputFiles: []string{"backendconfigpolicy/outlierdetection.yaml"},
 			outputFile: "backendconfigpolicy/outlierdetection.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2098,7 +2101,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Common HTTP Protocol - HTTP backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/commonhttpprotocol-httpbackend.yaml",
+			inputFiles: []string{"backendconfigpolicy/commonhttpprotocol-httpbackend.yaml"},
 			outputFile: "backendconfigpolicy/commonhttpprotocol-httpbackend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2109,7 +2112,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Common HTTP Protocol - HTTP2 backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/commonhttpprotocol-http2backend.yaml",
+			inputFiles: []string{"backendconfigpolicy/commonhttpprotocol-http2backend.yaml"},
 			outputFile: "backendconfigpolicy/commonhttpprotocol-http2backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2120,7 +2123,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with HTTP2 Protocol Options", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/http2.yaml",
+			inputFiles: []string{"backendconfigpolicy/http2.yaml"},
 			outputFile: "backendconfigpolicy/http2.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2131,7 +2134,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with TLS and SAN verification", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-san.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-san.yaml"},
 			outputFile: "backendconfigpolicy/tls-san.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2142,7 +2145,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with TLS and insecure skip verify", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-insecureskipverify.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-insecureskipverify.yaml"},
 			outputFile: "backendconfigpolicy/tls-insecureskipverify.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2153,7 +2156,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with simple TLS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/simple-tls.yaml",
+			inputFiles: []string{"backendconfigpolicy/simple-tls.yaml"},
 			outputFile: "backendconfigpolicy/simple-tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2164,7 +2167,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with system ca TLS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-system-ca.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-system-ca.yaml"},
 			outputFile: "backendconfigpolicy/tls-system-ca.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2175,7 +2178,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with system ca TLS in strict mode", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-system-ca.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-system-ca.yaml"},
 			outputFile: "backendconfigpolicy/tls-system-ca.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2188,7 +2191,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Circuit Breakers minimal", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/circuitbreakers-minimal.yaml",
+			inputFiles: []string{"backendconfigpolicy/circuitbreakers-minimal.yaml"},
 			outputFile: "backendconfigpolicy/circuitbreakers-minimal.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2199,7 +2202,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Circuit Breakers full", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/circuitbreakers-full.yaml",
+			inputFiles: []string{"backendconfigpolicy/circuitbreakers-full.yaml"},
 			outputFile: "backendconfigpolicy/circuitbreakers-full.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2210,7 +2213,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Circuit Breakers track remaining", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/circuitbreakers-track-remaining.yaml",
+			inputFiles: []string{"backendconfigpolicy/circuitbreakers-track-remaining.yaml"},
 			outputFile: "backendconfigpolicy/circuitbreakers-track-remaining.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2221,7 +2224,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with upstream proxy protocol V1", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/upstream-proxy-protocol-v1.yaml",
+			inputFiles: []string{"backendconfigpolicy/upstream-proxy-protocol-v1.yaml"},
 			outputFile: "backendconfigpolicy/upstream-proxy-protocol-v1.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2232,7 +2235,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with upstream proxy protocol V2", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/upstream-proxy-protocol-v2.yaml",
+			inputFiles: []string{"backendconfigpolicy/upstream-proxy-protocol-v2.yaml"},
 			outputFile: "backendconfigpolicy/upstream-proxy-protocol-v2.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2243,7 +2246,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with explicit generation", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/generation.yaml",
+			inputFiles: []string{"traffic-policy/generation.yaml"},
 			outputFile: "traffic-policy/generation.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -2254,7 +2257,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/route-http-acl.yaml",
+			inputFiles: []string{"http-acl/route-http-acl.yaml"},
 			outputFile: "http-acl/route-http-acl.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2265,7 +2268,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/httproute-http-acl.yaml",
+			inputFiles: []string{"http-acl/httproute-http-acl.yaml"},
 			outputFile: "http-acl/httproute-http-acl.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2276,7 +2279,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/gateway-http-acl.yaml",
+			inputFiles: []string{"http-acl/gateway-http-acl.yaml"},
 			outputFile: "http-acl/gateway-http-acl.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2287,7 +2290,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy with invalid CIDR rejected", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/invalid-cidr.yaml",
+			inputFiles: []string{"http-acl/invalid-cidr.yaml"},
 			outputFile: "http-acl/invalid-cidr.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2298,7 +2301,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/route-cel-rbac.yaml",
+			inputFiles: []string{"rbac/route-cel-rbac.yaml"},
 			outputFile: "rbac/route-cel-rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2309,7 +2312,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at route level with Deny action", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/route-cel-rbac-deny.yaml",
+			inputFiles: []string{"rbac/route-cel-rbac-deny.yaml"},
 			outputFile: "rbac/route-cel-rbac-deny.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2320,7 +2323,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/httproute-cel-rbac.yaml",
+			inputFiles: []string{"rbac/httproute-cel-rbac.yaml"},
 			outputFile: "rbac/httproute-cel-rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2331,7 +2334,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/gateway-cel-rbac.yaml",
+			inputFiles: []string{"rbac/gateway-cel-rbac.yaml"},
 			outputFile: "rbac/gateway-cel-rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2342,7 +2345,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("basic listener set", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/basic.yaml",
+			inputFiles: []string{"listener-sets/basic.yaml"},
 			outputFile: "listener-sets/basic.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2353,7 +2356,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set and gateway with no allowed listeners", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/no-allowed-lis.yaml",
+			inputFiles: []string{"listener-sets/no-allowed-lis.yaml"},
 			outputFile: "listener-sets/no-allowed-lis.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2364,7 +2367,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set accepted with rejected individual listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/accepted-ls-rejected-listener.yaml",
+			inputFiles: []string{"listener-sets/accepted-ls-rejected-listener.yaml"},
 			outputFile: "listener-sets/accepted-ls-rejected-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2375,7 +2378,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with tls listener and secret in same namespace", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-same-ns.yaml",
+			inputFiles: []string{"listener-sets/tls-same-ns.yaml"},
 			outputFile: "listener-sets/tls-same-ns.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2386,7 +2389,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with tls listener and secret in different namespace without reference grant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-missing-reference-grant.yaml",
+			inputFiles: []string{"listener-sets/tls-missing-reference-grant.yaml"},
 			outputFile: "listener-sets/tls-missing-reference-grant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2397,7 +2400,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with tls listener and secret in different namespace with reference grant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-valid-reference-grant.yaml",
+			inputFiles: []string{"listener-sets/tls-valid-reference-grant.yaml"},
 			outputFile: "listener-sets/tls-valid-reference-grant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2408,7 +2411,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with TLS listener with TLS extension options", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-options.yaml",
+			inputFiles: []string{"listener-sets/tls-options.yaml"},
 			outputFile: "listener-sets/tls-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2419,7 +2422,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy RateLimit Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/rate-limit-full-config.yaml",
+			inputFiles: []string{"traffic-policy/rate-limit-full-config.yaml"},
 			outputFile: "traffic-policy/rate-limit-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2430,7 +2433,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy RateLimit with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/ratelimit-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/ratelimit-cross-namespace.yaml"},
 			outputFile: "traffic-policy/ratelimit-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2441,7 +2444,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS listener with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-listener-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-listener-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/tls-listener-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2452,7 +2455,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TCP listener with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tcp-listener-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tcp-listener-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/tcp-listener-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2463,7 +2466,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS listener with invalid secret ref", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-listener-invalid-secret-ref.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-listener-invalid-secret-ref.yaml"},
 			outputFile: "invalid-filter-chains/https-listener-invalid-secret-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2474,7 +2477,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS listener with multiple cert refs, one missing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-listener-multi-cert-one-missing.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-listener-multi-cert-one-missing.yaml"},
 			outputFile: "invalid-filter-chains/https-listener-multi-cert-one-missing.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2485,7 +2488,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS listener with invalid secret (missing private key)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-listener-invalid-secret.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-listener-invalid-secret.yaml"},
 			outputFile: "invalid-filter-chains/https-listener-invalid-secret.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2496,7 +2499,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS mixed listeners - no routes and with routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-mixed-listeners.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-mixed-listeners.yaml"},
 			outputFile: "invalid-filter-chains/tls-mixed-listeners.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2507,7 +2510,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TCP mixed listeners - no routes and with routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tcp-mixed-listeners.yaml",
+			inputFiles: []string{"invalid-filter-chains/tcp-mixed-listeners.yaml"},
 			outputFile: "invalid-filter-chains/tcp-mixed-listeners.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2518,7 +2521,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS same port listeners - both with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-same-port-both-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-same-port-both-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/tls-same-port-both-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2529,7 +2532,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS same port listeners - mixed routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-same-port-mixed-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-same-port-mixed-routes.yaml"},
 			outputFile: "invalid-filter-chains/tls-same-port-mixed-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2540,7 +2543,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS route with invalid backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-route-invalid-backend.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-route-invalid-backend.yaml"},
 			outputFile: "invalid-filter-chains/tls-route-invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2551,7 +2554,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS mixed listeners - invalid and valid secret refs", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-mixed-listeners.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-mixed-listeners.yaml"},
 			outputFile: "invalid-filter-chains/https-mixed-listeners.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2562,7 +2565,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway empty with ListenerSet TCP listener no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2573,7 +2576,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway empty with ListenerSet TLS listener no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2584,7 +2587,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway empty with ListenerSet TLS mixed listeners", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml"},
 			outputFile: "invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2595,7 +2598,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway HTTP listener with ListenerSet TCP listener no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2606,7 +2609,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway TCP listener no routes with ListenerSet HTTP listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml"},
 			outputFile: "invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2617,7 +2620,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway with reserved port should be rejected", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "validation/gateway-reserved-port.yaml",
+			inputFiles: []string{"validation/gateway-reserved-port.yaml"},
 			outputFile: "validation/gateway-reserved-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2628,7 +2631,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("XListenerSet with reserved port should be rejected", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "validation/xlistenerset-reserved-port.yaml",
+			inputFiles: []string{"validation/xlistenerset-reserved-port.yaml"},
 			outputFile: "validation/xlistenerset-reserved-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2639,7 +2642,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTP RequestRedirect filter", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing/request-redirect.yaml",
+			inputFiles: []string{"http-routing/request-redirect.yaml"},
 			outputFile: "http-routing/request-redirect.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2650,7 +2653,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTP RequestRedirect filter multiple listeners listener-scoped port", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing/request-redirect-multi-listener.yaml",
+			inputFiles: []string{"http-routing/request-redirect-multi-listener.yaml"},
 			outputFile: "http-routing/request-redirect-multi-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2661,7 +2664,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol on HTTP listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/http-proxy-protocol.yaml",
+			inputFiles: []string{"listener-policy/http-proxy-protocol.yaml"},
 			outputFile: "listener-policy/http-proxy-protocol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2672,7 +2675,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol on HTTPS listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/https-proxy-protocol.yaml",
+			inputFiles: []string{"listener-policy/https-proxy-protocol.yaml"},
 			outputFile: "listener-policy/https-proxy-protocol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2683,7 +2686,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol on TCP listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/tcp-proxy-protocol.yaml",
+			inputFiles: []string{"listener-policy/tcp-proxy-protocol.yaml"},
 			outputFile: "listener-policy/tcp-proxy-protocol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2694,7 +2697,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol allowing requests without header", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/http-proxy-protocol-allow-no-header.yaml",
+			inputFiles: []string{"listener-policy/http-proxy-protocol-allow-no-header.yaml"},
 			outputFile: "listener-policy/http-proxy-protocol-allow-no-header.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2705,7 +2708,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with per connection buffer limit", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-connection-buffer-limit.yaml",
+			inputFiles: []string{"listener-policy/per-connection-buffer-limit.yaml"},
 			outputFile: "listener-policy/per-connection-buffer-limit.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2716,7 +2719,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with per port settings", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-port.yaml",
+			inputFiles: []string{"listener-policy/per-port.yaml"},
 			outputFile: "listener-policy/per-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2727,7 +2730,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with per-listener mTLS override", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-listener-mtls.yaml",
+			inputFiles: []string{"listener-policy/per-listener-mtls.yaml"},
 			outputFile: "listener-policy/per-listener-mtls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2738,7 +2741,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with multiple per-listener mTLS override", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-listener-mtls-multiple.yaml",
+			inputFiles: []string{"listener-policy/per-listener-mtls-multiple.yaml"},
 			outputFile: "listener-policy/per-listener-mtls-multiple.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2749,7 +2752,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy merge happens in the default and perPort fields", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/deep-merge.yaml",
+			inputFiles: []string{"listener-policy/deep-merge.yaml"},
 			outputFile: "listener-policy/deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2760,7 +2763,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway.yaml",
+			inputFiles: []string{"jwt/gateway.yaml"},
 			outputFile: "jwt/gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2771,7 +2774,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level selecting listener with sectionName", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-listener.yaml",
+			inputFiles: []string{"jwt/gateway-listener.yaml"},
 			outputFile: "jwt/gateway-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2782,7 +2785,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level using configmap", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-configmap.yaml",
+			inputFiles: []string{"jwt/gateway-configmap.yaml"},
 			outputFile: "jwt/gateway-configmap.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2793,7 +2796,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy targeting listenerset", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/listenerset.yaml",
+			inputFiles: []string{"jwt/listenerset.yaml"},
 			outputFile: "jwt/listenerset.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2804,7 +2807,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/route.yaml",
+			inputFiles: []string{"jwt/route.yaml"},
 			outputFile: "jwt/route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2815,7 +2818,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy with cross-namespace backends", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/cross-namespace.yaml",
+			inputFiles: []string{"jwt/cross-namespace.yaml"},
 			outputFile: "jwt/cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2826,7 +2829,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/cross-namespace-extension.yaml",
+			inputFiles: []string{"jwt/cross-namespace-extension.yaml"},
 			outputFile: "jwt/cross-namespace-extension.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2837,7 +2840,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/httproute.yaml",
+			inputFiles: []string{"jwt/httproute.yaml"},
 			outputFile: "jwt/httproute.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2848,7 +2851,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway and route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-and-route.yaml",
+			inputFiles: []string{"jwt/gateway-and-route.yaml"},
 			outputFile: "jwt/gateway-and-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2859,7 +2862,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy and RBAC", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/rbac.yaml",
+			inputFiles: []string{"jwt/rbac.yaml"},
 			outputFile: "jwt/rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2870,7 +2873,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level with disable on route", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-disable.yaml",
+			inputFiles: []string{"jwt/gateway-disable.yaml"},
 			outputFile: "jwt/gateway-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2881,7 +2884,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at route level using remote JWKS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/httproute-remote-jwks.yaml",
+			inputFiles: []string{"jwt/httproute-remote-jwks.yaml"},
 			outputFile: "jwt/httproute-remote-jwks.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2892,7 +2895,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy with validation mode AllowMissing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-validation-mode.yaml",
+			inputFiles: []string{"jwt/gateway-validation-mode.yaml"},
 			outputFile: "jwt/gateway-validation-mode.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2903,7 +2906,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("OAuth2 policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/oauth2.yaml",
+			inputFiles: []string{"traffic-policy/oauth2.yaml"},
 			outputFile: "traffic-policy/oauth2.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",


### PR DESCRIPTION
## Summary

Standardizes the gateway translator table tests on `inputFiles []string` by removing the older `inputFile` field from `translatorTestCase`. The shared `TestBasic` helper now resolves every listed input manifest relative to `testutils/inputs`, and the existing single-manifest cases are represented as one-element slices.

This keeps the current test coverage behavior while leaving the table with one way to describe input manifests, as requested in #14069.

## Testing

- `git diff --check`
- `go test -tags e2e ./pkg/kgateway/translator/gateway -run '^TestBasic$/^gateway_with_no_routes_should_not_add_empty_filter_chain$'`

Fixes https://github.com/kgateway-dev/kgateway/issues/14069
