### PR TITLE
feat: support gateway-level traffic policy application to routes (#13596)

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -362,6 +362,18 @@ func (p *trafficPolicyPluginGwPass) ApplyRouteConfigPlugin(
 	}
 
 	p.handlePolicies(pCtx.FilterChainName, &pCtx.TypedFilterConfig, policy.spec)
+	p.applyGatewayLevelPerRouteSettings(policy.spec, out)
+}
+
+func (p *trafficPolicyPluginGwPass) applyGatewayLevelPerRouteSettings(spec trafficPolicySpecIr, out *envoyroutev3.RouteConfiguration) {
+	for _, vh := range out.VirtualHosts {
+		for _, route := range vh.Routes {
+			if route.GetRoute() == nil {
+				continue
+			}
+			p.handlePerRoutePolicies(spec, route)
+		}
+	}
 }
 
 func (p *trafficPolicyPluginGwPass) ApplyVhostPlugin(
@@ -686,7 +698,10 @@ func (p *trafficPolicyPluginGwPass) handlePerRoutePolicies(
 	}
 
 	if spec.timeouts != nil {
-		action.IdleTimeout = spec.timeouts.routeStreamIdleTimeout
+		// Only set idle timeout if not already set (route policy takes precedence)
+		if action.GetIdleTimeout() == nil {
+			action.IdleTimeout = spec.timeouts.routeStreamIdleTimeout
+		}
 		// Only set the route timeout if it is not already set, which implies that it was
 		// set by the builtin HTTPRouteTimeouts policy
 		if action.GetTimeout() == nil {

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -1052,6 +1052,27 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("TrafficPolicy timeout attached to GRPCRoute", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "traffic-policy/grpcroute-timeout.yaml",
+			outputFile: "traffic-policy/grpcroute-timeout.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("TrafficPolicy timeout targeting Gateway", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFile:  "traffic-policy/timeout-gateway.yaml",
+			outputFile: "traffic-policy/timeout-gateway.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
 	t.Run("http gateway with session persistence (cookie)", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFile:  "session-persistence/cookie.yaml",

--- a/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/timeout-gateway.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/timeout-gateway.yaml
@@ -1,0 +1,78 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 80
+      targetPort: test
+---
+# Route 1: inherits timeout from gateway-level policy (no route-level timeout)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-1
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+# Route 2: has its own route-level timeout policy (30s overrides gateway-level 60s)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-2
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example2.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+# Gateway-level policy: applies timeout 60s to all routes unless overridden
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-timeout
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  timeouts:
+    request: 60s
+---
+# Route-level policy: 30s timeout overrides the gateway-level 60s for example-route-2
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-2-timeout
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route-2
+  timeouts:
+    request: 30s

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-gateway.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-gateway.yaml
@@ -1,0 +1,204 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  metadata: {}
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  metadata: {}
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        timeouts:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-timeout
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        timeouts:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-timeout
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example2.com
+    name: listener~80~example2_com
+    routes:
+    - match:
+        prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            timeouts:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-2-timeout
+      name: listener~80~example2_com-route-0-httproute-example-route-2-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+        timeout: 30s
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-1-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+        timeout: 60s
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/gateway-timeout:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-2-timeout:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway


### PR DESCRIPTION
Signed-off-by: Erwan Leboucher <erwanleboucher@gmail.com>
(cherry picked from commit bb2133234c739bffc1d2381e50c5dabc06f2c4b8)

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Backport mainly to fix an issue where TrafficPolicy retry would not attach to HTTPS listeners.


# Change Type

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix an issue where TrafficPolicy retry would not attach to HTTPS listeners. Add support for gateway-level TrafficPolicy application to routes. TrafficPolicies attached to Gateways now apply to child HTTPRoutes, with route-level policies taking precedence over gateway-level ones.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

