### PR TITLE
[2.2] fix: Rate limit combined descriptors into a single action

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
@@ -98,23 +98,19 @@ func constructGlobalRateLimit(
 	}
 	// Create route rate limits and store in the RateLimitIR struct
 	out.globalRateLimit = &globalRateLimitIR{
-		provider: gwExtIR,
-		rateLimitActions: []*envoyroutev3.RateLimit{
-			{
-				Actions: actions,
-			},
-		},
+		provider:         gwExtIR,
+		rateLimitActions: actions,
 	}
 	return nil
 }
 
 // createRateLimitActions translates the API descriptors to Envoy route config rate limit actions
-func createRateLimitActions(descriptors []kgateway.RateLimitDescriptor) ([]*envoyroutev3.RateLimit_Action, error) {
+func createRateLimitActions(descriptors []kgateway.RateLimitDescriptor) ([]*envoyroutev3.RateLimit, error) {
 	if len(descriptors) == 0 {
 		return nil, errors.New("at least one descriptor is required for global rate limiting")
 	}
 
-	var result []*envoyroutev3.RateLimit_Action
+	var result []*envoyroutev3.RateLimit
 
 	// Process each descriptor
 	for _, descriptor := range descriptors {
@@ -173,7 +169,7 @@ func createRateLimitActions(descriptors []kgateway.RateLimitDescriptor) ([]*envo
 			}
 
 			// The final result is a slice of complete RateLimit objects
-			result = append(result, rateLimit.GetActions()...)
+			result = append(result, rateLimit)
 		}
 	}
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin_test.go
@@ -157,7 +157,7 @@ func TestCreateRateLimitActions(t *testing.T) {
 		name           string
 		descriptors    []kgateway.RateLimitDescriptor
 		expectedError  string
-		validateResult func(*testing.T, []*envoyroutev3.RateLimit_Action)
+		validateResult func(*testing.T, []*envoyroutev3.RateLimit)
 	}{
 		{
 			name: "with generic key descriptor",
@@ -174,9 +174,10 @@ func TestCreateRateLimitActions(t *testing.T) {
 					},
 				},
 			},
-			validateResult: func(t *testing.T, actions []*envoyroutev3.RateLimit_Action) {
-				require.Len(t, actions, 1)
-				genericKey := actions[0].GetGenericKey()
+			validateResult: func(t *testing.T, rateLimits []*envoyroutev3.RateLimit) {
+				require.Len(t, rateLimits, 1)
+				require.Len(t, rateLimits[0].GetActions(), 1)
+				genericKey := rateLimits[0].GetActions()[0].GetGenericKey()
 				require.NotNil(t, genericKey)
 				assert.Equal(t, "service", genericKey.DescriptorKey)
 				assert.Equal(t, "api", genericKey.DescriptorValue)
@@ -194,9 +195,10 @@ func TestCreateRateLimitActions(t *testing.T) {
 					},
 				},
 			},
-			validateResult: func(t *testing.T, actions []*envoyroutev3.RateLimit_Action) {
-				require.Len(t, actions, 1)
-				requestHeaders := actions[0].GetRequestHeaders()
+			validateResult: func(t *testing.T, rateLimits []*envoyroutev3.RateLimit) {
+				require.Len(t, rateLimits, 1)
+				require.Len(t, rateLimits[0].GetActions(), 1)
+				requestHeaders := rateLimits[0].GetActions()[0].GetRequestHeaders()
 				require.NotNil(t, requestHeaders)
 				assert.Equal(t, "X-User-ID", requestHeaders.HeaderName)
 				assert.Equal(t, "X-User-ID", requestHeaders.DescriptorKey)
@@ -213,9 +215,10 @@ func TestCreateRateLimitActions(t *testing.T) {
 					},
 				},
 			},
-			validateResult: func(t *testing.T, actions []*envoyroutev3.RateLimit_Action) {
-				require.Len(t, actions, 1)
-				remoteAddress := actions[0].GetRemoteAddress()
+			validateResult: func(t *testing.T, rateLimits []*envoyroutev3.RateLimit) {
+				require.Len(t, rateLimits, 1)
+				require.Len(t, rateLimits[0].GetActions(), 1)
+				remoteAddress := rateLimits[0].GetActions()[0].GetRemoteAddress()
 				require.NotNil(t, remoteAddress)
 			},
 		},
@@ -230,9 +233,10 @@ func TestCreateRateLimitActions(t *testing.T) {
 					},
 				},
 			},
-			validateResult: func(t *testing.T, actions []*envoyroutev3.RateLimit_Action) {
-				require.Len(t, actions, 1)
-				requestHeaders := actions[0].GetRequestHeaders()
+			validateResult: func(t *testing.T, rateLimits []*envoyroutev3.RateLimit) {
+				require.Len(t, rateLimits, 1)
+				require.Len(t, rateLimits[0].GetActions(), 1)
+				requestHeaders := rateLimits[0].GetActions()[0].GetRequestHeaders()
 				require.NotNil(t, requestHeaders)
 				assert.Equal(t, ":path", requestHeaders.HeaderName)
 				assert.Equal(t, "path", requestHeaders.DescriptorKey)
@@ -260,16 +264,18 @@ func TestCreateRateLimitActions(t *testing.T) {
 					},
 				},
 			},
-			validateResult: func(t *testing.T, actions []*envoyroutev3.RateLimit_Action) {
-				require.Len(t, actions, 2)
-				// First action is generic key
-				genericKey := actions[0].GetGenericKey()
+			validateResult: func(t *testing.T, rateLimits []*envoyroutev3.RateLimit) {
+				require.Len(t, rateLimits, 2)
+				// First RateLimit has generic key action
+				require.Len(t, rateLimits[0].GetActions(), 1)
+				genericKey := rateLimits[0].GetActions()[0].GetGenericKey()
 				require.NotNil(t, genericKey)
 				assert.Equal(t, "service", genericKey.DescriptorKey)
 				assert.Equal(t, "api", genericKey.DescriptorValue)
 
-				// Second action is remote address
-				remoteAddress := actions[1].GetRemoteAddress()
+				// Second RateLimit has remote address action
+				require.Len(t, rateLimits[1].GetActions(), 1)
+				remoteAddress := rateLimits[1].GetActions()[0].GetRemoteAddress()
 				require.NotNil(t, remoteAddress)
 			},
 		},
@@ -292,16 +298,17 @@ func TestCreateRateLimitActions(t *testing.T) {
 					},
 				},
 			},
-			validateResult: func(t *testing.T, actions []*envoyroutev3.RateLimit_Action) {
-				require.Len(t, actions, 2)
+			validateResult: func(t *testing.T, rateLimits []*envoyroutev3.RateLimit) {
+				require.Len(t, rateLimits, 1)
+				require.Len(t, rateLimits[0].GetActions(), 2)
 				// First action is generic key
-				genericKey := actions[0].GetGenericKey()
+				genericKey := rateLimits[0].GetActions()[0].GetGenericKey()
 				require.NotNil(t, genericKey)
 				assert.Equal(t, "service", genericKey.DescriptorKey)
 				assert.Equal(t, "api", genericKey.DescriptorValue)
 
 				// Second action is header
-				requestHeaders := actions[1].GetRequestHeaders()
+				requestHeaders := rateLimits[0].GetActions()[1].GetRequestHeaders()
 				require.NotNil(t, requestHeaders)
 				assert.Equal(t, "X-User-ID", requestHeaders.HeaderName)
 				assert.Equal(t, "X-User-ID", requestHeaders.DescriptorKey)

--- a/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/rate-limit-full-config.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/rate-limit-full-config.yaml
@@ -66,6 +66,12 @@ spec:
       descriptors:
       - entries:
         - type: Path
+        - type: Header
+          header: "x-header-1"
+      - entries:
+        - type: RemoteAddress
+        - type: Header
+          header: "x-header-2"
       extensionRef:
         name: default-ratelimit
 ---

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/multi-dimensional-descriptors.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/multi-dimensional-descriptors.yaml
@@ -185,10 +185,12 @@ Routes:
         - genericKey:
             descriptorKey: endpoint_type
             descriptorValue: api
+      - actions:
         - remoteAddress: {}
         - requestHeaders:
             descriptorKey: path
             headerName: :path
+      - actions:
         - requestHeaders:
             descriptorKey: X-Service-Auth
             headerName: X-Service-Auth

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/multiple-descriptors-or.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/multiple-descriptors-or.yaml
@@ -208,9 +208,11 @@ Routes:
             - requestHeaders:
                 descriptorKey: X-User-Type
                 headerName: X-User-Type
+          - actions:
             - requestHeaders:
                 descriptorKey: path
                 headerName: :path
+          - actions:
             - genericKey:
                 descriptorKey: rate_limit_bypass
                 descriptorValue: "false"

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/rate-limit-full-config.yaml
@@ -146,6 +146,14 @@ Routes:
             - requestHeaders:
                 descriptorKey: path
                 headerName: :path
+            - requestHeaders:
+                descriptorKey: x-header-1
+                headerName: x-header-1
+          - actions:
+            - remoteAddress: {}
+            - requestHeaders:
+                descriptorKey: x-header-2
+                headerName: x-header-2
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Backport of https://github.com/kgateway-dev/kgateway/pull/14157
 
Fixes incorrect translation of global rate limit descriptors into Envoy route config.

Previously, createRateLimitActions returned []*RateLimit_Action and all descriptors were collapsed into a single RateLimit entry with all actions merged together. This is wrong: in Envoy, a single RateLimit entry with multiple actions means all actions must match to form one combined descriptor key. Multiple independent descriptors require separate RateLimit entries.
The fix changes createRateLimitActions to return []*RateLimit — one per descriptor — and stores them directly as rateLimitActions rather than wrapping them in a single RateLimit. Each descriptor now produces its own independent rate limit check, matching Envoy's intended semantics.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix global rate limit descriptor translation: multiple descriptors now correctly produce separate Envoy RateLimit actions instead of being merged into a single combined action.
```
