### PR TITLE
test: Backport skip-on-old-Istio logic

### DIFF
--- a/test/e2e/tests/automtls_istio_test.go
+++ b/test/e2e/tests/automtls_istio_test.go
@@ -11,7 +11,12 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
 	. "github.com/kgateway-dev/kgateway/v2/test/e2e/tests"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/install"
+	testruntime "github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/runtime"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
+)
+
+const (
+	minAutomtlsIstioVersion = "1.24.2"
 )
 
 // TestKgatewayIstioAutoMtls is the function which executes a series of tests against a given installation
@@ -19,8 +24,13 @@ func TestKgatewayIstioAutoMtls(t *testing.T) {
 	ctx := context.Background()
 
 	// Set Istio version if not already set
-	if os.Getenv("ISTIO_VERSION") == "" {
-		os.Setenv("ISTIO_VERSION", "1.25.1") // Using default istio version
+	if os.Getenv(testruntime.IstioVersionEnv) == "" {
+		os.Setenv(testruntime.IstioVersionEnv, testruntime.DefaultIstioVersion) // Using default istio version
+	}
+
+	if testruntime.ShouldSkipIstioVersion(t, minAutomtlsIstioVersion) {
+		t.Skip("Skipping due to https://github.com/istio/istio/issues/53846 which is fixed in Istio >= 1.24.2")
+		return
 	}
 
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "automtls-istio-test")

--- a/test/e2e/tests/waypoint_test.go
+++ b/test/e2e/tests/waypoint_test.go
@@ -11,15 +11,25 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
 	. "github.com/kgateway-dev/kgateway/v2/test/e2e/tests"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/install"
+	testruntime "github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/runtime"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
+)
+
+const (
+	minWaypointIstioVersion = "1.25.1"
 )
 
 func TestKgatewayWaypoint(t *testing.T) {
 	ctx := context.Background()
 
 	// Set Istio version if not already set
-	if os.Getenv("ISTIO_VERSION") == "" {
-		os.Setenv("ISTIO_VERSION", "1.25.1") // Using minimum required version that supports multiple TargetRef types for Istio Authz policies.
+	if os.Getenv(testruntime.IstioVersionEnv) == "" {
+		os.Setenv(testruntime.IstioVersionEnv, testruntime.DefaultIstioVersion) // Using minimum required version that supports multiple TargetRef types for Istio Authz policies.
+	}
+
+	if testruntime.ShouldSkipIstioVersion(t, minWaypointIstioVersion) {
+		t.Skip("Skipping waypoint tests due to istio version requirements")
+		return
 	}
 
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "kgateway-waypoint-test")

--- a/test/e2e/testutils/runtime/env.go
+++ b/test/e2e/testutils/runtime/env.go
@@ -2,6 +2,30 @@
 
 package runtime
 
-const (
-	IstioVersionEnv = "ISTIO_VERSION"
+import (
+	"os"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
 )
+
+const (
+	IstioVersionEnv     = "ISTIO_VERSION"
+	DefaultIstioVersion = "1.25.1"
+)
+
+// ShouldSkipIstioVersion reports whether the current Istio version (from ISTIO_VERSION env)
+// is older than minVersion. Use this to skip tests that require a minimum Istio version.
+// It calls t.Fatalf if ISTIO_VERSION is unset or not valid semver.
+func ShouldSkipIstioVersion(t *testing.T, minVersion string) bool {
+	t.Helper()
+	istioVersion, ok := os.LookupEnv(IstioVersionEnv)
+	if !ok {
+		t.Fatalf("required environment variable %s not set", IstioVersionEnv)
+	}
+	current, err := semver.NewVersion(istioVersion)
+	if err != nil {
+		t.Fatalf("failed to parse istio version %s as semver: %v", istioVersion, err)
+	}
+	return current.LessThan(semver.MustParse(minVersion))
+}


### PR DESCRIPTION
# Description

For nightly tests we use several Istio versions. Skip tests intelligently if Istio is too old to support the feature under test. See #13385 and #13486
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind flake

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
