### PR TITLE
feat: expose a label selector to limit service discovery 

### DIFF
--- a/api/settings/settings.go
+++ b/api/settings/settings.go
@@ -203,6 +203,12 @@ type Settings struct {
 	// E.g., [{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"In","values":["infra"]}]},{"matchLabels":{"app":"a"}}]
 	DiscoveryNamespaceSelectors string `split_words:"true" default:"[]"`
 
+	// ServiceLabelSelector is a Kubernetes label selector string used to filter which Services
+	// are included in discovery and sent to Envoy as clusters.
+	// Defaults to empty, which selects all services.
+	// Uses the same syntax as kubectl -l / --selector (e.g., "app=my-app,tier=frontend").
+	ServiceLabelSelector string `split_words:"true" default:""`
+
 	// EnableEnvoy enables kgateway to send config to Envoy
 	EnableEnvoy bool `split_words:"true" default:"true"`
 

--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -122,6 +122,8 @@ spec:
               value: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
             - name: KGW_DISCOVERY_NAMESPACE_SELECTORS
               value: {{ .Values.discoveryNamespaceSelectors | toJson | quote }}
+            - name: KGW_SERVICE_LABEL_SELECTOR
+              value: {{ .Values.serviceLabelSelector | quote }}
             - name: KGW_POLICY_MERGE
               value: {{ .Values.policyMerge | toJson | quote }}
             - name: KGW_VALIDATION_MODE

--- a/install/helm/kgateway/values.yaml
+++ b/install/helm/kgateway/values.yaml
@@ -258,6 +258,11 @@ image:
 # -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Kgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/envoy/latest/install/advanced/#namespace-discovery.
 discoveryNamespaceSelectors: []
 
+# -- Kubernetes label selector string used to filter which Services are included in discovery and
+#    sent to Envoy as clusters. Uses the same syntax as kubectl -l / --selector
+#    (e.g., "app=my-app,tier=frontend"). Defaults to empty, which selects all services.
+serviceLabelSelector: ""
+
 # -- Map of GatewayClass names to GatewayParameters references that will be set on
 #    the default GatewayClasses managed by kgateway. Each entry must define both the
 #    name and namespace of the GatewayParameters resource.

--- a/pkg/pluginsdk/collections/collections.go
+++ b/pkg/pluginsdk/collections/collections.go
@@ -134,7 +134,10 @@ func NewCommonCollections(
 
 	serviceClient := kclient.NewFiltered[*corev1.Service](
 		client,
-		kclient.Filter{ObjectFilter: client.ObjectFilter()},
+		kclient.Filter{
+			ObjectFilter:  client.ObjectFilter(),
+			LabelSelector: settings.ServiceLabelSelector,
+		},
 	)
 	services := krt.WrapClient(serviceClient, krtOptions.ToOptions("Services")...)
 


### PR DESCRIPTION
# Description

This enables users to set a label selector that applies to kgateway's service discovery, enabling to limit the how many clusters are created on envoy instances. See discussion in #13586 

It relies on isio's kclient.Filter `LabelSelector` field. The default value is `""` which is interpreted as "no selector" by the server. Thus, the default behaviour (to list all services) is not changed.

# Change Type

```
/kind feature
```

# Changelog

```release-note
Enable setting a label selector on services discovered by kgateway to limit the amount of clusters created on envoy.
```

# Additional Notes
AI disclosure: Claude implemented the changes, I have reviewed and tested them on my cluster.

How to use: set the following values on your Helm deployment
```
helm upgrade -i -n kgateway-system kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
--version v2.3.1 --set serviceLabelSelector kgateway=enabled
```

Sorry I'm not very familiar with the test suite and where to document this. Suggestions welcome