### PR TITLE
perf: memoize BackendObjectIR ClusterName

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backend/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backend/plugin.go
@@ -89,7 +89,7 @@ func NewPlugin(commoncol *collections.CommonCollections) sdk.Plugin {
 			Name:      i.GetName(),
 		}
 		backend := ir.NewBackendObjectIR(objSrc, 0, "")
-		backend.GvPrefix = ExtensionName
+		backend.SetGvPrefix(ExtensionName)
 		backend.CanonicalHostname = hostname(i)
 		backend.AppProtocol = parseAppProtocol(i)
 		backend.Obj = i
@@ -98,8 +98,6 @@ func NewPlugin(commoncol *collections.CommonCollections) sdk.Plugin {
 
 		// Parse common annotations
 		ir.ParseObjectAnnotations(&backend, i)
-
-		backend.InitClusterName()
 		return &backend
 	})
 	return sdk.Plugin{

--- a/pkg/kgateway/extensions2/plugins/backend/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backend/plugin.go
@@ -99,6 +99,7 @@ func NewPlugin(commoncol *collections.CommonCollections) sdk.Plugin {
 		// Parse common annotations
 		ir.ParseObjectAnnotations(&backend, i)
 
+		backend.InitClusterName()
 		return &backend
 	})
 	return sdk.Plugin{

--- a/pkg/kgateway/extensions2/plugins/backend/status.go
+++ b/pkg/kgateway/extensions2/plugins/backend/status.go
@@ -36,8 +36,8 @@ func buildRegisterCallback(
 			}
 
 			resNN := types.NamespacedName{
-				Name:      in.ObjectSource.Name,
-				Namespace: in.ObjectSource.Namespace,
+				Name:      in.GetName(),
+				Namespace: in.GetNamespace(),
 			}
 
 			err := retry.Do(

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate.go
@@ -45,15 +45,12 @@ func validateXDS(
 			},
 		}
 	}
-	dummyBackend := ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "core",
-			Kind:      "Service",
-			Name:      "test-backend",
-			Namespace: "test",
-		},
-		Port: 80,
-	}
+	dummyBackend := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "core",
+		Kind:      "Service",
+		Name:      "test-backend",
+		Namespace: "test",
+	}, 80, "")
 	processBackend(ctx, policyIR, dummyBackend, testCluster)
 
 	builder := bootstrap.New()

--- a/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
@@ -85,7 +85,7 @@ func (d *destrulePlugin) processBackend(kctx krt.HandlerContext, ctx context.Con
 		return
 	}
 
-	trafficPolicy := getTrafficPolicy(destrule, uint32(in.Port)) //nolint:gosec // G115: BackendObjectIR.Port is int32 representing a port number, always in valid range
+	trafficPolicy := getTrafficPolicy(destrule, uint32(in.GetPort())) //nolint:gosec // G115: BackendObjectIR port is int32 representing a port number, always in valid range
 	outlier := trafficPolicy.GetOutlierDetection()
 	if outlier == nil {
 		return

--- a/pkg/kgateway/extensions2/plugins/istio/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/istio/plugin.go
@@ -209,6 +209,7 @@ func createDefaultIstioMatch() *envoyclusterv3.Cluster_TransportSocketMatch {
 }
 
 func buildSni(upstream ir.BackendObjectIR) string {
+	port := upstream.GetPort() //nolint:gosec // G115: port is int32 representing a port number, always in valid range
 	switch us := upstream.Obj.(type) {
 	case *corev1.Service:
 		return buildDNSSrvSubsetKey(
@@ -217,13 +218,13 @@ func buildSni(upstream ir.BackendObjectIR) string {
 				us.Namespace,
 				"cluster.local", // TODO we need a setting like Istio has for trustDomain
 			),
-			uint32(upstream.GetPort()),
+			uint32(port),
 		)
 	default:
-		if upstream.GetPort() != 0 && upstream.CanonicalHostname != "" {
+		if port != 0 && upstream.CanonicalHostname != "" {
 			return buildDNSSrvSubsetKey(
 				upstream.CanonicalHostname,
-				uint32(upstream.GetPort()),
+				uint32(port),
 			)
 		}
 	}

--- a/pkg/kgateway/extensions2/plugins/istio/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/istio/plugin.go
@@ -217,13 +217,13 @@ func buildSni(upstream ir.BackendObjectIR) string {
 				us.Namespace,
 				"cluster.local", // TODO we need a setting like Istio has for trustDomain
 			),
-			uint32(upstream.Port),
+			uint32(upstream.GetPort()),
 		)
 	default:
-		if upstream.Port != 0 && upstream.CanonicalHostname != "" {
+		if upstream.GetPort() != 0 && upstream.CanonicalHostname != "" {
 			return buildDNSSrvSubsetKey(
 				upstream.CanonicalHostname,
-				uint32(upstream.Port),
+				uint32(upstream.GetPort()),
 			)
 		}
 	}

--- a/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
+++ b/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
@@ -104,6 +104,7 @@ func BuildServiceBackendObjectIR(svc *corev1.Service, svcPort int32, svcProtocol
 	// Parse common annotations
 	ir.ParseObjectAnnotations(&backend, svc)
 
+	backend.InitClusterName()
 	return backend
 }
 

--- a/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
+++ b/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
@@ -80,7 +80,7 @@ func BuildServiceBackendObjectIR(svc *corev1.Service, svcPort int32, svcProtocol
 	backend := ir.NewBackendObjectIR(objSrc, svcPort, "")
 	backend.Obj = svc
 	backend.AppProtocol = ir.ParseAppProtocol(&svcProtocol)
-	backend.GvPrefix = BackendClusterPrefix
+	backend.SetGvPrefix(BackendClusterPrefix)
 	backend.CanonicalHostname = kubeutils.GetServiceHostname(svc.Name, svc.Namespace)
 
 	// Set the port name for sectionName based policy attachment
@@ -104,7 +104,6 @@ func BuildServiceBackendObjectIR(svc *corev1.Service, svcPort int32, svcProtocol
 	// Parse common annotations
 	ir.ParseObjectAnnotations(&backend, svc)
 
-	backend.InitClusterName()
 	return backend
 }
 

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/access_logging_listener_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/access_logging_listener_plugin_test.go
@@ -1287,20 +1287,22 @@ func TestConvertJsonFormat_EdgeCases(t *testing.T) {
 					tc.config,
 					// Example grpcBackends map for upstreams
 					map[string]*ir.BackendObjectIR{
-						"grpc-log-0": {
-							ObjectSource: ir.ObjectSource{
+						"grpc-log-0": func() *ir.BackendObjectIR {
+							backend := ir.NewBackendObjectIR(ir.ObjectSource{
 								Kind:      "Backend",
 								Name:      "test-service",
 								Namespace: "default",
-							},
-						},
-						"otel-log-0": {
-							ObjectSource: ir.ObjectSource{
+							}, 0, "")
+							return &backend
+						}(),
+						"otel-log-0": func() *ir.BackendObjectIR {
+							backend := ir.NewBackendObjectIR(ir.ObjectSource{
 								Kind:      "Backend",
 								Name:      "test-service",
 								Namespace: "default",
-							},
-						},
+							}, 0, "")
+							return &backend
+						}(),
 					},
 				)
 				require.NoError(t, err, "failed to convert access log config")

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/tracing_listener_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/tracing_listener_plugin_test.go
@@ -443,16 +443,15 @@ func TestTracingConverter(t *testing.T) {
 			t.Cleanup(cancel)
 
 			t.Run(tc.name, func(t *testing.T) {
+				backend := ir.NewBackendObjectIR(ir.ObjectSource{
+					Kind:      "Backend",
+					Name:      "test-service",
+					Namespace: "default",
+				}, 0, "")
+
 				provider, config, err := translateTracing(
 					tc.config,
-					func() *ir.BackendObjectIR {
-						backend := ir.NewBackendObjectIR(ir.ObjectSource{
-							Kind:      "Backend",
-							Name:      "test-service",
-							Namespace: "default",
-						}, 0, "")
-						return &backend
-					}(),
+					&backend,
 				)
 				updateTracingConfig(&ir.HcmContext{
 					Gateway: ir.GatewayIR{

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/tracing_listener_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/tracing_listener_plugin_test.go
@@ -445,13 +445,14 @@ func TestTracingConverter(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				provider, config, err := translateTracing(
 					tc.config,
-					&ir.BackendObjectIR{
-						ObjectSource: ir.ObjectSource{
+					func() *ir.BackendObjectIR {
+						backend := ir.NewBackendObjectIR(ir.ObjectSource{
 							Kind:      "Backend",
 							Name:      "test-service",
 							Namespace: "default",
-						},
-					},
+						}, 0, "")
+						return &backend
+					}(),
 				)
 				updateTracingConfig(&ir.HcmContext{
 					Gateway: ir.GatewayIR{

--- a/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
@@ -149,5 +149,6 @@ func BuildServiceEntryBackendObjectIR(
 	ir.ParseObjectAnnotations(&backend, se)
 
 	backend.AttachedPolicies = ir.AttachedPolicies{}
+	backend.InitClusterName()
 	return backend
 }

--- a/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
@@ -130,7 +130,7 @@ func BuildServiceEntryBackendObjectIR(
 	// to get the ref-index-based logic instead of the krt-key based lookup.
 	backend := ir.NewBackendObjectIR(objSrc, svcPort, hostname)
 	backend.AppProtocol = ir.ParseAppProtocol(new(svcProtocol))
-	backend.GvPrefix = BackendClusterPrefix
+	backend.SetGvPrefix(BackendClusterPrefix)
 	backend.CanonicalHostname = hostname
 	backend.Obj = se
 
@@ -149,6 +149,5 @@ func BuildServiceEntryBackendObjectIR(
 	ir.ParseObjectAnnotations(&backend, se)
 
 	backend.AttachedPolicies = ir.AttachedPolicies{}
-	backend.InitClusterName()
 	return backend
 }

--- a/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
@@ -99,14 +99,15 @@ func endpointsFromWorkloads(
 	// this should never miss, we only call buildInlineCLA using BackendObjectIR
 	// generated from the ServiceEntry iteself
 	var servicePort *networking.ServicePort
+	backendPort := be.GetPort()
 	for _, sp := range se.Spec.GetPorts() {
-		if int32(sp.GetNumber()) == be.Port { //nolint:gosec // G115: ServiceEntry port numbers are always valid port range (1-65535)
+		if int32(sp.GetNumber()) == backendPort { //nolint:gosec // G115: ServiceEntry port numbers are always valid port range (1-65535)
 			servicePort = sp
 			break
 		}
 	}
 
-	seTargetPort := be.Port
+	seTargetPort := backendPort
 	if sePortTargetPort := servicePort.GetTargetPort(); sePortTargetPort > 0 {
 		seTargetPort = int32(sePortTargetPort) //nolint:gosec // G115: ServiceEntry target port numbers are always valid port range (1-65535)
 	}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt_test.go
@@ -629,15 +629,13 @@ func TestTranslateJwksRemote(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
-		backend := &ir.BackendObjectIR{
-			ObjectSource: ir.ObjectSource{
-				Kind:      "Service",
-				Namespace: "backend-ns",
-				Name:      "backend",
-			},
-			GvPrefix: "svc",
-			Port:     8443,
-		}
+		backendVal := ir.NewBackendObjectIR(ir.ObjectSource{
+			Kind:      "Service",
+			Namespace: "backend-ns",
+			Name:      "backend",
+		}, 8443, "")
+		backendVal.SetGvPrefix("svc")
+		backend := &backendVal
 		resolver := &fakeBackendResolver{backend: backend}
 		out := &jwtauthnv3.JwtProvider{}
 		cacheDuration := metav1.Duration{Duration: time.Minute}

--- a/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
@@ -154,7 +154,7 @@ func ApplyIngressUseWaypointCluster(in ir.BackendObjectIR, out *envoyclusterv3.C
 		Endpoints:   make([]*envoyendpointv3.LocalityLbEndpoints, 0, 1),
 	}
 
-	if endpoint := claEndpoint(sortedAddresses, uint32(in.Port)); endpoint != nil { //nolint:gosec // G115: BackendObjectIR.Port is int32 representing a port number, always in valid range
+	if endpoint := claEndpoint(sortedAddresses, uint32(in.GetPort())); endpoint != nil { //nolint:gosec // G115: BackendObjectIR port is int32 representing a port number, always in valid range
 		out.GetLoadAssignment().Endpoints = append(out.GetLoadAssignment().GetEndpoints(), endpoint)
 	}
 }

--- a/pkg/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
@@ -146,11 +146,10 @@ func (s Service) BackendObject(port uint32) ir.BackendObjectIR {
 		Name:      s.GetName(),
 	}
 	backend := ir.NewBackendObjectIR(objSrc, int32(port), "") //nolint:gosec // G115: port is uint32 representing a port number, safe to convert to int32
-	backend.GvPrefix = kubernetes.BackendClusterPrefix
+	backend.SetGvPrefix(kubernetes.BackendClusterPrefix)
 	backend.CanonicalHostname = hostname
 	backend.Obj = s.Object
 	backend.AttachedPolicies = ir.AttachedPolicies{}
-	backend.InitClusterName()
 	return backend
 }
 

--- a/pkg/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
@@ -139,20 +139,19 @@ func (s Service) BackendObject(port uint32) ir.BackendObjectIR {
 	}
 
 	// fallback: assume k8s
-	return ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     s.GetObjectKind().GroupVersionKind().Group,
-			Kind:      s.GetObjectKind().GroupVersionKind().Kind,
-			Namespace: s.GetNamespace(),
-			Name:      s.GetName(),
-		},
-		Port:              int32(port), //nolint:gosec // G115: port is uint32 representing a port number, safe to convert to int32
-		GvPrefix:          kubernetes.BackendClusterPrefix,
-		CanonicalHostname: hostname,
-		Obj:               s.Object,
-		ObjIr:             nil, // TODO currently
-		AttachedPolicies:  ir.AttachedPolicies{},
+	objSrc := ir.ObjectSource{
+		Group:     s.GetObjectKind().GroupVersionKind().Group,
+		Kind:      s.GetObjectKind().GroupVersionKind().Kind,
+		Namespace: s.GetNamespace(),
+		Name:      s.GetName(),
 	}
+	backend := ir.NewBackendObjectIR(objSrc, int32(port), "") //nolint:gosec // G115: port is uint32 representing a port number, safe to convert to int32
+	backend.GvPrefix = kubernetes.BackendClusterPrefix
+	backend.CanonicalHostname = hostname
+	backend.Obj = s.Object
+	backend.AttachedPolicies = ir.AttachedPolicies{}
+	backend.InitClusterName()
+	return backend
 }
 
 // TODO remove this when we support multiple hostnames

--- a/pkg/kgateway/proxy_syncer/cla_test.go
+++ b/pkg/kgateway/proxy_syncer/cla_test.go
@@ -14,12 +14,10 @@ import (
 
 func TestTranslatesDestrulesFailoverPriority(t *testing.T) {
 	g := gomega.NewWithT(t)
-	us := ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Namespace: "ns",
-			Name:      "name",
-		},
-	}
+	us := ir.NewBackendObjectIR(ir.ObjectSource{
+		Namespace: "ns",
+		Name:      "name",
+	}, 0, "")
 	efu := ir.NewEndpointsForBackend(us)
 	efu.Add(ir.PodLocality{Region: "R1"}, ir.EndpointWithMd{
 		LbEndpoint: &envoyendpointv3.LbEndpoint{
@@ -84,12 +82,10 @@ func TestTranslatesDestrulesFailoverPriority(t *testing.T) {
 // similar to TestTranslatesDestrulesFailoverPriority but implicit
 func TestTranslatesDestrulesFailover(t *testing.T) {
 	g := gomega.NewWithT(t)
-	us := ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Namespace: "ns",
-			Name:      "name",
-		},
-	}
+	us := ir.NewBackendObjectIR(ir.ObjectSource{
+		Namespace: "ns",
+		Name:      "name",
+	}, 0, "")
 	efu := ir.NewEndpointsForBackend(us)
 	efu.Add(ir.PodLocality{Region: "R1"}, ir.EndpointWithMd{
 		LbEndpoint: &envoyendpointv3.LbEndpoint{

--- a/pkg/kgateway/proxy_syncer/status_test.go
+++ b/pkg/kgateway/proxy_syncer/status_test.go
@@ -58,39 +58,35 @@ func TestBackendPolicyStatus(t *testing.T) {
 		},
 	}
 
-	backend1 := ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "",
-			Kind:      "Service",
-			Namespace: "default",
-			Name:      "reviews",
-		},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{
-				wellknown.BackendTLSPolicyGVK.GroupKind(): {
-					tlsPolicyAtt,
-				},
-				connPolGK: {
-					connPolicy1Att,
-				},
+	backend1 := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      "reviews",
+	}, 0, "")
+	backend1.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{
+			wellknown.BackendTLSPolicyGVK.GroupKind(): {
+				tlsPolicyAtt,
+			},
+			connPolGK: {
+				connPolicy1Att,
 			},
 		},
 	}
-	backend2 := ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "",
-			Kind:      "Service",
-			Namespace: "default",
-			Name:      "ratings",
-		},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{
-				wellknown.BackendTLSPolicyGVK.GroupKind(): {
-					tlsPolicyAtt,
-				},
-				connPolGK: {
-					connPolicy2Att,
-				},
+	backend2 := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      "ratings",
+	}, 0, "")
+	backend2.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{
+			wellknown.BackendTLSPolicyGVK.GroupKind(): {
+				tlsPolicyAtt,
+			},
+			connPolGK: {
+				connPolicy2Att,
 			},
 		},
 	}
@@ -110,10 +106,11 @@ func TestBackendPolicyStatus(t *testing.T) {
 		Name:      connPolicy1Att.PolicyRef.Name,
 	}]
 	a.Len(connpolicy1report.Ancestors, 1)
+	backend1ObjSrc := backend1.GetObjectSource()
 	ancestor1ConnPolicy1Report := connpolicy1report.Ancestors[reports.ParentRefKey{
-		Group:          backend1.Group,
-		Kind:           backend1.Kind,
-		NamespacedName: types.NamespacedName{Namespace: backend1.Namespace, Name: backend1.Name},
+		Group:          backend1ObjSrc.Group,
+		Kind:           backend1ObjSrc.Kind,
+		NamespacedName: backend1.NamespacedName(),
 	}]
 	a.NotNil(ancestor1ConnPolicy1Report)
 	diff := cmp.Diff(
@@ -144,10 +141,11 @@ func TestBackendPolicyStatus(t *testing.T) {
 		Name:      connPolicy2Att.PolicyRef.Name,
 	}]
 	a.Len(connpolicy2report.Ancestors, 1)
+	backend2ObjSrc := backend2.GetObjectSource()
 	ancestor1ConnPolicy2Report := connpolicy2report.Ancestors[reports.ParentRefKey{
-		Group:          backend2.Group,
-		Kind:           backend2.Kind,
-		NamespacedName: types.NamespacedName{Namespace: backend2.Namespace, Name: backend2.Name},
+		Group:          backend2ObjSrc.Group,
+		Kind:           backend2ObjSrc.Kind,
+		NamespacedName: backend2.NamespacedName(),
 	}]
 	a.NotNil(ancestor1ConnPolicy2Report)
 	diff = cmp.Diff(
@@ -173,9 +171,9 @@ func TestBackendPolicyStatus(t *testing.T) {
 	}]
 	a.Len(tlsPolicyreport.Ancestors, 2)
 	ancestor1TLSPolicyreport := tlsPolicyreport.Ancestors[reports.ParentRefKey{
-		Group:          backend1.Group,
-		Kind:           backend1.Kind,
-		NamespacedName: types.NamespacedName{Namespace: backend1.Namespace, Name: backend1.Name},
+		Group:          backend1ObjSrc.Group,
+		Kind:           backend1ObjSrc.Kind,
+		NamespacedName: backend1.NamespacedName(),
 	}]
 	a.NotNil(ancestor1TLSPolicyreport)
 	diff = cmp.Diff(
@@ -192,9 +190,9 @@ func TestBackendPolicyStatus(t *testing.T) {
 	)
 	a.Empty(diff)
 	ancestor2TLSPolicyreport := tlsPolicyreport.Ancestors[reports.ParentRefKey{
-		Group:          backend2.Group,
-		Kind:           backend2.Kind,
-		NamespacedName: types.NamespacedName{Namespace: backend2.Namespace, Name: backend2.Name},
+		Group:          backend2ObjSrc.Group,
+		Kind:           backend2ObjSrc.Kind,
+		NamespacedName: backend2.NamespacedName(),
 	}]
 	a.NotNil(ancestor2TLSPolicyreport)
 	diff = cmp.Diff(
@@ -225,18 +223,16 @@ func TestBackendPolicyStatusWithSectionName(t *testing.T) {
 		Errors: []error{},
 	}
 
-	backend := ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "",
-			Kind:      "Service",
-			Namespace: "default",
-			Name:      "my-svc",
-		},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{
-				wellknown.BackendTLSPolicyGVK.GroupKind(): {
-					tlsPolicyWithSectionName,
-				},
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      "my-svc",
+	}, 0, "")
+	backend.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{
+			wellknown.BackendTLSPolicyGVK.GroupKind(): {
+				tlsPolicyWithSectionName,
 			},
 		},
 	}

--- a/pkg/kgateway/query/backend_variants_test.go
+++ b/pkg/kgateway/query/backend_variants_test.go
@@ -137,6 +137,6 @@ func testBackendObjectIR(name string, port int32) ir.BackendObjectIR {
 			Generation:      1,
 		},
 	}
-	backend.GvPrefix = "kube"
+	backend.SetGvPrefix("kube")
 	return backend
 }

--- a/pkg/kgateway/query/query_test.go
+++ b/pkg/kgateway/query/query_test.go
@@ -1389,16 +1389,14 @@ func k8sUpstreams(services krt.Collection[*corev1.Service]) krt.Collection[ir.Ba
 		uss := []ir.BackendObjectIR{}
 
 		for _, port := range svc.Spec.Ports {
-			uss = append(uss, ir.BackendObjectIR{
-				ObjectSource: ir.ObjectSource{
-					Kind:      SvcGk.Kind,
-					Group:     SvcGk.Group,
-					Namespace: svc.Namespace,
-					Name:      svc.Name,
-				},
-				Obj:  svc,
-				Port: port.Port,
-			})
+			backend := ir.NewBackendObjectIR(ir.ObjectSource{
+				Kind:      SvcGk.Kind,
+				Group:     SvcGk.Group,
+				Namespace: svc.Namespace,
+				Name:      svc.Name,
+			}, port.Port, "")
+			backend.Obj = svc
+			uss = append(uss, backend)
 		}
 		return uss
 	})

--- a/pkg/kgateway/translator/httproute/translate_httproute_test.go
+++ b/pkg/kgateway/translator/httproute/translate_httproute_test.go
@@ -107,16 +107,14 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 					},
 				}
 				// Setup the backendObjIR
-				up = &ir.BackendObjectIR{
-					ObjectSource: ir.ObjectSource{
-						Namespace: backingSvc.Namespace,
-						Name:      backingSvc.Name,
-						Kind:      "Service",
-						Group:     "",
-					},
-					Port: 8080,
-					Obj:  backingSvc,
-				}
+				backend := ir.NewBackendObjectIR(ir.ObjectSource{
+					Namespace: backingSvc.Namespace,
+					Name:      backingSvc.Name,
+					Kind:      "Service",
+					Group:     "",
+				}, 8080, "")
+				backend.Obj = backingSvc
+				up = &backend
 				// Setup the route rules
 				route.Spec.Rules = []gwv1.HTTPRouteRule{
 					{
@@ -189,16 +187,14 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 		When("referencing a non-existent backing service", func() {
 			BeforeEach(func() {
 				// Setup the backendObjIR
-				up = &ir.BackendObjectIR{
-					ObjectSource: ir.ObjectSource{
-						Namespace: backingSvc.Namespace,
-						Name:      backingSvc.Name,
-						Kind:      "Service",
-						Group:     "",
-					},
-					Port: 8080,
-					Obj:  backingSvc,
-				}
+				backend := ir.NewBackendObjectIR(ir.ObjectSource{
+					Namespace: backingSvc.Namespace,
+					Name:      backingSvc.Name,
+					Kind:      "Service",
+					Group:     "",
+				}, 8080, "")
+				backend.Obj = backingSvc
+				up = &backend
 				// Setup the route rules
 				route.Spec.Rules = []gwv1.HTTPRouteRule{
 					{

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -57,10 +57,7 @@ func (t *BackendTranslator) TranslateBackend(
 	backend *ir.BackendObjectIR,
 ) (*envoyclusterv3.Cluster, error) {
 	// defensive checks that the backend is supported and has a plugin that can translate it.
-	gk := schema.GroupKind{
-		Group: backend.Group,
-		Kind:  backend.Kind,
-	}
+	gk := backend.GetGroupKind()
 	process, ok := t.ContributedBackends[gk]
 	if !ok {
 		return nil, errors.New("no backend translator found for " + gk.String())
@@ -72,7 +69,7 @@ func (t *BackendTranslator) TranslateBackend(
 	// Check for pre-existing errors in the Backend IR before starting translation.
 	// Exit translation early if we have errors
 	if backend.Errors != nil {
-		logger.Error("backend has pre-existing errors", "backend", backend.Name, "errors", backend.Errors)
+		logger.Error("backend has pre-existing errors", "backend", backend.GetName(), "errors", backend.Errors)
 		return buildBlackholeCluster(backend), errors.Join(backend.Errors...)
 	}
 

--- a/pkg/kgateway/translator/irtranslator/backend_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_test.go
@@ -29,19 +29,22 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
 
+func newTestBackend(objSrc ir.ObjectSource, port int32) *ir.BackendObjectIR {
+	backend := ir.NewBackendObjectIR(objSrc, port, "")
+	return &backend
+}
+
 func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 	var bt irtranslator.BackendTranslator
 	var ucc ir.UniquelyConnectedClient
 	var kctx krt.TestingDummyContext
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "group",
-			Kind:      "kind",
-			Name:      "name",
-			Namespace: "namespace",
-		},
-		AppProtocol: ir.HTTP2AppProtocol,
-	}
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "group",
+		Kind:      "kind",
+		Name:      "name",
+		Namespace: "namespace",
+	}, 0)
+	backend.AppProtocol = ir.HTTP2AppProtocol
 	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
 		{Group: "group", Kind: "kind"}: {
 			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
@@ -64,14 +67,12 @@ func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 }
 
 func TestBackendTranslatorAppliesDnsLookupFamilyToDnsCluster(t *testing.T) {
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "group",
-			Kind:      "kind",
-			Name:      "name",
-			Namespace: "namespace",
-		},
-	}
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "group",
+		Kind:      "kind",
+		Name:      "name",
+		Namespace: "namespace",
+	}, 0)
 
 	var bt irtranslator.BackendTranslator
 	bt.CommonCols = &collections.CommonCollections{
@@ -117,18 +118,15 @@ func TestBackendTranslatorHandlesBackendIRErrors(t *testing.T) {
 	// No attached policies needed for this test.
 	backendError1 := errors.New("invalid backend hostname")
 	backendError2 := errors.New("unsupported backend protocol")
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "core",
-			Kind:      "Service",
-			Name:      "invalid-svc",
-			Namespace: "test-ns",
-		},
-		Port:   80,
-		Errors: []error{backendError1, backendError2},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{},
-		},
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "core",
+		Kind:      "Service",
+		Name:      "invalid-svc",
+		Namespace: "test-ns",
+	}, 80)
+	backend.Errors = []error{backendError1, backendError2}
+	backend.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{},
 	}
 
 	var bt irtranslator.BackendTranslator
@@ -166,26 +164,24 @@ func TestBackendTranslatorHandlesBackendIRErrors(t *testing.T) {
 func TestBackendTranslatorPropagatesPolicyErrors(t *testing.T) {
 	policyError1 := errors.New("invalid TLS certificate")
 	policyError2 := errors.New("invalid health check configuration")
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "group",
-			Kind:      "kind",
-			Name:      "name",
-			Namespace: "namespace",
-		},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{
-				{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"}: {
-					{
-						GroupKind: schema.GroupKind{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"},
-						Errors:    []error{policyError1},
-					},
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "group",
+		Kind:      "kind",
+		Name:      "name",
+		Namespace: "namespace",
+	}, 0)
+	backend.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{
+			{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"}: {
+				{
+					GroupKind: schema.GroupKind{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"},
+					Errors:    []error{policyError1},
 				},
-				{Group: "gateway-api", Kind: "BackendTLSPolicy"}: {
-					{
-						GroupKind: schema.GroupKind{Group: "gateway-api", Kind: "BackendTLSPolicy"},
-						Errors:    []error{policyError2},
-					},
+			},
+			{Group: "gateway-api", Kind: "BackendTLSPolicy"}: {
+				{
+					GroupKind: schema.GroupKind{Group: "gateway-api", Kind: "BackendTLSPolicy"},
+					Errors:    []error{policyError2},
 				},
 			},
 		},
@@ -241,20 +237,15 @@ func TestBackendTranslatorHandlesXDSValidationErrors(t *testing.T) {
 	}
 
 	// BackendIR with no errors.
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "core",
-			Kind:      "Service",
-			Name:      "test-svc",
-			Namespace: "test-ns",
-		},
-		Port: 80,
-		// No pre-existing errors
-		Errors: nil,
-		// No attached policies that would cause errors
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{},
-		},
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "core",
+		Kind:      "Service",
+		Name:      "test-svc",
+		Namespace: "test-ns",
+	}, 80)
+	backend.Errors = nil
+	backend.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{},
 	}
 
 	var bt irtranslator.BackendTranslator
@@ -291,26 +282,24 @@ func TestBackendTranslatorHandlesXDSValidationErrors(t *testing.T) {
 }
 
 func TestBackendTranslatorAppliesGatewayBackendClientCertificate(t *testing.T) {
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "group",
-			Kind:      "kind",
-			Name:      "name",
-			Namespace: "namespace",
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "group",
+		Kind:      "kind",
+		Name:      "name",
+		Namespace: "namespace",
+	}, 0)
+	backend.GatewayBackendClientCertificate = &ir.GatewayBackendClientCertificateIR{
+		Certificate: ir.TLSCertificate{
+			CertChain:  []byte("gateway-cert"),
+			PrivateKey: []byte("gateway-key"),
 		},
-		GatewayBackendClientCertificate: &ir.GatewayBackendClientCertificateIR{
-			Certificate: ir.TLSCertificate{
-				CertChain:  []byte("gateway-cert"),
-				PrivateKey: []byte("gateway-key"),
-			},
-		},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{
-				{Group: "gateway-api", Kind: "BackendTLSPolicy"}: {
-					{
-						GroupKind: schema.GroupKind{Group: "gateway-api", Kind: "BackendTLSPolicy"},
-						PolicyIr:  new(testPolicyIR),
-					},
+	}
+	backend.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{
+			{Group: "gateway-api", Kind: "BackendTLSPolicy"}: {
+				{
+					GroupKind: schema.GroupKind{Group: "gateway-api", Kind: "BackendTLSPolicy"},
+					PolicyIr:  new(testPolicyIR),
 				},
 			},
 		},
@@ -358,22 +347,20 @@ func TestBackendTranslatorAppliesGatewayBackendClientCertificate(t *testing.T) {
 }
 
 func TestBackendTranslatorDoesNotEnableTLSForGatewayBackendClientCertificate(t *testing.T) {
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "group",
-			Kind:      "kind",
-			Name:      "name",
-			Namespace: "namespace",
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "group",
+		Kind:      "kind",
+		Name:      "name",
+		Namespace: "namespace",
+	}, 0)
+	backend.GatewayBackendClientCertificate = &ir.GatewayBackendClientCertificateIR{
+		Certificate: ir.TLSCertificate{
+			CertChain:  []byte("gateway-cert"),
+			PrivateKey: []byte("gateway-key"),
 		},
-		GatewayBackendClientCertificate: &ir.GatewayBackendClientCertificateIR{
-			Certificate: ir.TLSCertificate{
-				CertChain:  []byte("gateway-cert"),
-				PrivateKey: []byte("gateway-key"),
-			},
-		},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{},
-		},
+	}
+	backend.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{},
 	}
 
 	var bt irtranslator.BackendTranslator
@@ -393,26 +380,24 @@ func TestBackendTranslatorDoesNotEnableTLSForGatewayBackendClientCertificate(t *
 }
 
 func TestBackendTranslatorAppliesGatewayBackendClientCertificateToTransportSocketMatches(t *testing.T) {
-	backend := &ir.BackendObjectIR{
-		ObjectSource: ir.ObjectSource{
-			Group:     "group",
-			Kind:      "kind",
-			Name:      "name",
-			Namespace: "namespace",
+	backend := newTestBackend(ir.ObjectSource{
+		Group:     "group",
+		Kind:      "kind",
+		Name:      "name",
+		Namespace: "namespace",
+	}, 0)
+	backend.GatewayBackendClientCertificate = &ir.GatewayBackendClientCertificateIR{
+		Certificate: ir.TLSCertificate{
+			CertChain:  []byte("gateway-cert"),
+			PrivateKey: []byte("gateway-key"),
 		},
-		GatewayBackendClientCertificate: &ir.GatewayBackendClientCertificateIR{
-			Certificate: ir.TLSCertificate{
-				CertChain:  []byte("gateway-cert"),
-				PrivateKey: []byte("gateway-key"),
-			},
-		},
-		AttachedPolicies: ir.AttachedPolicies{
-			Policies: map[schema.GroupKind][]ir.PolicyAtt{
-				{Group: "istio.io", Kind: "Settings"}: {
-					{
-						GroupKind: schema.GroupKind{Group: "istio.io", Kind: "Settings"},
-						PolicyIr:  new(testPolicyIR),
-					},
+	}
+	backend.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{
+			{Group: "istio.io", Kind: "Settings"}: {
+				{
+					GroupKind: schema.GroupKind{Group: "istio.io", Kind: "Settings"},
+					PolicyIr:  new(testPolicyIR),
 				},
 			},
 		},

--- a/pkg/krtcollections/endpoints.go
+++ b/pkg/krtcollections/endpoints.go
@@ -101,10 +101,7 @@ func transformK8sEndpoints(inputs EndpointsInputs,
 				logger.Warn(warn) //nolint:sloglint // ignore formatting
 			}
 		}()
-		key := types.NamespacedName{
-			Namespace: backend.Namespace,
-			Name:      backend.Name,
-		}
+		key := backend.NamespacedName()
 		kubeSvcLogger := logger.With("kubesvc", key)
 
 		kubeBackend, ok := backend.Obj.(*corev1.Service)
@@ -116,9 +113,9 @@ func transformK8sEndpoints(inputs EndpointsInputs,
 
 		kubeSvcLogger.Debug("building endpoints")
 
-		kubeSvcPort, singlePortSvc := findPortForService(kubeBackend, uint32(backend.Port)) //nolint:gosec // G115: backend.Port is validated to be valid port range
+		kubeSvcPort, singlePortSvc := findPortForService(kubeBackend, uint32(backend.GetPort())) //nolint:gosec // G115: backend port is validated to be valid port range
 		if kubeSvcPort == nil {
-			kubeSvcLogger.Debug("port not found for service", "port", backend.Port)
+			kubeSvcLogger.Debug("port not found for service", "port", backend.GetPort())
 			return nil
 		}
 

--- a/pkg/krtcollections/endpoints_test.go
+++ b/pkg/krtcollections/endpoints_test.go
@@ -25,19 +25,33 @@ import (
 	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
 )
 
-func newBackendObjectIR(in ir.BackendObjectIR) ir.BackendObjectIR {
-	src := in.ObjectSource
-	port := in.Port
-	extraKey := in.ExtraKey
-	b := ir.NewBackendObjectIR(src, port, extraKey)
+type backendObjectIRInput struct {
+	ObjectSource      ir.ObjectSource
+	Port              int32
+	ExtraKey          string
+	Obj               metav1.Object
+	CanonicalHostname string
+	AppProtocol       ir.AppProtocol
+	PortName          string
+	Aliases           []ir.ObjectSource
+	AttachedPolicies  ir.AttachedPolicies
+}
+
+func newBackendObjectIR(in backendObjectIRInput) ir.BackendObjectIR {
+	b := ir.NewBackendObjectIR(in.ObjectSource, in.Port, in.ExtraKey)
 	b.Obj = in.Obj
+	b.CanonicalHostname = in.CanonicalHostname
+	b.AppProtocol = in.AppProtocol
+	b.PortName = in.PortName
+	b.Aliases = in.Aliases
+	b.AttachedPolicies = in.AttachedPolicies
 	return b
 }
 
 func TestEndpointsForUpstreamOrderDoesntMatter(t *testing.T) {
 	g := NewWithT(t)
 
-	us := newBackendObjectIR(ir.BackendObjectIR{
+	us := newBackendObjectIR(backendObjectIRInput{
 		ObjectSource: ir.ObjectSource{
 			Namespace: "ns",
 			Name:      "svc",
@@ -160,7 +174,7 @@ func TestEndpointsForUpstreamOrderDoesntMatter(t *testing.T) {
 func TestEndpointsForUpstreamWithDifferentNameButSameEndpoints(t *testing.T) {
 	g := NewWithT(t)
 
-	us := newBackendObjectIR(ir.BackendObjectIR{
+	us := newBackendObjectIR(backendObjectIRInput{
 		ObjectSource: ir.ObjectSource{
 			Namespace: "ns",
 			Name:      "svc",
@@ -183,7 +197,7 @@ func TestEndpointsForUpstreamWithDifferentNameButSameEndpoints(t *testing.T) {
 			},
 		},
 	})
-	usd := newBackendObjectIR(ir.BackendObjectIR{
+	usd := newBackendObjectIR(backendObjectIRInput{
 		ObjectSource: ir.ObjectSource{
 			Namespace: "ns",
 			Name:      "discovered-name",
@@ -290,7 +304,7 @@ func TestEndpointsForUpstreamWithDifferentTrafficDistributionButSameEndpoints(t 
 	g := NewWithT(t)
 
 	// Create base backend object
-	baseObj := ir.BackendObjectIR{
+	baseObj := backendObjectIRInput{
 		ObjectSource: ir.ObjectSource{
 			Namespace: "ns",
 			Name:      "svc",
@@ -443,7 +457,7 @@ func TestFindPortInEndpointSliceMatchesNamedTargetPortWhenEndpointPortNameDiffer
 func TestEndpointsForGatewayScopedBackendsWithSameEndpointsHaveDifferentHashes(t *testing.T) {
 	g := NewWithT(t)
 
-	baseBackend := newBackendObjectIR(ir.BackendObjectIR{
+	baseBackend := newBackendObjectIR(backendObjectIRInput{
 		ObjectSource: ir.ObjectSource{
 			Namespace: "ns",
 			Name:      "svc",
@@ -579,7 +593,7 @@ func TestEndpoints(t *testing.T) {
 				},
 			},
 
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",
@@ -642,7 +656,7 @@ func TestEndpoints(t *testing.T) {
 			name: "no endpoint slices returns empty endpoints",
 			// no EndpointSlice objects in inputs; only the Service backend is present
 			inputs: []any{},
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",
@@ -700,7 +714,7 @@ func TestEndpoints(t *testing.T) {
 					},
 				},
 			},
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",
@@ -828,7 +842,7 @@ func TestEndpoints(t *testing.T) {
 				},
 			},
 
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",
@@ -978,7 +992,7 @@ func TestEndpoints(t *testing.T) {
 					},
 				},
 			},
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",
@@ -1128,7 +1142,7 @@ func TestEndpoints(t *testing.T) {
 					},
 				},
 			},
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",
@@ -1248,7 +1262,7 @@ func TestEndpoints(t *testing.T) {
 					},
 				},
 			},
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",
@@ -1344,7 +1358,7 @@ func TestEndpoints(t *testing.T) {
 					},
 				},
 			},
-			upstream: newBackendObjectIR(ir.BackendObjectIR{
+			upstream: newBackendObjectIR(backendObjectIRInput{
 				ObjectSource: ir.ObjectSource{
 					Namespace: "ns",
 					Name:      "svc",

--- a/pkg/krtcollections/endpoints_test.go
+++ b/pkg/krtcollections/endpoints_test.go
@@ -458,7 +458,7 @@ func TestEndpointsForGatewayScopedBackendsWithSameEndpointsHaveDifferentHashes(t
 			},
 		},
 	})
-	baseBackend.GvPrefix = "kube"
+	baseBackend.SetGvPrefix("kube")
 
 	clientCertificate := &ir.GatewayBackendClientCertificateIR{}
 	gateway1 := ir.ObjectSource{

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -143,11 +143,11 @@ func (i *BackendIndex) attachPoliciesToBackend(
 	backendObj ir.BackendObjectIR,
 ) *ir.BackendObjectIR {
 	// Look up service-wide policies (no sectionName).
-	policies := i.policies.getTargetingPoliciesForBackends(kctx, backendObj.ObjectSource, "", backendObj.GetObjectLabels(), false)
+	policies := i.policies.getTargetingPoliciesForBackends(kctx, backendObj.GetObjectSource(), "", backendObj.GetObjectLabels(), false)
 	// Also look up port specific policies if the backend has a port name (for example BackendTLSPolicy with sectionName).
 	// excludeGlobal=true since global policies are already included from the first lookup above.
 	if backendObj.PortName != "" {
-		portPolicies := i.policies.getTargetingPoliciesForBackends(kctx, backendObj.ObjectSource, backendObj.PortName, backendObj.GetObjectLabels(), true)
+		portPolicies := i.policies.getTargetingPoliciesForBackends(kctx, backendObj.GetObjectSource(), backendObj.PortName, backendObj.GetObjectLabels(), true)
 		policies = preferPortSpecificBackendTLSPolicies(policies, portPolicies)
 		policies = append(policies, portPolicies...)
 	}
@@ -223,7 +223,7 @@ func (i *BackendIndex) AddBackends(gk schema.GroupKind, col krt.Collection[ir.Ba
 			return nil
 		}
 		for _, alias := range backendObj.Aliases {
-			aliasKeys = append(aliasKeys, backendKey{ObjectSource: alias, port: backendObj.Port})
+			aliasKeys = append(aliasKeys, backendKey{ObjectSource: alias, port: backendObj.GetPort()})
 		}
 		return aliasKeys
 	})

--- a/pkg/krtcollections/policy_test.go
+++ b/pkg/krtcollections/policy_test.go
@@ -63,10 +63,10 @@ func TestGetBackendSameNamespace(t *testing.T) {
 			if backends[0].Err != nil {
 				t.Fatalf("backend has error %v", backends[0].Err)
 			}
-			if backends[0].BackendObject.Name != "foo" {
+			if backends[0].BackendObject.GetName() != "foo" {
 				t.Fatalf("backend incorrect name")
 			}
-			if backends[0].BackendObject.Namespace != "default" {
+			if backends[0].BackendObject.GetNamespace() != "default" {
 				t.Fatalf("backend incorrect ns")
 			}
 		})
@@ -90,10 +90,10 @@ func TestGetBackendDifNsWithRefGrant(t *testing.T) {
 			if backends[0].Err != nil {
 				t.Fatalf("backend has error %v", backends[0].Err)
 			}
-			if backends[0].BackendObject.Name != "foo" {
+			if backends[0].BackendObject.GetName() != "foo" {
 				t.Fatalf("backend incorrect name")
 			}
-			if backends[0].BackendObject.Namespace != "default2" {
+			if backends[0].BackendObject.GetNamespace() != "default2" {
 				t.Fatalf("backend incorrect ns")
 			}
 		})

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -29,11 +29,6 @@ type ObjectSource struct {
 	Kind      string `json:"kind,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name"`
-
-	// resourceName caches the formatted resource name. Populated by
-	// withResourceName when an ObjectSource flows through a constructor that
-	// keys on it; lazy fallback in ResourceName covers struct-literal callers.
-	resourceName string
 }
 
 // GetKind returns the kind of the route.
@@ -55,25 +50,11 @@ func (c ObjectSource) GetNamespace() string {
 }
 
 func (c ObjectSource) ResourceName() string {
-	if c.resourceName != "" {
-		return c.resourceName
-	}
 	return buildObjectSourceName(c.Group, c.Kind, c.Namespace, c.Name)
 }
 
 func (c ObjectSource) String() string {
-	return c.ResourceName()
-}
-
-// withResourceName returns a copy of objSource with the resourceName cache
-// populated. Used by constructors that hand the ObjectSource off to KRT, where
-// ResourceName() will be called repeatedly as the key.
-func withResourceName(objSource ObjectSource) ObjectSource {
-	if objSource.resourceName != "" {
-		return objSource
-	}
-	objSource.resourceName = buildObjectSourceName(objSource.Group, objSource.Kind, objSource.Namespace, objSource.Name)
-	return objSource
+	return buildObjectSourceName(c.Group, c.Kind, c.Namespace, c.Name)
 }
 
 // buildObjectSourceName produces "group/kind/namespace/name" without the
@@ -215,7 +196,6 @@ type BackendObjectIR struct {
 // and cluster names. Callers that want a non-empty GvPrefix should follow up
 // with SetGvPrefix, which keeps the cached cluster name in sync.
 func NewBackendObjectIR(objSource ObjectSource, port int32, extraKey string) BackendObjectIR {
-	objSource = withResourceName(objSource)
 	return BackendObjectIR{
 		ObjectSource: objSource,
 		Port:         port,

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -178,6 +178,7 @@ type BackendObjectIR struct {
 	// SetGvPrefix (the only setter that mutates a cluster-name-relevant field
 	// post-construction). ClusterName() falls back to recomputing if empty so
 	// struct-literal callers still work.
+	// +noKrtEquals We compare the cached ClusterName in Equals()
 	clusterName string
 
 	// TrafficDistribution is the desired traffic distribution for the backend.

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -29,6 +29,11 @@ type ObjectSource struct {
 	Kind      string `json:"kind,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 	Name      string `json:"name"`
+
+	// resourceName caches the formatted resource name. Populated by
+	// withResourceName when an ObjectSource flows through a constructor that
+	// keys on it; lazy fallback in ResourceName covers struct-literal callers.
+	resourceName string
 }
 
 // GetKind returns the kind of the route.
@@ -50,11 +55,25 @@ func (c ObjectSource) GetNamespace() string {
 }
 
 func (c ObjectSource) ResourceName() string {
+	if c.resourceName != "" {
+		return c.resourceName
+	}
 	return buildObjectSourceName(c.Group, c.Kind, c.Namespace, c.Name)
 }
 
 func (c ObjectSource) String() string {
-	return buildObjectSourceName(c.Group, c.Kind, c.Namespace, c.Name)
+	return c.ResourceName()
+}
+
+// withResourceName returns a copy of objSource with the resourceName cache
+// populated. Used by constructors that hand the ObjectSource off to KRT, where
+// ResourceName() will be called repeatedly as the key.
+func withResourceName(objSource ObjectSource) ObjectSource {
+	if objSource.resourceName != "" {
+		return objSource
+	}
+	objSource.resourceName = buildObjectSourceName(objSource.Group, objSource.Kind, objSource.Namespace, objSource.Name)
+	return objSource
 }
 
 // buildObjectSourceName produces "group/kind/namespace/name" without the
@@ -174,8 +193,10 @@ type BackendObjectIR struct {
 	// resourceName is the pre-calculated resource name. used as the krt resource name.
 	resourceName string
 
-	// clusterName is the pre-calculated Envoy cluster name. Populated by InitClusterName()
-	// after GvPrefix/ExtraKey are set. ClusterName() falls back to recomputing if empty.
+	// clusterName is the pre-calculated Envoy cluster name. Kept in sync by
+	// SetGvPrefix (the only setter that mutates a cluster-name-relevant field
+	// post-construction). ClusterName() falls back to recomputing if empty so
+	// struct-literal callers still work.
 	clusterName string
 
 	// TrafficDistribution is the desired traffic distribution for the backend.
@@ -190,13 +211,17 @@ type BackendObjectIR struct {
 	GatewayBackendClientCertificate *GatewayBackendClientCertificateIR
 }
 
-// NewBackendObjectIR creates a new BackendObjectIR with pre-calculated resource name
+// NewBackendObjectIR creates a new BackendObjectIR with pre-calculated resource
+// and cluster names. Callers that want a non-empty GvPrefix should follow up
+// with SetGvPrefix, which keeps the cached cluster name in sync.
 func NewBackendObjectIR(objSource ObjectSource, port int32, extraKey string) BackendObjectIR {
+	objSource = withResourceName(objSource)
 	return BackendObjectIR{
 		ObjectSource: objSource,
 		Port:         port,
 		ExtraKey:     extraKey,
 		resourceName: BackendResourceName(objSource, port, extraKey),
+		clusterName:  buildClusterName("", objSource.Kind, objSource.Namespace, objSource.Name, extraKey, port),
 	}
 }
 
@@ -253,9 +278,7 @@ func (c BackendObjectIR) CloneForGatewayBackendClientCertificate(
 	clone := c
 	clone.ExtraKey = gatewayBackendClientCertificateExtraKey(c.ExtraKey, gateway)
 	clone.resourceName = BackendResourceName(clone.ObjectSource, clone.Port, clone.ExtraKey)
-	// Invalidate the cached cluster name since ExtraKey changed; rebuild eagerly.
-	clone.clusterName = ""
-	clone.InitClusterName()
+	clone.clusterName = buildClusterName(clone.GvPrefix, clone.Kind, clone.Namespace, clone.Name, clone.ExtraKey, clone.Port)
 	clone.GatewayBackendClientCertificate = clientCertificate
 	return clone
 }
@@ -268,21 +291,20 @@ func gatewayBackendClientCertificateExtraKey(baseExtraKey string, gateway Object
 	return baseExtraKey + "_" + suffix
 }
 
+// SetGvPrefix sets GvPrefix and keeps the cached cluster name in sync. This is
+// the supported way to set GvPrefix post-construction; assigning the exported
+// field directly works but leaves the cached cluster name stale until the next
+// fallback recompute.
+func (c *BackendObjectIR) SetGvPrefix(prefix string) {
+	c.GvPrefix = prefix
+	c.clusterName = buildClusterName(prefix, c.Kind, c.Namespace, c.Name, c.ExtraKey, c.Port)
+}
+
 func (c BackendObjectIR) ClusterName() string {
 	if c.clusterName != "" {
 		return c.clusterName
 	}
 	return buildClusterName(c.GvPrefix, c.Kind, c.Namespace, c.Name, c.ExtraKey, c.Port)
-}
-
-// InitClusterName precomputes and caches the Envoy cluster name on the receiver.
-// Callers should invoke this after setting GvPrefix and ExtraKey (or any field
-// that participates in the cluster name). It is a no-op if already computed.
-func (c *BackendObjectIR) InitClusterName() {
-	if c.clusterName != "" {
-		return
-	}
-	c.clusterName = buildClusterName(c.GvPrefix, c.Kind, c.Namespace, c.Name, c.ExtraKey, c.Port)
 }
 
 func buildClusterName(gvPrefix, kind, namespace, name, extraKey string, port int32) string {
@@ -291,9 +313,10 @@ func buildClusterName(gvPrefix, kind, namespace, name, extraKey string, port int
 		gvPrefix = strings.ToLower(kind)
 	}
 	// Use strings.Builder + strconv to avoid fmt.Sprintf overhead since this
-	// runs on a hot translation path.
+	// runs on a hot translation path. Capacity: fields + up to 4 underscores +
+	// up to 5-digit port.
 	var sb strings.Builder
-	sb.Grow(len(gvPrefix) + len(namespace) + len(name) + len(extraKey) + 8)
+	sb.Grow(len(gvPrefix) + len(namespace) + len(name) + len(extraKey) + 9)
 	sb.WriteString(gvPrefix)
 	sb.WriteByte('_')
 	sb.WriteString(namespace)

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -50,11 +50,26 @@ func (c ObjectSource) GetNamespace() string {
 }
 
 func (c ObjectSource) ResourceName() string {
-	return fmt.Sprintf("%s/%s/%s/%s", c.Group, c.Kind, c.Namespace, c.Name)
+	return buildObjectSourceName(c.Group, c.Kind, c.Namespace, c.Name)
 }
 
 func (c ObjectSource) String() string {
-	return fmt.Sprintf("%s/%s/%s/%s", c.Group, c.Kind, c.Namespace, c.Name)
+	return buildObjectSourceName(c.Group, c.Kind, c.Namespace, c.Name)
+}
+
+// buildObjectSourceName produces "group/kind/namespace/name" without the
+// fmt.Sprintf format-parse overhead. Hot path for KRT keying.
+func buildObjectSourceName(group, kind, namespace, name string) string {
+	var sb strings.Builder
+	sb.Grow(len(group) + len(kind) + len(namespace) + len(name) + 3)
+	sb.WriteString(group)
+	sb.WriteByte('/')
+	sb.WriteString(kind)
+	sb.WriteByte('/')
+	sb.WriteString(namespace)
+	sb.WriteByte('/')
+	sb.WriteString(name)
+	return sb.String()
 }
 
 func (c ObjectSource) Equals(in ObjectSource) bool {

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -117,13 +117,19 @@ func ParseAppProtocol(appProtocol *string) AppProtocol {
 	}
 }
 
+// BackendObjectIR is the IR representation of a single backend target.
+//
+// Construct instances with NewBackendObjectIR and use the accessor methods
+// below for cluster-name-relevant identity fields. Those inputs are kept
+// private so callers cannot accidentally mutate cached derived values such as
+// ResourceName() and ClusterName() after construction.
 type BackendObjectIR struct {
-	// Ref to source object. sometimes the group and kind are not populated from api-server, so
-	// set them explicitly here, and pass this around as the reference.
-	ObjectSource `json:",inline"`
+	// objectSource identifies the source resource. Keep it private so callers
+	// cannot mutate cluster-name-relevant fields after construction.
+	objectSource ObjectSource
 	// optional port for if ObjectSource is a service that can have multiple ports.
 	// +krtEqualsTodo propagate backend port differences in equality
-	Port int32
+	port int32
 	// optional port name for the backend (e.g., "https", "http"). Used for sectionName based
 	// policy attachment (e.g., BackendTLSPolicy targeting a specific port by name).
 	// +krtEqualsTodo propagate backend port name differences in equality
@@ -135,7 +141,7 @@ type BackendObjectIR struct {
 	// prefix the cluster name with this string to distinguish it from other GVKs.
 	// here explicitly as it shows up in stats. each (group, kind) pair should have a unique prefix.
 	// +krtEqualsTodo incorporate prefix changes into equality or remove field
-	GvPrefix string
+	gvPrefix string
 	// for things that integrate with destination rule, we need to know what hostname to use.
 	// +krtEqualsTodo evaluate canonical hostname equality
 	CanonicalHostname string
@@ -156,7 +162,7 @@ type BackendObjectIR struct {
 	// CanonicalHostname. We should see if it's possible to have multiple
 	// CanonicalHostnames.
 	// +krtEqualsTodo determine equality semantics for extra key
-	ExtraKey string
+	extraKey string
 
 	// RequiresPolicyStatus indicates if this Backend may require updating status of an attached policy
 	// This is essentially a precomputation of whether there are any 'AttachedPolicies' that are objects
@@ -193,14 +199,14 @@ type BackendObjectIR struct {
 	GatewayBackendClientCertificate *GatewayBackendClientCertificateIR
 }
 
-// NewBackendObjectIR creates a new BackendObjectIR with pre-calculated resource
-// and cluster names. Callers that want a non-empty GvPrefix should follow up
-// with SetGvPrefix, which keeps the cached cluster name in sync.
+// NewBackendObjectIR creates a BackendObjectIR with pre-calculated resource and
+// cluster names. Callers that need a non-default cluster prefix should follow
+// up with SetGvPrefix, which keeps the cached cluster name in sync.
 func NewBackendObjectIR(objSource ObjectSource, port int32, extraKey string) BackendObjectIR {
 	return BackendObjectIR{
-		ObjectSource: objSource,
-		Port:         port,
-		ExtraKey:     extraKey,
+		objectSource: objSource,
+		port:         port,
+		extraKey:     extraKey,
 		resourceName: BackendResourceName(objSource, port, extraKey),
 		clusterName:  buildClusterName("", objSource.Kind, objSource.Namespace, objSource.Name, extraKey, port),
 	}
@@ -225,7 +231,7 @@ func (c BackendObjectIR) ResourceName() string {
 }
 
 func (c BackendObjectIR) Equals(in BackendObjectIR) bool {
-	if !c.ObjectSource.Equals(in.ObjectSource) {
+	if !c.objectSource.Equals(in.objectSource) {
 		return false
 	}
 	if !versionEquals(c.Obj, in.Obj) {
@@ -260,9 +266,9 @@ func (c BackendObjectIR) CloneForGatewayBackendClientCertificate(
 	clientCertificate *GatewayBackendClientCertificateIR,
 ) BackendObjectIR {
 	clone := c
-	clone.ExtraKey = gatewayBackendClientCertificateExtraKey(c.ExtraKey, gateway)
-	clone.resourceName = BackendResourceName(clone.ObjectSource, clone.Port, clone.ExtraKey)
-	clone.clusterName = buildClusterName(clone.GvPrefix, clone.Kind, clone.Namespace, clone.Name, clone.ExtraKey, clone.Port)
+	clone.extraKey = gatewayBackendClientCertificateExtraKey(c.extraKey, gateway)
+	clone.resourceName = BackendResourceName(clone.objectSource, clone.port, clone.extraKey)
+	clone.clusterName = buildClusterName(clone.gvPrefix, clone.objectSource.Kind, clone.objectSource.Namespace, clone.objectSource.Name, clone.extraKey, clone.port)
 	clone.GatewayBackendClientCertificate = clientCertificate
 	return clone
 }
@@ -275,20 +281,18 @@ func gatewayBackendClientCertificateExtraKey(baseExtraKey string, gateway Object
 	return baseExtraKey + "_" + suffix
 }
 
-// SetGvPrefix sets GvPrefix and keeps the cached cluster name in sync. This is
-// the supported way to set GvPrefix post-construction; assigning the exported
-// field directly works but leaves the cached cluster name stale until the next
-// fallback recompute.
+// SetGvPrefix sets the cluster-name prefix and keeps the cached cluster name in
+// sync.
 func (c *BackendObjectIR) SetGvPrefix(prefix string) {
-	c.GvPrefix = prefix
-	c.clusterName = buildClusterName(prefix, c.Kind, c.Namespace, c.Name, c.ExtraKey, c.Port)
+	c.gvPrefix = prefix
+	c.clusterName = buildClusterName(prefix, c.objectSource.Kind, c.objectSource.Namespace, c.objectSource.Name, c.extraKey, c.port)
 }
 
 func (c BackendObjectIR) ClusterName() string {
 	if c.clusterName != "" {
 		return c.clusterName
 	}
-	return buildClusterName(c.GvPrefix, c.Kind, c.Namespace, c.Name, c.ExtraKey, c.Port)
+	return buildClusterName(c.gvPrefix, c.objectSource.Kind, c.objectSource.Namespace, c.objectSource.Name, c.extraKey, c.port)
 }
 
 func buildClusterName(gvPrefix, kind, namespace, name, extraKey string, port int32) string {
@@ -315,8 +319,34 @@ func buildClusterName(gvPrefix, kind, namespace, name, extraKey string, port int
 	return sb.String()
 }
 
+// GetObjectSource returns the immutable identity for this backend.
 func (c BackendObjectIR) GetObjectSource() ObjectSource {
-	return c.ObjectSource
+	return c.objectSource
+}
+
+// GetGroupKind returns the backend source GroupKind.
+func (c BackendObjectIR) GetGroupKind() schema.GroupKind {
+	return c.objectSource.GetGroupKind()
+}
+
+// GetName returns the backend source name.
+func (c BackendObjectIR) GetName() string {
+	return c.objectSource.GetName()
+}
+
+// GetNamespace returns the backend source namespace.
+func (c BackendObjectIR) GetNamespace() string {
+	return c.objectSource.GetNamespace()
+}
+
+// NamespacedName returns the backend source namespaced name.
+func (c BackendObjectIR) NamespacedName() types.NamespacedName {
+	return c.objectSource.NamespacedName()
+}
+
+// GetPort returns the backend port associated with this backend instance.
+func (c BackendObjectIR) GetPort() int32 {
+	return c.port
 }
 
 func (c BackendObjectIR) GetObjectLabels() map[string]string {

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -159,6 +159,10 @@ type BackendObjectIR struct {
 	// resourceName is the pre-calculated resource name. used as the krt resource name.
 	resourceName string
 
+	// clusterName is the pre-calculated Envoy cluster name. Populated by InitClusterName()
+	// after GvPrefix/ExtraKey are set. ClusterName() falls back to recomputing if empty.
+	clusterName string
+
 	// TrafficDistribution is the desired traffic distribution for the backend.
 	TrafficDistribution wellknown.TrafficDistribution
 
@@ -234,6 +238,9 @@ func (c BackendObjectIR) CloneForGatewayBackendClientCertificate(
 	clone := c
 	clone.ExtraKey = gatewayBackendClientCertificateExtraKey(c.ExtraKey, gateway)
 	clone.resourceName = BackendResourceName(clone.ObjectSource, clone.Port, clone.ExtraKey)
+	// Invalidate the cached cluster name since ExtraKey changed; rebuild eagerly.
+	clone.clusterName = ""
+	clone.InitClusterName()
 	clone.GatewayBackendClientCertificate = clientCertificate
 	return clone
 }
@@ -247,15 +254,43 @@ func gatewayBackendClientCertificateExtraKey(baseExtraKey string, gateway Object
 }
 
 func (c BackendObjectIR) ClusterName() string {
+	if c.clusterName != "" {
+		return c.clusterName
+	}
+	return buildClusterName(c.GvPrefix, c.Kind, c.Namespace, c.Name, c.ExtraKey, c.Port)
+}
+
+// InitClusterName precomputes and caches the Envoy cluster name on the receiver.
+// Callers should invoke this after setting GvPrefix and ExtraKey (or any field
+// that participates in the cluster name). It is a no-op if already computed.
+func (c *BackendObjectIR) InitClusterName() {
+	if c.clusterName != "" {
+		return
+	}
+	c.clusterName = buildClusterName(c.GvPrefix, c.Kind, c.Namespace, c.Name, c.ExtraKey, c.Port)
+}
+
+func buildClusterName(gvPrefix, kind, namespace, name, extraKey string, port int32) string {
 	// TODO: fix this to somthing that's friendly to stats
-	gvPrefix := c.GvPrefix
-	if c.GvPrefix == "" {
-		gvPrefix = strings.ToLower(c.Kind)
+	if gvPrefix == "" {
+		gvPrefix = strings.ToLower(kind)
 	}
-	if c.ExtraKey != "" {
-		return fmt.Sprintf("%s_%s_%s_%s_%d", gvPrefix, c.Namespace, c.Name, c.ExtraKey, c.Port)
+	// Use strings.Builder + strconv to avoid fmt.Sprintf overhead since this
+	// runs on a hot translation path.
+	var sb strings.Builder
+	sb.Grow(len(gvPrefix) + len(namespace) + len(name) + len(extraKey) + 8)
+	sb.WriteString(gvPrefix)
+	sb.WriteByte('_')
+	sb.WriteString(namespace)
+	sb.WriteByte('_')
+	sb.WriteString(name)
+	if extraKey != "" {
+		sb.WriteByte('_')
+		sb.WriteString(extraKey)
 	}
-	return fmt.Sprintf("%s_%s_%s_%d", gvPrefix, c.Namespace, c.Name, c.Port)
+	sb.WriteByte('_')
+	sb.WriteString(strconv.Itoa(int(port)))
+	return sb.String()
 }
 
 func (c BackendObjectIR) GetObjectSource() ObjectSource {

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -239,6 +239,9 @@ func (c BackendObjectIR) Equals(in BackendObjectIR) bool {
 	if c.resourceName != in.resourceName {
 		return false
 	}
+	if c.ClusterName() != in.ClusterName() {
+		return false
+	}
 	if c.DisableIstioAutoMTLS != in.DisableIstioAutoMTLS {
 		return false
 	}

--- a/pkg/pluginsdk/ir/backend_test.go
+++ b/pkg/pluginsdk/ir/backend_test.go
@@ -201,6 +201,39 @@ func TestBackendObjectIRClusterName(t *testing.T) {
 	})
 }
 
+func TestBackendObjectIRSetGvPrefixUpdatesClusterName(t *testing.T) {
+	backend := NewBackendObjectIR(ObjectSource{
+		Namespace: "default",
+		Name:      "test-service",
+		Kind:      "Service",
+	}, 8080, "")
+
+	// Before SetGvPrefix the cached name uses the lowercased Kind as prefix.
+	assert.Equal(t, "service_default_test-service_8080", backend.ClusterName())
+
+	backend.SetGvPrefix("kube")
+
+	assert.Equal(t, "kube_default_test-service_8080", backend.ClusterName())
+}
+
+func TestBackendObjectIRCloneRecomputesClusterName(t *testing.T) {
+	backend := NewBackendObjectIR(ObjectSource{
+		Namespace: "ns",
+		Name:      "svc",
+		Kind:      "Service",
+	}, 80, "")
+	backend.SetGvPrefix("kube")
+
+	original := backend.ClusterName()
+	clone := backend.CloneForGatewayBackendClientCertificate(
+		ObjectSource{Group: "gateway.networking.k8s.io", Kind: "Gateway", Namespace: "gwns", Name: "gw"},
+		&GatewayBackendClientCertificateIR{},
+	)
+
+	assert.NotEqual(t, original, clone.ClusterName(), "clone should have a distinct cluster name after ExtraKey change")
+	assert.Contains(t, clone.ClusterName(), "gw_backend_client_cert_gwns_gw")
+}
+
 func TestGatewayBackendClientCertificateIRMarshalJSONRedactsCertificate(t *testing.T) {
 	clientCertificate := GatewayBackendClientCertificateIR{
 		Certificate: TLSCertificate{

--- a/pkg/pluginsdk/ir/backend_test.go
+++ b/pkg/pluginsdk/ir/backend_test.go
@@ -72,13 +72,13 @@ func TestParseAppProtocol(t *testing.T) {
 
 func createTestBackendObjectIR(trafficDist wellknown.TrafficDistribution) BackendObjectIR {
 	return BackendObjectIR{
-		ObjectSource: ObjectSource{
+		objectSource: ObjectSource{
 			Namespace: "default",
 			Name:      "test-service",
 			Group:     "",
 			Kind:      "Service",
 		},
-		Port: 8080,
+		port: 8080,
 		Obj: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "test-service",
@@ -178,8 +178,8 @@ func TestBackendObjectIREquals(t *testing.T) {
 
 func TestBackendObjectIRClusterName(t *testing.T) {
 	base := createTestBackendObjectIR(wellknown.TrafficDistributionAny)
-	base.Kind = "Service"
-	base.resourceName = BackendResourceName(base.ObjectSource, base.Port, base.ExtraKey)
+	base.objectSource.Kind = "Service"
+	base.resourceName = BackendResourceName(base.objectSource, base.port, base.extraKey)
 
 	t.Run("keeps the same name when BackendTLSPolicy is attached", func(t *testing.T) {
 		withPolicy := base

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -305,7 +305,7 @@ func versionEquals(a, b metav1.Object) bool {
 }
 
 func (c PolicyWrapper) Equals(in PolicyWrapper) bool {
-	if !c.ObjectSource.Equals(in.ObjectSource) {
+	if c.ObjectSource != in.ObjectSource {
 		return false
 	}
 

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -305,7 +305,7 @@ func versionEquals(a, b metav1.Object) bool {
 }
 
 func (c PolicyWrapper) Equals(in PolicyWrapper) bool {
-	if c.ObjectSource != in.ObjectSource {
+	if !c.ObjectSource.Equals(in.ObjectSource) {
 		return false
 	}
 

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -123,17 +123,18 @@ func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
 	// to mitigate https://github.com/envoyproxy/envoy/issues/13070 / https://github.com/envoyproxy/envoy/issues/13009
 
 	h := fnv.New64a()
+	objSrc := us.GetObjectSource()
 	h.Write([]byte(us.ResourceName()))
 	h.Write([]byte{0})
 	h.Write([]byte(us.ClusterName()))
 	h.Write([]byte{0})
-	h.Write([]byte(us.Group))
+	h.Write([]byte(objSrc.Group))
 	h.Write([]byte{0})
-	h.Write([]byte(us.Kind))
+	h.Write([]byte(objSrc.Kind))
 	h.Write([]byte{0})
-	h.Write([]byte(us.Name))
+	h.Write([]byte(objSrc.Name))
 	h.Write([]byte{0})
-	h.Write([]byte(us.Namespace))
+	h.Write([]byte(objSrc.Namespace))
 	for k, v := range labels {
 		h.Write([]byte{0})
 		h.Write([]byte(k + "=" + v))
@@ -147,7 +148,7 @@ func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
 		LbEps:                make(map[PodLocality][]EndpointWithMd),
 		ClusterName:          us.ClusterName(),
 		UpstreamResourceName: us.ResourceName(),
-		Port:                 uint32(us.Port), //nolint:gosec // G115: upstream port is always valid port range
+		Port:                 uint32(us.GetPort()), //nolint:gosec // G115: upstream port is always valid port range
 		Hostname:             us.CanonicalHostname,
 		LbEpsEqualityHash:    upstreamHash,
 		upstreamHash:         upstreamHash,

--- a/pkg/pluginsdk/ir/routes.go
+++ b/pkg/pluginsdk/ir/routes.go
@@ -72,7 +72,7 @@ func (c HttpRouteIR) Equals(in HttpRouteIR) bool {
 	// as backends resolution may change when they are added/remove we need to check equality for them as well
 	// we don't need to check the whole backend, just the cluster name (that may swap in and out of black-hole)
 	// note - if we stop setting cluster to black whole here (and always set it to the expect cluster name) we can remove the backend equality check.
-	return c.ObjectSource.Equals(in.ObjectSource) &&
+	return c.ObjectSource == in.ObjectSource &&
 		versionEquals(c.SourceObject, in.SourceObject) &&
 		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
 		c.rulesEqual(in) &&
@@ -143,7 +143,7 @@ func (c TcpRouteIR) ResourceName() string {
 }
 
 func (c TcpRouteIR) Equals(in TcpRouteIR) bool {
-	return c.ObjectSource.Equals(in.ObjectSource) &&
+	return c.ObjectSource == in.ObjectSource &&
 		versionEquals(c.SourceObject, in.SourceObject) &&
 		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
 		backendsEqual(c.Backends, in.Backends)
@@ -189,7 +189,7 @@ func (c TlsRouteIR) ResourceName() string {
 }
 
 func (c TlsRouteIR) Equals(in TlsRouteIR) bool {
-	return c.ObjectSource.Equals(in.ObjectSource) &&
+	return c.ObjectSource == in.ObjectSource &&
 		versionEquals(c.SourceObject, in.SourceObject) &&
 		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
 		backendsEqual(c.Backends, in.Backends)

--- a/pkg/pluginsdk/ir/routes.go
+++ b/pkg/pluginsdk/ir/routes.go
@@ -72,7 +72,7 @@ func (c HttpRouteIR) Equals(in HttpRouteIR) bool {
 	// as backends resolution may change when they are added/remove we need to check equality for them as well
 	// we don't need to check the whole backend, just the cluster name (that may swap in and out of black-hole)
 	// note - if we stop setting cluster to black whole here (and always set it to the expect cluster name) we can remove the backend equality check.
-	return c.ObjectSource == in.ObjectSource &&
+	return c.ObjectSource.Equals(in.ObjectSource) &&
 		versionEquals(c.SourceObject, in.SourceObject) &&
 		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
 		c.rulesEqual(in) &&
@@ -143,7 +143,7 @@ func (c TcpRouteIR) ResourceName() string {
 }
 
 func (c TcpRouteIR) Equals(in TcpRouteIR) bool {
-	return c.ObjectSource == in.ObjectSource &&
+	return c.ObjectSource.Equals(in.ObjectSource) &&
 		versionEquals(c.SourceObject, in.SourceObject) &&
 		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
 		backendsEqual(c.Backends, in.Backends)
@@ -189,7 +189,7 @@ func (c TlsRouteIR) ResourceName() string {
 }
 
 func (c TlsRouteIR) Equals(in TlsRouteIR) bool {
-	return c.ObjectSource == in.ObjectSource &&
+	return c.ObjectSource.Equals(in.ObjectSource) &&
 		versionEquals(c.SourceObject, in.SourceObject) &&
 		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
 		backendsEqual(c.Backends, in.Backends)

--- a/pkg/pluginsdk/ir/routes_test.go
+++ b/pkg/pluginsdk/ir/routes_test.go
@@ -749,7 +749,7 @@ func TestHTTPRouteIREquals(t *testing.T) {
 			a := assert.New(t)
 
 			got := tt.a.Equals(tt.b)
-			a.Equal(tt.want, got, cmp.Diff(tt.a, tt.b, cmpopts.IgnoreUnexported(BackendObjectIR{})))
+			a.Equal(tt.want, got, cmp.Diff(tt.a, tt.b, cmpopts.IgnoreUnexported(BackendObjectIR{}, ObjectSource{})))
 		})
 	}
 }

--- a/pkg/pluginsdk/ir/routes_test.go
+++ b/pkg/pluginsdk/ir/routes_test.go
@@ -749,7 +749,7 @@ func TestHTTPRouteIREquals(t *testing.T) {
 			a := assert.New(t)
 
 			got := tt.a.Equals(tt.b)
-			a.Equal(tt.want, got, cmp.Diff(tt.a, tt.b, cmpopts.IgnoreUnexported(BackendObjectIR{}, ObjectSource{})))
+			a.Equal(tt.want, got, cmp.Diff(tt.a, tt.b, cmpopts.IgnoreUnexported(BackendObjectIR{})))
 		})
 	}
 }

--- a/pkg/pluginsdk/ir/routes_test.go
+++ b/pkg/pluginsdk/ir/routes_test.go
@@ -308,8 +308,8 @@ func TestHTTPRouteIREquals(t *testing.T) {
 
 	// Test data for testing backing destination object comparison
 	httpBackendObj := BackendObjectIR{
-		ObjectSource:     ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
-		Port:             80,
+		objectSource:     ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
+		port:             80,
 		Obj:              base,
 		resourceName:     "/Service/ns/svc:80",
 		AppProtocol:      DefaultAppProtocol,
@@ -317,8 +317,8 @@ func TestHTTPRouteIREquals(t *testing.T) {
 	}
 	// same as httpBackendObj but with WebSocket AppProtocol. Generated is 2 to simulate an update.
 	wsBackendObj := BackendObjectIR{
-		ObjectSource:     ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
-		Port:             80,
+		objectSource:     ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
+		port:             80,
 		Obj:              baseGen2,
 		resourceName:     "/Service/ns/svc:80",
 		AppProtocol:      WebSocketAppProtocol,


### PR DESCRIPTION
# Description

This PR reduces backend translation overhead on a hot path by precomputing `BackendObjectIR` cluster names and replacing a few `fmt.Sprintf`-based string builders with cheaper `strings.Builder` logic.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```