### PR TITLE
[v2.2.x] Fix xDS TLS env var mismatch in Helm template

### DIFF
--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -113,8 +113,8 @@ spec:
             - name: KGW_ENABLE_WAYPOINT
               value: "true"
             {{- end }}
-            {{- if .Values.controller.xds.tls.enabled }}
-            - name: KGW_XDS_TLS_ENABLED
+            {{- if and .Values.controller.xds.tls.enabled (not (and .Values.controller.extraEnv (hasKey .Values.controller.extraEnv "KGW_XDS_TLS"))) }}
+            - name: KGW_XDS_TLS
               value: "true"
             {{- end }}
             - name: POD_NAMESPACE

--- a/test/helm/testdata/kgateway/xds-tls-enabled.golden
+++ b/test/helm/testdata/kgateway/xds-tls-enabled.golden
@@ -344,7 +344,7 @@ spec:
               value: "true"
             - name: KGW_GATEWAY_CLASS_PARAMETERS_REFS
               value: "{}"
-            - name: KGW_XDS_TLS_ENABLED
+            - name: KGW_XDS_TLS
               value: "true"
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
# Description
Simple cherry-pick backport of #14050
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix xDS TLS env var name in Helm chart: `KGW_XDS_TLS_ENABLED` is renamed to `KGW_XDS_TLS` to match the runtime settings key. Users who set `controller.xds.tls.enabled: true` will now have xDS TLS correctly enabled without requiring a manual `extraEnv` workaround.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
See #14049