### PR TITLE
chore: SKILL to help update code & images to avoid CVEs

### DIFF
--- a/.agents/skills/cve-bump
+++ b/.agents/skills/cve-bump
@@ -1,0 +1,1 @@
+../../.claude/skills/cve-bump

--- a/.claude/skills/cve-bump/SKILL.md
+++ b/.claude/skills/cve-bump/SKILL.md
@@ -84,33 +84,67 @@ GO-XXXX-XXXX advisory table with fixed versions. Extract with `jq`'s
 
 ## Workflow
 
-There are five phases. Do them in order; do not skip the planning phase
+There are six phases. Do them in order; do not skip the planning phase
 even if there is only one finding.
 
-### 1. Detect the branch to scan
+### 1. Show the landscape (cross-branch summary)
 
-The osv-scanner workflow only uploads findings for the supported
-branches. Topic branches must query the branch they are based on.
-
-Run the detection helper:
+Before pulling raw alerts, run the cheap summary mode across all four
+supported branches so the user can see the shape of the problem:
 
 ```bash
-.claude/skills/cve-bump/scripts/detect_base.sh
+./hack/osvtool \
+    --branch main --branch v2.1.x --branch v2.2.x --branch v2.3.x \
+    --target source --state open
 ```
 
-It prints one line: the supported branch the current HEAD is most
-likely based on (most-recent merge-base across `main`, `v2.1.x`,
-`v2.2.x`, `v2.3.x`), or `main` if it cannot decide.
+This emits YAML with per-branch totals, **counts by severity (all
+levels)**, max alert age, last successful scan timestamp, and a
+clickable URL to each branch's code-scanning UI. Show it to the user
+verbatim — it orients them in one screen and gives them the
+severity breakdown they need to answer the next question.
 
-Show the detected branch to the user and ask them to confirm or
-override. Phrase it like: "Querying alerts for branch `<X>`. OK, or pick
-another?" — short, no menu. Accept any of the four supported branches.
+Use `--state open` (not `todo`) here so the medium/low counts are
+visible. The user is about to decide whether to include them; they
+should see the numbers first.
 
-### 2. Pull the raw alerts
+### 2. Decide severity scope and target branch
+
+Ask the user two short questions, back to back:
+
+1. **Severity scope**: just critical/high (`--state todo`), or all open
+   severities including medium/low (`--state open`)? Recommend
+   critical/high since that matches how teams typically prioritize, but
+   the landscape view from phase 1 shows the full severity breakdown so
+   the user can make an informed call (e.g. if there are 30 mediums on
+   `v2.1.x` that they want to clear ahead of a release). Just ask in
+   one sentence — no menu.
+
+2. **Branch to plan against**: the raw pull is single-branch because
+   planning depends on that branch's go.mod state. Run the detection
+   helper for a default:
+
+   ```bash
+   .claude/skills/cve-bump/scripts/detect_base.sh
+   ```
+
+   It prints one line — the supported branch the current HEAD is most
+   likely based on (most-recent merge-base across `main`, `v2.1.x`,
+   `v2.2.x`, `v2.3.x`), or `main` if it cannot decide. Confirm with
+   the user: "Planning against `<X>`. OK, or pick another?"
+
+If the landscape view in phase 1 showed zero alerts at the chosen
+severity for the chosen branch, stop here and tell the user — there is
+nothing to plan.
+
+### 3. Pull the raw alerts
 
 ```bash
-./hack/osvtool --raw --branch <branch> --target source --state open
+./hack/osvtool --raw --branch <branch> --target source --state <state>
 ```
+
+Where `<state>` is whatever the user picked in phase 2 (`todo` or
+`open`).
 
 Notes:
 
@@ -118,8 +152,6 @@ Notes:
   fixed by Dockerfile or base-image changes, not Go dep bumps, so they
   are out of scope for this skill. Mention any image findings to the
   user in passing and move on.
-- `--state open` is the default but be explicit so a future reader
-  understands the intent.
 - The output is YAML. Save it to a scratch path outside the repo so it
   is not accidentally committed. Use
   `/tmp/cve-bump/alerts-<branch>-<UTC-timestamp>.yaml` (mkdir -p first).
@@ -130,7 +162,7 @@ If `osvtool` errors with an auth message, surface the help text it
 prints — it already explains the fix (`gh auth refresh --scopes
 security_events` or a fine-grained PAT). Do not paper over it.
 
-### 3. Plan one action per finding
+### 4. Plan one action per finding
 
 For each alert, extract:
 
@@ -189,7 +221,7 @@ look. Columns: `CVE | severity | module | from → to | action`. Example:
 Then ask the user to OK the batch or call out specific rows to change.
 Wait for approval before touching files.
 
-### 4. Execute
+### 5. Execute
 
 After approval, in order:
 
@@ -206,7 +238,7 @@ After approval, in order:
 Do not stage anything (`git add`) and do not commit. The user reviews
 the dirty tree themselves.
 
-### 5. Verify
+### 6. Verify
 
 The user signed off on "build + scanner re-run only", so:
 
@@ -224,7 +256,7 @@ The user signed off on "build + scanner re-run only", so:
      `.` replaced by `-`.
    - The `make osv-scan` JSON schema is osv-scanner native
      (`results[].packages[].vulnerabilities[].id`), which is different
-     from the GitHub code-scanning YAML from phase 2. To diff, extract
+     from the GitHub code-scanning YAML from phase 3. To diff, extract
      the set of vuln IDs from each side with `jq`/`yq` and compare the
      sets — don't try to align records field-by-field. Report which
      CVEs the user expected to clear that still appear, and any new
@@ -233,7 +265,7 @@ The user signed off on "build + scanner re-run only", so:
    error. Tell the user and stop — do not try to install osv-scanner
    from source as a workaround.
 
-### 6. Report
+### 7. Report
 
 End with a brief summary listing each CVE, the action taken, and the
 file(s) touched. The user reads this against `git diff` to verify.

--- a/.claude/skills/cve-bump/SKILL.md
+++ b/.claude/skills/cve-bump/SKILL.md
@@ -89,24 +89,29 @@ even if there is only one finding.
 
 ### 1. Show the landscape (cross-branch summary)
 
-Before pulling raw alerts, run the cheap summary mode across all four
+Before pulling raw alerts, run the table mode across all four
 supported branches so the user can see the shape of the problem:
 
 ```bash
-./hack/osvtool \
+./hack/osvtool --table \
     --branch main --branch v2.1.x --branch v2.2.x --branch v2.3.x \
     --target source --state open
 ```
 
-This emits YAML with per-branch totals, **counts by severity (all
-levels)**, max alert age, last successful scan timestamp, and a
-clickable URL to each branch's code-scanning UI. Show it to the user
-verbatim — it orients them in one screen and gives them the
-severity breakdown they need to answer the next question.
+This emits a compact markdown table — one row per branch, columns:
+`branch | C | H | M | L | max age | last scan | code-scanning`.
+Show it to the user as-is; it is already tight enough to read in one
+glance.
 
 Use `--state open` (not `todo`) here so the medium/low counts are
 visible. The user is about to decide whether to include them; they
 should see the numbers first.
+
+**Do not** use the default YAML summary mode (without `--table`) for
+this — it emits ~60 lines per branch of nested fields the user does
+not need. If you ever want the full structured form (e.g. to grep a
+specific field), pipe it to a file under `/tmp/cve-bump/` instead of
+into the chat.
 
 ### 2. Decide severity scope and target branch
 
@@ -322,3 +327,7 @@ file(s) touched. The user reads this against `git diff` to verify.
   and `yq` — see the Tooling section.
 - Do **not** invoke `osv-scanner` directly. Use `make osv-scan` — it
   runs the scanner in Docker with the right config and output paths.
+- Do **not** dump the default YAML summary into the chat for the
+  cross-branch landscape view. Use `./hack/osvtool --table` (phase 1)
+  — it's a single small markdown table instead of dozens of lines of
+  nested YAML.

--- a/.claude/skills/cve-bump/SKILL.md
+++ b/.claude/skills/cve-bump/SKILL.md
@@ -42,6 +42,46 @@ Strong fit when the user says any of:
 Skip when the user wants a non-security dep bump (no CVE motivation) —
 `hack/bump_deps.sh` and a plain `go get` are usually right for those.
 
+## Tooling
+
+This is a Go shop. The repo does not ship a Python toolchain and many
+contributors do not have one installed — `pip install pyyaml` is **not**
+a viable step.
+
+For every parsing, filtering, or shaping task in this workflow, use:
+
+- **`jq`** for JSON. Required by `hack/osvtool` already, so present
+  whenever osvtool runs.
+- **`yq`** for YAML. Also required by `hack/osvtool`. Use
+  `yq -p=yaml -o=json` to convert the osvtool YAML back into JSON so
+  `jq` can do the heavy lifting.
+- **`go`**, `make`, standard shell builtins.
+
+Do **not** reach for `python`, `python3`, `node`, `ruby`, or
+`pip`/`npm install <anything>`. If you find yourself wanting one, write
+a `jq` expression instead — every shape in the osvtool output (alerts,
+rule metadata, message text, help tables) is straightforward to handle
+in jq.
+
+Concrete starter: to round-trip the saved YAML back to a JSON array of
+alerts and start filtering:
+
+```bash
+yq -p=yaml -o=json /tmp/cve-bump/alerts-<branch>-<ts>.yaml \
+  | jq '[ .[] | {
+      ghsa: .rule.id,
+      sev:  .rule.security_severity_level,
+      msg:  .most_recent_instance.message.text,
+      help: .rule.help,
+      url:  .html_url
+    } ]'
+```
+
+CVE IDs typically appear in `rule.full_description` or in the message
+text alongside the package and version; the `help` field contains the
+GO-XXXX-XXXX advisory table with fixed versions. Extract with `jq`'s
+`capture` / regex helpers or a small `sed`/`grep` pipeline, not Python.
+
 ## Workflow
 
 There are five phases. Do them in order; do not skip the planning phase
@@ -159,8 +199,8 @@ After approval, in order:
    `osv-scanner.toml`. The `reason` must be specific — name the
    pseudo-version timestamp, the fix release date, and the gap. Do not
    write generic reasons like "false positive" or "not applicable".
-4. If `go.sum` changed and the repo has `make generate-licenses`, run
-   it. (Check `Makefile` for the target first; skip silently if absent.)
+4. If `go.sum` changed, run `make generate-licenses` to refresh the
+   license attribution files.
 5. Run `make fmt-changed` to keep the diff clean.
 
 Do not stage anything (`git add`) and do not commit. The user reviews
@@ -173,12 +213,25 @@ The user signed off on "build + scanner re-run only", so:
 1. `go build -tags e2e ./...` — the `e2e` tag is required to compile
    all source per the repo's CLAUDE.md. If the build fails, the bump is
    not safe; stop and report.
-2. Local scanner re-run, if `osv-scanner` is on PATH:
-   `osv-scanner --config=osv-scanner.toml ./`. Diff against the
-   pre-bump alert list saved in step 2. Report which CVEs cleared and
-   which (if any) still appear.
-3. If `osv-scanner` is not on PATH, say so and note that CI will
-   re-scan on push. Do not attempt to install it.
+2. Local scanner re-run: **`make osv-scan`**. This is the canonical
+   way to run OSV-Scanner locally in kgateway — it shells out to
+   Docker (image `ghcr.io/google/osv-scanner-action`), so you do not
+   need a local `osv-scanner` binary. Do **not** reach for a
+   standalone `osv-scanner` invocation; the make target handles config
+   lookup, output paths, and reporter conversion in one shot.
+   - Results land at `_output/osv/<safe-branch>/results.json` (and a
+     SARIF sibling). `<safe-branch>` is the current branch with `/` and
+     `.` replaced by `-`.
+   - The `make osv-scan` JSON schema is osv-scanner native
+     (`results[].packages[].vulnerabilities[].id`), which is different
+     from the GitHub code-scanning YAML from phase 2. To diff, extract
+     the set of vuln IDs from each side with `jq`/`yq` and compare the
+     sets — don't try to align records field-by-field. Report which
+     CVEs the user expected to clear that still appear, and any new
+     ones the scanner surfaced that were not in the original plan.
+3. If Docker is not running, `make osv-scan` will fail with a Docker
+   error. Tell the user and stop — do not try to install osv-scanner
+   from source as a workaround.
 
 ### 6. Report
 
@@ -230,4 +283,10 @@ file(s) touched. The user reads this against `git diff` to verify.
   for a dep bump — they are not needed for non-API changes and they
   slow the loop down by ~30s for no benefit.
 - Do **not** scan an unsupported branch (e.g. `chandler/cveskill`)
-  directly — there are no alerts uploaded for it.
+  directly via `osvtool` — there are no GitHub-uploaded alerts for it.
+  (Note: `make osv-scan` does work on any branch because it runs the
+  scanner locally; that is fine for verification.)
+- Do **not** reach for Python, Node, or any other parser. Use `jq`
+  and `yq` — see the Tooling section.
+- Do **not** invoke `osv-scanner` directly. Use `make osv-scan` — it
+  runs the scanner in Docker with the right config and output paths.

--- a/.claude/skills/cve-bump/SKILL.md
+++ b/.claude/skills/cve-bump/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: cve-bump
+description: Patch CVEs surfaced by the kgateway OSV scanner by bumping the affected Go module dependencies (direct, indirect via require, or replace) and curating false-positive entries in osv-scanner.toml. Use this skill whenever the user wants to fix CVEs, address OSV-Scanner alerts, bump deps for security reasons, triage code-scanning findings, "see what CVEs we have", or do anything CVE/security-bump-flavored in this repo — even if they don't name the skill explicitly.
+---
+
+# cve-bump
+
+End-to-end workflow for clearing CVEs in kgateway's Go dependencies. The user
+wants a single pass: discover the alerts → decide the action for each →
+present a plan → apply the bumps and ignore-list updates → verify locally.
+
+## Why this skill exists
+
+CVE patching in kgateway is more mechanical than it looks, but the moving
+parts are easy to miss:
+
+- The scanner findings live in GitHub code-scanning, not the local tree.
+  `hack/osvtool` is the canonical way to fetch them.
+- Findings are uploaded per-branch and only the supported branches
+  (`main`, `v2.1.x`, `v2.2.x`, `v2.3.x`) get scanned, so a topic branch has
+  to query its base branch.
+- Some "vulnerabilities" are scanner false positives caused by
+  pseudo-version comparison quirks (see the istio.io entries in
+  `osv-scanner.toml`). These belong in the ignore list, not in go.mod
+  churn.
+- Indirect deps need either a `go get` of the parent that pulls in the
+  fixed version, or an explicit `require` to force MVS to pick the fixed
+  version. Getting this wrong looks like the bump "didn't take."
+
+The skill encodes those decisions so the human only has to approve the
+plan, not relearn the rules each time.
+
+## Trigger fit
+
+Strong fit when the user says any of:
+
+- "patch the CVEs", "fix the CVEs", "clear the OSV alerts"
+- "bump X for the CVE", "address GHSA-...", "what CVEs do we have?"
+- "scanner is complaining about Y", "osv-scanner findings"
+- "update deps for security"
+
+Skip when the user wants a non-security dep bump (no CVE motivation) —
+`hack/bump_deps.sh` and a plain `go get` are usually right for those.
+
+## Workflow
+
+There are five phases. Do them in order; do not skip the planning phase
+even if there is only one finding.
+
+### 1. Detect the branch to scan
+
+The osv-scanner workflow only uploads findings for the supported
+branches. Topic branches must query the branch they are based on.
+
+Run the detection helper:
+
+```bash
+.claude/skills/cve-bump/scripts/detect_base.sh
+```
+
+It prints one line: the supported branch the current HEAD is most
+likely based on (most-recent merge-base across `main`, `v2.1.x`,
+`v2.2.x`, `v2.3.x`), or `main` if it cannot decide.
+
+Show the detected branch to the user and ask them to confirm or
+override. Phrase it like: "Querying alerts for branch `<X>`. OK, or pick
+another?" — short, no menu. Accept any of the four supported branches.
+
+### 2. Pull the raw alerts
+
+```bash
+./hack/osvtool --raw --branch <branch> --target source --state open
+```
+
+Notes:
+
+- `--target source` filters out container-image findings — those are
+  fixed by Dockerfile or base-image changes, not Go dep bumps, so they
+  are out of scope for this skill. Mention any image findings to the
+  user in passing and move on.
+- `--state open` is the default but be explicit so a future reader
+  understands the intent.
+- The output is YAML. Save it to a scratch path outside the repo so it
+  is not accidentally committed. Use
+  `/tmp/cve-bump/alerts-<branch>-<UTC-timestamp>.yaml` (mkdir -p first).
+  This gives the user a record and lets us re-parse without another
+  GitHub call.
+
+If `osvtool` errors with an auth message, surface the help text it
+prints — it already explains the fix (`gh auth refresh --scopes
+security_events` or a fine-grained PAT). Do not paper over it.
+
+### 3. Plan one action per finding
+
+For each alert, extract:
+
+- CVE ID (`rule.id` is typically the GHSA; the CVE lives in
+  `rule.full_description` or `most_recent_instance.message.text`).
+- Severity (`rule.security_severity_level`).
+- Affected Go module + current pinned version.
+- Fixed version (the lowest version that resolves the advisory).
+- Whether the module is direct or indirect in this repo's go.mod.
+
+Then pick an action per the decision tree below.
+
+#### Decision tree
+
+```mermaid
+flowchart TD
+    A[Finding] --> B{Is the pinned version actually >= fix,<br/>once you account for pseudo-versions?}
+    B -- yes --> C[False positive → add to osv-scanner.toml]
+    B -- no --> D{Is the module direct in go.mod?}
+    D -- yes --> E[go get module@fixed-version]
+    D -- no --> F{Does a single parent dep<br/>own this transitive?}
+    F -- yes, and bumping it is reasonable --> G[go get parent@version-that-pulls-fix]
+    F -- no, or parent bump too risky --> H[Add explicit require<br/>go get module@fixed-version<br/>force MVS to pick the fix]
+```
+
+**Detecting pseudo-version false positives**: when the affected version
+looks like `v0.0.0-<14-digit-timestamp>-<sha>` and the fix version is a
+normal semver like `1.x`, OSV-Scanner compares them lexically as
+`"0.0.0" < "1.x"` and fires regardless of whether the pinned commit
+already includes the fix. Read the timestamp embedded in the
+pseudo-version and compare to the fix release date. If the pinned
+commit is newer, it is a false positive — add to `osv-scanner.toml`
+with a reason that names the timestamp, the fix release date, and the
+years/months gap. The five istio.io entries already in that file are
+the model to copy.
+
+**Choosing between parent bump and explicit require**: prefer the
+parent bump when (a) the parent is itself behind by only a minor/patch
+version, and (b) its changelog does not flag breaking changes for our
+usage. Otherwise add an explicit require — it is the smallest possible
+intervention and Go's MVS will honor it.
+
+#### Output: the plan
+
+Present the plan as a single fenced table the user can scan in one
+look. Columns: `CVE | severity | module | from → to | action`. Example:
+
+```
+| CVE             | sev | module                | from           | to        | action                |
+| --------------- | --- | --------------------- | -------------- | --------- | --------------------- |
+| CVE-2025-1111   | H   | golang.org/x/net      | v0.20.0        | v0.27.0   | go get (direct)       |
+| CVE-2025-2222   | M   | gopkg.in/foo.v3       | v3.1.0         | v3.2.1    | explicit require      |
+| CVE-2022-31045  | H   | istio.io/istio        | v0.0.0-2026... | (n/a)     | ignore: false pos     |
+```
+
+Then ask the user to OK the batch or call out specific rows to change.
+Wait for approval before touching files.
+
+### 4. Execute
+
+After approval, in order:
+
+1. For each `go get` action: `go get <module>@<version>`.
+2. `go mod tidy` once at the end.
+3. For each ignore action: append a `[[IgnoredVulns]]` entry to
+   `osv-scanner.toml`. The `reason` must be specific — name the
+   pseudo-version timestamp, the fix release date, and the gap. Do not
+   write generic reasons like "false positive" or "not applicable".
+4. If `go.sum` changed and the repo has `make generate-licenses`, run
+   it. (Check `Makefile` for the target first; skip silently if absent.)
+5. Run `make fmt-changed` to keep the diff clean.
+
+Do not stage anything (`git add`) and do not commit. The user reviews
+the dirty tree themselves.
+
+### 5. Verify
+
+The user signed off on "build + scanner re-run only", so:
+
+1. `go build -tags e2e ./...` — the `e2e` tag is required to compile
+   all source per the repo's CLAUDE.md. If the build fails, the bump is
+   not safe; stop and report.
+2. Local scanner re-run, if `osv-scanner` is on PATH:
+   `osv-scanner --config=osv-scanner.toml ./`. Diff against the
+   pre-bump alert list saved in step 2. Report which CVEs cleared and
+   which (if any) still appear.
+3. If `osv-scanner` is not on PATH, say so and note that CI will
+   re-scan on push. Do not attempt to install it.
+
+### 6. Report
+
+End with a brief summary listing each CVE, the action taken, and the
+file(s) touched. The user reads this against `git diff` to verify.
+
+## Edge cases worth knowing
+
+- **Pseudo-version on the fix side**: rare, but if a fix only exists at
+  a non-tagged commit, `go get module@<sha>` works. Mark this clearly
+  in the plan so the user is not surprised by a pseudo-version in
+  go.mod.
+- **Module renamed/moved**: if the advisory's module path no longer
+  exists upstream, a `replace` directive may be necessary. Treat this
+  as ambiguous and flag it for the user instead of writing the replace
+  silently.
+- **Multiple CVEs on one module**: combine into a single `go get` to
+  the highest required version. List them as separate rows in the plan
+  table but mark "(combined bump)" in the action column.
+- **Backport branches**: when scanning `v2.1.x` etc., the supported
+  upgrade window for a given module may be narrower (e.g. cannot move
+  to a new major). Default to the smallest version that resolves the
+  CVE within the same major.
+- **Topic branch with no alerts on the base branch**: possible if the
+  branch was just rebased after a recent scan. Tell the user; offer to
+  re-run after CI uploads fresh results.
+
+## Files this skill touches
+
+- `go.mod` / `go.sum` — version bumps
+- `osv-scanner.toml` — false-positive ignore entries (root-level; this
+  is the only scanner ignore file in this repo as of writing — `.snyk`,
+  `.grype.yaml`, `.trivyignore` are not present)
+- License attribution files, if `make generate-licenses` is wired up
+
+## Bundled scripts
+
+- `scripts/detect_base.sh` — prints the supported branch that the
+  current HEAD is most likely based on. Used in phase 1.
+
+## Things not to do
+
+- Do **not** commit or stage. The user does that.
+- Do **not** edit go.mod by hand — always go through `go get` so
+  go.sum stays consistent.
+- Do **not** add an `osv-scanner.toml` entry just to silence noise.
+  The reason field has to defend the entry to a future reader.
+- Do **not** run `make generate-all` or other heavy codegen targets
+  for a dep bump — they are not needed for non-API changes and they
+  slow the loop down by ~30s for no benefit.
+- Do **not** scan an unsupported branch (e.g. `chandler/cveskill`)
+  directly — there are no alerts uploaded for it.

--- a/.claude/skills/cve-bump/SKILL.md
+++ b/.claude/skills/cve-bump/SKILL.md
@@ -30,6 +30,50 @@ parts are easy to miss:
 The skill encodes those decisions so the human only has to approve the
 plan, not relearn the rules each time.
 
+## Protected dependencies
+
+Some dependencies are load-bearing enough that bumping them risks
+breaking the dataplane, compatibility with managed Kubernetes
+versions, or the Gateway API conformance contract. **Never bump any
+of these without an explicit, in-conversation yes from the user —
+even for a critical CVE.**
+
+- `github.com/envoyproxy/*` (Envoy and `go-control-plane`)
+- `k8s.io/*` (api, apimachinery, client-go, ...)
+- `istio.io/*`
+- `sigs.k8s.io/gateway-api` and other Gateway API modules
+
+How this gets enforced through the workflow:
+
+- In the plan (phase 4), surface protected-dep rows with the action
+  `needs approval (protected dep)` and list them in their own
+  bucket. Do not fold them into a batch `go get`.
+- In the execute step (phase 5), confirm each protected-dep bump
+  one-by-one before running `go get`. If the user says no, leave
+  the dep alone and list the CVE under "deferred — protected dep"
+  in the report.
+- Never silence a protected-dep CVE via `osv-scanner.toml` to avoid
+  asking. The ignore list is for false positives only.
+
+If a transitive bump (parent dep) would pull a new version of a
+protected dep through MVS, that still counts as bumping the
+protected dep. Detect it (`go list -m -json <module>` after the
+parent bump) and bring it back to the user.
+
+## CVEs with no known fix
+
+OSV-Scanner sometimes surfaces advisories that have no fixed
+version yet (or were withdrawn upstream). Do not:
+
+- Pin to a fork or a personal patch.
+- Add an `osv-scanner.toml` ignore entry just to clear the alert.
+- Invent a "mitigation" not stated in the advisory.
+
+Instead, collect these into a "no fix available" list during phase
+4 and surface them to the user verbatim in the report (phase 7):
+CVE / severity / module / pinned version / advisory URL. They are
+tracked, not patched.
+
 ## Trigger fit
 
 Strong fit when the user says any of:
@@ -90,18 +134,25 @@ even if there is only one finding.
 ### 1. Show the landscape (cross-branch summary)
 
 Before pulling raw alerts, run the table mode across all four
-supported branches so the user can see the shape of the problem:
+supported branches **for both targets** so the user sees source and
+image findings side by side:
 
 ```bash
+# Source-target landscape (the planning input for this skill)
 ./hack/osvtool --table \
     --branch main --branch v2.1.x --branch v2.2.x --branch v2.3.x \
     --target source --state open
+
+# Image-target landscape (will be revisited in phase 8)
+./hack/osvtool --table \
+    --branch main --branch v2.1.x --branch v2.2.x --branch v2.3.x \
+    --target image --state open
 ```
 
-This emits a compact markdown table — one row per branch, columns:
-`branch | C | H | M | L | max age | last scan | code-scanning`.
-Show it to the user as-is; it is already tight enough to read in one
-glance.
+Each call emits a compact markdown table — one row per branch,
+columns: `branch | C | H | M | L | max age | last scan |
+code-scanning`. Show both to the user as-is; together they fit in
+one screen and make image vs. source scope explicit.
 
 Use `--state open` (not `todo`) here so the medium/low counts are
 visible. The user is about to decide whether to include them; they
@@ -153,10 +204,11 @@ Where `<state>` is whatever the user picked in phase 2 (`todo` or
 
 Notes:
 
-- `--target source` filters out container-image findings — those are
-  fixed by Dockerfile or base-image changes, not Go dep bumps, so they
-  are out of scope for this skill. Mention any image findings to the
-  user in passing and move on.
+- `--target source` filters this pass to Go-mod findings only.
+  Image findings are addressed separately in phase 8 because their
+  actions are different (Dockerfile / base-image / apk changes) and
+  many of them resolve transitively once the source bumps land.
+  Do not try to plan them in the same table.
 - The output is YAML. Save it to a scratch path outside the repo so it
   is not accidentally committed. Use
   `/tmp/cve-bump/alerts-<branch>-<UTC-timestamp>.yaml` (mkdir -p first).
@@ -176,7 +228,9 @@ For each alert, extract:
 - Severity (`rule.security_severity_level`).
 - Affected Go module + current pinned version.
 - Fixed version (the lowest version that resolves the advisory).
+  May be **absent** — see the no-fix branch below.
 - Whether the module is direct or indirect in this repo's go.mod.
+- Whether the module is a [protected dependency](#protected-dependencies).
 
 Then pick an action per the decision tree below.
 
@@ -184,7 +238,11 @@ Then pick an action per the decision tree below.
 
 ```mermaid
 flowchart TD
-    A[Finding] --> B{Is the pinned version actually >= fix,<br/>once you account for pseudo-versions?}
+    A[Finding] --> N{Is there a fixed version<br/>in the advisory?}
+    N -- no --> NF[Report only:<br/>add to "no fix available" list]
+    N -- yes --> P{Is the module a protected dep<br/>envoy / k8s.io/* / istio.io/* / gateway-api?}
+    P -- yes --> PA[Needs approval:<br/>row in plan with action "needs approval protected dep"<br/>do not include in batch go get]
+    P -- no --> B{Is the pinned version actually >= fix,<br/>once you account for pseudo-versions?}
     B -- yes --> C[False positive → add to osv-scanner.toml]
     B -- no --> D{Is the module direct in go.mod?}
     D -- yes --> E[go get module@fixed-version]
@@ -212,8 +270,11 @@ intervention and Go's MVS will honor it.
 
 #### Output: the plan
 
-Present the plan as a single fenced table the user can scan in one
-look. Columns: `CVE | severity | module | from → to | action`. Example:
+Present the plan as up to three fenced tables so each bucket is
+visually distinct.
+
+**1. Actionable bumps** — what you intend to `go get` or ignore.
+Columns: `CVE | severity | module | from → to | action`.
 
 ```
 | CVE             | sev | module                | from           | to        | action                |
@@ -223,22 +284,57 @@ look. Columns: `CVE | severity | module | from → to | action`. Example:
 | CVE-2022-31045  | H   | istio.io/istio        | v0.0.0-2026... | (n/a)     | ignore: false pos     |
 ```
 
-Then ask the user to OK the batch or call out specific rows to change.
-Wait for approval before touching files.
+**2. Needs approval — protected deps** (omit the table if empty).
+Columns: `CVE | severity | module | from → to | reason`. The user
+must say yes per row before any of these move into the actionable
+batch.
+
+```
+| CVE             | sev | module                  | from     | to       | reason                  |
+| --------------- | --- | ----------------------- | -------- | -------- | ----------------------- |
+| CVE-2025-9999   | H   | k8s.io/apimachinery     | v0.31.2  | v0.31.5  | only fix is a k8s.io bump |
+```
+
+**3. No fix available** (omit the table if empty). Columns:
+`CVE | severity | module | pinned | advisory`. Read-only — no
+action proposed. These will be repeated verbatim in the final
+report.
+
+```
+| CVE             | sev | module                | pinned    | advisory                                        |
+| --------------- | --- | --------------------- | --------- | ----------------------------------------------- |
+| CVE-2025-7777   | M   | example.com/foo       | v1.4.0    | https://github.com/advisories/GHSA-xxxx-yyyy-zz |
+```
+
+Then ask the user to OK the actionable table, decide each
+protected-dep row, and acknowledge the no-fix list. Wait for
+explicit approval before touching files.
 
 ### 5. Execute
 
 After approval, in order:
 
-1. For each `go get` action: `go get <module>@<version>`.
-2. `go mod tidy` once at the end.
-3. For each ignore action: append a `[[IgnoredVulns]]` entry to
+1. **Protected-dep gate.** For any row whose action was `needs
+   approval (protected dep)`, only proceed if the user explicitly
+   said yes to that row. If unclear, ask again. Do not batch
+   protected deps into step 2 — `go get` them one at a time so the
+   user can stop the flow if a transitive surprise shows up.
+2. For each remaining `go get` action: `go get <module>@<version>`.
+3. `go mod tidy` once at the end.
+4. **Check for surprise protected-dep transitives.** After
+   `go mod tidy`, diff `go.mod` for any envoy / k8s.io / istio.io /
+   gateway-api lines that changed and were not in the approved
+   plan. If any did, stop, surface them to the user, and let them
+   decide (revert or approve).
+5. For each ignore action: append a `[[IgnoredVulns]]` entry to
    `osv-scanner.toml`. The `reason` must be specific — name the
    pseudo-version timestamp, the fix release date, and the gap. Do not
    write generic reasons like "false positive" or "not applicable".
-4. If `go.sum` changed, run `make generate-licenses` to refresh the
+   Never add an ignore entry for a no-fix CVE or a protected-dep
+   CVE just to clear noise.
+6. If `go.sum` changed, run `make generate-licenses` to refresh the
    license attribution files.
-5. Run `make fmt-changed` to keep the diff clean.
+7. Run `make fmt-changed` to keep the diff clean.
 
 Do not stage anything (`git add`) and do not commit. The user reviews
 the dirty tree themselves.
@@ -272,8 +368,59 @@ The user signed off on "build + scanner re-run only", so:
 
 ### 7. Report
 
-End with a brief summary listing each CVE, the action taken, and the
-file(s) touched. The user reads this against `git diff` to verify.
+End with the following sections, in order:
+
+1. **What changed.** One line per CVE that got an action: CVE,
+   module, from → to (or "ignore: <reason summary>"), and the
+   file(s) touched. The user reads this against `git diff`.
+2. **Deferred — protected dep.** Any protected-dep rows the user
+   said no to (or did not respond to). List CVE / module / proposed
+   version / why deferred so the next maintainer has the context.
+3. **No fix available.** Verbatim from the phase-4 table — CVE /
+   severity / module / pinned / advisory URL. Do not propose
+   workarounds. Do not add `osv-scanner.toml` entries for these.
+
+Then continue into phase 8.
+
+### 8. Image-target follow-up
+
+Image findings often resolve transitively once source bumps land
+(e.g. a Go binary baked into the image gets the fixed dep), but
+some do not — base-image CVEs and apk packages need Dockerfile or
+base-image changes.
+
+Refresh the image landscape against the planned branch:
+
+```bash
+./hack/osvtool --table \
+    --branch <branch> \
+    --target image --state open
+```
+
+Then prompt the user: "The source bumps are done. Image findings
+above remain on the published scan — most should clear once these
+bumps ship, but base-image / apk CVEs need a Dockerfile change.
+Want to plan that now, or defer?"
+
+Two important caveats to state plainly:
+
+- The `--table` view reflects the **last GitHub-uploaded scan**,
+  not the working tree. The source bumps you just made won't be
+  reflected in image scans until CI rebuilds and republishes
+  results.
+- A local image scan is possible via
+  `make osv-scan OSV_SCAN_IMAGES="<image-ref> ..."` (see
+  `osv-scan-latest-main-images` in the Makefile for the canonical
+  invocation against rolling-main images), but that scans
+  **already-built published images**, not the just-bumped working
+  tree. Mention this if the user asks why a "fixed" CVE still
+  appears locally.
+
+If the user says "defer", stop here. If they say "go", treat the
+image flow as a separate planning round — start a new plan with
+Dockerfile-level actions (do not extend the Go-mod plan with image
+actions, they live in different files and the decision tree above
+does not apply).
 
 ## Edge cases worth knowing
 
@@ -314,6 +461,16 @@ file(s) touched. The user reads this against `git diff` to verify.
 - Do **not** commit or stage. The user does that.
 - Do **not** edit go.mod by hand — always go through `go get` so
   go.sum stays consistent.
+- Do **not** bump a [protected dependency](#protected-dependencies)
+  without an explicit, in-conversation yes from the user — not in a
+  batch, not as a transitive pulled in by a parent bump. Surface it
+  for approval and wait.
+- Do **not** invent a workaround for a CVE with no upstream fix.
+  Do not pin to a fork, do not silence it via `osv-scanner.toml`.
+  List it in the no-fix bucket and move on.
+- Do **not** stop after the source bumps — phase 8 (image
+  follow-up) is part of the workflow. Prompt the user about
+  remaining image findings every time.
 - Do **not** add an `osv-scanner.toml` entry just to silence noise.
   The reason field has to defend the entry to a future reader.
 - Do **not** run `make generate-all` or other heavy codegen targets

--- a/.claude/skills/cve-bump/SKILL.md
+++ b/.claude/skills/cve-bump/SKILL.md
@@ -16,9 +16,9 @@ parts are easy to miss:
 
 - The scanner findings live in GitHub code-scanning, not the local tree.
   `hack/osvtool` is the canonical way to fetch them.
-- Findings are uploaded per-branch and only the supported branches
-  (`main`, `v2.1.x`, `v2.2.x`, `v2.3.x`) get scanned, so a topic branch has
-  to query its base branch.
+- Findings are uploaded per-branch and only the branches allowlisted in
+  the OSV scan workflow (`.github/workflows/osv-scanner.yaml`) get
+  scanned, so a topic branch has to query its base branch.
 - Some "vulnerabilities" are scanner false positives caused by
   pseudo-version comparison quirks (see the istio.io entries in
   `osv-scanner.toml`). These belong in the ignore list, not in go.mod
@@ -133,20 +133,19 @@ even if there is only one finding.
 
 ### 1. Show the landscape (cross-branch summary)
 
-Before pulling raw alerts, run the table mode across all four
-supported branches **for both targets** so the user sees source and
-image findings side by side:
+Before pulling raw alerts, run the table mode across all supported
+branches **for both targets** so the user sees source and image
+findings side by side. With no `--branch` flags, `osvtool` scans
+exactly the branches allowlisted in the OSV scan workflow
+(`.github/workflows/osv-scanner.yaml`), so this stays correct as LTS
+branches are cut or retired:
 
 ```bash
 # Source-target landscape (the planning input for this skill)
-./hack/osvtool --table \
-    --branch main --branch v2.1.x --branch v2.2.x --branch v2.3.x \
-    --target source --state open
+./hack/osvtool --table --target source --state open
 
 # Image-target landscape (will be revisited in phase 8)
-./hack/osvtool --table \
-    --branch main --branch v2.1.x --branch v2.2.x --branch v2.3.x \
-    --target image --state open
+./hack/osvtool --table --target image --state open
 ```
 
 Each call emits a compact markdown table — one row per branch,
@@ -173,7 +172,7 @@ Ask the user two short questions, back to back:
    critical/high since that matches how teams typically prioritize, but
    the landscape view from phase 1 shows the full severity breakdown so
    the user can make an informed call (e.g. if there are 30 mediums on
-   `v2.1.x` that they want to clear ahead of a release). Just ask in
+   `v2.2.x` that they want to clear ahead of a release). Just ask in
    one sentence — no menu.
 
 2. **Branch to plan against**: the raw pull is single-branch because
@@ -185,9 +184,11 @@ Ask the user two short questions, back to back:
    ```
 
    It prints one line — the supported branch the current HEAD is most
-   likely based on (most-recent merge-base across `main`, `v2.1.x`,
-   `v2.2.x`, `v2.3.x`), or `main` if it cannot decide. Confirm with
-   the user: "Planning against `<X>`. OK, or pick another?"
+   likely based on (most-recent merge-base across the branches the OSV
+   scan workflow allowlists, read from
+   `.github/workflows/osv-scanner.yaml`), or `main` if it cannot
+   decide. Confirm with the user: "Planning against `<X>`. OK, or pick
+   another?"
 
 If the landscape view in phase 1 showed zero alerts at the chosen
 severity for the chosen branch, stop here and tell the user — there is
@@ -435,7 +436,7 @@ does not apply).
 - **Multiple CVEs on one module**: combine into a single `go get` to
   the highest required version. List them as separate rows in the plan
   table but mark "(combined bump)" in the action column.
-- **Backport branches**: when scanning `v2.1.x` etc., the supported
+- **Backport branches**: when scanning `v2.2.x` etc., the supported
   upgrade window for a given module may be narrower (e.g. cannot move
   to a new major). Default to the smallest version that resolves the
   CVE within the same major.

--- a/.claude/skills/cve-bump/scripts/detect_base.sh
+++ b/.claude/skills/cve-bump/scripts/detect_base.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # Print the supported kgateway branch the current HEAD is most likely based on.
 #
-# Strategy: for each candidate (main, v2.1.x, v2.2.x, v2.3.x), find the
-# merge-base with HEAD and pick the one whose merge-base commit is most
-# recent. If HEAD is already on a candidate, print that. Falls back to
-# "main" if nothing can be resolved.
+# Candidates are the branches the OSV scanner actually uploads results for.
+# They are read from the scan workflow's allowlist
+# (.github/workflows/osv-scanner.yaml) rather than hardcoded, so this script
+# never drifts when an LTS branch is cut or retired — that file is already
+# the single source of truth the rest of this skill points at.
+#
+# Strategy: for each candidate, find the merge-base with HEAD and pick the one
+# whose merge-base commit is most recent. If HEAD is already on a candidate,
+# print that. Falls back to "main" if nothing can be resolved.
 #
 # Output: a single branch name on stdout. No diagnostics unless something
 # is genuinely wrong, in which case write to stderr and still exit 0 with
@@ -12,7 +17,29 @@
 
 set -euo pipefail
 
-candidates=(main v2.1.x v2.2.x v2.3.x)
+# Read the scan workflow's branch allowlist. The scheduled matrix is a
+# single-quoted JSON array, e.g. branches='["main","v2.2.x","v2.3.x"]'.
+candidates_from_workflow() {
+    local workflow="$1"
+    local line
+    [[ -f "$workflow" ]] || return 1
+    line="$(sed -nE "s/^[[:space:]]*branches='\[(.*)\]'.*/\1/p" "$workflow" | head -n1)"
+    [[ -n "$line" ]] || return 1
+    grep -oE '"[^"]+"' <<<"$line" | tr -d '"'
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+workflow="${repo_root:-.}/.github/workflows/osv-scanner.yaml"
+
+candidates=()
+while IFS= read -r c; do
+    [[ -n "$c" ]] && candidates+=("$c")
+done < <(candidates_from_workflow "$workflow" || true)
+
+if [[ "${#candidates[@]}" -eq 0 ]]; then
+    candidates=(main)
+    echo "warn: could not read OSV scan branch allowlist from ${workflow}; using 'main' only" >&2
+fi
 
 current="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 for c in "${candidates[@]}"; do

--- a/.claude/skills/cve-bump/scripts/detect_base.sh
+++ b/.claude/skills/cve-bump/scripts/detect_base.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Print the supported kgateway branch the current HEAD is most likely based on.
+#
+# Strategy: for each candidate (main, v2.1.x, v2.2.x, v2.3.x), find the
+# merge-base with HEAD and pick the one whose merge-base commit is most
+# recent. If HEAD is already on a candidate, print that. Falls back to
+# "main" if nothing can be resolved.
+#
+# Output: a single branch name on stdout. No diagnostics unless something
+# is genuinely wrong, in which case write to stderr and still exit 0 with
+# "main" as the default — callers should confirm with the user anyway.
+
+set -euo pipefail
+
+candidates=(main v2.1.x v2.2.x v2.3.x)
+
+current="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+for c in "${candidates[@]}"; do
+    if [[ "$current" == "$c" ]]; then
+        printf '%s\n' "$c"
+        exit 0
+    fi
+done
+
+best_branch=""
+best_ts=0
+for c in "${candidates[@]}"; do
+    # Prefer the local ref if present, otherwise the remote.
+    ref=""
+    if git rev-parse --verify --quiet "refs/heads/$c" >/dev/null; then
+        ref="refs/heads/$c"
+    elif git rev-parse --verify --quiet "refs/remotes/origin/$c" >/dev/null; then
+        ref="refs/remotes/origin/$c"
+    else
+        continue
+    fi
+
+    base="$(git merge-base "$ref" HEAD 2>/dev/null || true)"
+    if [[ -z "$base" ]]; then
+        continue
+    fi
+
+    ts="$(git -c log.showSignature=false show -s --format=%ct "$base" 2>/dev/null || echo 0)"
+    if (( ts > best_ts )); then
+        best_ts=$ts
+        best_branch=$c
+    fi
+done
+
+if [[ -n "$best_branch" ]]; then
+    printf '%s\n' "$best_branch"
+else
+    echo "main"
+    echo "warn: could not resolve any candidate branch locally; defaulting to main" >&2
+fi

--- a/.github/ISSUE_TEMPLATE/RELEASE-REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/RELEASE-REQUEST.md
@@ -28,7 +28,8 @@ PRs and/or issues that need to land before this release is cut. List the headlin
 
 - [ ] Create and push the `v<MAJOR>.<MINOR>.x` branch from `main` (see [`devel/contributing/releasing.md`](/devel/contributing/releasing.md))
 - [ ] Create a branch protection ruleset, or ask a maintainer to do so, for the `v<MAJOR>.<MINOR>.x` branch
-- [ ] Add the new release branch to [`.github/workflows/osv-scanner.yaml`](/.github/workflows/osv-scanner.yaml) (both the scheduled scan matrix and the `workflow_dispatch` branch options)
+- [ ] On `main`, bump `ROLLING_MAIN_VERSION` in the [`Makefile`](/Makefile) to the next minor's rolling tag via PR (e.g. after cutting `v2.3.x`, set it to `v2.4.0-main`), since `main` now tracks the next minor
+- [ ] Add the new release branch to [`.github/workflows/osv-scanner.yaml`](/.github/workflows/osv-scanner.yaml) (both the scheduled scan matrix and the `workflow_dispatch` branch options), and drop any branch that is no longer LTS. This list is the single source of truth for which branches get scanned; tooling such as `hack/osvtool` and the `cve-bump` skill reads it rather than hardcoding branches
 
 ## Publish the release
 

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -12,7 +12,6 @@ on:
         options:
           - all
           - main
-          - v2.1.x
           - v2.2.x
           - v2.3.x
 
@@ -43,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          branches='["main","v2.1.x","v2.2.x","v2.3.x"]'
+          branches='["main","v2.2.x","v2.3.x"]'
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             case "${{ inputs.branches }}" in
@@ -51,9 +50,6 @@ jobs:
                 ;;
               main)
                 branches='["main"]'
-                ;;
-              v2.1.x)
-                branches='["v2.1.x"]'
                 ;;
               v2.2.x)
                 branches='["v2.2.x"]'

--- a/devel/contributing/releasing.md
+++ b/devel/contributing/releasing.md
@@ -47,8 +47,11 @@ If the release branch **does not** exist, create one:
     git push ${REMOTE} v2.${MINOR}.x
     ```
 
-- Update the OSV security scan workflow branch allowlist in [.github/workflows/osv-scanner.yaml](../../.github/workflows/osv-scanner.yaml) to include the new release branch.
+- On `main`, bump `ROLLING_MAIN_VERSION` in the [Makefile](../../Makefile) to the next minor's rolling tag via a PR (for example, after cutting `v2.3.x`, set it to `v2.4.0-main`), since `main` now tracks the next minor.
+
+- Update the OSV security scan workflow branch allowlist in [.github/workflows/osv-scanner.yaml](../../.github/workflows/osv-scanner.yaml) to include the new release branch, and drop any branch that is no longer LTS.
   This workflow only scans an explicit set of branches, so each newly cut release branch must be added to both the scheduled scan matrix and the `workflow_dispatch` branch options.
+  This allowlist is the single source of truth for which branches get scanned: tooling such as [`hack/osvtool`](../../hack/osvtool) and the `cve-bump` skill reads it rather than hardcoding the branch list, so keeping it current is all that is needed.
 
 ### Patch Release
 

--- a/hack/osvtool
+++ b/hack/osvtool
@@ -318,7 +318,8 @@ emit_summary() {
     local tmpdir="$1"
     local repo="$2"
     local target="$3"
-    shift 3
+    local state="$4"
+    shift 4
     local branches=("$@")
     local branch
     local file
@@ -337,7 +338,7 @@ emit_summary() {
         file="${tmpdir}/branch_${i}.json"
         source_scan_file="${tmpdir}/branch_${i}.source.scans.json"
         image_scan_file="${tmpdir}/branch_${i}.image.scans.json"
-        url="https://github.com/${repo}/security/code-scanning?query=is%3Aopen+branch%3A${branch}"
+        url="https://github.com/${repo}/security/code-scanning?query=is%3A${state}+branch%3A${branch}"
         source_url="${url}+tool%3Aosv-scanner"
         image_url="${url}+tool%3Aosv-image-scanner"
         parts="${parts}$(
@@ -439,7 +440,8 @@ emit_table() {
     local tmpdir="$1"
     local repo="$2"
     local target="$3"
-    shift 3
+    local state="$4"
+    shift 4
     local branches=("$@")
     local branch
     local file
@@ -458,7 +460,7 @@ emit_table() {
         file="${tmpdir}/branch_${i}.json"
         source_scan_file="${tmpdir}/branch_${i}.source.scans.json"
         image_scan_file="${tmpdir}/branch_${i}.image.scans.json"
-        url="https://github.com/${repo}/security/code-scanning?query=is%3Aopen+branch%3A${branch}"
+        url="https://github.com/${repo}/security/code-scanning?query=is%3A${state}+branch%3A${branch}"
 
         jq -r \
             --arg branch "$branch" \
@@ -815,9 +817,9 @@ main() {
         fi
         emit_worst "$tmpdir" "$target" "${#image_platforms[@]}" "${image_platforms[@]}" "${branches[@]}" | yq -p=json -o=yaml
     elif [[ "$table" -eq 1 ]]; then
-        emit_table "$tmpdir" "$repo" "$target" "${branches[@]}"
+        emit_table "$tmpdir" "$repo" "$target" "$api_state" "${branches[@]}"
     else
-        emit_summary "$tmpdir" "$repo" "$target" "${branches[@]}" | yq -p=json -o=yaml
+        emit_summary "$tmpdir" "$repo" "$target" "$api_state" "${branches[@]}" | yq -p=json -o=yaml
     fi
 }
 

--- a/hack/osvtool
+++ b/hack/osvtool
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-Usage: osvtool [--branch <branch> ...] [--repo <owner/repo>] [--state <state>] [--target <target>] [--raw] [--worst]
+Usage: osvtool [--branch <branch> ...] [--repo <owner/repo>] [--state <state>] [--target <target>] [--raw] [--worst] [--table]
 
 Fetch OSV code-scanning alerts from GitHub.
 
@@ -33,6 +33,9 @@ Options:
                       found across the selected branches. Exits non-zero if the
                       latest OSV code scan on any selected branch is missing or
                       more than 72 hours old.
+  --table             Emit a compact markdown table (one row per branch) with
+                      severity counts, max alert age, last scan timestamp,
+                      and a link to the code-scanning UI.
   --workflow <path>   Workflow file used to discover default branches
                       (default: .github/workflows/osv-scanner.yaml)
   -h, --help          Show this help message
@@ -432,6 +435,61 @@ emit_summary() {
     printf '%s' "$parts" | jq -s 'add'
 }
 
+emit_table() {
+    local tmpdir="$1"
+    local repo="$2"
+    local target="$3"
+    shift 3
+    local branches=("$@")
+    local branch
+    local file
+    local source_scan_file
+    local image_scan_file
+    local url
+    local now
+
+    now="$(date +%s)"
+
+    printf '| branch | C | H | M | L | max age | last scan | code-scanning |\n'
+    printf '|---|---|---|---|---|---|---|---|\n'
+
+    for i in "${!branches[@]}"; do
+        branch="${branches[$i]}"
+        file="${tmpdir}/branch_${i}.json"
+        source_scan_file="${tmpdir}/branch_${i}.source.scans.json"
+        image_scan_file="${tmpdir}/branch_${i}.image.scans.json"
+        url="https://github.com/${repo}/security/code-scanning?query=is%3Aopen+branch%3A${branch}"
+
+        jq -r \
+            --arg branch "$branch" \
+            --arg target "$target" \
+            --arg url "$url" \
+            --argjson now "$now" \
+            --slurpfile sourceScans "$source_scan_file" \
+            --slurpfile imageScans "$image_scan_file" \
+            '
+            def sev: (.rule.security_severity_level // "unknown" | ascii_downcase);
+            def age_days($now): (($now - ((.created_at | fromdateiso8601)? // $now)) / 86400 | floor);
+            def count_sev($s): [.[] | select(sev == $s)] | length;
+            def max_age($now):
+                if length == 0 then "-"
+                else "\([.[] | age_days($now)] | max)d"
+                end;
+            def source_scans: ($sourceScans[0] // []);
+            def image_scans: ($imageScans[0] // []);
+            def selected_scans:
+                if $target == "source" then source_scans
+                elif $target == "image" then image_scans
+                else source_scans + image_scans
+                end;
+            def latest_scan($scans):
+                (($scans | max_by(.created_at)?) // null | .created_at? // "-");
+            "| \($branch) | \(count_sev("critical")) | \(count_sev("high")) | \(count_sev("medium")) | \(count_sev("low")) | \(max_age($now)) | \(latest_scan(selected_scans)) | [view](\($url)) |"
+            ' \
+            "$file"
+    done
+}
+
 scan_staleness() {
     local scan_file="$1"
     local branch="$2"
@@ -602,6 +660,7 @@ main() {
     local target="all"
     local raw=0
     local worst=0
+    local table=0
     local workflow_path=".github/workflows/osv-scanner.yaml"
     local filter='.'
     local target_filter_expr
@@ -663,6 +722,10 @@ main() {
                 worst=1
                 shift
                 ;;
+            --table)
+                table=1
+                shift
+                ;;
             --workflow)
                 if [[ $# -lt 2 || -z "${2:-}" ]]; then
                     echo "error: --workflow requires a value" >&2
@@ -679,8 +742,8 @@ main() {
         esac
     done
 
-    if [[ "$raw" -eq 1 && "$worst" -eq 1 ]]; then
-        echo "error: --raw and --worst cannot be used together" >&2
+    if (( raw + worst + table > 1 )); then
+        echo "error: --raw, --worst, and --table are mutually exclusive" >&2
         exit 2
     fi
 
@@ -751,6 +814,8 @@ main() {
             done < <(workflow_image_platforms "$workflow_path")
         fi
         emit_worst "$tmpdir" "$target" "${#image_platforms[@]}" "${image_platforms[@]}" "${branches[@]}" | yq -p=json -o=yaml
+    elif [[ "$table" -eq 1 ]]; then
+        emit_table "$tmpdir" "$repo" "$target" "${branches[@]}"
     else
         emit_summary "$tmpdir" "$repo" "$target" "${branches[@]}" | yq -p=json -o=yaml
     fi


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Coding agents can now leverage osv-scanner to bump dependencies to fix CVEs. Tested with Claude Code CLI `clear cves` and Codex CLI `$cve-bump`. Created using the Anthropic skill-creator skill and much iteration.

Also removes branch v2.1.x from OSV scans since it's not LTS after v2.3.0's release. (The old v2.1.x alerts will remain until closed.)

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
