### PR TITLE
test: replace inputFile with inputFiles in translator tests

### DIFF
--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 type translatorTestCase struct {
-	// TODO(#14069): Replace inputFile with inputFiles across this test suite.
-	inputFile  string
 	inputFiles []string
 	outputFile string
 	gwNN       types.NamespacedName
@@ -56,12 +54,9 @@ func TestBasic(t *testing.T) {
 				s.EnableAuthMetadata = true
 			},
 		}, settingOpts...)
-		inputs := in.inputFiles
-		if len(inputs) == 0 {
-			inputs = []string{in.inputFile}
-		}
-		inputFiles := make([]string, 0, len(inputs))
-		for _, input := range inputs {
+
+		inputFiles := make([]string, 0, len(in.inputFiles))
+		for _, input := range in.inputFiles {
 			inputFiles = append(inputFiles, filepath.Join(dir, "testutils/inputs/", input))
 		}
 		expectedProxyFile := filepath.Join(dir, "testutils/outputs/", in.outputFile)
@@ -70,7 +65,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with no routes should not add empty filter chain", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/gateway.yaml",
+			inputFiles: []string{"gateway-only/gateway.yaml"},
 			outputFile: "gateway-only/proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -81,7 +76,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with no valid listeners should report correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/gateway-invalid-listener.yaml",
+			inputFiles: []string{"gateway-only/gateway-invalid-listener.yaml"},
 			outputFile: "gateway-only/gateway-invalid-listener-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -92,7 +87,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with TLS listener with TLS options", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/tls-options.yaml",
+			inputFiles: []string{"gateway-only/tls-options.yaml"},
 			outputFile: "gateway-only/tls-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -103,7 +98,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with TLS listener with multiple TLS certificates", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-only/tls-multiple-certificates.yaml",
+			inputFiles: []string{"gateway-only/tls-multiple-certificates.yaml"},
 			outputFile: "gateway-only/tls-multiple-certificates.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -114,7 +109,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("gateway with FrontendTLSConfig", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "frontendtlsconfig/basic.yaml",
+			inputFiles: []string{"frontendtlsconfig/basic.yaml"},
 			outputFile: "frontendtlsconfig/basic.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -125,7 +120,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("frontendtlsconfig with verify subject alt names missing ca certificate", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "frontendtlsconfig/verify-subject-alt-names-missing-ca.yaml",
+			inputFiles: []string{"frontendtlsconfig/verify-subject-alt-names-missing-ca.yaml"},
 			outputFile: "frontendtlsconfig/verify-subject-alt-names-missing-ca.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -136,7 +131,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("frontendtlsconfig with invalid conditions", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "frontendtlsconfig/invalid-conditions.yaml",
+			inputFiles: []string{"frontendtlsconfig/invalid-conditions.yaml"},
 			outputFile: "frontendtlsconfig/invalid-conditions.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -147,7 +142,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with per connection buffer limit", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "gateway-per-conn-buf-lim/gateway.yaml",
+			inputFiles: []string{"gateway-per-conn-buf-lim/gateway.yaml"},
 			outputFile: "gateway-per-conn-buf-lim/proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -158,7 +153,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing/basic.yaml",
+			inputFiles: []string{"http-routing/basic.yaml"},
 			outputFile: "http-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -169,7 +164,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with custom class", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "custom-gateway-class",
+			inputFiles: []string{"custom-gateway-class"},
 			outputFile: "custom-gateway-class.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -180,7 +175,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("https gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-routing/gateway.yaml",
+			inputFiles: []string{"https-routing/gateway.yaml"},
 			outputFile: "https-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -191,7 +186,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("https gateway with invalid certificate ref", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-routing/invalid-cert.yaml",
+			inputFiles: []string{"https-routing/invalid-cert.yaml"},
 			outputFile: "https-invalid-cert-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -202,7 +197,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with multiple listeners on the same port", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "multiple-listeners-http-routing",
+			inputFiles: []string{"multiple-listeners-http-routing"},
 			outputFile: "multiple-listeners-http-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -213,7 +208,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("https gateway with multiple listeners on the same port", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "multiple-listeners-https-routing",
+			inputFiles: []string{"multiple-listeners-https-routing"},
 			outputFile: "multiple-listeners-https-routing-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -224,7 +219,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with multiple routing rules and HeaderModifier filter", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-with-header-modifier",
+			inputFiles: []string{"http-with-header-modifier"},
 			outputFile: "http-with-header-modifier-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -235,7 +230,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway API route sorting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "route-sort.yaml",
+			inputFiles: []string{"route-sort.yaml"},
 			outputFile: "route-sort.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -246,7 +241,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("weight based route sorting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "route-sort-weighted.yaml",
+			inputFiles: []string{"route-sort-weighted.yaml"},
 			outputFile: "route-sort-weighted.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -259,7 +254,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("httproute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing-missing-backend",
+			inputFiles: []string{"http-routing-missing-backend"},
 			outputFile: "http-routing-missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -270,7 +265,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("httproute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing-invalid-backend",
+			inputFiles: []string{"http-routing-invalid-backend"},
 			outputFile: "http-routing-invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -281,7 +276,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("httproute with backend port error reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/backend-ref-port-error.yaml",
+			inputFiles: []string{"backends/backend-ref-port-error.yaml"},
 			outputFile: "backends/backend-ref-port-error.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -292,7 +287,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy merging", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/merge.yaml",
+			inputFiles: []string{"traffic-policy/merge.yaml"},
 			outputFile: "traffic-policy/merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -303,7 +298,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with targetSelectors", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/label_based.yaml",
+			inputFiles: []string{"traffic-policy/label_based.yaml"},
 			outputFile: "traffic-policy/label_based.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -314,7 +309,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with targetSelectors and global policy attachment", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/label_based.yaml",
+			inputFiles: []string{"traffic-policy/label_based.yaml"},
 			outputFile: "traffic-policy/label_based_global_policy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -328,7 +323,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy gRPC ExtAuth different attachment points", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-grpc.yaml",
+			inputFiles: []string{"traffic-policy/extauth-grpc.yaml"},
 			outputFile: "traffic-policy/extauth-grpc.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -339,7 +334,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy HTTP ExtAuth different attachment points", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-http.yaml",
+			inputFiles: []string{"traffic-policy/extauth-http.yaml"},
 			outputFile: "traffic-policy/extauth-http.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -351,7 +346,7 @@ func TestBasic(t *testing.T) {
 	// test the default and fully configured values for gRPC ExtAuth
 	t.Run("TrafficPolicy gRPC ExtAuth Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-grpc-full-config.yaml",
+			inputFiles: []string{"traffic-policy/extauth-grpc-full-config.yaml"},
 			outputFile: "traffic-policy/extauth-grpc-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -363,7 +358,7 @@ func TestBasic(t *testing.T) {
 	// test the default and fully configured values for HTTP ExtAuth
 	t.Run("TrafficPolicy HTTP ExtAuth Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-http-full-config.yaml",
+			inputFiles: []string{"traffic-policy/extauth-http-full-config.yaml"},
 			outputFile: "traffic-policy/extauth-http-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -374,7 +369,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtAuth with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/extauth-cross-namespace.yaml"},
 			outputFile: "traffic-policy/extauth-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -385,7 +380,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-route.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-route.yaml"},
 			outputFile: "traffic-policy/api-key-auth-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -396,7 +391,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-httproute.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-httproute.yaml"},
 			outputFile: "traffic-policy/api-key-auth-httproute.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -407,7 +402,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-gateway.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-gateway.yaml"},
 			outputFile: "traffic-policy/api-key-auth-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -418,7 +413,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication route override gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-override.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-override.yaml"},
 			outputFile: "traffic-policy/api-key-auth-override.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -429,7 +424,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication route override gateway with sectionName", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-override-section.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-override-section.yaml"},
 			outputFile: "traffic-policy/api-key-auth-override-section.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -440,7 +435,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretRef", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-secretref.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-secretref.yaml"},
 			outputFile: "traffic-policy/api-key-auth-secretref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -451,7 +446,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretRef and ReferenceGrant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-secretref-with-refgrant.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-secretref-with-refgrant.yaml"},
 			outputFile: "traffic-policy/api-key-auth-secretref-with-refgrant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -462,7 +457,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretSelector and ReferenceGrant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-selector-with-refgrant.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-selector-with-refgrant.yaml"},
 			outputFile: "traffic-policy/api-key-auth-selector-with-refgrant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -473,7 +468,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy API Key Authentication with SecretSelector no matching secrets", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/api-key-auth-selector-no-matching-secret.yaml",
+			inputFiles: []string{"traffic-policy/api-key-auth-selector-no-matching-secret.yaml"},
 			outputFile: "traffic-policy/api-key-auth-selector-no-matching-secret.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -484,7 +479,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fail open rate limiting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fail-open",
+			inputFiles: []string{"traffic-policy/fail-open"},
 			outputFile: "traffic-policy/fail-open.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -495,7 +490,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with rate limiting for extension ref", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/filter-extension-ref",
+			inputFiles: []string{"traffic-policy/filter-extension-ref"},
 			outputFile: "traffic-policy/filter-extension-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -506,7 +501,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with rate limiting on gateway section attachment", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/gateway-section-attachment",
+			inputFiles: []string{"traffic-policy/gateway-section-attachment"},
 			outputFile: "traffic-policy/gateway-section-attachment.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -517,7 +512,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth with inline users at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/inline-users-route.yaml",
+			inputFiles: []string{"basic-auth/inline-users-route.yaml"},
 			outputFile: "basic-auth/inline-users-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -528,7 +523,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth with secret reference", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/secret-ref.yaml",
+			inputFiles: []string{"basic-auth/secret-ref.yaml"},
 			outputFile: "basic-auth/secret-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -539,7 +534,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth at gateway level with route override", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/gateway-with-route-override.yaml",
+			inputFiles: []string{"basic-auth/gateway-with-route-override.yaml"},
 			outputFile: "basic-auth/gateway-with-route-override.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -550,7 +545,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic auth disabled at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "basic-auth/route-disable.yaml",
+			inputFiles: []string{"basic-auth/route-disable.yaml"},
 			outputFile: "basic-auth/route-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -561,7 +556,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with local rate limiting configurable percentage", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/local-rate-limit-configurable-percentage.yaml",
+			inputFiles: []string{"traffic-policy/local-rate-limit-configurable-percentage.yaml"},
 			outputFile: "traffic-policy/local-rate-limit-configurable-percentage.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -572,7 +567,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with local and global rate limiting combined", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/local-and-global-combined",
+			inputFiles: []string{"traffic-policy/local-and-global-combined"},
 			outputFile: "traffic-policy/local-and-global-combined.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -583,7 +578,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with multi-dimensional rate limiting descriptors", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/multi-dimensional-descriptors",
+			inputFiles: []string{"traffic-policy/multi-dimensional-descriptors"},
 			outputFile: "traffic-policy/multi-dimensional-descriptors.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -594,7 +589,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with multiple descriptors OR rate limiting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/multiple-descriptors-or",
+			inputFiles: []string{"traffic-policy/multiple-descriptors-or"},
 			outputFile: "traffic-policy/multiple-descriptors-or.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -605,7 +600,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with multiple headers single descriptor rate limiting", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/multiple-headers-single-descriptor",
+			inputFiles: []string{"traffic-policy/multiple-headers-single-descriptor"},
 			outputFile: "traffic-policy/multiple-headers-single-descriptor.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -616,7 +611,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with rate limiting on route section attachment", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-section-attachment",
+			inputFiles: []string{"traffic-policy/route-section-attachment"},
 			outputFile: "traffic-policy/route-section-attachment.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -627,7 +622,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc different attachment points", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc.yaml",
+			inputFiles: []string{"traffic-policy/extproc.yaml"},
 			outputFile: "traffic-policy/extproc.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -638,7 +633,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-full-config.yaml",
+			inputFiles: []string{"traffic-policy/extproc-full-config.yaml"},
 			outputFile: "traffic-policy/extproc-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -649,7 +644,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/extproc-cross-namespace.yaml"},
 			outputFile: "traffic-policy/extproc-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -660,7 +655,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtAuth deep merge", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extauth-deep-merge.yaml",
+			inputFiles: []string{"traffic-policy/extauth-deep-merge.yaml"},
 			outputFile: "traffic-policy/extauth-deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -674,7 +669,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc deep merge", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-deep-merge.yaml",
+			inputFiles: []string{"traffic-policy/extproc-deep-merge.yaml"},
 			outputFile: "traffic-policy/extproc-deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -688,7 +683,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy ExtProc with overrides", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/extproc-overrides.yaml",
+			inputFiles: []string{"traffic-policy/extproc-overrides.yaml"},
 			outputFile: "traffic-policy/extproc-overrides.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -699,7 +694,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy Transformation deep merge", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/transformation-deep-merge.yaml",
+			inputFiles: []string{"traffic-policy/transformation-deep-merge.yaml"},
 			outputFile: "traffic-policy/transformation-deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -713,7 +708,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy Transformation skip body buffering", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/transformation-skip-body-buffering.yaml",
+			inputFiles: []string{"traffic-policy/transformation-skip-body-buffering.yaml"},
 			outputFile: "traffic-policy/transformation-skip-body-buffering.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -724,7 +719,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy transformation set metadata", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/transformation-set-metadata.yaml",
+			inputFiles: []string{"traffic-policy/transformation-set-metadata.yaml"},
 			outputFile: "traffic-policy/transformation-set-metadata.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -735,7 +730,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Load balancer with hash policies", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "loadbalancer/hash-policies.yaml",
+			inputFiles: []string{"loadbalancer/hash-policies.yaml"},
 			outputFile: "loadbalancer/hash-policies.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -746,7 +741,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with buffer attached to gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/buffer-gateway.yaml",
+			inputFiles: []string{"traffic-policy/buffer-gateway.yaml"},
 			outputFile: "traffic-policy/buffer-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -757,7 +752,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with buffer attached to route", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/buffer-route.yaml",
+			inputFiles: []string{"traffic-policy/buffer-route.yaml"},
 			outputFile: "traffic-policy/buffer-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -768,7 +763,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fault injection attached to route", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fault-injection-route.yaml",
+			inputFiles: []string{"traffic-policy/fault-injection-route.yaml"},
 			outputFile: "traffic-policy/fault-injection-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -779,7 +774,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fault injection attached to gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fault-injection-gateway.yaml",
+			inputFiles: []string{"traffic-policy/fault-injection-gateway.yaml"},
 			outputFile: "traffic-policy/fault-injection-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -790,7 +785,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with fault injection disable overriding gateway policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/fault-injection-disable.yaml",
+			inputFiles: []string{"traffic-policy/fault-injection-disable.yaml"},
 			outputFile: "traffic-policy/fault-injection-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -801,7 +796,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers attached to gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-gateway.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-gateway.yaml"},
 			outputFile: "traffic-policy/header-modifiers-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -812,7 +807,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers attached to routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-route.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-route.yaml"},
 			outputFile: "traffic-policy/header-modifiers-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -823,7 +818,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers attached to routes listenerset and gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-all.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-all.yaml"},
 			outputFile: "traffic-policy/header-modifiers-all.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -833,7 +828,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("TrafficPolicy with header modifiers from secret (same namespace)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -844,7 +839,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (cross namespace with ReferenceGrant)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-cross-namespace.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -855,7 +850,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (cross namespace, no ReferenceGrant)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -866,7 +861,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (policy and secret in different namespace from Gateway)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-policy-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-policy-cross-namespace.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-policy-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -877,7 +872,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (key/name defaulting)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-key-defaulting.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-key-defaulting.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-key-defaulting.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -888,7 +883,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with header modifiers from secret (all keys)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/header-modifiers-from-secret-all-keys.yaml",
+			inputFiles: []string{"traffic-policy/header-modifiers-from-secret-all-keys.yaml"},
 			outputFile: "traffic-policy/header-modifiers-from-secret-all-keys.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -899,7 +894,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with compression Policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/compression-route.yaml",
+			inputFiles: []string{"traffic-policy/compression-route.yaml"},
 			outputFile: "traffic-policy/compression-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -909,7 +904,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("TrafficPolicy with decompression Policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/decompression-route.yaml",
+			inputFiles: []string{"traffic-policy/decompression-route.yaml"},
 			outputFile: "traffic-policy/decompression-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -920,7 +915,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with url rewrite", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/url-rewrite.yaml",
+			inputFiles: []string{"traffic-policy/url-rewrite.yaml"},
 			outputFile: "traffic-policy/url-rewrite.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -931,7 +926,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with route tracing sampling overrides", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-tracing-sampling.yaml",
+			inputFiles: []string{"traffic-policy/route-tracing-sampling.yaml"},
 			outputFile: "traffic-policy/route-tracing-sampling.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -942,7 +937,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with route tracing disabled", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-tracing-disable.yaml",
+			inputFiles: []string{"traffic-policy/route-tracing-disable.yaml"},
 			outputFile: "traffic-policy/route-tracing-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -953,7 +948,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with route tracing custom tags", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/route-tracing-custom-tags.yaml",
+			inputFiles: []string{"traffic-policy/route-tracing-custom-tags.yaml"},
 			outputFile: "traffic-policy/route-tracing-custom-tags.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -964,7 +959,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcp gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/basic.yaml",
+			inputFiles: []string{"tcp-routing/basic.yaml"},
 			outputFile: "tcp-routing/basic-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -975,7 +970,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcproute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/missing-backend.yaml",
+			inputFiles: []string{"tcp-routing/missing-backend.yaml"},
 			outputFile: "tcp-routing/missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -986,7 +981,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcproute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/invalid-backend.yaml",
+			inputFiles: []string{"tcp-routing/invalid-backend.yaml"},
 			outputFile: "tcp-routing/invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -997,7 +992,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tcp gateway with multiple backend services", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/multi-backend.yaml",
+			inputFiles: []string{"tcp-routing/multi-backend.yaml"},
 			outputFile: "tcp-routing/multi-backend-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1008,7 +1003,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with tcproute", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/tls.yaml",
+			inputFiles: []string{"tcp-routing/tls.yaml"},
 			outputFile: "tcp-routing/tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1019,7 +1014,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway serving multiple certificates with tcproute", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tcp-routing/tls-multiple-certificates.yaml",
+			inputFiles: []string{"tcp-routing/tls-multiple-certificates.yaml"},
 			outputFile: "tcp-routing/tls-multiple-certificates.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1030,7 +1025,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/basic.yaml",
+			inputFiles: []string{"tls-routing/basic.yaml"},
 			outputFile: "tls-routing/basic-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1041,7 +1036,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tlsroute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/missing-backend.yaml",
+			inputFiles: []string{"tls-routing/missing-backend.yaml"},
 			outputFile: "tls-routing/missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1052,7 +1047,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tlsroute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/invalid-backend.yaml",
+			inputFiles: []string{"tls-routing/invalid-backend.yaml"},
 			outputFile: "tls-routing/invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1063,7 +1058,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with multiple backend services", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/multi-backend.yaml",
+			inputFiles: []string{"tls-routing/multi-backend.yaml"},
 			outputFile: "tls-routing/multi-backend-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1074,7 +1069,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("tls gateway with TLSRoute and TLS termination", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "tls-routing/tls-terminate.yaml",
+			inputFiles: []string{"tls-routing/tls-terminate.yaml"},
 			outputFile: "tls-routing/tls-terminate-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1085,7 +1080,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpc gateway with basic routing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/basic.yaml",
+			inputFiles: []string{"grpc-routing/basic.yaml"},
 			outputFile: "grpc-routing/basic-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1096,7 +1091,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpcroute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/missing-backend.yaml",
+			inputFiles: []string{"grpc-routing/missing-backend.yaml"},
 			outputFile: "grpc-routing/missing-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1107,7 +1102,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpcroute with invalid backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/invalid-backend.yaml",
+			inputFiles: []string{"grpc-routing/invalid-backend.yaml"},
 			outputFile: "grpc-routing/invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1118,7 +1113,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpc gateway with multiple backend services", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/multi-backend.yaml",
+			inputFiles: []string{"grpc-routing/multi-backend.yaml"},
 			outputFile: "grpc-routing/multi-backend-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1129,7 +1124,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("grpc route with https listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "grpc-routing/https-listener.yaml",
+			inputFiles: []string{"grpc-routing/https-listener.yaml"},
 			outputFile: "grpc-routing/https-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1140,7 +1135,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Basic service backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/basic.yaml",
+			inputFiles: []string{"backends/basic.yaml"},
 			outputFile: "backends/basic.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1151,7 +1146,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("AWS Lambda backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/aws_lambda.yaml",
+			inputFiles: []string{"backends/aws_lambda.yaml"},
 			outputFile: "backends/aws_lambda.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1162,7 +1157,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("GCP backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backends/gcp_backend.yaml",
+			inputFiles: []string{"backends/gcp_backend.yaml"},
 			outputFile: "backends/gcp_backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1173,7 +1168,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DFP Backend with TLS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "dfp/tls.yaml",
+			inputFiles: []string{"dfp/tls.yaml"},
 			outputFile: "dfp/tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1184,7 +1179,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DFP Backend with simple", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "dfp/simple.yaml",
+			inputFiles: []string{"dfp/simple.yaml"},
 			outputFile: "dfp/simple.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1195,7 +1190,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/tls.yaml",
+			inputFiles: []string{"backendtlspolicy/tls.yaml"},
 			outputFile: "backendtlspolicy/tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1206,7 +1201,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy with sectionName", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/tls-section-name.yaml",
+			inputFiles: []string{"backendtlspolicy/tls-section-name.yaml"},
 			outputFile: "backendtlspolicy/tls-section-name.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1231,7 +1226,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy with SAN", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/tls-san.yaml",
+			inputFiles: []string{"backendtlspolicy/tls-san.yaml"},
 			outputFile: "backendtlspolicy/tls-san.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1242,7 +1237,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy conflict resolution", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/conflict-resolution.yaml",
+			inputFiles: []string{"backendtlspolicy/conflict-resolution.yaml"},
 			outputFile: "backendtlspolicy/conflict-resolution.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1253,7 +1248,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend TLS Policy with Gateway backend client certificate", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendtlspolicy/gateway-client-certificate.yaml",
+			inputFiles: []string{"backendtlspolicy/gateway-client-certificate.yaml"},
 			outputFile: "backendtlspolicy/gateway-client-certificate.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1264,7 +1259,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Proxy with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "edge-cases/no_route.yaml",
+			inputFiles: []string{"edge-cases/no_route.yaml"},
 			outputFile: "no_route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1275,7 +1270,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Direct response", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/manifest.yaml",
+			inputFiles: []string{"directresponse/manifest.yaml"},
 			outputFile: "directresponse.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1286,7 +1281,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with missing reference reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/missing-ref.yaml",
+			inputFiles: []string{"directresponse/missing-ref.yaml"},
 			outputFile: "directresponse/missing-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1297,7 +1292,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with overlapping filters reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/overlapping-filters.yaml",
+			inputFiles: []string{"directresponse/overlapping-filters.yaml"},
 			outputFile: "directresponse/overlapping-filters.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1308,7 +1303,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with invalid backendRef filter reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/invalid-backendref-filter.yaml",
+			inputFiles: []string{"directresponse/invalid-backendref-filter.yaml"},
 			outputFile: "directresponse/invalid-backendref-filter.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1319,7 +1314,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with text body format", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/body-format-text.yaml",
+			inputFiles: []string{"directresponse/body-format-text.yaml"},
 			outputFile: "directresponse/body-format-text.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1330,7 +1325,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with JSON body format", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/body-format-json.yaml",
+			inputFiles: []string{"directresponse/body-format-json.yaml"},
 			outputFile: "directresponse/body-format-json.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1341,7 +1336,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("DirectResponse with content type in body format", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "directresponse/body-format-content-type.yaml",
+			inputFiles: []string{"directresponse/body-format-content-type.yaml"},
 			outputFile: "directresponse/body-format-content-type.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1352,7 +1347,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPRoutes with builtin timeout and retry", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httproute-timeout-retry/builtin.yaml",
+			inputFiles: []string{"httproute-timeout-retry/builtin.yaml"},
 			outputFile: "httproute-timeout-retry-proxy.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1363,7 +1358,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy timeout and retry", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/timeout-retry.yaml",
+			inputFiles: []string{"traffic-policy/timeout-retry.yaml"},
 			outputFile: "traffic-policy/timeout-retry.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1374,7 +1369,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy timeout attached to GRPCRoute", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/grpcroute-timeout.yaml",
+			inputFiles: []string{"traffic-policy/grpcroute-timeout.yaml"},
 			outputFile: "traffic-policy/grpcroute-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1385,7 +1380,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy timeout targeting Gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/timeout-gateway.yaml",
+			inputFiles: []string{"traffic-policy/timeout-gateway.yaml"},
 			outputFile: "traffic-policy/timeout-gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1395,7 +1390,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("http gateway with session persistence (cookie)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "session-persistence/cookie.yaml",
+			inputFiles: []string{"session-persistence/cookie.yaml"},
 			outputFile: "session-persistence/cookie.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1406,7 +1401,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("http gateway with session persistence (header)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "session-persistence/header.yaml",
+			inputFiles: []string{"session-persistence/header.yaml"},
 			outputFile: "session-persistence/header.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1417,7 +1412,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with upgrades", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-listener-pol/upgrades.yaml",
+			inputFiles: []string{"https-listener-pol/upgrades.yaml"},
 			outputFile: "https-listener-pol/upgrades.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1428,7 +1423,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with healthCheck", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/route-and-pol.yaml",
+			inputFiles: []string{"httplistenerpolicy/route-and-pol.yaml"},
 			outputFile: "httplistenerpolicy/route-and-pol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1439,7 +1434,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with idleTimeout", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/idle-timeout.yaml",
+			inputFiles: []string{"httplistenerpolicy/idle-timeout.yaml"},
 			outputFile: "httplistenerpolicy/idle-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1450,7 +1445,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with http2ProtocolOptions", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/http2-protocol-options.yaml",
+			inputFiles: []string{"httplistenerpolicy/http2-protocol-options.yaml"},
 			outputFile: "httplistenerpolicy/http2-protocol-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1461,7 +1456,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with preserveHttp1HeaderCase", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/preserve-http1-header-case.yaml",
+			inputFiles: []string{"httplistenerpolicy/preserve-http1-header-case.yaml"},
 			outputFile: "httplistenerpolicy/preserve-http1-header-case.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1472,7 +1467,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with useRemoteAddress absent", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/use-remote-addr-absent.yaml",
+			inputFiles: []string{"httplistenerpolicy/use-remote-addr-absent.yaml"},
 			outputFile: "httplistenerpolicy/use-remote-addr-absent.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1483,7 +1478,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with useRemoteAddress true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/use-remote-addr-true.yaml",
+			inputFiles: []string{"httplistenerpolicy/use-remote-addr-true.yaml"},
 			outputFile: "httplistenerpolicy/use-remote-addr-true.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1494,7 +1489,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with useRemoteAddress false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/use-remote-addr-false.yaml",
+			inputFiles: []string{"httplistenerpolicy/use-remote-addr-false.yaml"},
 			outputFile: "httplistenerpolicy/use-remote-addr-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1505,7 +1500,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with preserveExternalRequestId true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/preserve-external-request-id.yaml",
+			inputFiles: []string{"httplistenerpolicy/preserve-external-request-id.yaml"},
 			outputFile: "httplistenerpolicy/preserve-external-request-id.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1516,7 +1511,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with generateRequestId false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/generate-request-id-false.yaml",
+			inputFiles: []string{"httplistenerpolicy/generate-request-id-false.yaml"},
 			outputFile: "httplistenerpolicy/generate-request-id-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1527,7 +1522,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/accept-http10.yaml",
+			inputFiles: []string{"httplistenerpolicy/accept-http10.yaml"},
 			outputFile: "httplistenerpolicy/accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1538,7 +1533,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with defaultHostForHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/default-host-for-http10.yaml",
+			inputFiles: []string{"httplistenerpolicy/default-host-for-http10.yaml"},
 			outputFile: "httplistenerpolicy/default-host-for-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1549,7 +1544,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with defaultHostForHttp10 and no acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml",
+			inputFiles: []string{"httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml"},
 			outputFile: "httplistenerpolicy/default-host-for-http10-without-accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1560,7 +1555,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy merging", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/merge.yaml",
+			inputFiles: []string{"httplistenerpolicy/merge.yaml"},
 			outputFile: "httplistenerpolicy/merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1571,7 +1566,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with early header mutations (add/set/remove)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/early-header-mutation.yaml",
+			inputFiles: []string{"httplistenerpolicy/early-header-mutation.yaml"},
 			outputFile: "httplistenerpolicy/early-header-mutation.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1582,7 +1577,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with forwardClientCertDetails (mode defaulted)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/forward-client-cert-details.yaml",
+			inputFiles: []string{"httplistenerpolicy/forward-client-cert-details.yaml"},
 			outputFile: "httplistenerpolicy/forward-client-cert-details.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1593,7 +1588,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with uuidRequestIdConfig defaults", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/request-id-config-defaults.yaml",
+			inputFiles: []string{"httplistenerpolicy/request-id-config-defaults.yaml"},
 			outputFile: "httplistenerpolicy/request-id-config-defaults.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1604,7 +1599,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with uuidRequestIdConfig explicit false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/request-id-config-explicit.yaml",
+			inputFiles: []string{"httplistenerpolicy/request-id-config-explicit.yaml"},
 			outputFile: "httplistenerpolicy/request-id-config-explicit.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1615,7 +1610,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPListenerPolicy with uuidRequestIdConfig mixed values", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "httplistenerpolicy/request-id-config-mixed.yaml",
+			inputFiles: []string{"httplistenerpolicy/request-id-config-mixed.yaml"},
 			outputFile: "httplistenerpolicy/request-id-config-mixed.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1626,7 +1621,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with upgrades", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "https-listener-pol/upgrades.yaml",
+			inputFiles: []string{"https-listener-pol/upgrades.yaml"},
 			outputFile: "https-listener-pol/upgrades.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1637,7 +1632,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with healthCheck", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/route-and-pol.yaml",
+			inputFiles: []string{"listener-policy-http/route-and-pol.yaml"},
 			outputFile: "listener-policy-http/route-and-pol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1648,7 +1643,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with idleTimeout", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/idle-timeout.yaml",
+			inputFiles: []string{"listener-policy-http/idle-timeout.yaml"},
 			outputFile: "listener-policy-http/idle-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1659,7 +1654,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with http2ProtocolOptions", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/http2-protocol-options.yaml",
+			inputFiles: []string{"listener-policy-http/http2-protocol-options.yaml"},
 			outputFile: "listener-policy-http/http2-protocol-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1670,7 +1665,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with tcpKeepalive", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/tcp-keepalive.yaml",
+			inputFiles: []string{"listener-policy-http/tcp-keepalive.yaml"},
 			outputFile: "listener-policy-http/tcp-keepalive.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1681,7 +1676,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with preserveHttp1HeaderCase", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/preserve-http1-header-case.yaml",
+			inputFiles: []string{"listener-policy-http/preserve-http1-header-case.yaml"},
 			outputFile: "listener-policy-http/preserve-http1-header-case.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1692,7 +1687,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with useRemoteAddress absent", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/use-remote-addr-absent.yaml",
+			inputFiles: []string{"listener-policy-http/use-remote-addr-absent.yaml"},
 			outputFile: "listener-policy-http/use-remote-addr-absent.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1703,7 +1698,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with useRemoteAddress true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/use-remote-addr-true.yaml",
+			inputFiles: []string{"listener-policy-http/use-remote-addr-true.yaml"},
 			outputFile: "listener-policy-http/use-remote-addr-true.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1714,7 +1709,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with useRemoteAddress false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/use-remote-addr-false.yaml",
+			inputFiles: []string{"listener-policy-http/use-remote-addr-false.yaml"},
 			outputFile: "listener-policy-http/use-remote-addr-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1725,7 +1720,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with skipXFFAppend absent", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/skip-xff-append-absent.yaml",
+			inputFiles: []string{"listener-policy-http/skip-xff-append-absent.yaml"},
 			outputFile: "listener-policy-http/skip-xff-append-absent.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1736,7 +1731,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with skipXFFAppend true", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/skip-xff-append-true.yaml",
+			inputFiles: []string{"listener-policy-http/skip-xff-append-true.yaml"},
 			outputFile: "listener-policy-http/skip-xff-append-true.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1747,7 +1742,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with skipXFFAppend false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/skip-xff-append-false.yaml",
+			inputFiles: []string{"listener-policy-http/skip-xff-append-false.yaml"},
 			outputFile: "listener-policy-http/skip-xff-append-false.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1758,7 +1753,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffNumTrustedHops", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-num-trusted-hops.yaml",
+			inputFiles: []string{"listener-policy-http/xff-num-trusted-hops.yaml"},
 			outputFile: "listener-policy-http/xff-num-trusted-hops.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1769,7 +1764,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffNumTrustedHops and useRemoteAddress false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-num-trusted-hops-extension.yaml",
+			inputFiles: []string{"listener-policy-http/xff-num-trusted-hops-extension.yaml"},
 			outputFile: "listener-policy-http/xff-num-trusted-hops-extension.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1780,7 +1775,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffTrustedCIDRs", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-trusted-cidrs.yaml",
+			inputFiles: []string{"listener-policy-http/xff-trusted-cidrs.yaml"},
 			outputFile: "listener-policy-http/xff-trusted-cidrs.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1791,7 +1786,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with xffTrustedCIDRs and skipXFFAppend false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/xff-trusted-cidrs-no-skip-append.yaml",
+			inputFiles: []string{"listener-policy-http/xff-trusted-cidrs-no-skip-append.yaml"},
 			outputFile: "listener-policy-http/xff-trusted-cidrs-no-skip-append.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1802,7 +1797,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/accept-http10.yaml",
+			inputFiles: []string{"listener-policy-http/accept-http10.yaml"},
 			outputFile: "listener-policy-http/accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1813,7 +1808,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with defaultHostForHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/default-host-for-http10.yaml",
+			inputFiles: []string{"listener-policy-http/default-host-for-http10.yaml"},
 			outputFile: "listener-policy-http/default-host-for-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1824,7 +1819,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with defaultHostForHttp10 and no acceptHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/default-host-for-http10-without-accept-http10.yaml",
+			inputFiles: []string{"listener-policy-http/default-host-for-http10-without-accept-http10.yaml"},
 			outputFile: "listener-policy-http/default-host-for-http10-without-accept-http10.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1835,7 +1830,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy merging", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/merge.yaml",
+			inputFiles: []string{"listener-policy-http/merge.yaml"},
 			outputFile: "listener-policy-http/merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1846,7 +1841,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with early header mutations (add/set/remove)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/early-header-mutation.yaml",
+			inputFiles: []string{"listener-policy-http/early-header-mutation.yaml"},
 			outputFile: "listener-policy-http/early-header-mutation.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1857,7 +1852,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with forwardClientCertDetails (AppendForward)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/forward-client-cert-details.yaml",
+			inputFiles: []string{"listener-policy-http/forward-client-cert-details.yaml"},
 			outputFile: "listener-policy-http/forward-client-cert-details.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1868,7 +1863,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestHeadersKb", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-request-headers-kb.yaml",
+			inputFiles: []string{"listener-policy-http/max-request-headers-kb.yaml"},
 			outputFile: "listener-policy-http/max-request-headers-kb.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1879,7 +1874,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestsPerConnection", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1890,7 +1885,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestsPerConnection set to zero", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection-zero.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection-zero.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection-zero.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1901,7 +1896,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with maxRequestsPerConnection and idleTimeout", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection-with-idle-timeout.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection-with-idle-timeout.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection-with-idle-timeout.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1912,7 +1907,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy maxRequestsPerConnection merge conflict", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/max-requests-per-connection-merge-conflict.yaml",
+			inputFiles: []string{"listener-policy-http/max-requests-per-connection-merge-conflict.yaml"},
 			outputFile: "listener-policy-http/max-requests-per-connection-merge-conflict.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1923,7 +1918,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with stripHostPortMode AnyPort", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/strip-host-port-any-port.yaml",
+			inputFiles: []string{"listener-policy-http/strip-host-port-any-port.yaml"},
 			outputFile: "listener-policy-http/strip-host-port-any-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1934,7 +1929,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with stripHostPortMode MatchingPort", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/strip-host-port-matching-port.yaml",
+			inputFiles: []string{"listener-policy-http/strip-host-port-matching-port.yaml"},
 			outputFile: "listener-policy-http/strip-host-port-matching-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1945,7 +1940,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with uuidRequestIdConfig explicit false", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/request-id-config-explicit.yaml",
+			inputFiles: []string{"listener-policy-http/request-id-config-explicit.yaml"},
 			outputFile: "listener-policy-http/request-id-config-explicit.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1956,7 +1951,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with uuidRequestIdConfig defaults", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/request-id-config-defaults.yaml",
+			inputFiles: []string{"listener-policy-http/request-id-config-defaults.yaml"},
 			outputFile: "listener-policy-http/request-id-config-defaults.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1967,7 +1962,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with uuidRequestIdConfig mixed values", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/request-id-config-mixed.yaml",
+			inputFiles: []string{"listener-policy-http/request-id-config-mixed.yaml"},
 			outputFile: "listener-policy-http/request-id-config-mixed.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1978,7 +1973,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Service with appProtocol=kubernetes.io/h2c", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/svc-h2c.yaml",
+			inputFiles: []string{"backend-protocol/svc-h2c.yaml"},
 			outputFile: "backend-protocol/svc-h2c.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -1989,7 +1984,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with opentelemetry attributes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/opentelemetry.yaml",
+			inputFiles: []string{"listener-policy-http/opentelemetry.yaml"},
 			outputFile: "listener-policy-http/opentelemetry.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2000,7 +1995,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with runtime filter", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy-http/runtime-filter.yaml",
+			inputFiles: []string{"listener-policy-http/runtime-filter.yaml"},
 			outputFile: "listener-policy-http/runtime-filter.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2011,7 +2006,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Service with appProtocol=kubernetes.io/ws", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/svc-ws.yaml",
+			inputFiles: []string{"backend-protocol/svc-ws.yaml"},
 			outputFile: "backend-protocol/svc-ws.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2022,7 +2017,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Service with appProtocol=anything", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/svc-default.yaml",
+			inputFiles: []string{"backend-protocol/svc-default.yaml"},
 			outputFile: "backend-protocol/svc-default.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2033,7 +2028,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Static Backend with appProtocol=kubernetes.io/h2c", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/backend-h2c.yaml",
+			inputFiles: []string{"backend-protocol/backend-h2c.yaml"},
 			outputFile: "backend-protocol/backend-h2c.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2044,7 +2039,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Static Backend with appProtocol=kubernetes.io/ws", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/backend-ws.yaml",
+			inputFiles: []string{"backend-protocol/backend-ws.yaml"},
 			outputFile: "backend-protocol/backend-ws.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2055,7 +2050,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Static Backend with no appProtocol", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backend-protocol/backend-default.yaml",
+			inputFiles: []string{"backend-protocol/backend-default.yaml"},
 			outputFile: "backend-protocol/backend-default.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2066,7 +2061,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with LB Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/lb-config.yaml",
+			inputFiles: []string{"backendconfigpolicy/lb-config.yaml"},
 			outputFile: "backendconfigpolicy/lb-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2077,7 +2072,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with LB UseHostnameForHashing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/lb-usehostnameforhashing.yaml",
+			inputFiles: []string{"backendconfigpolicy/lb-usehostnameforhashing.yaml"},
 			outputFile: "backendconfigpolicy/lb-usehostnameforhashing.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2088,7 +2083,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with DNS settings", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/dns.yaml",
+			inputFiles: []string{"backendconfigpolicy/dns.yaml"},
 			outputFile: "backendconfigpolicy/dns.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2099,7 +2094,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Health Check", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/healthcheck.yaml",
+			inputFiles: []string{"backendconfigpolicy/healthcheck.yaml"},
 			outputFile: "backendconfigpolicy/healthcheck.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2110,7 +2105,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with OutlierDetection", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/outlierdetection.yaml",
+			inputFiles: []string{"backendconfigpolicy/outlierdetection.yaml"},
 			outputFile: "backendconfigpolicy/outlierdetection.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2121,7 +2116,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Common HTTP Protocol - HTTP backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/commonhttpprotocol-httpbackend.yaml",
+			inputFiles: []string{"backendconfigpolicy/commonhttpprotocol-httpbackend.yaml"},
 			outputFile: "backendconfigpolicy/commonhttpprotocol-httpbackend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2132,7 +2127,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Common HTTP Protocol - HTTP2 backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/commonhttpprotocol-http2backend.yaml",
+			inputFiles: []string{"backendconfigpolicy/commonhttpprotocol-http2backend.yaml"},
 			outputFile: "backendconfigpolicy/commonhttpprotocol-http2backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2143,7 +2138,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with HTTP2 Protocol Options", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/http2.yaml",
+			inputFiles: []string{"backendconfigpolicy/http2.yaml"},
 			outputFile: "backendconfigpolicy/http2.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2154,7 +2149,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with TLS and SAN verification", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-san.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-san.yaml"},
 			outputFile: "backendconfigpolicy/tls-san.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2165,7 +2160,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with TLS and insecure skip verify", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-insecureskipverify.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-insecureskipverify.yaml"},
 			outputFile: "backendconfigpolicy/tls-insecureskipverify.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2176,7 +2171,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with simple TLS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/simple-tls.yaml",
+			inputFiles: []string{"backendconfigpolicy/simple-tls.yaml"},
 			outputFile: "backendconfigpolicy/simple-tls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2187,7 +2182,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with system ca TLS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-system-ca.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-system-ca.yaml"},
 			outputFile: "backendconfigpolicy/tls-system-ca.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2198,7 +2193,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with system ca TLS in strict mode", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/tls-system-ca.yaml",
+			inputFiles: []string{"backendconfigpolicy/tls-system-ca.yaml"},
 			outputFile: "backendconfigpolicy/tls-system-ca.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2211,7 +2206,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Circuit Breakers minimal", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/circuitbreakers-minimal.yaml",
+			inputFiles: []string{"backendconfigpolicy/circuitbreakers-minimal.yaml"},
 			outputFile: "backendconfigpolicy/circuitbreakers-minimal.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2222,7 +2217,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Circuit Breakers full", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/circuitbreakers-full.yaml",
+			inputFiles: []string{"backendconfigpolicy/circuitbreakers-full.yaml"},
 			outputFile: "backendconfigpolicy/circuitbreakers-full.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2233,7 +2228,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with Circuit Breakers track remaining", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/circuitbreakers-track-remaining.yaml",
+			inputFiles: []string{"backendconfigpolicy/circuitbreakers-track-remaining.yaml"},
 			outputFile: "backendconfigpolicy/circuitbreakers-track-remaining.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2244,7 +2239,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with upstream proxy protocol V1", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/upstream-proxy-protocol-v1.yaml",
+			inputFiles: []string{"backendconfigpolicy/upstream-proxy-protocol-v1.yaml"},
 			outputFile: "backendconfigpolicy/upstream-proxy-protocol-v1.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2255,7 +2250,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Backend Config Policy with upstream proxy protocol V2", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "backendconfigpolicy/upstream-proxy-protocol-v2.yaml",
+			inputFiles: []string{"backendconfigpolicy/upstream-proxy-protocol-v2.yaml"},
 			outputFile: "backendconfigpolicy/upstream-proxy-protocol-v2.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2266,7 +2261,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy with explicit generation", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/generation.yaml",
+			inputFiles: []string{"traffic-policy/generation.yaml"},
 			outputFile: "traffic-policy/generation.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
@@ -2277,7 +2272,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/route-http-acl.yaml",
+			inputFiles: []string{"http-acl/route-http-acl.yaml"},
 			outputFile: "http-acl/route-http-acl.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2288,7 +2283,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/httproute-http-acl.yaml",
+			inputFiles: []string{"http-acl/httproute-http-acl.yaml"},
 			outputFile: "http-acl/httproute-http-acl.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2299,7 +2294,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/gateway-http-acl.yaml",
+			inputFiles: []string{"http-acl/gateway-http-acl.yaml"},
 			outputFile: "http-acl/gateway-http-acl.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2310,7 +2305,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HttpACL Policy with invalid CIDR rejected", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-acl/invalid-cidr.yaml",
+			inputFiles: []string{"http-acl/invalid-cidr.yaml"},
 			outputFile: "http-acl/invalid-cidr.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2321,7 +2316,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/route-cel-rbac.yaml",
+			inputFiles: []string{"rbac/route-cel-rbac.yaml"},
 			outputFile: "rbac/route-cel-rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2332,7 +2327,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at route level with Deny action", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/route-cel-rbac-deny.yaml",
+			inputFiles: []string{"rbac/route-cel-rbac-deny.yaml"},
 			outputFile: "rbac/route-cel-rbac-deny.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2343,7 +2338,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/httproute-cel-rbac.yaml",
+			inputFiles: []string{"rbac/httproute-cel-rbac.yaml"},
 			outputFile: "rbac/httproute-cel-rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2354,7 +2349,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("RBAC Policy at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "rbac/gateway-cel-rbac.yaml",
+			inputFiles: []string{"rbac/gateway-cel-rbac.yaml"},
 			outputFile: "rbac/gateway-cel-rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2365,7 +2360,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("basic listener set", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/basic.yaml",
+			inputFiles: []string{"listener-sets/basic.yaml"},
 			outputFile: "listener-sets/basic.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2376,7 +2371,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set and gateway with no allowed listeners", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/no-allowed-lis.yaml",
+			inputFiles: []string{"listener-sets/no-allowed-lis.yaml"},
 			outputFile: "listener-sets/no-allowed-lis.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2387,7 +2382,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set accepted with rejected individual listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/accepted-ls-rejected-listener.yaml",
+			inputFiles: []string{"listener-sets/accepted-ls-rejected-listener.yaml"},
 			outputFile: "listener-sets/accepted-ls-rejected-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2398,7 +2393,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with tls listener and secret in same namespace", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-same-ns.yaml",
+			inputFiles: []string{"listener-sets/tls-same-ns.yaml"},
 			outputFile: "listener-sets/tls-same-ns.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2409,7 +2404,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with tls listener and secret in different namespace without reference grant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-missing-reference-grant.yaml",
+			inputFiles: []string{"listener-sets/tls-missing-reference-grant.yaml"},
 			outputFile: "listener-sets/tls-missing-reference-grant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2420,7 +2415,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with tls listener and secret in different namespace with reference grant", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-valid-reference-grant.yaml",
+			inputFiles: []string{"listener-sets/tls-valid-reference-grant.yaml"},
 			outputFile: "listener-sets/tls-valid-reference-grant.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2431,7 +2426,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("listener set with TLS listener with TLS extension options", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-sets/tls-options.yaml",
+			inputFiles: []string{"listener-sets/tls-options.yaml"},
 			outputFile: "listener-sets/tls-options.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2442,7 +2437,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy RateLimit Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/rate-limit-full-config.yaml",
+			inputFiles: []string{"traffic-policy/rate-limit-full-config.yaml"},
 			outputFile: "traffic-policy/rate-limit-full-config.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2453,7 +2448,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TrafficPolicy RateLimit with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/ratelimit-cross-namespace.yaml",
+			inputFiles: []string{"traffic-policy/ratelimit-cross-namespace.yaml"},
 			outputFile: "traffic-policy/ratelimit-cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2464,7 +2459,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS listener with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-listener-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-listener-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/tls-listener-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2475,7 +2470,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TCP listener with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tcp-listener-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tcp-listener-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/tcp-listener-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2486,7 +2481,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS listener with invalid secret ref", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-listener-invalid-secret-ref.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-listener-invalid-secret-ref.yaml"},
 			outputFile: "invalid-filter-chains/https-listener-invalid-secret-ref.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2497,7 +2492,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS listener with multiple cert refs, one missing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-listener-multi-cert-one-missing.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-listener-multi-cert-one-missing.yaml"},
 			outputFile: "invalid-filter-chains/https-listener-multi-cert-one-missing.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2508,7 +2503,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS listener with invalid secret (missing private key)", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-listener-invalid-secret.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-listener-invalid-secret.yaml"},
 			outputFile: "invalid-filter-chains/https-listener-invalid-secret.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2519,7 +2514,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS mixed listeners - no routes and with routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-mixed-listeners.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-mixed-listeners.yaml"},
 			outputFile: "invalid-filter-chains/tls-mixed-listeners.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2530,7 +2525,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TCP mixed listeners - no routes and with routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tcp-mixed-listeners.yaml",
+			inputFiles: []string{"invalid-filter-chains/tcp-mixed-listeners.yaml"},
 			outputFile: "invalid-filter-chains/tcp-mixed-listeners.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2541,7 +2536,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS same port listeners - both with no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-same-port-both-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-same-port-both-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/tls-same-port-both-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2552,7 +2547,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS same port listeners - mixed routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-same-port-mixed-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-same-port-mixed-routes.yaml"},
 			outputFile: "invalid-filter-chains/tls-same-port-mixed-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2563,7 +2558,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("TLS route with invalid backend", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/tls-route-invalid-backend.yaml",
+			inputFiles: []string{"invalid-filter-chains/tls-route-invalid-backend.yaml"},
 			outputFile: "invalid-filter-chains/tls-route-invalid-backend.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2574,7 +2569,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTPS mixed listeners - invalid and valid secret refs", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/https-mixed-listeners.yaml",
+			inputFiles: []string{"invalid-filter-chains/https-mixed-listeners.yaml"},
 			outputFile: "invalid-filter-chains/https-mixed-listeners.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2585,7 +2580,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway empty with ListenerSet TCP listener no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/gateway-empty-listenerset-tcp-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2596,7 +2591,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway empty with ListenerSet TLS listener no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/gateway-empty-listenerset-tls-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2607,7 +2602,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway empty with ListenerSet TLS mixed listeners", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml"},
 			outputFile: "invalid-filter-chains/gateway-empty-listenerset-tls-mixed.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2618,7 +2613,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway HTTP listener with ListenerSet TCP listener no routes", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml"},
 			outputFile: "invalid-filter-chains/gateway-http-listenerset-tcp-no-routes.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2629,7 +2624,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway TCP listener no routes with ListenerSet HTTP listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml",
+			inputFiles: []string{"invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml"},
 			outputFile: "invalid-filter-chains/gateway-tcp-no-routes-listenerset-http.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2640,7 +2635,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("Gateway with reserved port should be rejected", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "validation/gateway-reserved-port.yaml",
+			inputFiles: []string{"validation/gateway-reserved-port.yaml"},
 			outputFile: "validation/gateway-reserved-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2651,7 +2646,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("XListenerSet with reserved port should be rejected", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "validation/xlistenerset-reserved-port.yaml",
+			inputFiles: []string{"validation/xlistenerset-reserved-port.yaml"},
 			outputFile: "validation/xlistenerset-reserved-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2662,7 +2657,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTP RequestRedirect filter", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing/request-redirect.yaml",
+			inputFiles: []string{"http-routing/request-redirect.yaml"},
 			outputFile: "http-routing/request-redirect.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2673,7 +2668,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("HTTP RequestRedirect filter multiple listeners listener-scoped port", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "http-routing/request-redirect-multi-listener.yaml",
+			inputFiles: []string{"http-routing/request-redirect-multi-listener.yaml"},
 			outputFile: "http-routing/request-redirect-multi-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2684,7 +2679,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol on HTTP listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/http-proxy-protocol.yaml",
+			inputFiles: []string{"listener-policy/http-proxy-protocol.yaml"},
 			outputFile: "listener-policy/http-proxy-protocol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2695,7 +2690,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol on HTTPS listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/https-proxy-protocol.yaml",
+			inputFiles: []string{"listener-policy/https-proxy-protocol.yaml"},
 			outputFile: "listener-policy/https-proxy-protocol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2706,7 +2701,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol on TCP listener", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/tcp-proxy-protocol.yaml",
+			inputFiles: []string{"listener-policy/tcp-proxy-protocol.yaml"},
 			outputFile: "listener-policy/tcp-proxy-protocol.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2717,7 +2712,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with proxy protocol allowing requests without header", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/http-proxy-protocol-allow-no-header.yaml",
+			inputFiles: []string{"listener-policy/http-proxy-protocol-allow-no-header.yaml"},
 			outputFile: "listener-policy/http-proxy-protocol-allow-no-header.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2728,7 +2723,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with per connection buffer limit", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-connection-buffer-limit.yaml",
+			inputFiles: []string{"listener-policy/per-connection-buffer-limit.yaml"},
 			outputFile: "listener-policy/per-connection-buffer-limit.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2739,7 +2734,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with per port settings", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-port.yaml",
+			inputFiles: []string{"listener-policy/per-port.yaml"},
 			outputFile: "listener-policy/per-port.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2750,7 +2745,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with per-listener mTLS override", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-listener-mtls.yaml",
+			inputFiles: []string{"listener-policy/per-listener-mtls.yaml"},
 			outputFile: "listener-policy/per-listener-mtls.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2761,7 +2756,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy with multiple per-listener mTLS override", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/per-listener-mtls-multiple.yaml",
+			inputFiles: []string{"listener-policy/per-listener-mtls-multiple.yaml"},
 			outputFile: "listener-policy/per-listener-mtls-multiple.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2772,7 +2767,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("ListenerPolicy merge happens in the default and perPort fields", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "listener-policy/deep-merge.yaml",
+			inputFiles: []string{"listener-policy/deep-merge.yaml"},
 			outputFile: "listener-policy/deep-merge.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2783,7 +2778,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway.yaml",
+			inputFiles: []string{"jwt/gateway.yaml"},
 			outputFile: "jwt/gateway.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2794,7 +2789,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level selecting listener with sectionName", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-listener.yaml",
+			inputFiles: []string{"jwt/gateway-listener.yaml"},
 			outputFile: "jwt/gateway-listener.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2805,7 +2800,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level using configmap", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-configmap.yaml",
+			inputFiles: []string{"jwt/gateway-configmap.yaml"},
 			outputFile: "jwt/gateway-configmap.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2816,7 +2811,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy targeting listenerset", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/listenerset.yaml",
+			inputFiles: []string{"jwt/listenerset.yaml"},
 			outputFile: "jwt/listenerset.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2827,7 +2822,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/route.yaml",
+			inputFiles: []string{"jwt/route.yaml"},
 			outputFile: "jwt/route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2838,7 +2833,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy with cross-namespace backends", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/cross-namespace.yaml",
+			inputFiles: []string{"jwt/cross-namespace.yaml"},
 			outputFile: "jwt/cross-namespace.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2849,7 +2844,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy with cross-namespace GatewayExtension", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/cross-namespace-extension.yaml",
+			inputFiles: []string{"jwt/cross-namespace-extension.yaml"},
 			outputFile: "jwt/cross-namespace-extension.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2860,7 +2855,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at httproute level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/httproute.yaml",
+			inputFiles: []string{"jwt/httproute.yaml"},
 			outputFile: "jwt/httproute.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2871,7 +2866,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway and route level", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-and-route.yaml",
+			inputFiles: []string{"jwt/gateway-and-route.yaml"},
 			outputFile: "jwt/gateway-and-route.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2882,7 +2877,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy and RBAC", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/rbac.yaml",
+			inputFiles: []string{"jwt/rbac.yaml"},
 			outputFile: "jwt/rbac.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2893,7 +2888,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at gateway level with disable on route", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-disable.yaml",
+			inputFiles: []string{"jwt/gateway-disable.yaml"},
 			outputFile: "jwt/gateway-disable.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2904,7 +2899,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy at route level using remote JWKS", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/httproute-remote-jwks.yaml",
+			inputFiles: []string{"jwt/httproute-remote-jwks.yaml"},
 			outputFile: "jwt/httproute-remote-jwks.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2915,7 +2910,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("JWT Policy with validation mode AllowMissing", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "jwt/gateway-validation-mode.yaml",
+			inputFiles: []string{"jwt/gateway-validation-mode.yaml"},
 			outputFile: "jwt/gateway-validation-mode.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
@@ -2926,7 +2921,7 @@ func TestBasic(t *testing.T) {
 
 	t.Run("OAuth2 policy", func(t *testing.T) {
 		test(t, translatorTestCase{
-			inputFile:  "traffic-policy/oauth2.yaml",
+			inputFiles: []string{"traffic-policy/oauth2.yaml"},
 			outputFile: "traffic-policy/oauth2.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->
- Standardizes the gateway translator test suite on `inputFiles []string` by removing the older `inputFile` field from `translatorTestCase`. 
- All test cases now use `inputFiles: []string{...}` consistently, and the fallback logic that read `inputFile` when `inputFiles` was empty has been removed.

Fixes #14069

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind cleanup
# Changelog


<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
