### PR TITLE
ServiceEntry: Promote configured WE annotations into workload labels

### DIFF
--- a/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
@@ -139,6 +139,7 @@ func initServiceEntryCollections(
 		commonCols.LocalityPods,
 		opts.Aliaser,
 		opts.WorkloadEntriesExclusionLabelKeys,
+		opts.PromoteWorkloadEntryAnnotations,
 	)
 
 	// init the outputs
@@ -182,6 +183,7 @@ func selectedWorkloads(
 	Pods krt.Collection[krtcollections.LocalityPod],
 	aliaser Aliaser,
 	weExclusionLabelKeys sets.Set[string],
+	promoteAnnotationKeys sets.Set[string],
 ) (
 	krt.Collection[selectedWorkload],
 	krt.Index[string, selectedWorkload],
@@ -222,6 +224,8 @@ func selectedWorkloads(
 		workload := selectedWorkloadFromEntry(
 			we.GetName(), we.GetNamespace(),
 			we.GetObjectMeta().GetLabels(),
+			we.GetObjectMeta().GetAnnotations(),
+			promoteAnnotationKeys,
 			&we.Spec,
 			selectedByServiceEntries,
 		)
@@ -262,6 +266,8 @@ func selectedWorkloads(
 func selectedWorkloadFromEntry(
 	name, namespace string,
 	metadataLabels map[string]string,
+	metadataAnnotations map[string]string,
+	promoteAnnotationKeys sets.Set[string],
 	weSpec *networking.WorkloadEntry,
 	selectedBy []seSelector,
 ) selectedWorkload {
@@ -273,6 +279,15 @@ func selectedWorkloadFromEntry(
 		// WorkloadEntry has two places to specify labels.
 		// Merge the spec labels on top of the metadata ones
 		labels = maps.MergeCopy(metadataLabels, labels)
+	}
+
+	// Promote configured WorkloadEntry metadata annotations into the labels so that
+	// endpoint plugins can observe them. This is an opaque string copy; kgateway is
+	// agnostic to what the keys mean or how their values are interpreted.
+	for key := range promoteAnnotationKeys {
+		if v, ok := metadataAnnotations[key]; ok {
+			labels[key] = v
+		}
 	}
 
 	// WorkloadEntry has a field for network, but we should also respect the label.

--- a/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
@@ -23,6 +23,8 @@ func (s *serviceEntryPlugin) buildInlineEndpoints(be ir.BackendObjectIR, se *net
 			fmt.Sprintf("%s-endpoints-%d", se.Name, i), // synthetic name
 			se.Namespace, // inherit se namespace
 			nil,          // no metadata labels to inherit
+			nil,          // no metadata annotations to promote
+			nil,          // no annotation keys to promote
 			e,
 			nil, // not in krt, don't need selectedBy
 		)
@@ -37,6 +39,8 @@ func (s *serviceEntryPlugin) buildInlineEndpoints(be ir.BackendObjectIR, se *net
 				fmt.Sprintf("%s-hosts-%d", se.Name, i), // synthetic name
 				se.Namespace,                           // inherit se namespace
 				nil,                                    // no metadata labels to inherit
+				nil,                                    // no metadata annotations to promote
+				nil,                                    // no annotation keys to promote
 				&networking.WorkloadEntry{Address: hostname},
 				nil, // not in krt, don't need selectedBy
 			)

--- a/pkg/kgateway/extensions2/plugins/serviceentry/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/plugin.go
@@ -42,6 +42,13 @@ type Options struct {
 	// Settings.WorkloadEntriesExclusionLabels is used. Use an empty set to explicitly disable
 	// exclusions.
 	WorkloadEntriesExclusionLabelKeys sets.Set[string]
+
+	// PromoteWorkloadEntryAnnotations is the set of WorkloadEntry annotation keys that, if present
+	// on the WorkloadEntry's metadata, are copied verbatim into the workload's AugmentedLabels so
+	// that endpoint plugins can observe them. kgateway is agnostic to what the keys mean; it does
+	// an opaque string copy. Callers (e.g. downstream distributions) supply the keys they care
+	// about. When nil or empty, no annotations are promoted.
+	PromoteWorkloadEntryAnnotations sets.Set[string]
 }
 
 func NewPlugin(

--- a/pkg/kgateway/extensions2/plugins/serviceentry/promote_annotations_test.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/promote_annotations_test.go
@@ -1,0 +1,92 @@
+package serviceentry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networking "istio.io/api/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TestSelectedWorkloadFromEntry_PromoteAnnotations verifies the generic WorkloadEntry
+// annotation-promotion behavior: configured annotation keys are copied verbatim into
+// AugmentedLabels, unconfigured keys are left alone, and absent annotations are a no-op.
+// The keys here are arbitrary; kgateway is agnostic to what they mean.
+func TestSelectedWorkloadFromEntry_PromoteAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		metadataLabels      map[string]string
+		metadataAnnotations map[string]string
+		promoteKeys         sets.Set[string]
+		wantLabel           map[string]string // key -> expected value in AugmentedLabels
+		wantAbsentKeys      []string
+	}{
+		{
+			name: "nil promote set promotes nothing",
+			metadataAnnotations: map[string]string{
+				"example.io/promote-me": "42",
+			},
+			promoteKeys:    nil,
+			wantAbsentKeys: []string{"example.io/promote-me"},
+		},
+		{
+			name: "configured key is promoted into labels",
+			metadataAnnotations: map[string]string{
+				"example.io/promote-me": "42",
+			},
+			promoteKeys: sets.New("example.io/promote-me"),
+			wantLabel:   map[string]string{"example.io/promote-me": "42"},
+		},
+		{
+			name: "unconfigured annotation key is not promoted",
+			metadataAnnotations: map[string]string{
+				"example.io/promote-me": "42",
+				"example.io/ignore-me":  "99",
+			},
+			promoteKeys:    sets.New("example.io/promote-me"),
+			wantLabel:      map[string]string{"example.io/promote-me": "42"},
+			wantAbsentKeys: []string{"example.io/ignore-me"},
+		},
+		{
+			name:                "absent annotation is a no-op",
+			metadataAnnotations: nil,
+			promoteKeys:         sets.New("example.io/promote-me"),
+			wantAbsentKeys:      []string{"example.io/promote-me"},
+		},
+		{
+			name: "promoted value coexists with existing labels",
+			metadataLabels: map[string]string{
+				"app": "foo",
+			},
+			metadataAnnotations: map[string]string{
+				"example.io/promote-me": "42",
+			},
+			promoteKeys: sets.New("example.io/promote-me"),
+			wantLabel: map[string]string{
+				"app":                   "foo",
+				"example.io/promote-me": "42",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workload := selectedWorkloadFromEntry(
+				"we", "ns",
+				tt.metadataLabels,
+				tt.metadataAnnotations,
+				tt.promoteKeys,
+				&networking.WorkloadEntry{Address: "1.2.3.4"},
+				nil,
+			)
+
+			for k, want := range tt.wantLabel {
+				assert.Equal(t, want, workload.AugmentedLabels[k], "label %q", k)
+			}
+			for _, k := range tt.wantAbsentKeys {
+				_, ok := workload.AugmentedLabels[k]
+				assert.False(t, ok, "label %q should be absent", k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Add `Options.PromoteWorkloadEntryAnnotations` so callers can supply a set of WorkloadEntry annotation keys to copy verbatim into AugmentedLabels, letting endpoint plugins observe them.
kgateway stays agnostic to the keys' meaning.

Main reason not to include all annotations instead of configured ones:
1. Annotation values aren't valid label values
2. Collisions with meaningful labels
3. Endpoint hash stability

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

(not a user facing change)

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
