### PR TITLE
feat: add tcp_proxy translation hook to ProxyTranslationPass

### DIFF
--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -404,6 +404,24 @@ func (h *filterChainTranslator) computeTcpFilters(l ir.TcpIR, reporter sdkreport
 		}
 	}
 
+	// Allow plugins to tweak the TcpProxy (e.g. attaching access logs).
+	// Per-listener TCP policy state is stashed by ApplyListenerPlugin, so we only
+	// need to give each pass a chance to read it back here.
+	pctx := &ir.TcpContext{
+		ListenerPort: h.listener.BindPort,
+		Gateway:      h.gateway,
+	}
+	for _, plug := range h.pluginPass {
+		if err := plug.ApplyTcpProxy(pctx, cfg); err != nil {
+			reporter.SetCondition(sdkreporter.ListenerCondition{
+				Type:    gwv1.ListenerConditionProgrammed,
+				Reason:  gwv1.ListenerReasonInvalid,
+				Status:  metav1.ConditionFalse,
+				Message: "Error processing TcpProxy plugin: " + err.Error(),
+			})
+		}
+	}
+
 	tcpFilter, _ := NewFilterWithTypedConfig(wellknown.TCPProxy, cfg)
 
 	return append(networkFilters, tcpFilter)

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -12,6 +12,7 @@ import (
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoytcpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -123,6 +124,14 @@ type HcmContext struct {
 	Gateway      GatewayIR
 }
 
+// TcpContext is passed to ApplyTcpProxy when translating a TCP/TLS filter chain.
+// Unlike HcmContext, no Policy is provided: per-listener TCP policies are stashed
+// by ApplyListenerPlugin (keyed by port) and read back by the plugin during ApplyTcpProxy.
+type TcpContext struct {
+	ListenerPort uint32
+	Gateway      GatewayIR
+}
+
 // ProxyTranslationPass represents a single translation pass for a gateway using envoy. It can hold state
 // for the duration of the translation.
 // Each of the functions here will be called in the order they appear in the interface.
@@ -190,6 +199,12 @@ type ProxyTranslationPass interface {
 		pCtx *HcmContext,
 		out *envoy_hcm.HttpConnectionManager) error
 
+	// ApplyTcpProxy is called 1 time per TCP/TLS filter chain after listeners and allows tweaking
+	// the `tcp_proxy` network filter (e.g. attaching access logs).
+	ApplyTcpProxy(
+		pCtx *TcpContext,
+		out *envoytcpv3.TcpProxy) error
+
 	// called 1 time (per envoy proxy). replaces GeneratedResources and allows adding clusters to the envoy.
 	ResourcesToAdd() Resources
 }
@@ -202,6 +217,10 @@ func (s UnimplementedProxyTranslationPass) ApplyListenerPlugin(pCtx *ListenerCon
 }
 
 func (s UnimplementedProxyTranslationPass) ApplyHCM(pCtx *HcmContext, out *envoy_hcm.HttpConnectionManager) error {
+	return nil
+}
+
+func (s UnimplementedProxyTranslationPass) ApplyTcpProxy(pCtx *TcpContext, out *envoytcpv3.TcpProxy) error {
 	return nil
 }
 


### PR DESCRIPTION
# Description

Adds `ApplyTcpProxy` to the `ProxyTranslationPass` interface, letting plugins tweak the `envoy.filters.network.tcp_proxy` network filter, mirroring the existing `ApplyHCM` hook for HTTP.
  - **What changed:**
    - New `TcpContext` carrying the listener port and gateway IR.
    - `ApplyTcpProxy` added to the `ProxyTranslationPass` interface.
    - `UnimplementedProxyTranslationPass` gets a nil-returning `ApplyTcpProxy`
      default, so every existing plugin compiles and behaves unchanged.
    - The `irtranslator` invokes `ApplyTcpProxy` for each pass when building
      TCP filter chains in `computeTcpFilters`.
  - **Related issues:** part of #14014.

  Additive only, no behavior change. Follow-up PRs add the `tcpSettings` API field and the plugin implementation.

  # Change Type
/kind feature

  # Changelog

  ```release-note
  NONE
  ```