### PR TITLE
[v2.3.x] fix: standard ports not added to Location header (#14086)

### DIFF
--- a/pkg/kgateway/translator/gateway/testutils/inputs/http-routing/request-redirect-multi-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/http-routing/request-redirect-multi-listener.yaml
@@ -1,5 +1,6 @@
 # Same HTTPRoute attached to multiple HTTP listeners with RequestRedirect and no scheme/port.
-# Each listener's redirect must use that listener's port (issue #13889).
+# Each listener's redirect must inherit that listener's port unless it is the default port
+# for the listener protocol, in which case the port should be omitted from Location.
 kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1
 metadata:

--- a/pkg/kgateway/translator/gateway/testutils/inputs/http-routing/request-redirect.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/http-routing/request-redirect.yaml
@@ -142,4 +142,44 @@ spec:
     filters:
     - type: RequestRedirect
       requestRedirect:
-        statusCode: 301        
+        statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-default-port
+spec:
+  parentRefs:
+    - name: test
+  hostnames:
+    - "https-default-port.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /rule0
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 302
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-default-port
+spec:
+  parentRefs:
+    - name: test
+  hostnames:
+    - "http-default-port.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /rule0
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: http
+        statusCode: 302

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-routing/request-redirect-multi-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-routing/request-redirect-multi-listener.yaml
@@ -104,7 +104,6 @@ Routes:
       name: listener~80~redirect-multi_example_com-route-0-httproute-multi-listener-redirect-default-0-0-matcher-0
       redirect:
         pathRedirect: /somewhere/
-        portRedirect: 80
 - ignorePortInHostMatching: true
   name: listener~8080
   virtualHosts:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-routing/request-redirect.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-routing/request-redirect.yaml
@@ -43,6 +43,26 @@ Routes:
         portRedirect: 8080
         responseCode: FOUND
   - domains:
+    - http-default-port.com
+    name: listener~8080~http-default-port_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /rule0
+      name: listener~8080~http-default-port_com-route-0-httproute-http-default-port-default-0-0-matcher-0
+      redirect:
+        responseCode: FOUND
+        schemeRedirect: http
+  - domains:
+    - https-default-port.com
+    name: listener~8080~https-default-port_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /rule0
+      name: listener~8080~https-default-port_com-route-0-httproute-https-default-port-default-0-0-matcher-0
+      redirect:
+        httpsRedirect: true
+        responseCode: FOUND
+  - domains:
     - invalid-code-char.com
     name: listener~8080~invalid-code-char_com
     routes:
@@ -124,7 +144,7 @@ Statuses:
         status: "True"
         type: ResolvedRefs
       listeners:
-      - attachedRoutes: 5
+      - attachedRoutes: 7
         conditions:
         - lastTransitionTime: null
           message: Successfully accepted Listener
@@ -153,6 +173,42 @@ Statuses:
         - group: gateway.networking.k8s.io
           kind: GRPCRoute
   httpRoutes:
+    default/http-default-port:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: test
+    default/https-default-port:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: test
     default/invalid-code-char:
       parents:
       - conditions:

--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -422,6 +422,7 @@ func (h *httpRouteConfigurationTranslator) runRoutePlugins(
 			In:                in,
 			TypedFilterConfig: typedPerFilterConfig,
 			ListenerPort:      h.listener.BindPort,
+			ListenerHasTLS:    h.fc.TLS != nil,
 		}
 		reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 		policies, mergeOrigins := mergePolicies(pass, pols)

--- a/pkg/krtcollections/builtin.go
+++ b/pkg/krtcollections/builtin.go
@@ -422,19 +422,13 @@ func translateScheme(out *envoyroutev3.RedirectAction, scheme *string) {
 	}
 }
 
-func translatePort(scheme string, port *gwv1.PortNumber) uint32 {
-	// If port is explicitly provided, use it regardless of scheme
-	if port != nil {
-		return uint32(*port) //nolint:gosec // G115: Gateway API PortNumber is int32, always valid port range
-	}
-	// Otherwise, use default port for the scheme
+func defaultPortForScheme(scheme string) uint32 {
 	switch strings.ToLower(scheme) {
 	case "http":
 		return 80
 	case "https":
 		return 443
 	default:
-		// Scheme is empty and port is nil - needs listener port (return 0 as sentinel)
 		return 0
 	}
 }
@@ -824,12 +818,16 @@ func (h *RoutesIndex) convertfilterIR(
 }
 
 type requestRedirectIr struct {
-	// Redir is the redirect action to apply to the route.
+	// Redir is the base redirect action (hostname, status code, scheme rewrite,
+	// path rewrite). PortRedirect is intentionally left unset here and resolved
+	// per listener in applyRedirectPortPostProcessing, because the same IR is
+	// reused across every listener the HTTPRoute attaches to.
 	Redir *envoyroutev3.RedirectAction
-	// NeedsListenerPort indicates that the redirect port should be set to the listener port
-	// when scheme is empty and port is nil. This is set during IR creation and resolved
-	// during apply() when we have access to the listener context.
-	NeedsListenerPort bool
+	// Scheme and Port preserve the user's raw intent from the
+	// HTTPRequestRedirectFilter so that port resolution can distinguish
+	// "user omitted this field" from "user picked a default value".
+	Scheme *string
+	Port   *gwv1.PortNumber
 }
 
 func (r *requestRedirectIr) apply(
@@ -863,24 +861,32 @@ func convertRequestRedirectIR(
 		return nil, err
 	}
 
-	portRedirect := translatePort(ptr.Deref(f.Scheme, ""), f.Port)
 	redir := &envoyroutev3.RedirectAction{
 		HostRedirect: translateHostname(f.Hostname),
 		ResponseCode: statusCode,
-		PortRedirect: portRedirect,
+		// PortRedirect is intentionally left unset; see applyRedirectPortPostProcessing.
 	}
 	translateScheme(redir, f.Scheme)
 	translatePathRewrite(redir, f.Path)
 
 	return &requestRedirectIr{
-		Redir:             redir,
-		NeedsListenerPort: portRedirect == 0 && f.Scheme == nil && f.Port == nil,
+		Redir:  redir,
+		Scheme: f.Scheme,
+		Port:   f.Port,
 	}, nil
 }
 
-// applyRedirectPortPostProcessing handles the special case where redirect port needs
-// to be set to the listener port when both scheme and port are nil in the redirect filter.
-// Per Gateway API spec: "If redirect scheme is empty, the redirect port MUST be the Gateway Listener port."
+// applyRedirectPortPostProcessing resolves the redirect PortRedirect for the
+// current listener per the Gateway API spec:
+//
+//   - If filter.Port is set, use it.
+//   - Else if filter.Scheme is set, use the scheme's well-known port
+//     (http=80, https=443).
+//   - Else, use the Gateway Listener port.
+//
+// Per the spec the port is omitted from the Location header when the effective
+// port matches the effective scheme's well-known default (http+80, https+443).
+// In Envoy, leaving PortRedirect at 0 omits the port from the Location header.
 func applyRedirectPortPostProcessing(
 	pCtx *ir.RouteContext,
 	pol *builtinPlugin,
@@ -890,13 +896,41 @@ func applyRedirectPortPostProcessing(
 		return
 	}
 	redirectIr, ok := pol.filter.policy.(*requestRedirectIr)
-	if !ok || !redirectIr.NeedsListenerPort {
+	if !ok {
 		return
 	}
 	redirect := outputRoute.GetRedirect()
-	if redirect != nil && redirect.GetPortRedirect() == 0 {
-		redirect.PortRedirect = pCtx.ListenerPort
+	if redirect == nil {
+		return
 	}
+
+	// Effective scheme: filter.Scheme if set, otherwise inferred from the listener.
+	effectiveScheme := strings.ToLower(ptr.Deref(redirectIr.Scheme, ""))
+	if effectiveScheme == "" {
+		if pCtx.ListenerHasTLS {
+			effectiveScheme = "https"
+		} else {
+			effectiveScheme = "http"
+		}
+	}
+
+	// Effective port: filter.Port > scheme default > listener port.
+	var effectivePort uint32
+	switch {
+	case redirectIr.Port != nil:
+		effectivePort = uint32(*redirectIr.Port) //nolint:gosec // G115: Gateway API PortNumber is int32 in valid port range
+	case redirectIr.Scheme != nil:
+		effectivePort = defaultPortForScheme(effectiveScheme)
+	default:
+		effectivePort = pCtx.ListenerPort
+	}
+
+	// Omit the port when it matches the scheme's well-known default.
+	if effectivePort == defaultPortForScheme(effectiveScheme) {
+		redirect.PortRedirect = 0
+		return
+	}
+	redirect.PortRedirect = effectivePort
 }
 
 // URL REWRITE IR

--- a/pkg/krtcollections/builtin.go
+++ b/pkg/krtcollections/builtin.go
@@ -695,8 +695,17 @@ func (p *builtinPluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputRoute *
 
 	var errs error
 	if pol.filter != nil {
+		// Only post-process redirects when this policy is allowed to set the
+		// route redirect. Lower-priority request-redirect policies still run
+		// through ApplyForRoute, but must not recompute PortRedirect for a
+		// higher-priority redirect that already won the merge.
+		canPostProcessRedirect := outputRoute != nil &&
+			pol.filter.filterType == gwv1.HTTPRouteFilterRequestRedirect &&
+			policy.IsSettable(outputRoute.GetRedirect(), mergeOpts)
 		pol.filter.apply(outputRoute, mergeOpts)
-		applyRedirectPortPostProcessing(pCtx, pol, outputRoute)
+		if canPostProcessRedirect {
+			applyRedirectPortPostProcessing(pCtx, pol, outputRoute)
+		}
 	}
 
 	p.applyRulePolicy(pCtx, pol.rule, mergeOpts, outputRoute)

--- a/pkg/krtcollections/builtin_test.go
+++ b/pkg/krtcollections/builtin_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/policy"
 )
@@ -966,4 +967,53 @@ func TestRequestRedirectSamePolicyMultipleListeners(t *testing.T) {
 	assert.Equal(t, uint32(666), route666.GetRedirect().GetPortRedirect())
 	assert.Equal(t, uint32(8080), route8080.GetRedirect().GetPortRedirect())
 	assert.Equal(t, uint32(0), redirectIR.Redir.GetPortRedirect(), "IR redirect template must keep PortRedirect unset")
+}
+
+func TestRequestRedirectLowerPriorityPolicyDoesNotPostProcessWinningRedirect(t *testing.T) {
+	winningRedirectIR, err := convertRequestRedirectIR(nil, &gwv1.HTTPRequestRedirectFilter{
+		Scheme: new("https"),
+		Port:   new(gwv1.PortNumber(8443)),
+	}, nil, nil)
+	require.NoError(t, err)
+
+	losingRedirectIR, err := convertRequestRedirectIR(nil, &gwv1.HTTPRequestRedirectFilter{}, nil, nil)
+	require.NoError(t, err)
+
+	pass := &builtinPluginGwPass{}
+	outputRoute := &envoyroutev3.Route{}
+
+	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{
+		ListenerPort: 80,
+		Policy: &builtinPlugin{
+			filter: &filterIR{
+				filterType: gwv1.HTTPRouteFilterRequestRedirect,
+				policy:     winningRedirectIR,
+			},
+		},
+		InheritedPolicyPriority: apiannotations.ShallowMergePreferChild,
+	}, outputRoute))
+
+	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{
+		ListenerPort: 80,
+		Policy: &builtinPlugin{
+			filter: &filterIR{
+				filterType: gwv1.HTTPRouteFilterRequestRedirect,
+				policy:     losingRedirectIR,
+			},
+		},
+		InheritedPolicyPriority: apiannotations.ShallowMergePreferChild,
+	}, outputRoute))
+
+	expectedRedirect := &envoyroutev3.RedirectAction{
+		SchemeRewriteSpecifier: &envoyroutev3.RedirectAction_HttpsRedirect{
+			HttpsRedirect: true,
+		},
+		PortRedirect: 8443,
+		ResponseCode: envoyroutev3.RedirectAction_FOUND,
+	}
+	assert.True(t, proto.Equal(expectedRedirect, outputRoute.GetRedirect()),
+		"lower-priority redirect must not mutate the winning redirect\nexpected: %+v\nactual: %+v",
+		expectedRedirect,
+		outputRoute.GetRedirect(),
+	)
 }

--- a/pkg/krtcollections/builtin_test.go
+++ b/pkg/krtcollections/builtin_test.go
@@ -665,11 +665,11 @@ func TestRequestMirror(t *testing.T) {
 
 func TestRequestRedirect(t *testing.T) {
 	tests := []struct {
-		name                  string
-		filter                *gwv1.HTTPRequestRedirectFilter
-		listenerPort          uint32
-		expectedRedirect      *envoyroutev3.RedirectAction
-		expectedNeedsListener bool
+		name             string
+		filter           *gwv1.HTTPRequestRedirectFilter
+		listenerPort     uint32
+		listenerHasTLS   bool
+		expectedRedirect *envoyroutev3.RedirectAction
 	}{
 		{
 			name: "scheme and port both nil uses listener port",
@@ -682,10 +682,32 @@ func TestRequestRedirect(t *testing.T) {
 				PortRedirect: 8080,
 				ResponseCode: envoyroutev3.RedirectAction_FOUND,
 			},
-			expectedNeedsListener: true,
 		},
 		{
-			name: "scheme http with port nil uses default 80",
+			name: "scheme and port both nil omits default HTTP listener port 80",
+			filter: &gwv1.HTTPRequestRedirectFilter{
+				Scheme: nil,
+				Port:   nil,
+			},
+			listenerPort: 80,
+			expectedRedirect: &envoyroutev3.RedirectAction{
+				ResponseCode: envoyroutev3.RedirectAction_FOUND,
+			},
+		},
+		{
+			name: "scheme and port both nil omits default HTTPS listener port 443",
+			filter: &gwv1.HTTPRequestRedirectFilter{
+				Scheme: nil,
+				Port:   nil,
+			},
+			listenerPort:   443,
+			listenerHasTLS: true,
+			expectedRedirect: &envoyroutev3.RedirectAction{
+				ResponseCode: envoyroutev3.RedirectAction_FOUND,
+			},
+		},
+		{
+			name: "scheme http with port nil omits default port 80",
 			filter: &gwv1.HTTPRequestRedirectFilter{
 				Scheme: new("http"),
 				Port:   nil,
@@ -695,12 +717,11 @@ func TestRequestRedirect(t *testing.T) {
 				SchemeRewriteSpecifier: &envoyroutev3.RedirectAction_SchemeRedirect{
 					SchemeRedirect: "http",
 				},
-				PortRedirect: 80,
 				ResponseCode: envoyroutev3.RedirectAction_FOUND,
 			},
 		},
 		{
-			name: "scheme https with port nil uses default 443",
+			name: "scheme https with port nil omits default port 443",
 			filter: &gwv1.HTTPRequestRedirectFilter{
 				Scheme: new("https"),
 				Port:   nil,
@@ -710,7 +731,6 @@ func TestRequestRedirect(t *testing.T) {
 				SchemeRewriteSpecifier: &envoyroutev3.RedirectAction_HttpsRedirect{
 					HttpsRedirect: true,
 				},
-				PortRedirect: 443,
 				ResponseCode: envoyroutev3.RedirectAction_FOUND,
 			},
 		},
@@ -723,6 +743,29 @@ func TestRequestRedirect(t *testing.T) {
 			listenerPort: 8080,
 			expectedRedirect: &envoyroutev3.RedirectAction{
 				PortRedirect: 9090,
+				ResponseCode: envoyroutev3.RedirectAction_FOUND,
+			},
+		},
+		{
+			name: "scheme nil with explicit default HTTP port is omitted",
+			filter: &gwv1.HTTPRequestRedirectFilter{
+				Scheme: nil,
+				Port:   new(gwv1.PortNumber(80)),
+			},
+			listenerPort: 80,
+			expectedRedirect: &envoyroutev3.RedirectAction{
+				ResponseCode: envoyroutev3.RedirectAction_FOUND,
+			},
+		},
+		{
+			name: "scheme nil with explicit default HTTPS port is omitted",
+			filter: &gwv1.HTTPRequestRedirectFilter{
+				Scheme: nil,
+				Port:   new(gwv1.PortNumber(443)),
+			},
+			listenerPort:   443,
+			listenerHasTLS: true,
+			expectedRedirect: &envoyroutev3.RedirectAction{
 				ResponseCode: envoyroutev3.RedirectAction_FOUND,
 			},
 		},
@@ -757,6 +800,34 @@ func TestRequestRedirect(t *testing.T) {
 			},
 		},
 		{
+			name: "explicit default https port is omitted",
+			filter: &gwv1.HTTPRequestRedirectFilter{
+				Scheme: new("https"),
+				Port:   new(gwv1.PortNumber(443)),
+			},
+			listenerPort: 8080,
+			expectedRedirect: &envoyroutev3.RedirectAction{
+				SchemeRewriteSpecifier: &envoyroutev3.RedirectAction_HttpsRedirect{
+					HttpsRedirect: true,
+				},
+				ResponseCode: envoyroutev3.RedirectAction_FOUND,
+			},
+		},
+		{
+			name: "explicit default http port is omitted",
+			filter: &gwv1.HTTPRequestRedirectFilter{
+				Scheme: new("http"),
+				Port:   new(gwv1.PortNumber(80)),
+			},
+			listenerPort: 8080,
+			expectedRedirect: &envoyroutev3.RedirectAction{
+				SchemeRewriteSpecifier: &envoyroutev3.RedirectAction_SchemeRedirect{
+					SchemeRedirect: "http",
+				},
+				ResponseCode: envoyroutev3.RedirectAction_FOUND,
+			},
+		},
+		{
 			name: "hostname redirect",
 			filter: &gwv1.HTTPRequestRedirectFilter{
 				Hostname: new(gwv1.PreciseHostname("example.com")),
@@ -767,7 +838,6 @@ func TestRequestRedirect(t *testing.T) {
 				PortRedirect: 8080,
 				ResponseCode: envoyroutev3.RedirectAction_FOUND,
 			},
-			expectedNeedsListener: true,
 		},
 		{
 			name: "status code 302 found",
@@ -779,7 +849,6 @@ func TestRequestRedirect(t *testing.T) {
 				PortRedirect: 8080,
 				ResponseCode: envoyroutev3.RedirectAction_FOUND,
 			},
-			expectedNeedsListener: true,
 		},
 		{
 			name: "complete redirect with all fields",
@@ -822,7 +891,6 @@ func TestRequestRedirect(t *testing.T) {
 				PortRedirect: 8080,
 				ResponseCode: envoyroutev3.RedirectAction_FOUND,
 			},
-			expectedNeedsListener: true,
 		},
 	}
 
@@ -831,7 +899,6 @@ func TestRequestRedirect(t *testing.T) {
 			redirectIR, err := convertRequestRedirectIR(nil, tt.filter, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, redirectIR)
-			assert.Equal(t, tt.expectedNeedsListener, redirectIR.NeedsListenerPort, "NeedsListenerPort flag mismatch")
 
 			builtinPol := &builtinPlugin{
 				filter: &filterIR{
@@ -840,8 +907,9 @@ func TestRequestRedirect(t *testing.T) {
 				},
 			}
 			pCtx := &ir.RouteContext{
-				ListenerPort: tt.listenerPort,
-				Policy:       builtinPol,
+				ListenerPort:   tt.listenerPort,
+				ListenerHasTLS: tt.listenerHasTLS,
+				Policy:         builtinPol,
 			}
 
 			outputRoute := &envoyroutev3.Route{}
@@ -869,7 +937,6 @@ func TestRequestRedirectSamePolicyMultipleListeners(t *testing.T) {
 		StatusCode: new(301),
 	}, nil, nil)
 	require.NoError(t, err)
-	require.True(t, redirectIR.NeedsListenerPort)
 
 	builtinPol := &builtinPlugin{
 		filter: &filterIR{
@@ -880,14 +947,23 @@ func TestRequestRedirectSamePolicyMultipleListeners(t *testing.T) {
 	pass := &builtinPluginGwPass{}
 
 	route80 := &envoyroutev3.Route{}
-	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{ListenerPort: 80, Policy: builtinPol}, route80))
+	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{
+		ListenerPort: 80,
+		Policy:       builtinPol,
+	}, route80))
 	route666 := &envoyroutev3.Route{}
-	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{ListenerPort: 666, Policy: builtinPol}, route666))
+	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{
+		ListenerPort: 666,
+		Policy:       builtinPol,
+	}, route666))
 	route8080 := &envoyroutev3.Route{}
-	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{ListenerPort: 8080, Policy: builtinPol}, route8080))
+	require.NoError(t, pass.ApplyForRoute(&ir.RouteContext{
+		ListenerPort: 8080,
+		Policy:       builtinPol,
+	}, route8080))
 
-	assert.Equal(t, uint32(80), route80.GetRedirect().GetPortRedirect())
+	assert.Equal(t, uint32(0), route80.GetRedirect().GetPortRedirect())
 	assert.Equal(t, uint32(666), route666.GetRedirect().GetPortRedirect())
 	assert.Equal(t, uint32(8080), route8080.GetRedirect().GetPortRedirect())
-	assert.Equal(t, uint32(0), redirectIR.Redir.GetPortRedirect(), "IR redirect template must keep sentinel port")
+	assert.Equal(t, uint32(0), redirectIR.Redir.GetPortRedirect(), "IR redirect template must keep PortRedirect unset")
 }

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -113,6 +113,10 @@ type RouteContext struct {
 	TypedFilterConfig TypedFilterConfigMap
 	// ListenerPort is the port of the Gateway listener that this route is attached to
 	ListenerPort uint32
+	// ListenerHasTLS reports whether the Gateway listener terminates TLS (i.e. is
+	// an HTTPS listener). Used by request-redirect post-processing to infer the
+	// effective scheme when the redirect filter doesn't set one.
+	ListenerHasTLS bool
 
 	InheritedPolicyPriority apiannotations.InheritedPolicyPriorityValue
 }


### PR DESCRIPTION
Signed-off-by: omar <omar.hammami@solo.io>
(cherry picked from commit 5bab12e912880bf43fd524bb8224c6b599924ea6)

# Description

Fixes [#13579](https://github.com/kgateway-dev/kgateway/issues/13579).

This updates `RequestRedirect` translation so kgateway no longer emits `port_redirect` when the resulting `Location` header would use the default port for the resolved scheme:
- `http` + `:80`
- `https` + `:443`

The change covers both cases where the default comes from the redirect `scheme` and where it comes from the listener protocol when `scheme` and `port` are unset. It also threads listener protocol through route translation so listener-port post-processing can distinguish "inherit listener port" from "omit default port".

# Change Type
/kind fix

# Changelog

```release-note
Fixed HTTPRoute RequestRedirect handling so redirect Location headers no longer include default ports (:80 for HTTP, :443 for HTTPS).
```