### PR TITLE
perf: make the EDS ConfigSource a package-level singleton

### DIFF
--- a/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
+++ b/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
@@ -28,7 +28,8 @@ const BackendClusterPrefix = "kube"
 // edsClusterConfig is shared across all EDS clusters since its contents are
 // identical for every kubernetes Service backend. Sharing the pointer avoids
 // reallocating the (ConfigSource, Ads, AggregatedConfigSource) tuple per UCC.
-// The xDS server must treat this as read-only.
+// Do not mutate this in place; clone first if per-cluster customization is
+// needed.
 var edsClusterConfig = &envoyclusterv3.Cluster_EdsClusterConfig{
 	EdsConfig: &envoycorev3.ConfigSource{
 		ResourceApiVersion: envoycorev3.ApiVersion_V3,

--- a/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
+++ b/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
@@ -25,6 +25,23 @@ import (
 
 const BackendClusterPrefix = "kube"
 
+// edsClusterConfig is shared across all EDS clusters since its contents are
+// identical for every kubernetes Service backend. Sharing the pointer avoids
+// reallocating the (ConfigSource, Ads, AggregatedConfigSource) tuple per UCC.
+// The xDS server must treat this as read-only.
+var edsClusterConfig = &envoyclusterv3.Cluster_EdsClusterConfig{
+	EdsConfig: &envoycorev3.ConfigSource{
+		ResourceApiVersion: envoycorev3.ApiVersion_V3,
+		ConfigSourceSpecifier: &envoycorev3.ConfigSource_Ads{
+			Ads: &envoycorev3.AggregatedConfigSource{},
+		},
+	},
+}
+
+var edsClusterDiscoveryType = &envoyclusterv3.Cluster_Type{
+	Type: envoyclusterv3.Cluster_EDS,
+}
+
 func NewPlugin(ctx context.Context, commonCol *collections.CommonCollections) sdk.Plugin {
 	epSliceClient := kclient.NewFiltered[*discoveryv1.EndpointSlice](
 		commonCol.Client,
@@ -108,17 +125,8 @@ func BuildServiceBackendObjectIR(svc *corev1.Service, svcPort int32, svcProtocol
 }
 
 func processBackend(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
-	out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{
-		Type: envoyclusterv3.Cluster_EDS,
-	}
-	out.EdsClusterConfig = &envoyclusterv3.Cluster_EdsClusterConfig{
-		EdsConfig: &envoycorev3.ConfigSource{
-			ResourceApiVersion: envoycorev3.ApiVersion_V3,
-			ConfigSourceSpecifier: &envoycorev3.ConfigSource_Ads{
-				Ads: &envoycorev3.AggregatedConfigSource{},
-			},
-		},
-	}
+	out.ClusterDiscoveryType = edsClusterDiscoveryType
+	out.EdsClusterConfig = edsClusterConfig
 	out.IgnoreHealthOnHostRemoval = true
 	return nil
 }


### PR DESCRIPTION
# Description

based on analysis of memory profiles, we can be more efficient here.

pkg/kgateway/extensions2/plugins/kubernetes/k8s.go:114. Builds the same Cluster_EdsClusterConfig{ EdsConfig: &core.ConfigSource{ ConfigSourceSpecifier: &Ads{ Ads: &AggregatedConfigSource{} } } } for every cluster. This struct is identical for every EDS cluster in the entire control plane. The EDS config is read downstream, but not mutated.


# Change Type

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
