### PR TITLE
fix: register xDS cert watcher with manager for proper lifecycle

### DIFF
--- a/pkg/kgateway/setup/setup.go
+++ b/pkg/kgateway/setup/setup.go
@@ -305,7 +305,9 @@ func (s *setup) Start(ctx context.Context) error {
 	}
 
 	// Create shared certificate watcher if TLS is enabled. This watcher is used by both the xDS server
-	// and the Gateway controller to kick reconciliation on cert changes.
+	// and the Gateway controller to kick reconciliation on cert changes. New() synchronously loads
+	// the cert, so GetCertificate is usable immediately; the manager runs Start() to enable rotation
+	// and propagates any failure as a fatal manager error rather than swallowing it.
 	var certWatcher *certwatcher.CertWatcher
 	if s.globalSettings.XdsTLS {
 		var err error
@@ -313,12 +315,9 @@ func (s *setup) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		go func() {
-			if err := certWatcher.Start(ctx); err != nil {
-				slog.Error("failed to start TLS certificate watcher", "error", err)
-			}
-			slog.Info("started TLS certificate watcher")
-		}()
+		if err := mgr.Add(certWatcher); err != nil {
+			return fmt.Errorf("failed to register TLS certificate watcher with manager: %w", err)
+		}
 	}
 
 	// Only create Envoy control plane if Envoy controller is enabled


### PR DESCRIPTION
# Description

Refs #13847.

The xDS TLS certificate watcher was started in a fire-and-forget goroutine that swallowed `Start()` errors:

```go
go func() {
    if err := certWatcher.Start(ctx); err != nil {
        slog.Error("failed to start TLS certificate watcher", "error", err)
    }
    slog.Info("started TLS certificate watcher")
}()
```

The race-condition concern raised in #13847 is not real: `certwatcher.New()` synchronously loads cert + key into `currentCert` before returning, so `GetCertificate` (xDS gRPC) and `RegisterCallback` (gateway controller) are usable from the moment `New()` returns. `Start()` only enables fsnotify-driven rotation; it is not required for initial TLS to work.

However, the swallowed-error behavior is a real (smaller) issue: if `Start()` fails (e.g., fsnotify can't add the watch after its 10s poll), cert rotation silently stops working with no signal until the cert expires.

`certwatcher.CertWatcher` already implements `Runnable` (`Start(ctx) error`) and `NeedLeaderElection() bool { return false }`, so the conventional integration is `mgr.Add(certWatcher)`. The manager then owns its lifecycle and propagates a `Start()` failure as a fatal manager error.

# Change Type

/kind fix

# Changelog

```release-note
Register the xDS TLS certificate watcher with the controller manager so that failures to start it are surfaced as fatal errors rather than silently disabling certificate rotation.
```

# Additional Notes

Initial TLS behavior is unchanged: `certwatcher.New()` still loads the cert synchronously, and `xds.TLSCertPath` / `xds.TLSKeyPath` errors still cause `setup.Start` to return before the xDS server is created. Only the path for `Start()`-time failures changes.