### PR TITLE
fix: prevent gateway-level retry from overriding listener retry on HTTP

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -372,13 +372,29 @@ func (p *trafficPolicyPluginGwPass) ApplyRouteConfigPlugin(
 	p.applyGatewayLevelPerRouteSettings(policy.spec, out)
 }
 
+// applyGatewayLevelPerRouteSettings applies per-route settings from a policy attached at the
+// route-config scope, i.e. a Gateway-attached policy, or a Listener-attached policy on an HTTPS
+// filter chain (HTTPS chains do not carry vhost-attached policies, so their listener policies are
+// applied here via the merged route-config policy).
 func (p *trafficPolicyPluginGwPass) applyGatewayLevelPerRouteSettings(spec trafficPolicySpecIr, out *envoyroutev3.RouteConfiguration) {
 	for _, vh := range out.VirtualHosts {
+		// Apply the retry policy at the virtual-host scope rather than the route scope.
+		// Envoy resolves a route's retry policy with the route-level taking precedence over the
+		// vhost-level. A route-config policy is the least specific (Gateway < Listener < Route), so
+		// writing its retry onto the route would incorrectly override more specific retry policies:
+		//   - a route-attached retry policy (set on the route action via ApplyForRoute), and
+		//   - a Listener-attached retry policy applied at vhost scope for shared HTTP filter chains
+		//     (set via ApplyVhostPlugin -> handlePerVHostPolicies, which runs before this pass).
+		// Only set it when the vhost has none yet so those more specific policies win.
+		if vh.GetRetryPolicy() == nil && spec.retry != nil {
+			vh.RetryPolicy = spec.retry.policy
+		}
 		for _, route := range vh.Routes {
 			if route.GetRoute() == nil {
 				continue
 			}
-			p.handlePerRoutePolicies(spec, route)
+			// Retry is handled at the vhost scope above; everything else applies per route.
+			p.handlePerRoutePolicies(spec, route, false /* applyRetry */)
 		}
 	}
 }
@@ -403,7 +419,9 @@ func (p *trafficPolicyPluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputR
 		return nil
 	}
 
-	p.handlePerRoutePolicies(policy.spec, outputRoute)
+	// A route-attached policy is the most specific scope, so its retry policy is applied
+	// directly on the route action (which takes precedence over any vhost-level retry).
+	p.handlePerRoutePolicies(policy.spec, outputRoute, true /* applyRetry */)
 	p.handlePolicies(pCtx.FilterChainName, &pCtx.TypedFilterConfig, policy.spec)
 
 	return nil
@@ -705,10 +723,14 @@ func (p *trafficPolicyPluginGwPass) handlePolicies(
 	p.handleHttpACL(fcn, typedFilterConfig, spec.httpACL)
 }
 
-// handlePerRoutePolicies handles policies that are meant to be processed at the route level
+// handlePerRoutePolicies handles policies that are meant to be processed at the route level.
+// applyRetry controls whether the retry policy is written onto the route action: it should be true
+// only for the most specific (route-attached) scope. Less specific scopes apply retry at the vhost
+// level (see applyGatewayLevelPerRouteSettings) to preserve Envoy's route-over-vhost precedence.
 func (p *trafficPolicyPluginGwPass) handlePerRoutePolicies(
 	spec trafficPolicySpecIr,
 	out *envoyroutev3.Route,
+	applyRetry bool,
 ) {
 	// A parent route rule with a delegated backend will not have RouteAction set.
 	// Routes with redirect/direct response also do not have RouteAction.
@@ -740,8 +762,9 @@ func (p *trafficPolicyPluginGwPass) handlePerRoutePolicies(
 	}
 
 	// Only set the retry policy if it is not already set, which implies that it was
-	// set by the builtin HTTPRouteRetry policy
-	if action.GetRetryPolicy() == nil && spec.retry != nil {
+	// set by the builtin HTTPRouteRetry policy. applyRetry is false for less specific
+	// (gateway/HTTPS-listener) scopes, which apply retry at the vhost level instead.
+	if applyRetry && action.GetRetryPolicy() == nil && spec.retry != nil {
 		action.RetryPolicy = spec.retry.policy
 	}
 

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -1481,6 +1481,17 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("TrafficPolicy retry targeting Gateway and listener on HTTP", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"traffic-policy/http-retry-gateway-and-listener.yaml"},
+			outputFile: "traffic-policy/http-retry-gateway-and-listener.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("TrafficPolicy timeout targeting Gateway", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"traffic-policy/timeout-gateway.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/http-retry-gateway-and-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/http-retry-gateway-and-listener.yaml
@@ -1,0 +1,98 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 80
+      targetPort: test
+---
+# Route 1: inherits the listener-level retry (no route-level policy).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-1
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+# Route 2: has its own route-level retry policy (most specific, must win).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route-2
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example2.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+# Gateway-level policy: least specific. Must NOT override the listener-level retry.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-retry
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  retry:
+    retryOn:
+    - gateway-error
+    attempts: 1
+---
+# Listener-level policy: more specific than gateway. Applied at vhost scope for HTTP.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: listener-retry
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+    sectionName: http
+  retry:
+    retryOn:
+    - connect-failure
+    attempts: 3
+---
+# Route-level policy: most specific. Must win on example-route-2.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-2-retry
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route-2
+  retry:
+    retryOn:
+    - reset
+    attempts: 5

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/http-retry-gateway-and-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/http-retry-gateway-and-listener.yaml
@@ -1,0 +1,244 @@
+Clusters:
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        retry:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-retry
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        retry:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-retry
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example2.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          retry:
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-retry
+    name: listener~80~example2_com
+    retryPolicy:
+      numRetries: 3
+      retryBackOff:
+        baseInterval: 0.025s
+      retryOn: connect-failure
+    routes:
+    - match:
+        prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            retry:
+            - gateway.kgateway.dev/TrafficPolicy/default/route-2-retry
+      name: listener~80~example2_com-route-0-httproute-example-route-2-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+        retryPolicy:
+          numRetries: 5
+          retryBackOff:
+            baseInterval: 0.025s
+          retryOn: reset
+  - domains:
+    - example.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          retry:
+          - gateway.kgateway.dev/TrafficPolicy/default/listener-retry
+    name: listener~80~example_com
+    retryPolicy:
+      numRetries: 3
+      retryBackOff:
+        baseInterval: 0.025s
+      retryOn: connect-failure
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-1-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 2
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route-1:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+    default/example-route-2:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    TrafficPolicy/default/gateway-retry:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/listener-retry:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway
+    TrafficPolicy/default/route-2-retry:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway


### PR DESCRIPTION
# Description

Commit bb2133234c (#13596, \"support gateway-level traffic policy application to routes\") introduced `applyGatewayLevelPerRouteSettings()`, which writes the retry policy from a route-config-scoped `TrafficPolicy` (a Gateway-attached policy, or a Listener-attached policy on an HTTPS filter chain) onto **every route**. In Envoy a route-level retry policy takes precedence over a vhost-level one, i.e. the route is the most specific scope.

That is correct for **HTTPS** listeners: the Gateway- and Listener-attached policies merge into a single policy (the Listener wins), and writing the result per route is what made retry work on HTTPS listeners (which do not carry vhost-attached policies).

It is **wrong for HTTP** listeners. On shared plaintext filter chains, Listener-attached policies are applied at the **vhost** scope (`ApplyVhostPlugin` -> `handlePerVHostPolicies` sets `vh.RetryPolicy`). The new code then wrote the *less specific* Gateway-level retry onto the route, which silently overrode the Listener-specific retry.

### Fix

Apply the route-config-scoped retry at the **virtual-host** level instead, guarded by \"only if the vhost has none yet\". `ComputeRouteConfiguration` runs the vhost plugins before the route-config plugins, so the precedence falls out naturally:

- **HTTP**: the vhost already holds the Listener retry, so the Gateway pass skips it. A Gateway-only retry still falls through to the vhost (so gateway-level retry keeps working on plaintext listeners).
- **HTTPS**: the vhost is empty, so it is set from the merged (Listener-wins) policy.
- A **route-attached** retry stays on the route action and still wins (route > vhost).

`handlePerRoutePolicies` gains an `applyRetry` flag so only the most specific (route-attached) scope writes retry onto the route action; the route-config scope passes `false` and relies on the vhost-level application above.

### Testing

- Adds golden test `traffic-policy/http-retry-gateway-and-listener.yaml`: an HTTP listener with Gateway-, Listener- (sectionName), and Route-level retry policies together. The output confirms both vhosts get the Listener retry, route-2 gets its Route retry, and the Gateway retry never overrides.
- Existing `TrafficPolicy HTTPS retry`, `timeout and retry`, and `timeout targeting Gateway` golden tests still pass, along with the full `TestBasic` suite and the trafficpolicy plugin unit tests.

# Change Type

/kind fix

# Changelog

```release-note
Fixed a bug where a Gateway-level TrafficPolicy retry policy would override a more specific Listener-level retry policy on HTTP listeners.
```

## Additional Notes

Listener-attached **timeouts** on shared HTTP filter chains remain a separate, pre-existing gap (`handlePerVHostPolicies` only handles retry, and Envoy has no vhost-level timeout). That is out of scope for this fix.