### PR TITLE
[2.3] fix: stop deferring per-client xDS on a not-yet-ready EDS cluster

### DIFF
--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -228,12 +228,11 @@ func snapshotPerClient(
 			endpointRes.Items,
 			clustersForUcc.erroredClusters,
 		); len(missingEndpointClusters) > 0 {
-			logger.Info(
-				"defer building snapshot until all referenced EDS resources are ready",
+			logger.Warn(
+				"publishing snapshot with referenced EDS clusters still awaiting CLAs; relying on Envoy initial_fetch_timeout",
 				"client", ucc.ResourceName(),
 				"missing_endpoint_clusters", missingEndpointClusters,
 			)
-			return nil
 		}
 
 		snap.erroredClusters = clustersForUcc.erroredClusters

--- a/pkg/kgateway/proxy_syncer/perclient_eds_gate_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_eds_gate_test.go
@@ -1,0 +1,223 @@
+package proxy_syncer
+
+import (
+	"testing"
+	"time"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/xds"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
+)
+
+// TestSnapshotPerClientPublishesWhenReferencedEDSClusterCLAAbsent verifies the
+// inverse of the old defer-forever behavior: a referenced EDS cluster that is
+// present in CDS but whose ClusterLoadAssignment has not yet arrived must NOT
+// freeze the whole client's snapshot forever. The snapshot publishes anyway and
+// Envoy relies on its initial_fetch_timeout for the genuinely-late CLA. A
+// present-but-empty CLA is a valid steady state for Kube Services, so an absent
+// CLA is not a reason to strand the client on stale endpoints indefinitely.
+func TestSnapshotPerClientPublishesWhenReferencedEDSClusterCLAAbsent(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
+	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
+
+	uccs := krt.NewStaticCollection[ir.UniqlyConnectedClient](nil, []ir.UniqlyConnectedClient{ucc})
+	routes := sliceToResources([]*envoyroutev3.RouteConfiguration{
+		{
+			Name: "route-config",
+			VirtualHosts: []*envoyroutev3.VirtualHost{
+				{
+					Name:    "vhost",
+					Domains: []string{"*"},
+					Routes: []*envoyroutev3.Route{
+						{
+							Name: "eds-route",
+							Action: &envoyroutev3.Route_Route{
+								Route: &envoyroutev3.RouteAction{
+									ClusterSpecifier: &envoyroutev3.RouteAction_Cluster{Cluster: "cluster-a"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
+	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{{
+		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
+		Routes:             routes,
+		Listeners:          listeners,
+		ReferencedClusters: collectReferencedClusters(routes, listeners),
+	}})
+	// cluster-a is an EDS cluster present in CDS, but no CLA is ever delivered.
+	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
+		{
+			Client: ucc,
+			Name:   "cluster-a",
+			Cluster: &envoyclusterv3.Cluster{
+				Name: "cluster-a",
+				ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
+					Type: envoyclusterv3.Cluster_EDS,
+				},
+			},
+			ClusterVersion: 1,
+		},
+	})
+	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, nil)
+
+	snapshots := snapshotPerClient(
+		krtutil.KrtOptions{},
+		uccs,
+		mostXdsSnapshots,
+		PerClientEnvoyEndpoints{
+			endpoints: endpointCol,
+			index: krtpkg.UnnamedIndex(endpointCol, func(ep UccWithEndpoints) []string {
+				return []string{ep.Client.ResourceName()}
+			}),
+		},
+		PerClientEnvoyClusters{
+			clusters: clusterCol,
+			index: krtpkg.UnnamedIndex(clusterCol, func(cluster uccWithCluster) []string {
+				return []string{cluster.Client.ResourceName()}
+			}),
+		},
+	)
+
+	g.Eventually(func() int {
+		return len(snapshots.List())
+	}, 2*time.Second, 20*time.Millisecond).Should(gomega.Equal(1),
+		"a referenced EDS cluster without a CLA must not freeze the snapshot forever")
+
+	snap := snapshots.List()[0].snap
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"),
+		"the published snapshot must contain the referenced EDS cluster")
+}
+
+// TestSnapshotPerClientPublishesPresentCLAWhenOtherClusterCLAMissing verifies
+// that a missing CLA for one referenced EDS cluster (cluster-b) does not prevent
+// another referenced EDS cluster's (cluster-a) present CLA from being published
+// in the same snapshot. The whole client is no longer stranded just because a
+// single cluster's CLA is still in flight.
+func TestSnapshotPerClientPublishesPresentCLAWhenOtherClusterCLAMissing(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
+	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
+
+	uccs := krt.NewStaticCollection[ir.UniqlyConnectedClient](nil, []ir.UniqlyConnectedClient{ucc})
+	routes := sliceToResources([]*envoyroutev3.RouteConfiguration{
+		{
+			Name: "route-config",
+			VirtualHosts: []*envoyroutev3.VirtualHost{
+				{
+					Name:    "vhost",
+					Domains: []string{"*"},
+					Routes: []*envoyroutev3.Route{
+						{
+							Name: "weighted-route",
+							Action: &envoyroutev3.Route_Route{
+								Route: &envoyroutev3.RouteAction{
+									ClusterSpecifier: &envoyroutev3.RouteAction_WeightedClusters{
+										WeightedClusters: &envoyroutev3.WeightedCluster{
+											Clusters: []*envoyroutev3.WeightedCluster_ClusterWeight{
+												{Name: "cluster-a", Weight: wrapperspb.UInt32(1)},
+												{Name: "cluster-b", Weight: wrapperspb.UInt32(1)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
+	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{{
+		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
+		Routes:             routes,
+		Listeners:          listeners,
+		ReferencedClusters: collectReferencedClusters(routes, listeners),
+	}})
+	// Both cluster-a and cluster-b are EDS clusters present in CDS.
+	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
+		{
+			Client: ucc,
+			Name:   "cluster-a",
+			Cluster: &envoyclusterv3.Cluster{
+				Name: "cluster-a",
+				ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
+					Type: envoyclusterv3.Cluster_EDS,
+				},
+			},
+			ClusterVersion: 1,
+		},
+		{
+			Client: ucc,
+			Name:   "cluster-b",
+			Cluster: &envoyclusterv3.Cluster{
+				Name: "cluster-b",
+				ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
+					Type: envoyclusterv3.Cluster_EDS,
+				},
+			},
+			ClusterVersion: 2,
+		},
+	})
+	// Only cluster-a's CLA has arrived (an explicit empty CLA is a valid steady
+	// state). cluster-b's CLA is still missing.
+	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, []UccWithEndpoints{
+		{
+			Client: ucc,
+			Endpoints: &envoyendpointv3.ClusterLoadAssignment{
+				ClusterName: "cluster-a",
+			},
+			EndpointsHash: 3,
+			endpointsName: "cluster-a",
+		},
+	})
+
+	snapshots := snapshotPerClient(
+		krtutil.KrtOptions{},
+		uccs,
+		mostXdsSnapshots,
+		PerClientEnvoyEndpoints{
+			endpoints: endpointCol,
+			index: krtpkg.UnnamedIndex(endpointCol, func(ep UccWithEndpoints) []string {
+				return []string{ep.Client.ResourceName()}
+			}),
+		},
+		PerClientEnvoyClusters{
+			clusters: clusterCol,
+			index: krtpkg.UnnamedIndex(clusterCol, func(cluster uccWithCluster) []string {
+				return []string{cluster.Client.ResourceName()}
+			}),
+		},
+	)
+
+	g.Eventually(func() int {
+		return len(snapshots.List())
+	}, 2*time.Second, 20*time.Millisecond).Should(gomega.Equal(1),
+		"a missing CLA for cluster-b must not prevent publishing cluster-a's CLA")
+
+	snap := snapshots.List()[0].snap
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-b"))
+	g.Expect(snap.Resources[envoycachetypes.Endpoint].Items).To(gomega.HaveKey("cluster-a"),
+		"cluster-a's present CLA must be published even though cluster-b's CLA is missing")
+}

--- a/pkg/kgateway/proxy_syncer/perclient_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_test.go
@@ -314,9 +314,12 @@ func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testi
 		},
 	)
 
-	g.Consistently(func() int {
+	// A referenced EDS cluster present in CDS but whose CLA has not yet arrived
+	// must NOT freeze the snapshot forever: the snapshot publishes and Envoy
+	// relies on its initial_fetch_timeout for the genuinely-late CLA.
+	g.Eventually(func() int {
 		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
 
 	endpointCol.UpdateObject(UccWithEndpoints{
 		Client: ucc,
@@ -327,12 +330,13 @@ func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testi
 		endpointsName: "cluster-a",
 	})
 
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
-
-	snap := snapshots.List()[0].snap
-	g.Expect(snap.Resources[envoycachetypes.Endpoint].Items).To(gomega.HaveKey("cluster-a"))
+	g.Eventually(func() map[string]envoycachetypes.ResourceWithTTL {
+		list := snapshots.List()
+		if len(list) != 1 {
+			return nil
+		}
+		return list[0].snap.Resources[envoycachetypes.Endpoint].Items
+	}, time.Second, 20*time.Millisecond).Should(gomega.HaveKey("cluster-a"))
 }
 
 func TestSnapshotPerClientStillPublishesWhenReferencedClusterErrored(t *testing.T) {


### PR DESCRIPTION
# Description

**Motivation:** PR #13868 added readiness guards to the per-client xDS snapshot builder (`snapshotPerClient` in `pkg/kgateway/proxy_syncer/perclient.go`). Guard #3 deferred publishing the *entire* per-client snapshot -- by `return nil`, which surfaces as a KRT Delete that the syncer treats as a no-op -- whenever any referenced EDS cluster was present in CDS but its `ClusterLoadAssignment` had not yet arrived. Because the Delete is a no-op, Envoy keeps its last snapshot, so a client could be stranded indefinitely on **stale endpoints**, sending traffic to pods that no longer exist (upstream connection failures). This hit only some replicas of a gateway, depending on event timing.

**What changed:** Guard #3 is demoted from a defer-forever to a non-blocking warning. A referenced EDS cluster whose CLA is not yet present no longer blocks the snapshot; we publish and rely on Envoy's `initial_fetch_timeout` for the rare genuinely-late CLA. Kube Services already always emit an (even empty) CLA, so a present-but-empty CLA is a valid steady state -- there is no reason to withhold the whole client's config for it. Guard #2 (missing CDS clusters) is unchanged.

**Related issues:** Refines the behavior introduced in #13868. Refs #14184.

# Change Type

/kind fix

# Changelog

```release-note
Fixed an issue where a proxy could be stranded on stale endpoints (causing upstream connection failures) when a referenced cluster's endpoint data was temporarily unavailable; the control plane now publishes the snapshot and relies on Envoy's initial fetch timeout instead of deferring indefinitely.
```

# Additional Notes

- Single-file behavior change (`perclient.go`, guard #3 body only).
- Tests: new `perclient_eds_gate_test.go` proves the snapshot now publishes when a referenced EDS cluster's CLA is absent, and that a missing CLA for one cluster does not block another cluster's present CLA. Updated the assertions of the existing `TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints` (which encoded the old defer behavior). Full `proxy_syncer` suite green.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->
