### PR TITLE
tests: Add transfomation policy for upgrade tests

### DIFF
--- a/test/e2e/features/upgrade/suite.go
+++ b/test/e2e/features/upgrade/suite.go
@@ -76,6 +76,22 @@ func (s *testingSuite) applyManifests() func() {
 	}
 }
 
+// verifyRequestWithTransformation verifies that the TrafficPolicy in setup.yaml is being applied:
+// the X-Upgrade-Test header must be set to "header-modified" on every response.
+func (s *testingSuite) verifyRequestWithTransformation() {
+	s.T().Helper()
+	common.BaseGateway.Send(
+		s.T(),
+		&testmatchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Headers:    map[string]any{"X-Upgrade-Test": "header-modified"},
+		},
+		curl.WithPath("/headers"),
+		curl.WithHostHeader("example.com"),
+		curl.WithPort(8080),
+	)
+}
+
 // TestUpgrade upgrades both the CRD chart and the controller chart from the previously installed
 // remote release to the locally-built chart, then verifies the installation is healthy.
 func (s *testingSuite) TestUpgrade() {
@@ -88,13 +104,7 @@ func (s *testingSuite) TestUpgrade() {
 		Name:      "gateway",
 		Namespace: "default",
 	})
-	common.BaseGateway.Send(
-		s.T(),
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK},
-		curl.WithPath("/"),
-		curl.WithHostHeader("example.com"),
-		curl.WithPort(8080),
-	)
+	s.verifyRequestWithTransformation()
 	s.T().Logf(" ok")
 
 	s.TestInstallation.InstallKgatewayCRDsFromLocalChart(s.Ctx, s.T())
@@ -116,26 +126,14 @@ func (s *testingSuite) TestUpgrade() {
 
 	// Ensure the same gateway works after the upgrade.
 	s.T().Logf("checking connectivity with the gateway after the upgrade...")
-	common.BaseGateway.Send(
-		s.T(),
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK},
-		curl.WithPath("/"),
-		curl.WithHostHeader("example.com"),
-		curl.WithPort(8080),
-	)
+	s.verifyRequestWithTransformation()
 	s.T().Logf(" ok")
 
 	// Recreate the same gateway and ensure it works after the upgrade
 	cleanup()
 	s.applyManifests()
 	s.T().Logf("checking connectivity with the gateway after recreating it...")
-	common.BaseGateway.Send(
-		s.T(),
-		&testmatchers.HttpResponse{StatusCode: http.StatusOK},
-		curl.WithPath("/"),
-		curl.WithHostHeader("example.com"),
-		curl.WithPort(8080),
-	)
+	s.verifyRequestWithTransformation()
 	s.T().Logf(" ok")
 }
 

--- a/test/e2e/features/upgrade/testdata/setup.yaml
+++ b/test/e2e/features/upgrade/testdata/setup.yaml
@@ -40,7 +40,7 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: example-route
-  headerModifiers:
+  transformation:
     response:
       set:
         - name: X-Upgrade-Test

--- a/test/e2e/features/upgrade/testdata/setup.yaml
+++ b/test/e2e/features/upgrade/testdata/setup.yaml
@@ -29,3 +29,19 @@ spec:
     - backendRefs:
       - name: httpbin
         port: 8000
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: upgrade-header-policy
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: example-route
+  headerModifiers:
+    response:
+      set:
+        - name: X-Upgrade-Test
+          value: "header-modified"


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Adds a transformation policy for the upgrade tests. This validates the rustormation does not break between versions

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind cleanup
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
