### PR TITLE
fix(session-persistence): always set cookie path to `/`

### DIFF
--- a/pkg/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/session-persistence/cookie.yaml
@@ -65,6 +65,7 @@ Routes:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: Session-A
+                  path: /
                   ttl: 10s
     - match:
         safeRegex:
@@ -84,6 +85,7 @@ Routes:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: Session-B
+                  path: /
                   ttl: 31536000s
     - match:
         safeRegex:
@@ -103,6 +105,7 @@ Routes:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: Session-B
+                  path: /
     - match:
         pathSeparatedPrefix: /c1
       name: listener~80~*-route-3-httproute-example-route-default-0-0-matcher-0
@@ -119,6 +122,7 @@ Routes:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: Session-A
+                  path: /
                   ttl: 10s
     - match:
         pathSeparatedPrefix: /c2
@@ -136,6 +140,7 @@ Routes:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: Session-B
+                  path: /
                   ttl: 31536000s
     - match:
         pathSeparatedPrefix: /c3
@@ -153,6 +158,7 @@ Routes:
                 '@type': type.googleapis.com/envoy.extensions.http.stateful_session.cookie.v3.CookieBasedSessionState
                 cookie:
                   name: Session-B
+                  path: /
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/krtcollections/builtin.go
+++ b/pkg/krtcollections/builtin.go
@@ -354,6 +354,13 @@ func convertSessionPersistence(sessionPersistence *gwv1.SessionPersistence) *sta
 		cookie := &httpv3.Cookie{
 			Name: utils.SanitizeCookieName(ptr.Deref(sessionPersistence.SessionName, "sessionPersistence")),
 			Ttl:  ttl,
+			// Always set path to root to set cookie for all requests to hostname.
+			// Default browser behavior otherwise is to use the current "directory" of the request.
+			// When a request comes in without session cookie for a subpath, it would be limited to that subpath and
+			// requests to unrelated subpaths could get routed to a different upstream.
+			// Cf. https://httpwg.org/specs/rfc6265.html#sane-path
+			// This intentionally ignores the specification in GEP-1619 as computing the "correct" path can lead to unintended consequences.
+			Path: "/",
 		}
 		// Only set LifetimeType if present in CookieConfig
 		if sessionPersistence.CookieConfig != nil &&


### PR DESCRIPTION
# Description

In order to ensure consistent behavior for cookie-based session persistence, we always set the cookie's `Path` attribute to `/`. This is intentionally *not* following GEP-1619 as the semantics described there would require more work and are being questioned upstream right now, anyway. Setting a path at all is strictly "more" correct than not setting it, so this works as a stopgap solution for now.

**Related issues:** This partially addresses #14123, but does *not* fully resolve it.

# Change Type

```
/kind fix
```

# Changelog

```release-note
Always set `Path` attribute to `/` for cookie-based session persistence.
**Note:** This intentionally differs from the behavior that [GEP-1619](https://gateway-api.sigs.k8s.io/geps/gep-1619/#path) describes. If you wish to mimic the per-matched-path session persistence specified there, use multiple rules with different cookie names.
```
