### PR TITLE
chore: Rolling main bumps from v2.3.0-main to v2.4.0-main

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -171,7 +171,7 @@ release:
   replace_existing_artifacts: true
   target_commitish: "{{ .FullCommit }}"
   header: |
-    {{ if eq .Env.VERSION "v2.3.0-main" }}
+    {{ if eq .Env.VERSION "v2.4.0-main" }}
     🚀 Rolling main build of kgateway!
     ---
     It includes the latest changes but may be unstable. Use it for testing and providing feedback.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ comma := ,
 # where actual semver is desired.
 VERSION ?= v1.0.1-dev
 export VERSION
-ROLLING_MAIN_VERSION ?= v2.3.0-main
+ROLLING_MAIN_VERSION ?= v2.4.0-main
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,14 +6,14 @@ Automation is in place to build and publish releases for all commits merged into
 
 This enables devs and users to have concrete artifacts for testing which contain features and bug fixes which have not yet made it into a patch or minor release.
 
-The version is rolling, based on the next minor version release, e.g. `v2.3.0-main`.
+The version is rolling, based on the next minor version release, e.g. `v2.4.0-main`.
 
 The usable artifacts are pushed to GHCR and visible on the [packages page](https://github.com/orgs/kgateway-dev/packages?repo_name=kgateway).
 
 Typically this will be consumed via the helm charts, and can be used directly, such as:
 ```bash
-helm install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds --version v2.3.0-main --namespace kgateway-system --create-namespace
-helm install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --version v2.3.0-main --namespace kgateway-system --create-namespace
+helm install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds --version v2.4.0-main --namespace kgateway-system --create-namespace
+helm install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --version v2.4.0-main --namespace kgateway-system --create-namespace
 ```
 
 ## Developer documentation

--- a/hack/setup-via-release.sh
+++ b/hack/setup-via-release.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 cluster_type="kind"
 cluster_name=""
-kgw_version="v2.3.0-main"
+kgw_version="v2.4.0-main"
 helm_registry="oci://cr.kgateway.dev/kgateway-dev/charts"
 namespace="kgateway-system"
 k8s_version=""
@@ -49,7 +49,7 @@ Options:
   -h, --help                     Show this help message
   --k3d                          Use k3d instead of kind
   -c, --cluster-name NAME        Cluster name                   (default: <type>-kgw-<version>-gw-<gw-version>-<channel>)
-  -v, --version VERSION          kgateway helm chart version    (default: v2.3.0-main)
+  -v, --version VERSION          kgateway helm chart version    (default: v2.4.0-main)
   -r, --registry URL             Helm OCI registry              (default: oci://cr.kgateway.dev/kgateway-dev/charts)
   -n, --namespace NS             Install namespace              (default: kgateway-system)
   -k, --k8s-version VER          Node image version             (kind: kindest/node tag, k3d: k3s semver)

--- a/pkg/validator/default_envoy_image.txt
+++ b/pkg/validator/default_envoy_image.txt
@@ -1,1 +1,1 @@
-ghcr.io/kgateway-dev/envoy-wrapper:v2.3.0-main
+ghcr.io/kgateway-dev/envoy-wrapper:v2.4.0-main


### PR DESCRIPTION
# Description

To avoid splitting this into two PRs, I'm changing pkg/validator/default_envoy_image.txt here. After this merges but before the release workflow is complete (less than 1 hour, typically), other PRs and local devs will have tests fail because the image doesn't yet exist.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->


<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind bump

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Because v2.3.0 has been released, v2.4.0-main is now the rolling tag for the very latest `main` prerelease artifacts.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
