### PR TITLE
v2.1.x branch is no longer LTS

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -12,7 +12,6 @@ on:
         options:
           - all
           - main
-          - v2.1.x
           - v2.2.x
           - v2.3.x
 
@@ -38,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          branches='["main","v2.1.x","v2.2.x","v2.3.x"]'
+          branches='["main","v2.2.x","v2.3.x"]'
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             case "${{ inputs.branches }}" in
@@ -46,9 +45,6 @@ jobs:
                 ;;
               main)
                 branches='["main"]'
-                ;;
-              v2.1.x)
-                branches='["v2.1.x"]'
                 ;;
               v2.2.x)
                 branches='["v2.2.x"]'


### PR DESCRIPTION
# Description

Removes 2.1 LTS branch from OSV scanner since it's EOL.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
