### PR TITLE
fix: re-publish xDS for proxies stranded without a current snapshot

### DIFF
--- a/pkg/kgateway/proxy_syncer/defer_watchdog.go
+++ b/pkg/kgateway/proxy_syncer/defer_watchdog.go
@@ -1,0 +1,157 @@
+package proxy_syncer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+const (
+	// deferWatchdogInterval is how often the watchdog scans live UCCs for
+	// stuck/deferred snapshots. A non-round value is used so the scan does
+	// not line up with other periodic loops in the process.
+	deferWatchdogInterval = 7 * time.Second
+
+	// deferWatchdogThreshold is how long a live UCC may sit without a current
+	// xDS snapshot before the watchdog republishes its last known wrapper. It
+	// is intentionally longer than a normal controller restart warmup so the
+	// watchdog never races the regular per-client transform during steady
+	// startup; it only fires when a client is genuinely stranded.
+	deferWatchdogThreshold = 20 * time.Second
+)
+
+// deferWatchdogRepublishes counts how many times the watchdog had to
+// republish a last-known snapshot for a live UCC that had been deferred
+// past the threshold. A persistently nonzero rate indicates the readiness
+// guards in snapshotPerClient are stranding clients on stale config.
+var deferWatchdogRepublishes = metrics.NewCounter(
+	metrics.CounterOpts{
+		Subsystem: snapshotSubsystem,
+		Name:      "defer_watchdog_republishes_total",
+		Help:      "Total number of stuck/deferred per-client snapshots republished by the defer watchdog",
+	},
+	[]string{gatewayLabel, namespaceLabel},
+)
+
+// deferWatchdog is a safety valve that guarantees no live UCC (uniquely
+// connected client / Envoy replica) is left without a current xDS snapshot
+// indefinitely, independent of KRT event delivery.
+//
+// snapshotPerClient defers publishing (returns nil) when its per-client
+// inputs look incoherent; KRT surfaces that as a Delete, whose handler in
+// proxy_syncer.go is an intentional no-op so Envoy keeps its last-published
+// snapshot. If a readiness guard becomes permanently true for one UCC, that
+// client is stranded on stale endpoints and never republishes. The watchdog
+// detects this case and republishes the last wrapper we saw for the client,
+// which self-heals the staleness and is harmless when the client is healthy.
+type deferWatchdog struct {
+	pt   *ProxyTranslator
+	uccs krt.Collection[ir.UniqlyConnectedClient]
+
+	mu          sync.Mutex
+	lastWrapper map[string]XdsSnapWrapper
+	lastChange  map[string]time.Time
+
+	// clock is injectable for tests; defaults to time.Now.
+	clock func() time.Time
+}
+
+func newDeferWatchdog(pt *ProxyTranslator, uccs krt.Collection[ir.UniqlyConnectedClient]) *deferWatchdog {
+	return &deferWatchdog{
+		pt:          pt,
+		uccs:        uccs,
+		lastWrapper: map[string]XdsSnapWrapper{},
+		lastChange:  map[string]time.Time{},
+		clock:       time.Now,
+	}
+}
+
+// observe records the latest per-client snapshot event so the watchdog can
+// republish the last known good wrapper later if the client gets stranded.
+// A Delete is a defer signal: we record the time of the change but keep the
+// last wrapper so we still have something to republish.
+func (wd *deferWatchdog) observe(e krt.Event[XdsSnapWrapper]) {
+	key := e.Latest().ResourceName()
+
+	wd.mu.Lock()
+	defer wd.mu.Unlock()
+
+	if e.Event != controllers.EventDelete {
+		wd.lastWrapper[key] = e.Latest()
+	}
+	wd.lastChange[key] = wd.clock()
+}
+
+// reconcileOnce republishes the last known wrapper for any live UCC that has
+// no current snapshot in the xDS cache and has been in that state for at
+// least threshold. Clients with a healthy current snapshot are skipped.
+func (wd *deferWatchdog) reconcileOnce(ctx context.Context, threshold time.Duration) {
+	liveKeys := make(map[string]struct{})
+	for _, ucc := range wd.uccs.List() {
+		liveKeys[ucc.ResourceName()] = struct{}{}
+	}
+
+	now := wd.clock()
+
+	wd.mu.Lock()
+	defer wd.mu.Unlock()
+
+	for key := range liveKeys {
+		// A healthy current snapshot in the cache means this client is fine.
+		if snap, err := wd.pt.xdsCache.GetSnapshot(key); err == nil && snap != nil {
+			continue
+		}
+
+		// No snapshot for this live client. Only act once it has been stuck
+		// past the threshold, so we never race the normal transform during
+		// steady startup.
+		lastChange, seen := wd.lastChange[key]
+		if seen && now.Sub(lastChange) < threshold {
+			continue
+		}
+
+		wrapper, ok := wd.lastWrapper[key]
+		if !ok {
+			// Nothing to republish yet; we have never seen a wrapper for this
+			// client. Leave it for the normal transform to populate.
+			continue
+		}
+
+		cd := getDetailsFromXDSClientResourceName(key)
+		var age time.Duration
+		if seen {
+			age = now.Sub(lastChange)
+		}
+		logger.Warn(
+			"xds snapshot missing/deferred past threshold; republishing last known wrapper",
+			"client", key,
+			"age", age,
+		)
+		deferWatchdogRepublishes.Inc(
+			metrics.Label{Name: gatewayLabel, Value: cd.Gateway},
+			metrics.Label{Name: namespaceLabel, Value: cd.Namespace},
+		)
+		wd.pt.syncXds(ctx, wrapper)
+	}
+}
+
+// run drives reconcileOnce on a ticker until ctx is cancelled.
+func (wd *deferWatchdog) run(ctx context.Context, interval, threshold time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			wd.reconcileOnce(ctx, threshold)
+		}
+	}
+}

--- a/pkg/kgateway/proxy_syncer/defer_watchdog_test.go
+++ b/pkg/kgateway/proxy_syncer/defer_watchdog_test.go
@@ -1,0 +1,146 @@
+package proxy_syncer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/onsi/gomega"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/utils/ptr"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/xds"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+// newTestWrapper builds a minimal but valid XdsSnapWrapper for proxyKey with a
+// single cluster, so syncXds publishes a non-nil snapshot the cache will store.
+func newTestWrapper(proxyKey string) XdsSnapWrapper {
+	snapshot := &envoycache.Snapshot{}
+	snapshot.Resources[envoycachetypes.Cluster] = envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
+		{Resource: &envoyclusterv3.Cluster{Name: "cluster-a"}},
+	})
+	return XdsSnapWrapper{
+		snap:     snapshot,
+		proxyKey: proxyKey,
+	}
+}
+
+func newTestWatchdog(t *testing.T, ucc ir.UniqlyConnectedClient) (*deferWatchdog, envoycache.SnapshotCache) {
+	t.Helper()
+
+	cache := envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil)
+	pt := NewProxyTranslator(cache)
+	uccs := krt.NewStaticCollection[ir.UniqlyConnectedClient](nil, []ir.UniqlyConnectedClient{ucc})
+	wd := newDeferWatchdog(&pt, uccs)
+	return wd, cache
+}
+
+// TestDeferWatchdogRepublishesStrandedClient covers Case A: a live UCC with no
+// snapshot in the cache, a last known wrapper recorded, and an age past the
+// threshold. reconcileOnce must republish so GetSnapshot then succeeds.
+func TestDeferWatchdogRepublishesStrandedClient(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
+	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
+	key := ucc.ResourceName()
+
+	wd, cache := newTestWatchdog(t, ucc)
+
+	now := time.Unix(1000, 0)
+	wd.clock = func() time.Time { return now }
+
+	// Record a last known wrapper as if a snapshot had been built, then the
+	// client was deferred (Delete) and never republished.
+	wd.observe(krt.Event[XdsSnapWrapper]{
+		New:   ptr.To(newTestWrapper(key)),
+		Event: controllers.EventAdd,
+	})
+
+	// The cache must start empty for this client.
+	_, err := cache.GetSnapshot(key)
+	g.Expect(err).To(gomega.HaveOccurred(), "cache should have no snapshot for the client initially")
+
+	// Advance the clock past the threshold and reconcile.
+	now = now.Add(deferWatchdogThreshold + time.Second)
+	wd.reconcileOnce(context.Background(), deferWatchdogThreshold)
+
+	snap, err := cache.GetSnapshot(key)
+	g.Expect(err).ToNot(gomega.HaveOccurred(), "watchdog should have republished the last known wrapper")
+	g.Expect(snap).ToNot(gomega.BeNil())
+}
+
+// TestDeferWatchdogSkipsHealthyClient covers Case B: a live UCC that already
+// has a current snapshot in the cache must not be republished.
+func TestDeferWatchdogSkipsHealthyClient(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
+	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
+	key := ucc.ResourceName()
+
+	wd, cache := newTestWatchdog(t, ucc)
+
+	now := time.Unix(2000, 0)
+	wd.clock = func() time.Time { return now }
+
+	// Publish a healthy snapshot up front.
+	healthy := newTestWrapper(key)
+	wd.pt.syncXds(context.Background(), healthy)
+	before, err := cache.GetSnapshot(key)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Record a different last known wrapper that the watchdog would publish if
+	// it (incorrectly) treated the healthy client as stranded.
+	other := newTestWrapper(key)
+	wd.observe(krt.Event[XdsSnapWrapper]{
+		New:   ptr.To(other),
+		Event: controllers.EventAdd,
+	})
+
+	// Even well past the threshold, a healthy client is skipped.
+	now = now.Add(deferWatchdogThreshold + time.Hour)
+	wd.reconcileOnce(context.Background(), deferWatchdogThreshold)
+
+	after, err := cache.GetSnapshot(key)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	// The cache must still hold the originally published snapshot, not the
+	// watchdog's recorded wrapper.
+	g.Expect(after).To(gomega.BeIdenticalTo(before),
+		"healthy client snapshot must not be overwritten by the watchdog")
+}
+
+// TestDeferWatchdogWaitsUntilThreshold covers Case C: a live UCC with no
+// snapshot but whose last change is within the threshold must not be
+// republished yet.
+func TestDeferWatchdogWaitsUntilThreshold(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
+	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
+	key := ucc.ResourceName()
+
+	wd, cache := newTestWatchdog(t, ucc)
+
+	now := time.Unix(3000, 0)
+	wd.clock = func() time.Time { return now }
+
+	// A Delete carries the prior object in Old; Latest() returns it for deletes.
+	wd.observe(krt.Event[XdsSnapWrapper]{
+		Old:   ptr.To(newTestWrapper(key)),
+		Event: controllers.EventDelete,
+	})
+
+	// Advance only part way to the threshold.
+	now = now.Add(deferWatchdogThreshold / 2)
+	wd.reconcileOnce(context.Background(), deferWatchdogThreshold)
+
+	_, err := cache.GetSnapshot(key)
+	g.Expect(err).To(gomega.HaveOccurred(), "watchdog must not republish before the threshold elapses")
+}

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -457,8 +457,10 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 		s.backendPolicyReportQueue.Enqueue(o.Latest().reportMap)
 	})
 
+	wd := newDeferWatchdog(&s.proxyTranslator, s.uniqueClients)
 	s.perclientSnapCollection.RegisterBatch(func(o []krt.Event[XdsSnapWrapper]) {
 		for _, e := range o {
+			wd.observe(e)
 			cd := getDetailsFromXDSClientResourceName(e.Latest().ResourceName())
 
 			if e.Event != controllers.EventDelete {
@@ -493,6 +495,8 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 			})
 		}
 	}, true)
+
+	go wd.run(ctx, deferWatchdogInterval, deferWatchdogThreshold)
 
 	s.ready.Store(true)
 	<-ctx.Done()


### PR DESCRIPTION
# Description

**Motivation:** The per-client snapshot builder can defer publishing for a UCC (connected proxy). If a deferral becomes effectively permanent for one replica — the failure mode behind the stale-endpoints incident — nothing re-publishes its config and it is silently stranded. There is no backstop that guarantees every live proxy eventually has an up-to-date snapshot.

**What changed:** A watchdog reconciler (`defer_watchdog.go`) that closes the loop independently of KRT event delivery.

- It observes every per-client snapshot event in the existing `RegisterBatch` handler, recording the last wrapper and last-change time per proxy.
- On a periodic tick (`deferWatchdogInterval`), for any proxy in the live `uniqueClients` set that has no current snapshot in the xDS cache and has been in that state past `deferWatchdogThreshold` (set longer than normal restart warmup), it logs a warning, increments a metric, and re-publishes the last wrapper it saw.

This is a safety valve: with the carry-forward fix present it self-heals (the last wrapper is a fresh best-effort snapshot); standalone it provides loud detection + a re-publish attempt. It references no fields added by other PRs, so it compiles and works on its own.

**Related issues:** Hardens against the class of bug reported around #13868.

# Change Type

/kind fix

# Changelog

```release-note
Added a watchdog that detects proxies left without an up-to-date xDS snapshot and re-publishes their configuration, preventing a proxy from being permanently stranded on stale config.
```

# Additional Notes

- Files: new `defer_watchdog.go` (+ test); `proxy_syncer.go` `Start()` wiring only (construct watchdog, `observe` inside the existing batch loop, launch `go wd.run(...)`). No new imports in `proxy_syncer.go`; no `ProxySyncer` struct fields added; the watchdog metric is declared in its own file (no `metrics.go` change).
- Tests: `defer_watchdog_test.go` drives `reconcileOnce` with an injected clock and a real snapshot cache — republishes a stranded client, skips a healthy one, and waits until the threshold elapses.