### PR TITLE
simplify BackendObjectIR

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backend/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backend/plugin.go
@@ -88,8 +88,7 @@ func NewPlugin(commoncol *collections.CommonCollections) sdk.Plugin {
 			Namespace: i.GetNamespace(),
 			Name:      i.GetName(),
 		}
-		backend := ir.NewBackendObjectIR(objSrc, 0, "")
-		backend.SetGvPrefix(ExtensionName)
+		backend := ir.NewBackendObjectIR(objSrc, 0, "", ExtensionName)
 		backend.CanonicalHostname = hostname(i)
 		backend.AppProtocol = parseAppProtocol(i)
 		backend.Obj = i

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/validate.go
@@ -50,7 +50,7 @@ func validateXDS(
 		Kind:      "Service",
 		Name:      "test-backend",
 		Namespace: "test",
-	}, 80, "")
+	}, 80, "", "")
 	processBackend(ctx, policyIR, dummyBackend, testCluster)
 
 	builder := bootstrap.New()

--- a/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
+++ b/pkg/kgateway/extensions2/plugins/kubernetes/k8s.go
@@ -77,10 +77,9 @@ func BuildServiceBackendObjectIR(svc *corev1.Service, svcPort int32, svcProtocol
 		Namespace: svc.Namespace,
 		Name:      svc.Name,
 	}
-	backend := ir.NewBackendObjectIR(objSrc, svcPort, "")
+	backend := ir.NewBackendObjectIR(objSrc, svcPort, "", BackendClusterPrefix)
 	backend.Obj = svc
 	backend.AppProtocol = ir.ParseAppProtocol(&svcProtocol)
-	backend.SetGvPrefix(BackendClusterPrefix)
 	backend.CanonicalHostname = kubeutils.GetServiceHostname(svc.Name, svc.Namespace)
 
 	// Set the port name for sectionName based policy attachment

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/access_logging_listener_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/access_logging_listener_plugin_test.go
@@ -1292,7 +1292,7 @@ func TestConvertJsonFormat_EdgeCases(t *testing.T) {
 								Kind:      "Backend",
 								Name:      "test-service",
 								Namespace: "default",
-							}, 0, "")
+							}, 0, "", "")
 							return &backend
 						}(),
 						"otel-log-0": func() *ir.BackendObjectIR {
@@ -1300,7 +1300,7 @@ func TestConvertJsonFormat_EdgeCases(t *testing.T) {
 								Kind:      "Backend",
 								Name:      "test-service",
 								Namespace: "default",
-							}, 0, "")
+							}, 0, "", "")
 							return &backend
 						}(),
 					},

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/tracing_listener_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/tracing_listener_plugin_test.go
@@ -447,7 +447,7 @@ func TestTracingConverter(t *testing.T) {
 					Kind:      "Backend",
 					Name:      "test-service",
 					Namespace: "default",
-				}, 0, "")
+				}, 0, "", "")
 
 				provider, config, err := translateTracing(
 					tc.config,

--- a/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
@@ -128,9 +128,8 @@ func BuildServiceEntryBackendObjectIR(
 	// build per-hostname backends; since getBackend tries to use krt-key by
 	// default, it will never find ServiceEntry, so we "alias" ServiceEntry to ServiceEntry
 	// to get the ref-index-based logic instead of the krt-key based lookup.
-	backend := ir.NewBackendObjectIR(objSrc, svcPort, hostname)
+	backend := ir.NewBackendObjectIR(objSrc, svcPort, hostname, BackendClusterPrefix)
 	backend.AppProtocol = ir.ParseAppProtocol(new(svcProtocol))
-	backend.SetGvPrefix(BackendClusterPrefix)
 	backend.CanonicalHostname = hostname
 	backend.Obj = se
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt_test.go
@@ -633,8 +633,7 @@ func TestTranslateJwksRemote(t *testing.T) {
 			Kind:      "Service",
 			Namespace: "backend-ns",
 			Name:      "backend",
-		}, 8443, "")
-		backendVal.SetGvPrefix("svc")
+		}, 8443, "", "svc")
 		backend := &backendVal
 		resolver := &fakeBackendResolver{backend: backend}
 		out := &jwtauthnv3.JwtProvider{}

--- a/pkg/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/waypointquery/service_model.go
@@ -145,8 +145,7 @@ func (s Service) BackendObject(port uint32) ir.BackendObjectIR {
 		Namespace: s.GetNamespace(),
 		Name:      s.GetName(),
 	}
-	backend := ir.NewBackendObjectIR(objSrc, int32(port), "") //nolint:gosec // G115: port is uint32 representing a port number, safe to convert to int32
-	backend.SetGvPrefix(kubernetes.BackendClusterPrefix)
+	backend := ir.NewBackendObjectIR(objSrc, int32(port), "", kubernetes.BackendClusterPrefix) //nolint:gosec // G115: port is uint32 representing a port number, safe to convert to int32
 	backend.CanonicalHostname = hostname
 	backend.Obj = s.Object
 	backend.AttachedPolicies = ir.AttachedPolicies{}

--- a/pkg/kgateway/proxy_syncer/backendtls_synthetic_test.go
+++ b/pkg/kgateway/proxy_syncer/backendtls_synthetic_test.go
@@ -120,7 +120,7 @@ func TestPerClientClustersUpdateWhenBackendTLSPolicyAddedLater(t *testing.T) {
 				Kind:      "Service",
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
-			}, port.Port, "")
+			}, port.Port, "", "")
 			backend.Obj = svc
 			backend.PortName = port.Name
 			out = append(out, backend)

--- a/pkg/kgateway/proxy_syncer/cla_test.go
+++ b/pkg/kgateway/proxy_syncer/cla_test.go
@@ -17,7 +17,7 @@ func TestTranslatesDestrulesFailoverPriority(t *testing.T) {
 	us := ir.NewBackendObjectIR(ir.ObjectSource{
 		Namespace: "ns",
 		Name:      "name",
-	}, 0, "")
+	}, 0, "", "")
 	efu := ir.NewEndpointsForBackend(us)
 	efu.Add(ir.PodLocality{Region: "R1"}, ir.EndpointWithMd{
 		LbEndpoint: &envoyendpointv3.LbEndpoint{
@@ -85,7 +85,7 @@ func TestTranslatesDestrulesFailover(t *testing.T) {
 	us := ir.NewBackendObjectIR(ir.ObjectSource{
 		Namespace: "ns",
 		Name:      "name",
-	}, 0, "")
+	}, 0, "", "")
 	efu := ir.NewEndpointsForBackend(us)
 	efu.Add(ir.PodLocality{Region: "R1"}, ir.EndpointWithMd{
 		LbEndpoint: &envoyendpointv3.LbEndpoint{

--- a/pkg/kgateway/proxy_syncer/gateway_backend_variants_test.go
+++ b/pkg/kgateway/proxy_syncer/gateway_backend_variants_test.go
@@ -210,7 +210,7 @@ func serviceBackends(services krt.Collection[*corev1.Service]) krt.Collection[ir
 				Kind:      "Service",
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
-			}, port.Port, "")
+			}, port.Port, "", "")
 			backend.Obj = svc
 			backends = append(backends, backend)
 		}

--- a/pkg/kgateway/proxy_syncer/status_test.go
+++ b/pkg/kgateway/proxy_syncer/status_test.go
@@ -63,7 +63,7 @@ func TestBackendPolicyStatus(t *testing.T) {
 		Kind:      "Service",
 		Namespace: "default",
 		Name:      "reviews",
-	}, 0, "")
+	}, 0, "", "")
 	backend1.AttachedPolicies = ir.AttachedPolicies{
 		Policies: map[schema.GroupKind][]ir.PolicyAtt{
 			wellknown.BackendTLSPolicyGVK.GroupKind(): {
@@ -79,7 +79,7 @@ func TestBackendPolicyStatus(t *testing.T) {
 		Kind:      "Service",
 		Namespace: "default",
 		Name:      "ratings",
-	}, 0, "")
+	}, 0, "", "")
 	backend2.AttachedPolicies = ir.AttachedPolicies{
 		Policies: map[schema.GroupKind][]ir.PolicyAtt{
 			wellknown.BackendTLSPolicyGVK.GroupKind(): {
@@ -228,7 +228,7 @@ func TestBackendPolicyStatusWithSectionName(t *testing.T) {
 		Kind:      "Service",
 		Namespace: "default",
 		Name:      "my-svc",
-	}, 0, "")
+	}, 0, "", "")
 	backend.AttachedPolicies = ir.AttachedPolicies{
 		Policies: map[schema.GroupKind][]ir.PolicyAtt{
 			wellknown.BackendTLSPolicyGVK.GroupKind(): {

--- a/pkg/kgateway/query/backend_variants_test.go
+++ b/pkg/kgateway/query/backend_variants_test.go
@@ -128,7 +128,7 @@ func testBackendObjectIR(name string, port int32) ir.BackendObjectIR {
 		Kind:      "Service",
 		Namespace: "default",
 		Name:      name,
-	}, port, "")
+	}, port, "", "kube")
 	backend.Obj = &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
@@ -137,6 +137,5 @@ func testBackendObjectIR(name string, port int32) ir.BackendObjectIR {
 			Generation:      1,
 		},
 	}
-	backend.SetGvPrefix("kube")
 	return backend
 }

--- a/pkg/kgateway/query/query_test.go
+++ b/pkg/kgateway/query/query_test.go
@@ -1394,7 +1394,7 @@ func k8sUpstreams(services krt.Collection[*corev1.Service]) krt.Collection[ir.Ba
 				Group:     SvcGk.Group,
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
-			}, port.Port, "")
+			}, port.Port, "", "")
 			backend.Obj = svc
 			uss = append(uss, backend)
 		}

--- a/pkg/kgateway/translator/httproute/translate_httproute_test.go
+++ b/pkg/kgateway/translator/httproute/translate_httproute_test.go
@@ -112,7 +112,7 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 					Name:      backingSvc.Name,
 					Kind:      "Service",
 					Group:     "",
-				}, 8080, "")
+				}, 8080, "", "")
 				backend.Obj = backingSvc
 				up = &backend
 				// Setup the route rules
@@ -192,7 +192,7 @@ var _ = Describe("GatewayHttpRouteTranslator", func() {
 					Name:      backingSvc.Name,
 					Kind:      "Service",
 					Group:     "",
-				}, 8080, "")
+				}, 8080, "", "")
 				backend.Obj = backingSvc
 				up = &backend
 				// Setup the route rules

--- a/pkg/kgateway/translator/irtranslator/backend_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func newTestBackend(objSrc ir.ObjectSource, port int32) *ir.BackendObjectIR {
-	backend := ir.NewBackendObjectIR(objSrc, port, "")
+	backend := ir.NewBackendObjectIR(objSrc, port, "", "")
 	return &backend
 }
 

--- a/pkg/krtcollections/endpoints_test.go
+++ b/pkg/krtcollections/endpoints_test.go
@@ -29,6 +29,7 @@ type backendObjectIRInput struct {
 	ObjectSource      ir.ObjectSource
 	Port              int32
 	ExtraKey          string
+	GvPrefix          string
 	Obj               metav1.Object
 	CanonicalHostname string
 	AppProtocol       ir.AppProtocol
@@ -38,7 +39,7 @@ type backendObjectIRInput struct {
 }
 
 func newBackendObjectIR(in backendObjectIRInput) ir.BackendObjectIR {
-	b := ir.NewBackendObjectIR(in.ObjectSource, in.Port, in.ExtraKey)
+	b := ir.NewBackendObjectIR(in.ObjectSource, in.Port, in.ExtraKey, in.GvPrefix)
 	b.Obj = in.Obj
 	b.CanonicalHostname = in.CanonicalHostname
 	b.AppProtocol = in.AppProtocol
@@ -464,7 +465,8 @@ func TestEndpointsForGatewayScopedBackendsWithSameEndpointsHaveDifferentHashes(t
 			Group:     "",
 			Kind:      "Service",
 		},
-		Port: 8080,
+		Port:     8080,
+		GvPrefix: "kube",
 		Obj: &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "svc",
@@ -472,8 +474,6 @@ func TestEndpointsForGatewayScopedBackendsWithSameEndpointsHaveDifferentHashes(t
 			},
 		},
 	})
-	baseBackend.SetGvPrefix("kube")
-
 	clientCertificate := &ir.GatewayBackendClientCertificateIR{}
 	gateway1 := ir.ObjectSource{
 		Group:     gwv1.GroupVersion.Group,

--- a/pkg/krtcollections/grpc_route_test.go
+++ b/pkg/krtcollections/grpc_route_test.go
@@ -536,7 +536,7 @@ func k8sSvcUpstreams(services krt.Collection[*corev1.Service]) krt.Collection[ir
 				Group:     "",
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
-			}, port.Port, "")
+			}, port.Port, "", "")
 			backend.Obj = svc
 
 			uss = append(uss, backend)

--- a/pkg/krtcollections/policy_backendtls_test.go
+++ b/pkg/krtcollections/policy_backendtls_test.go
@@ -142,7 +142,7 @@ func TestGetBackendFromRefReturnsPolicyAttachedBackend(t *testing.T) {
 				Kind:      svcGk.Kind,
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
-			}, port.Port, "")
+			}, port.Port, "", "")
 			backend.Obj = svc
 			backend.PortName = port.Name
 			out = append(out, backend)
@@ -264,7 +264,7 @@ func TestBackendPoliciesUpdateWhenBackendTLSPolicyCreatedAfterService(t *testing
 				Kind:      svcGk.Kind,
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
-			}, port.Port, "")
+			}, port.Port, "", "")
 			backend.Obj = svc
 			backend.PortName = port.Name
 			out = append(out, backend)

--- a/pkg/krtcollections/policy_test.go
+++ b/pkg/krtcollections/policy_test.go
@@ -401,7 +401,7 @@ func k8sSvcUpstreams(services krt.Collection[*corev1.Service]) krt.Collection[ir
 				Group:     svcGk.Group,
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
-			}, port.Port, "")
+			}, port.Port, "", "")
 			backend.Obj = svc
 			uss = append(uss, backend)
 		}
@@ -423,7 +423,7 @@ func backendUpstreams(backendCol krt.Collection[*kgateway.Backend]) krt.Collecti
 			Group:     backendGk.Group,
 			Namespace: backend.Namespace,
 			Name:      backend.Name,
-		}, port, "")
+		}, port, "", "")
 		backendIR.Obj = backend
 		return &backendIR
 	})

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -139,7 +139,8 @@ type BackendObjectIR struct {
 	AppProtocol AppProtocol
 
 	// prefix the cluster name with this string to distinguish it from other GVKs.
-	// here explicitly as it shows up in stats. each (group, kind) pair should have a unique prefix.
+	// kept private and immutable after construction. each (group, kind) pair
+	// should have a unique prefix because it shows up in stats.
 	// +krtEqualsTodo incorporate prefix changes into equality or remove field
 	gvPrefix string
 	// for things that integrate with destination rule, we need to know what hostname to use.
@@ -180,10 +181,8 @@ type BackendObjectIR struct {
 	// resourceName is the pre-calculated resource name. used as the krt resource name.
 	resourceName string
 
-	// clusterName is the pre-calculated Envoy cluster name. Kept in sync by
-	// SetGvPrefix (the only setter that mutates a cluster-name-relevant field
-	// post-construction). ClusterName() falls back to recomputing if empty so
-	// struct-literal callers still work.
+	// clusterName is the pre-calculated Envoy cluster name. ClusterName() falls
+	// back to recomputing if empty so struct-literal callers still work.
 	// +noKrtEquals We compare the cached ClusterName in Equals()
 	clusterName string
 
@@ -200,15 +199,16 @@ type BackendObjectIR struct {
 }
 
 // NewBackendObjectIR creates a BackendObjectIR with pre-calculated resource and
-// cluster names. Callers that need a non-default cluster prefix should follow
-// up with SetGvPrefix, which keeps the cached cluster name in sync.
-func NewBackendObjectIR(objSource ObjectSource, port int32, extraKey string) BackendObjectIR {
+// cluster names. Callers should pass the final cluster prefix up front; if
+// empty, the lower-cased backend kind is used.
+func NewBackendObjectIR(objSource ObjectSource, port int32, extraKey, gvPrefix string) BackendObjectIR {
 	return BackendObjectIR{
 		objectSource: objSource,
 		port:         port,
+		gvPrefix:     gvPrefix,
 		extraKey:     extraKey,
 		resourceName: BackendResourceName(objSource, port, extraKey),
-		clusterName:  buildClusterName("", objSource.Kind, objSource.Namespace, objSource.Name, extraKey, port),
+		clusterName:  buildClusterName(gvPrefix, objSource.Kind, objSource.Namespace, objSource.Name, extraKey, port),
 	}
 }
 
@@ -279,13 +279,6 @@ func gatewayBackendClientCertificateExtraKey(baseExtraKey string, gateway Object
 		return suffix
 	}
 	return baseExtraKey + "_" + suffix
-}
-
-// SetGvPrefix sets the cluster-name prefix and keeps the cached cluster name in
-// sync.
-func (c *BackendObjectIR) SetGvPrefix(prefix string) {
-	c.gvPrefix = prefix
-	c.clusterName = buildClusterName(prefix, c.objectSource.Kind, c.objectSource.Namespace, c.objectSource.Name, c.extraKey, c.port)
 }
 
 func (c BackendObjectIR) ClusterName() string {

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -181,8 +181,7 @@ type BackendObjectIR struct {
 	// resourceName is the pre-calculated resource name. used as the krt resource name.
 	resourceName string
 
-	// clusterName is the pre-calculated Envoy cluster name. ClusterName() falls
-	// back to recomputing if empty so struct-literal callers still work.
+	// clusterName is the pre-calculated Envoy cluster name.
 	// +noKrtEquals We compare the cached ClusterName in Equals()
 	clusterName string
 
@@ -282,10 +281,7 @@ func gatewayBackendClientCertificateExtraKey(baseExtraKey string, gateway Object
 }
 
 func (c BackendObjectIR) ClusterName() string {
-	if c.clusterName != "" {
-		return c.clusterName
-	}
-	return buildClusterName(c.gvPrefix, c.objectSource.Kind, c.objectSource.Namespace, c.objectSource.Name, c.extraKey, c.port)
+	return c.clusterName
 }
 
 func buildClusterName(gvPrefix, kind, namespace, name, extraKey string, port int32) string {

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -141,7 +141,7 @@ type BackendObjectIR struct {
 	// prefix the cluster name with this string to distinguish it from other GVKs.
 	// kept private and immutable after construction. each (group, kind) pair
 	// should have a unique prefix because it shows up in stats.
-	// +krtEqualsTodo incorporate prefix changes into equality or remove field
+	// +noKrtEquals gvPrefix is compared in ClusterName()
 	gvPrefix string
 	// for things that integrate with destination rule, we need to know what hostname to use.
 	// +krtEqualsTodo evaluate canonical hostname equality
@@ -199,8 +199,12 @@ type BackendObjectIR struct {
 
 // NewBackendObjectIR creates a BackendObjectIR with pre-calculated resource and
 // cluster names. Callers should pass the final cluster prefix up front; if
-// empty, the lower-cased backend kind is used.
+// empty, the lower-cased backend kind is used and stored on the IR.
 func NewBackendObjectIR(objSource ObjectSource, port int32, extraKey, gvPrefix string) BackendObjectIR {
+	if gvPrefix == "" {
+		gvPrefix = strings.ToLower(objSource.Kind)
+	}
+
 	return BackendObjectIR{
 		objectSource: objSource,
 		port:         port,

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -214,7 +214,7 @@ func NewBackendObjectIR(objSource ObjectSource, port int32, extraKey, gvPrefix s
 func BackendResourceName(objSource ObjectSource, port int32, extraKey string) string {
 	var sb strings.Builder
 	sb.WriteString(objSource.ResourceName())
-	sb.WriteString(fmt.Sprintf(":%d", port))
+	fmt.Fprintf(&sb, ":%d", port)
 
 	if extraKey != "" {
 		sb.WriteRune('_')

--- a/pkg/pluginsdk/ir/backend_test.go
+++ b/pkg/pluginsdk/ir/backend_test.go
@@ -207,6 +207,17 @@ func TestBackendObjectIRConstructsClusterNameWithPrefix(t *testing.T) {
 	assert.Equal(t, "kube_default_test-service_8080", backend.ClusterName())
 }
 
+func TestBackendObjectIRNormalizesEmptyPrefix(t *testing.T) {
+	backend := NewBackendObjectIR(ObjectSource{
+		Namespace: "default",
+		Name:      "test-service",
+		Kind:      "Service",
+	}, 8080, "", "")
+
+	assert.Equal(t, "service", backend.gvPrefix)
+	assert.Equal(t, "service_default_test-service_8080", backend.ClusterName())
+}
+
 func TestBackendObjectIRCloneRecomputesClusterName(t *testing.T) {
 	backend := NewBackendObjectIR(ObjectSource{
 		Namespace: "ns",

--- a/pkg/pluginsdk/ir/backend_test.go
+++ b/pkg/pluginsdk/ir/backend_test.go
@@ -71,25 +71,23 @@ func TestParseAppProtocol(t *testing.T) {
 }
 
 func createTestBackendObjectIR(trafficDist wellknown.TrafficDistribution) BackendObjectIR {
-	return BackendObjectIR{
-		objectSource: ObjectSource{
-			Namespace: "default",
-			Name:      "test-service",
-			Group:     "",
-			Kind:      "Service",
+	backend := NewBackendObjectIR(ObjectSource{
+		Namespace: "default",
+		Name:      "test-service",
+		Group:     "",
+		Kind:      "Service",
+	}, 8080, "", "")
+	backend.Obj = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-service",
+			Namespace:       "default",
+			UID:             "test-uid",
+			ResourceVersion: "1",
+			Generation:      1,
 		},
-		port: 8080,
-		Obj: &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "test-service",
-				Namespace:       "default",
-				UID:             "test-uid",
-				ResourceVersion: "1",
-				Generation:      1,
-			},
-		},
-		TrafficDistribution: trafficDist,
 	}
+	backend.TrafficDistribution = trafficDist
+	return backend
 }
 
 func TestBackendObjectIREquals(t *testing.T) {
@@ -178,8 +176,6 @@ func TestBackendObjectIREquals(t *testing.T) {
 
 func TestBackendObjectIRClusterName(t *testing.T) {
 	base := createTestBackendObjectIR(wellknown.TrafficDistributionAny)
-	base.objectSource.Kind = "Service"
-	base.resourceName = BackendResourceName(base.objectSource, base.port, base.extraKey)
 
 	t.Run("keeps the same name when BackendTLSPolicy is attached", func(t *testing.T) {
 		withPolicy := base
@@ -201,17 +197,12 @@ func TestBackendObjectIRClusterName(t *testing.T) {
 	})
 }
 
-func TestBackendObjectIRSetGvPrefixUpdatesClusterName(t *testing.T) {
+func TestBackendObjectIRConstructsClusterNameWithPrefix(t *testing.T) {
 	backend := NewBackendObjectIR(ObjectSource{
 		Namespace: "default",
 		Name:      "test-service",
 		Kind:      "Service",
-	}, 8080, "")
-
-	// Before SetGvPrefix the cached name uses the lowercased Kind as prefix.
-	assert.Equal(t, "service_default_test-service_8080", backend.ClusterName())
-
-	backend.SetGvPrefix("kube")
+	}, 8080, "", "kube")
 
 	assert.Equal(t, "kube_default_test-service_8080", backend.ClusterName())
 }
@@ -221,8 +212,7 @@ func TestBackendObjectIRCloneRecomputesClusterName(t *testing.T) {
 		Namespace: "ns",
 		Name:      "svc",
 		Kind:      "Service",
-	}, 80, "")
-	backend.SetGvPrefix("kube")
+	}, 80, "", "kube")
 
 	original := backend.ClusterName()
 	clone := backend.CloneForGatewayBackendClientCertificate(

--- a/pkg/pluginsdk/ir/routes_test.go
+++ b/pkg/pluginsdk/ir/routes_test.go
@@ -307,23 +307,25 @@ func TestHTTPRouteIREquals(t *testing.T) {
 	}}
 
 	// Test data for testing backing destination object comparison
-	httpBackendObj := BackendObjectIR{
-		objectSource:     ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
-		port:             80,
-		Obj:              base,
-		resourceName:     "/Service/ns/svc:80",
-		AppProtocol:      DefaultAppProtocol,
-		AttachedPolicies: AttachedPolicies{},
-	}
+	httpBackendObj := NewBackendObjectIR(
+		ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
+		80,
+		"",
+		"",
+	)
+	httpBackendObj.Obj = base
+	httpBackendObj.AppProtocol = DefaultAppProtocol
+	httpBackendObj.AttachedPolicies = AttachedPolicies{}
 	// same as httpBackendObj but with WebSocket AppProtocol. Generated is 2 to simulate an update.
-	wsBackendObj := BackendObjectIR{
-		objectSource:     ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
-		port:             80,
-		Obj:              baseGen2,
-		resourceName:     "/Service/ns/svc:80",
-		AppProtocol:      WebSocketAppProtocol,
-		AttachedPolicies: AttachedPolicies{},
-	}
+	wsBackendObj := NewBackendObjectIR(
+		ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"},
+		80,
+		"",
+		"",
+	)
+	wsBackendObj.Obj = baseGen2
+	wsBackendObj.AppProtocol = WebSocketAppProtocol
+	wsBackendObj.AttachedPolicies = AttachedPolicies{}
 	ruleWithHttpBackend := []HttpRouteRuleIR{{
 		ExtensionRefs:    emptyPolicies,
 		AttachedPolicies: emptyPolicies,

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -767,7 +767,7 @@ func (tc TestCase) Run(
 		Kind:      "test-backend-plugin",
 		Namespace: "default",
 		Name:      "example-svc",
-	}, 80, "")
+	}, 80, "", "")
 	extensions.ContributesBackends[gk] = pluginsdk.BackendPlugin{
 		Backends: krt.NewStaticCollection(nil, []ir.BackendObjectIR{
 			testBackend,


### PR DESCRIPTION
# Description

follow up to https://github.com/kgateway-dev/kgateway/pull/14092

remove SetGvPrefix and add gvPrefix to constructor. 

# Change Type

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
