### PR TITLE
[2.3] chore: forward-port release workflow qemu version pin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,6 +166,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392" # v3.6.0
+        with:
+          # Pin the binfmt/QEMU emulator to a specific version. The action caches
+          # the emulator image (`cache-image: true`) under a key derived from the
+          # image ref; with the default `latest` tag that key is version-less, so a
+          # cache populated during QEMU's 8.2-era arm64 ELF-loader regression keeps
+          # getting restored even after Docker Hub's `latest` advances. That stale
+          # emulator segfaults running arm64 glibc trigger scripts
+          # (`Processing triggers for libc-bin ... qemu: uncaught target signal 11`)
+          # during cross-platform `docker build`, breaking the arm64 release image.
+          # A versioned tag gives a version-specific cache key (sidestepping the
+          # poisoned `latest` cache) and a QEMU build that contains the upstream fix.
+          image: tonistiigi/binfmt:qemu-v10.2.1
       - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10.0
 
       - name: Download release notes


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Fixes a bug where the moving docker image tag 'latest' gets cached at version V and then used later when V is not the latest version. https://github.com/kgateway-dev/kgateway/pull/14155 ran into this.
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes
Already on v2.2.x and main.
<!--
Any extra context or edge cases for reviewers.
-->
