### PR TITLE
perf: reorder waypoint backend filters before gateway lookup

### DIFF
--- a/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
@@ -83,6 +83,20 @@ type PerClientProcessor struct {
 }
 
 func (t *PerClientProcessor) processBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
+	// Cheap UCC-only filter first: if the ucc doesn't have the
+	// ambient.istio.io/redirection=enabled annotation, nothing this plugin does
+	// can affect the output. Skipping here avoids the expensive Gateway
+	// FetchOne below for the dominant case (most UCCs are not ambient).
+	if val, ok := ucc.Labels[istioannot.AmbientRedirection.Name]; !ok || val != "enabled" {
+		return
+	}
+
+	// Cheap backend filter next: skip backends (and their namespaces/aliases)
+	// that aren't opted in to ingress-use-waypoint.
+	if !HasIngressUseWaypointLabel(kctx, t.commonCols, in) {
+		return
+	}
+
 	// If the ucc has a waypoint gateway class we will let it have an EDS cluster
 	// First try the annotation (for long gateway names > 63 chars), then fall back to the label
 	gwName := ucc.Labels[wellknown.GatewayNameAnnotation]
@@ -98,19 +112,6 @@ func (t *PerClientProcessor) processBackend(kctx krt.HandlerContext, ctx context
 	gwir := krt.FetchOne(kctx, t.commonCols.GatewayIndex.Gateways, krt.FilterKey(gwKey.ResourceName()))
 	if gwir == nil || gwir.Obj == nil || string(gwir.Obj.Spec.GatewayClassName) == t.waypointGatewayClassName {
 		// no op
-		return
-	}
-
-	// If the ucc doesn't have the ambient.istio.io/redirection=enabled annotation, we don't need to do anything
-	// For efficiency, the specific annotation (if exists) has been addeded to the augmented labels of the ucc.
-	if val, ok := ucc.Labels[istioannot.AmbientRedirection.Name]; !ok || val != "enabled" {
-		// no op
-		return
-	}
-
-	// Only handle backends with the istio.io/ingress-use-waypoint label
-	if !HasIngressUseWaypointLabel(kctx, t.commonCols, in) {
-		// Neither the backend nor any relevant namespace/alias has the label, skip processing
 		return
 	}
 


### PR DESCRIPTION
# Description

Reorders `processBackend()` in the waypoint plugin so the cheap ambient-redirection and ingress-use-waypoint filters run before the expensive Gateway lookup. This keeps the change isolated from the other perf work in #14092 and makes the optimization easier to review on its own.

# Change Type

/kind cleanup


## Changelog
```release-note
NONE
```