### PR TITLE
cleanup: suppress noisy dump loggin on e2e test failure

### DIFF
--- a/pkg/utils/cmdutils/cmd.go
+++ b/pkg/utils/cmdutils/cmd.go
@@ -35,6 +35,12 @@ type Cmd interface {
 	// WithStderr sets the io.Reader used for stderr
 	WithStderr(io.Writer) Cmd
 
+	// WithQuiet suppresses the "+ <command>" trace line that is otherwise
+	// printed to stderr when running under the e2e build tag. Useful when a
+	// caller runs many commands and does not want to flood test output (for
+	// example, the test failure dump tool).
+	WithQuiet() Cmd
+
 	PrettyCommand() string
 }
 

--- a/pkg/utils/cmdutils/cmd.go
+++ b/pkg/utils/cmdutils/cmd.go
@@ -35,13 +35,25 @@ type Cmd interface {
 	// WithStderr sets the io.Reader used for stderr
 	WithStderr(io.Writer) Cmd
 
-	// WithQuiet suppresses the "+ <command>" trace line that is otherwise
-	// printed to stderr when running under the e2e build tag. Useful when a
-	// caller runs many commands and does not want to flood test output (for
-	// example, the test failure dump tool).
-	WithQuiet() Cmd
-
 	PrettyCommand() string
+}
+
+// QuietableCmd is an optional extension implemented by Cmd values that can
+// suppress the "+ <command>" trace line that is otherwise printed to stderr
+// when running under the e2e build tag.
+type QuietableCmd interface {
+	WithQuiet() Cmd
+}
+
+// WithQuiet suppresses command trace output for Cmd implementations that
+// support it. For Cmd values that do not implement QuietableCmd, it returns
+// the original command unchanged.
+func WithQuiet(cmd Cmd) Cmd {
+	if quietable, ok := cmd.(QuietableCmd); ok {
+		return quietable.WithQuiet()
+	}
+
+	return cmd
 }
 
 // Cmder abstracts over creating commands

--- a/pkg/utils/cmdutils/cmd.go
+++ b/pkg/utils/cmdutils/cmd.go
@@ -35,25 +35,11 @@ type Cmd interface {
 	// WithStderr sets the io.Reader used for stderr
 	WithStderr(io.Writer) Cmd
 
-	PrettyCommand() string
-}
-
-// QuietableCmd is an optional extension implemented by Cmd values that can
-// suppress the "+ <command>" trace line that is otherwise printed to stderr
-// when running under the e2e build tag.
-type QuietableCmd interface {
+	// WithQuiet suppresses the "+ <command>" trace line that is otherwise
+	// printed to stderr when running under the e2e build tag.
 	WithQuiet() Cmd
-}
 
-// WithQuiet suppresses command trace output for Cmd implementations that
-// support it. For Cmd values that do not implement QuietableCmd, it returns
-// the original command unchanged.
-func WithQuiet(cmd Cmd) Cmd {
-	if quietable, ok := cmd.(QuietableCmd); ok {
-		return quietable.WithQuiet()
-	}
-
-	return cmd
+	PrettyCommand() string
 }
 
 // Cmder abstracts over creating commands

--- a/pkg/utils/cmdutils/local.go
+++ b/pkg/utils/cmdutils/local.go
@@ -44,6 +44,7 @@ func (c *LocalCmder) Command(ctx context.Context, name string, arg ...string) Cm
 type LocalCmd struct {
 	*exec.Cmd
 	combinedOutput *threadsafe.Buffer
+	quiet          bool
 }
 
 // WithEnv sets env
@@ -78,13 +79,19 @@ func (cmd *LocalCmd) WithStderr(w io.Writer) Cmd {
 	return cmd
 }
 
+// WithQuiet suppresses the "+ <command>" trace line
+func (cmd *LocalCmd) WithQuiet() Cmd {
+	cmd.quiet = true
+	return cmd
+}
+
 // Run runs the command
 // If the returned error is non-nil, it should be of type *RunError
 func (cmd *LocalCmd) Run() *RunError {
 	// Combined output is used to capture the stdout and stderr of the command for logging
 	var combinedOutput threadsafe.Buffer
 
-	if printCommands {
+	if printCommands && !cmd.quiet {
 		// Print to stderr to avoid interfering with stdout intended for parsing
 		fmt.Fprintf(os.Stderr, "+ %s\n", PrettyCommand(false, cmd.Args[0], cmd.Args[1:]...))
 	}
@@ -106,7 +113,7 @@ func (cmd *LocalCmd) Run() *RunError {
 // Start starts the command but doesn't block
 // If the returned error is non-nil, it should be of type *RunError
 func (cmd *LocalCmd) Start() *RunError {
-	if printCommands {
+	if printCommands && !cmd.quiet {
 		// Print to stderr to avoid interfering with stdout intended for parsing
 		fmt.Fprintf(os.Stderr, "+ %s\n", PrettyCommand(false, cmd.Args[0], cmd.Args[1:]...))
 	}

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -92,7 +92,7 @@ func (c *Cli) Command(ctx context.Context, args ...string) cmdutils.Cmd {
 		WithStdout(c.receiver).
 		WithStderr(c.receiver)
 	if c.quiet {
-		cmd = cmd.WithQuiet()
+		cmd = cmdutils.WithQuiet(cmd)
 	}
 	return cmd
 }

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -449,7 +449,7 @@ func (c *Cli) GetPodsInNsWithLabel(ctx context.Context, namespace string, label 
 	getPodNamesCmd := c.Command(ctx, "get", "pod", "-n", namespace,
 		"--selector", label, "--output", "jsonpath='{.items[*].metadata.name}'")
 	err := getPodNamesCmd.WithStdout(podStdOut).WithStderr(podStdErr).Run().Cause()
-	if err != nil && !c.quiet {
+	if err != nil {
 		fmt.Printf("error running get pod names command: %v\n", err)
 	}
 

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -27,6 +27,10 @@ type Cli struct {
 	// kubeContext is the optional value of the context for a given kubernetes cluster
 	// If it is not supplied, no context will be included in the command
 	kubeContext string
+
+	// quiet suppresses the "+ <command>" trace line and the Cli's own status
+	// logging. Commands produced by a quiet Cli are run with WithQuiet().
+	quiet bool
 }
 
 // PodExecOptions describes the options used to execute a command in a pod
@@ -66,6 +70,15 @@ func (c *Cli) WithKubeContext(kubeContext string) *Cli {
 	return c
 }
 
+// WithQuiet returns a copy of the Cli that suppresses the "+ <command>" trace
+// line and the Cli's own status logging. It returns a copy rather than mutating
+// in place so callers can quiet a shared Cli without affecting other users of it.
+func (c *Cli) WithQuiet() *Cli {
+	clone := *c
+	clone.quiet = true
+	return &clone
+}
+
 // Command returns a Cmd that executes kubectl command, including the --context if it is defined
 // The Cmd sets the Stdout and Stderr to the receiver of the Cli
 func (c *Cli) Command(ctx context.Context, args ...string) cmdutils.Cmd {
@@ -73,11 +86,15 @@ func (c *Cli) Command(ctx context.Context, args ...string) cmdutils.Cmd {
 		args = append([]string{"--context", c.kubeContext}, args...)
 	}
 
-	return cmdutils.Command(ctx, "kubectl", args...).
+	cmd := cmdutils.Command(ctx, "kubectl", args...).
 		// For convenience, we set the stdout and stderr to the receiver
 		// This can still be overwritten by consumers who use the commands
 		WithStdout(c.receiver).
 		WithStderr(c.receiver)
+	if c.quiet {
+		cmd = cmd.WithQuiet()
+	}
+	return cmd
 }
 
 // RunCommand creates a Cmd and then runs it
@@ -280,11 +297,15 @@ func (c *Cli) DeploymentRolloutStatus(ctx context.Context, deployment string, ex
 // If an error was encountered while starting the PortForwarder, it is returned as well
 // NOTE: It is the callers responsibility to close this port-forward
 func (c *Cli) StartPortForward(ctx context.Context, options ...portforward.Option) (portforward.PortForwarder, error) {
-	options = append([]portforward.Option{
+	defaults := []portforward.Option{
 		// We define some default values, which users can then override
 		portforward.WithWriters(c.receiver, c.receiver),
 		portforward.WithKubeContext(c.kubeContext),
-	}, options...)
+	}
+	if c.quiet {
+		defaults = append(defaults, portforward.WithQuiet())
+	}
+	options = append(defaults, options...)
 
 	portForwarder := portforward.NewCliPortForwarder(options...)
 	err := portForwarder.Start(
@@ -428,14 +449,16 @@ func (c *Cli) GetPodsInNsWithLabel(ctx context.Context, namespace string, label 
 	getPodNamesCmd := c.Command(ctx, "get", "pod", "-n", namespace,
 		"--selector", label, "--output", "jsonpath='{.items[*].metadata.name}'")
 	err := getPodNamesCmd.WithStdout(podStdOut).WithStderr(podStdErr).Run().Cause()
-	if err != nil {
+	if err != nil && !c.quiet {
 		fmt.Printf("error running get pod names command: %v\n", err)
 	}
 
 	// Clean up and check the output
 	podNamesString := strings.Trim(podStdOut.String(), "'")
 	if podNamesString == "" {
-		fmt.Printf("no %s pods found in namespace %s\n", label, namespace)
+		if !c.quiet {
+			fmt.Printf("no %s pods found in namespace %s\n", label, namespace)
+		}
 		return []string{}, nil
 	}
 

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -92,7 +92,7 @@ func (c *Cli) Command(ctx context.Context, args ...string) cmdutils.Cmd {
 		WithStdout(c.receiver).
 		WithStderr(c.receiver)
 	if c.quiet {
-		cmd = cmdutils.WithQuiet(cmd)
+		cmd = cmd.WithQuiet()
 	}
 	return cmd
 }

--- a/pkg/utils/kubeutils/portforward/cli_portforwarder.go
+++ b/pkg/utils/kubeutils/portforward/cli_portforwarder.go
@@ -68,7 +68,7 @@ func (c *cliPortForwarder) startOnce(ctx context.Context) error {
 	)
 
 	// Print command being executed when enabled
-	if printPortForwardCommands {
+	if printPortForwardCommands && !c.properties.quiet {
 		args := []string{
 			"port-forward",
 			"-n",

--- a/pkg/utils/kubeutils/portforward/options.go
+++ b/pkg/utils/kubeutils/portforward/options.go
@@ -20,6 +20,7 @@ type properties struct {
 	localAddress      string
 	stdout            io.Writer
 	stderr            io.Writer
+	quiet             bool
 }
 
 func WithKindCluster(kindClusterName string) Option {
@@ -88,6 +89,14 @@ func WithWriters(out, err io.Writer) Option {
 	return func(config *properties) {
 		config.stdout = out
 		config.stderr = err
+	}
+}
+
+// WithQuiet suppresses the "+ kubectl port-forward ..." trace line that is
+// otherwise printed to stderr when running under the e2e build tag.
+func WithQuiet() Option {
+	return func(config *properties) {
+		config.quiet = true
 	}
 }
 

--- a/test/e2e/features/basicrouting/suite.go
+++ b/test/e2e/features/basicrouting/suite.go
@@ -88,6 +88,9 @@ func (s *testingSuite) SetupSuite() {
 }
 
 func (s *testingSuite) TestGatewayWithRoute() {
+	// XXX TEMPORARY: deliberate failure to exercise the on-failure dump path in CI
+	// so we can verify the dump-logging cleanup. REVERT BEFORE MERGING.
+	s.T().Fatal("deliberate failure to trigger dump-on-fail (remove me)")
 	s.assertSuccessfulResponse()
 }
 

--- a/test/e2e/features/basicrouting/suite.go
+++ b/test/e2e/features/basicrouting/suite.go
@@ -88,9 +88,6 @@ func (s *testingSuite) SetupSuite() {
 }
 
 func (s *testingSuite) TestGatewayWithRoute() {
-	// XXX TEMPORARY: deliberate failure to exercise the on-failure dump path in CI
-	// so we can verify the dump-logging cleanup. REVERT BEFORE MERGING.
-	s.T().Fatal("deliberate failure to trigger dump-on-fail (remove me)")
 	s.assertSuccessfulResponse()
 }
 

--- a/test/envoyutils/admincli/client.go
+++ b/test/envoyutils/admincli/client.go
@@ -71,13 +71,15 @@ func NewClient() *Client {
 //
 // Designed to be used by tests and CLI from outside of a cluster where `kubectl` is present.
 // In all other cases, `NewClient` is preferred
-func NewPortForwardedClient(ctx context.Context, proxySelector, namespace string) (*Client, func(), error) {
+func NewPortForwardedClient(ctx context.Context, proxySelector, namespace string, pfOpts ...portforward.Option) (*Client, func(), error) {
 	selector := portforward.WithResourceSelector(proxySelector, namespace)
 
 	// 1. Open a port-forward to the Kubernetes Deployment, so that we can query the Envoy Admin API directly
-	portForwarder, err := kubectl.NewCli().StartPortForward(ctx,
+	pfArgs := append([]portforward.Option{
 		selector,
-		portforward.WithRemotePort(int(wellknown.EnvoyAdminPort)))
+		portforward.WithRemotePort(int(wellknown.EnvoyAdminPort)),
+	}, pfOpts...)
+	portForwarder, err := kubectl.NewCli().StartPortForward(ctx, pfArgs...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmdutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils/kubectl"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils/portforward"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
@@ -363,13 +364,13 @@ func ControllerDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog i
 				)
 
 			krtSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.krt_snapshot.log", podName)))
-			err = adminClient.KrtSnapshotCmd(ctx).WithQuiet().WithStdout(krtSnapshotFile).Run().Cause()
+			err = cmdutils.WithQuiet(adminClient.KrtSnapshotCmd(ctx)).WithStdout(krtSnapshotFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running krt snapshot command: %v\n", err)
 			}
 
 			xdsSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.xds_snapshot.log", podName)))
-			err = adminClient.XdsSnapshotCmd(ctx).WithQuiet().WithStdout(xdsSnapshotFile).Run().Cause()
+			err = cmdutils.WithQuiet(adminClient.XdsSnapshotCmd(ctx)).WithStdout(xdsSnapshotFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running xds snapshot command: %v\n", err)
 			}
@@ -413,25 +414,25 @@ func EnvoyDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, _ io.Writer, 
 			defer shutdown()
 
 			configDumpFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.config.log", proxy)))
-			err = adminCli.ConfigDumpCmd(ctx, nil).WithQuiet().WithStdout(configDumpFile).Run().Cause()
+			err = cmdutils.WithQuiet(adminCli.ConfigDumpCmd(ctx, nil)).WithStdout(configDumpFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running config dump command: %v\n", err)
 			}
 
 			statsFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.stats.log", proxy)))
-			err = adminCli.StatsCmd(ctx, nil).WithQuiet().WithStdout(statsFile).Run().Cause()
+			err = cmdutils.WithQuiet(adminCli.StatsCmd(ctx, nil)).WithStdout(statsFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running stats command: %v\n", err)
 			}
 
 			clustersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.clusters.log", proxy)))
-			err = adminCli.ClustersCmd(ctx).WithQuiet().WithStdout(clustersFile).Run().Cause()
+			err = cmdutils.WithQuiet(adminCli.ClustersCmd(ctx)).WithStdout(clustersFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running clusters command: %v\n", err)
 			}
 
 			listenersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.listeners.log", proxy)))
-			err = adminCli.ListenersCmd(ctx).WithQuiet().WithStdout(listenersFile).Run().Cause()
+			err = cmdutils.WithQuiet(adminCli.ListenersCmd(ctx)).WithStdout(listenersFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running listeners command: %v\n", err)
 			}

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
-
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils/kubectl"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils/portforward"
@@ -39,9 +37,15 @@ func StandardKgatewayDumpOnFail(outLog io.Writer, kubectlCli *kubectl.Cli, outDi
 	// only wipe at the start of the dump
 	wipeOutDir(outDir)
 
-	KubeDumpOnFail(ctx, kubectlCli, outLog, outDir, namespaces)
-	ControllerDumpOnFail(ctx, kubectlCli, outLog, outDir, namespaces)
-	EnvoyDumpOnFail(ctx, kubectlCli, outLog, outDir, namespaces)
+	// Run all dump commands quietly so the cluster-state collection doesn't
+	// flood the test output with hundreds of "+ kubectl ..." trace lines.
+	// The collected state is still written to files under outDir and uploaded
+	// as a CI artifact for anyone who needs to debug further.
+	quietCli := kubectlCli.WithQuiet()
+
+	KubeDumpOnFail(ctx, quietCli, outLog, outDir, namespaces)
+	ControllerDumpOnFail(ctx, quietCli, outLog, outDir, namespaces)
+	EnvoyDumpOnFail(ctx, quietCli, outLog, outDir, namespaces)
 
 	fmt.Printf("Test failed. Logs and cluster state are available in %s\n", outDir)
 }
@@ -64,8 +68,6 @@ func KubeDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog io.Writ
 	recordKubeState(ctx, kubectlCli, fileAtPath(filepath.Join(outDir, "kube-state.log")))
 
 	recordKubeDump(outDir, namespaces...)
-
-	fmt.Printf("Finished dumping kubernetes state\n")
 }
 
 func recordDockerState(f *os.File) {
@@ -163,12 +165,12 @@ func recordKubeDump(outDir string, namespaces ...string) {
 	for _, ns := range namespaces {
 		// ...a pod logs subdirectoy
 		if err := recordPods(filepath.Join(outDir, ns, "_pods"), ns); err != nil {
-			fmt.Printf("error recording pod logs: %f, \n", err)
+			fmt.Printf("error recording pod logs: %v\n", err)
 		}
 
 		// ...and a subdirectory for each kgateway CRD with non-zero resources
 		if err := recordCRs(filepath.Join(outDir, ns), ns); err != nil {
-			fmt.Printf("error recording pod logs: %f, \n", err)
+			fmt.Printf("error recording CRs: %v\n", err)
 		}
 	}
 }
@@ -277,7 +279,10 @@ func kubeGet(namespace string, kubeType string, name string) (string, string, er
 }
 
 func kubeExecute(args []string) (string, string, error) {
-	cli := kubectl.NewCli().WithReceiver(ginkgo.GinkgoWriter)
+	// Quiet so the dump doesn't emit "+ kubectl ..." trace lines. The default
+	// receiver (io.Discard) also drops kubectl's own stderr (e.g. the noisy
+	// "No resources found in X namespace." messages) since we only consume stdout.
+	cli := kubectl.NewCli().WithQuiet()
 
 	var outLocation threadsafe.Buffer
 	runError := cli.Command(context.Background(), args...).WithStdout(&outLocation).Run()
@@ -321,16 +326,13 @@ func ControllerDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog i
 	for _, ns := range namespaces {
 		controllerPodNames, err := kubectlCli.GetPodsInNsWithLabel(ctx, ns, "kgateway=kgateway")
 		if err != nil {
-			fmt.Printf("error fetching controller pod names: %f\n", err)
+			fmt.Printf("error fetching controller pod names: %v\n", err)
 			continue
 		}
 
 		if len(controllerPodNames) == 0 {
-			fmt.Printf("no kgateway=kgateway pods found in namespace %s\n", ns)
 			continue
 		}
-
-		fmt.Printf("found controller pods: %s\n", strings.Join(controllerPodNames, ", "))
 
 		namespaceOutDir := filepath.Join(outDir, ns)
 		setupOutDir(namespaceOutDir)
@@ -345,7 +347,7 @@ func ControllerDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog i
 				portforward.WithPorts(int(wellknown.KgatewayAdminPort), int(wellknown.KgatewayAdminPort)),
 			)
 			if err != nil {
-				fmt.Printf("error starting port forward to controller admin port: %f\n", err)
+				fmt.Printf("error starting port forward to controller admin port: %v\n", err)
 			}
 
 			defer func() {
@@ -361,18 +363,16 @@ func ControllerDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog i
 				)
 
 			krtSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.krt_snapshot.log", podName)))
-			err = adminClient.KrtSnapshotCmd(ctx).WithStdout(krtSnapshotFile).Run().Cause()
+			err = adminClient.KrtSnapshotCmd(ctx).WithQuiet().WithStdout(krtSnapshotFile).Run().Cause()
 			if err != nil {
-				fmt.Printf("error running krt snapshot command: %f\n", err)
+				fmt.Printf("error running krt snapshot command: %v\n", err)
 			}
 
 			xdsSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.xds_snapshot.log", podName)))
-			err = adminClient.XdsSnapshotCmd(ctx).WithStdout(xdsSnapshotFile).Run().Cause()
+			err = adminClient.XdsSnapshotCmd(ctx).WithQuiet().WithStdout(xdsSnapshotFile).Run().Cause()
 			if err != nil {
-				fmt.Printf("error running xds snapshot command: %f\n", err)
+				fmt.Printf("error running xds snapshot command: %v\n", err)
 			}
-
-			fmt.Printf("finished dumping controller state\n")
 		}
 	}
 }
@@ -390,56 +390,51 @@ func EnvoyDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, _ io.Writer, 
 
 		kubeGatewayProxies, err := kubectlCli.GetPodsInNsWithLabel(ctx, ns, "kgateway=kube-gateway")
 		if err != nil {
-			fmt.Printf("error fetching kube-gateway proxies: %f\n", err)
+			fmt.Printf("error fetching kube-gateway proxies: %v\n", err)
 		} else {
 			proxies = append(proxies, kubeGatewayProxies...)
 		}
 
 		if len(proxies) == 0 {
-			fmt.Printf("no proxies found in namespace %s\n", ns)
 			continue
 		}
-
-		fmt.Printf("found proxies: %s\n", strings.Join(proxies, ", "))
 
 		envoyOutDir := filepath.Join(outDir, ns)
 		setupOutDir(envoyOutDir)
 
 		for _, proxy := range proxies {
 			adminCli, shutdown, err := admincli.NewPortForwardedClient(ctx,
-				fmt.Sprintf("pod/%s", proxy), ns)
+				fmt.Sprintf("pod/%s", proxy), ns, portforward.WithQuiet())
 			if err != nil {
-				fmt.Printf("error creating admin cli: %f\n", err)
+				fmt.Printf("error creating admin cli: %v\n", err)
 				continue
 			}
 
 			defer shutdown()
 
 			configDumpFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.config.log", proxy)))
-			err = adminCli.ConfigDumpCmd(ctx, nil).WithStdout(configDumpFile).Run().Cause()
+			err = adminCli.ConfigDumpCmd(ctx, nil).WithQuiet().WithStdout(configDumpFile).Run().Cause()
 			if err != nil {
-				fmt.Printf("error running config dump command: %f\n", err)
+				fmt.Printf("error running config dump command: %v\n", err)
 			}
 
 			statsFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.stats.log", proxy)))
-			err = adminCli.StatsCmd(ctx, nil).WithStdout(statsFile).Run().Cause()
+			err = adminCli.StatsCmd(ctx, nil).WithQuiet().WithStdout(statsFile).Run().Cause()
 			if err != nil {
-				fmt.Printf("error running stats command: %f\n", err)
+				fmt.Printf("error running stats command: %v\n", err)
 			}
 
 			clustersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.clusters.log", proxy)))
-			err = adminCli.ClustersCmd(ctx).WithStdout(clustersFile).Run().Cause()
+			err = adminCli.ClustersCmd(ctx).WithQuiet().WithStdout(clustersFile).Run().Cause()
 			if err != nil {
-				fmt.Printf("error running clusters command: %f\n", err)
+				fmt.Printf("error running clusters command: %v\n", err)
 			}
 
 			listenersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.listeners.log", proxy)))
-			err = adminCli.ListenersCmd(ctx).WithStdout(listenersFile).Run().Cause()
+			err = adminCli.ListenersCmd(ctx).WithQuiet().WithStdout(listenersFile).Run().Cause()
 			if err != nil {
-				fmt.Printf("error running listeners command: %f\n", err)
+				fmt.Printf("error running listeners command: %v\n", err)
 			}
-
-			fmt.Printf("finished dumping envoy state\n")
 		}
 	}
 }
@@ -447,7 +442,7 @@ func EnvoyDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, _ io.Writer, 
 func wipeOutDir(outDir string) {
 	err := os.RemoveAll(outDir)
 	if err != nil {
-		fmt.Printf("error wiping out directory: %f\n", err)
+		fmt.Printf("error wiping out directory: %v\n", err)
 	}
 }
 
@@ -455,7 +450,7 @@ func wipeOutDir(outDir string) {
 func setupOutDir(outdir string) {
 	err := os.MkdirAll(outdir, os.ModePerm)
 	if err != nil {
-		fmt.Printf("error creating log directory: %f\n", err)
+		fmt.Printf("error creating log directory: %v\n", err)
 	}
 }
 
@@ -463,7 +458,7 @@ func setupOutDir(outdir string) {
 func fileAtPath(path string) *os.File {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
-		fmt.Printf("unable to openfile: %f\n", err)
+		fmt.Printf("unable to openfile: %v\n", err)
 	}
 	return f
 }
@@ -487,6 +482,6 @@ func writeMetricsLog(ctx context.Context, outDir string, ns string, podName stri
 		"curl", "http://localhost:9091/metrics")
 	err := metricsCmd.WithStdout(metricsFile).WithStderr(metricsFile).Run().Cause()
 	if err != nil {
-		fmt.Printf("error running metrics command: %f\n", err)
+		fmt.Printf("error running metrics command: %v\n", err)
 	}
 }

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -29,7 +29,7 @@ func StandardKgatewayDumpOnFail(outLog io.Writer, kubectlCli *kubectl.Cli, outDi
 	if os.Getenv(testutils.SkipDump) == "true" {
 		return
 	}
-	fmt.Printf("Test failed. Dumping state from %s...\n", strings.Join(namespaces, ", "))
+	fmt.Printf("Starting cluster state dump for namespaces: %s...\n", strings.Join(namespaces, ", "))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -47,7 +47,7 @@ func StandardKgatewayDumpOnFail(outLog io.Writer, kubectlCli *kubectl.Cli, outDi
 	ControllerDumpOnFail(ctx, quietCli, outLog, outDir, namespaces)
 	EnvoyDumpOnFail(ctx, quietCli, outLog, outDir, namespaces)
 
-	fmt.Printf("Test failed. Logs and cluster state are available in %s\n", outDir)
+	fmt.Printf("Finished cluster state dump; logs and artifacts are available in %s\n", outDir)
 }
 
 // KubeDumpOnFail creates a small dump of the kubernetes state when a test fails.

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmdutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils/kubectl"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils/portforward"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
@@ -364,13 +363,13 @@ func ControllerDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog i
 				)
 
 			krtSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.krt_snapshot.log", podName)))
-			err = cmdutils.WithQuiet(adminClient.KrtSnapshotCmd(ctx)).WithStdout(krtSnapshotFile).Run().Cause()
+			err = adminClient.KrtSnapshotCmd(ctx).WithQuiet().WithStdout(krtSnapshotFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running krt snapshot command: %v\n", err)
 			}
 
 			xdsSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.xds_snapshot.log", podName)))
-			err = cmdutils.WithQuiet(adminClient.XdsSnapshotCmd(ctx)).WithStdout(xdsSnapshotFile).Run().Cause()
+			err = adminClient.XdsSnapshotCmd(ctx).WithQuiet().WithStdout(xdsSnapshotFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running xds snapshot command: %v\n", err)
 			}
@@ -414,25 +413,25 @@ func EnvoyDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, _ io.Writer, 
 			defer shutdown()
 
 			configDumpFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.config.log", proxy)))
-			err = cmdutils.WithQuiet(adminCli.ConfigDumpCmd(ctx, nil)).WithStdout(configDumpFile).Run().Cause()
+			err = adminCli.ConfigDumpCmd(ctx, nil).WithQuiet().WithStdout(configDumpFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running config dump command: %v\n", err)
 			}
 
 			statsFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.stats.log", proxy)))
-			err = cmdutils.WithQuiet(adminCli.StatsCmd(ctx, nil)).WithStdout(statsFile).Run().Cause()
+			err = adminCli.StatsCmd(ctx, nil).WithQuiet().WithStdout(statsFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running stats command: %v\n", err)
 			}
 
 			clustersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.clusters.log", proxy)))
-			err = cmdutils.WithQuiet(adminCli.ClustersCmd(ctx)).WithStdout(clustersFile).Run().Cause()
+			err = adminCli.ClustersCmd(ctx).WithQuiet().WithStdout(clustersFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running clusters command: %v\n", err)
 			}
 
 			listenersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.listeners.log", proxy)))
-			err = cmdutils.WithQuiet(adminCli.ListenersCmd(ctx)).WithStdout(listenersFile).Run().Cause()
+			err = adminCli.ListenersCmd(ctx).WithQuiet().WithStdout(listenersFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running listeners command: %v\n", err)
 			}


### PR DESCRIPTION
# Description

When an e2e test fails, kgateway dumps the cluster state (pod logs, CRs, Envoy/controller config) into files that get uploaded as a CI artifact for debugging. The problem is the dump also prints 2000+ lines of noise to the terminal mostly **+ kubectl ...** traces and **No resources found messages** . 

which buries the actual test failure and makes it slow to figure out what broke.

This PR silences that terminal noise. The dump still collects everything and uploads the same artifact, so anyone who needs to dig deeper can download it. Only the redundant terminal output is gone.

Fixes #14052

[fail](https://github.com/devc007/kgateway/actions/runs/26207815914/job/77111416767?pr=6)
Original [PR](https://github.com/devc007/kgateway/pull/6)

# Change Type
```
/kind cleanup
```

# Changelog
```release-note
NONE
```

# Additional Notes
```
Verified on CI by forcing a test failure: the failed job's log no longer shows the noise, and the uploaded bug-report artifact still contains all the same files.
```
