### PR TITLE
fix: applyRedirectPortPostProcessing only when allowed

### DIFF
--- a/pkg/krtcollections/builtin.go
+++ b/pkg/krtcollections/builtin.go
@@ -695,8 +695,17 @@ func (p *builtinPluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputRoute *
 
 	var errs error
 	if pol.filter != nil {
+		// Only post-process redirects when this policy is allowed to set the
+		// route redirect. Lower-priority request-redirect policies still run
+		// through ApplyForRoute, but must not recompute PortRedirect for a
+		// higher-priority redirect that already won the merge.
+		canPostProcessRedirect := outputRoute != nil &&
+			pol.filter.filterType == gwv1.HTTPRouteFilterRequestRedirect &&
+			policy.IsSettable(outputRoute.GetRedirect(), mergeOpts)
 		pol.filter.apply(outputRoute, mergeOpts)
-		applyRedirectPortPostProcessing(pCtx, pol, outputRoute)
+		if canPostProcessRedirect {
+			applyRedirectPortPostProcessing(pCtx, pol, outputRoute)
+		}
 	}
 
 	p.applyRulePolicy(pCtx, pol.rule, mergeOpts, outputRoute)

--- a/pkg/krtcollections/builtin_test.go
+++ b/pkg/krtcollections/builtin_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/policy"
 )
@@ -966,4 +967,53 @@ func TestRequestRedirectSamePolicyMultipleListeners(t *testing.T) {
 	assert.Equal(t, uint32(666), route666.GetRedirect().GetPortRedirect())
 	assert.Equal(t, uint32(8080), route8080.GetRedirect().GetPortRedirect())
 	assert.Equal(t, uint32(0), redirectIR.Redir.GetPortRedirect(), "IR redirect template must keep PortRedirect unset")
+}
+
+func TestRequestRedirectLowerPriorityPolicyDoesNotPostProcessWinningRedirect(t *testing.T) {
+	winningRedirectIR, err := convertRequestRedirectIR(nil, &gwv1.HTTPRequestRedirectFilter{
+		Scheme: new("https"),
+		Port:   new(gwv1.PortNumber(8443)),
+	}, nil, nil)
+	require.NoError(t, err)
+
+	losingRedirectIR, err := convertRequestRedirectIR(nil, &gwv1.HTTPRequestRedirectFilter{}, nil, nil)
+	require.NoError(t, err)
+
+	pass := &builtinPluginGwPass{}
+	outputRoute := &envoyroutev3.Route{}
+
+	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{
+		ListenerPort: 80,
+		Policy: &builtinPlugin{
+			filter: &filterIR{
+				filterType: gwv1.HTTPRouteFilterRequestRedirect,
+				policy:     winningRedirectIR,
+			},
+		},
+		InheritedPolicyPriority: apiannotations.ShallowMergePreferChild,
+	}, outputRoute))
+
+	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{
+		ListenerPort: 80,
+		Policy: &builtinPlugin{
+			filter: &filterIR{
+				filterType: gwv1.HTTPRouteFilterRequestRedirect,
+				policy:     losingRedirectIR,
+			},
+		},
+		InheritedPolicyPriority: apiannotations.ShallowMergePreferChild,
+	}, outputRoute))
+
+	expectedRedirect := &envoyroutev3.RedirectAction{
+		SchemeRewriteSpecifier: &envoyroutev3.RedirectAction_HttpsRedirect{
+			HttpsRedirect: true,
+		},
+		PortRedirect: 8443,
+		ResponseCode: envoyroutev3.RedirectAction_FOUND,
+	}
+	assert.True(t, proto.Equal(expectedRedirect, outputRoute.GetRedirect()),
+		"lower-priority redirect must not mutate the winning redirect\nexpected: %+v\nactual: %+v",
+		expectedRedirect,
+		outputRoute.GetRedirect(),
+	)
 }


### PR DESCRIPTION
# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

fixes case: https://github.com/kgateway-dev/kgateway/pull/14095#discussion_r3290062018

follow up to https://github.com/kgateway-dev/kgateway/pull/14086

Updated the redirect merge path so post-processing only runs when the current policy could actually set outputRoute.Redirect in the first place. 

# Change Type

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
