### PR TITLE
perf: replace proto.Clone with shallow copy

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backend/static.go
+++ b/pkg/kgateway/extensions2/plugins/backend/static.go
@@ -126,8 +126,13 @@ func processStatic(ir *StaticIr, out *envoyclusterv3.Cluster) {
 	}
 
 	if ir.loadAssignment != nil {
-		// clone needed to avoid adding cluster name to original object in the IR.
-		out.LoadAssignment = proto.Clone(ir.loadAssignment).(*envoyendpointv3.ClusterLoadAssignment)
-		out.LoadAssignment.ClusterName = out.GetName()
+		// shallow copy: inner messages are treated as read-only downstream;
+		// only ClusterName differs per cluster
+		out.LoadAssignment = &envoyendpointv3.ClusterLoadAssignment{
+			ClusterName:    out.GetName(),
+			Endpoints:      ir.loadAssignment.GetEndpoints(),
+			NamedEndpoints: ir.loadAssignment.GetNamedEndpoints(),
+			Policy:         ir.loadAssignment.GetPolicy(),
+		}
 	}
 }

--- a/pkg/kgateway/extensions2/plugins/backend/static_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/static_test.go
@@ -60,3 +60,28 @@ func TestProcessStaticUsesCustomDnsCluster(t *testing.T) {
 	assert.Equal(t, "example.com", endpoint.GetAddress().GetSocketAddress().GetAddress())
 	assert.Equal(t, uint32(8080), endpoint.GetAddress().GetSocketAddress().GetPortValue())
 }
+
+func TestProcessStaticDoesNotMutateCachedLoadAssignment(t *testing.T) {
+	ir, err := buildStaticIr(&kgateway.StaticBackend{
+		Hosts: []kgateway.Host{{
+			Host: "example.com",
+			Port: 8080,
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ir)
+	require.NotNil(t, ir.loadAssignment)
+	require.Empty(t, ir.loadAssignment.GetClusterName())
+
+	firstCluster := &envoyclusterv3.Cluster{Name: "first-cluster"}
+	secondCluster := &envoyclusterv3.Cluster{Name: "second-cluster"}
+
+	processStatic(ir, firstCluster)
+	processStatic(ir, secondCluster)
+
+	require.NotNil(t, firstCluster.LoadAssignment)
+	require.NotNil(t, secondCluster.LoadAssignment)
+	assert.Equal(t, "first-cluster", firstCluster.LoadAssignment.GetClusterName())
+	assert.Equal(t, "second-cluster", secondCluster.LoadAssignment.GetClusterName())
+	assert.Empty(t, ir.loadAssignment.GetClusterName(), "cached IR load assignment should remain reusable")
+}


### PR DESCRIPTION
# Description

The change replaces a full `proto.Clone()` of the cached `ClusterLoadAssignment` with a shallow struct copy that shares the inner sub-messages (`Endpoints`, `NamedEndpoints`, `Policy`) and only sets a fresh top-level `ClusterName`. This is a performance optimization in the cluster-translation hot path — it avoids deep-cloning the entire endpoint tree just to override one string field.

# Change Type

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
