### PR TITLE
fix: derive ENVTEST_K8S_VERSION from client-go in go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,9 @@ golden-translator-%:
 # Env test
 #----------------------------------------------------------------------------------
 
-ENVTEST_K8S_VERSION = 1.31
+# Derived from the k8s.io/client-go version in go.mod (client-go v0.X.Y => K8s 1.X)
+# so the envtest binaries track the Kubernetes libraries instead of drifting.
+ENVTEST_K8S_VERSION ?= $(shell grep -E '^\s*k8s.io/client-go ' go.mod | awk '{print $$2}' | sed -E 's/v0\.([0-9]+)\..*/1.\1/')
 ENVTEST ?= go -C tools tool setup-envtest
 
 .PHONY: envtest-path

--- a/Makefile
+++ b/Makefile
@@ -473,9 +473,10 @@ golden-translator-%:
 # Env test
 #----------------------------------------------------------------------------------
 
-# Derived from the k8s.io/client-go version in go.mod (client-go v0.X.Y => K8s 1.X)
-# so the envtest binaries track the Kubernetes libraries instead of drifting.
-ENVTEST_K8S_VERSION ?= $(shell grep -E '^\s*k8s.io/client-go ' go.mod | awk '{print $$2}' | sed -E 's/v0\.([0-9]+)\..*/1.\1/')
+# Derived from the k8s.io/client-go version (client-go v0.X.Y => K8s 1.X) so the
+# envtest binaries track the Kubernetes libraries instead of drifting. Uses
+# `go list -m` (as GINKGO_VERSION does) so it respects require/replace directives.
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f '{{.Version}}' k8s.io/client-go | sed -E 's/v0\.([0-9]+)\..*/1.\1/')
 ENVTEST ?= go -C tools tool setup-envtest
 
 .PHONY: envtest-path


### PR DESCRIPTION
# Description

`ENVTEST_K8S_VERSION` was hardcoded to `1.31`, which drifts from the actual
Kubernetes libraries as `k8s.io/client-go` is bumped. This derives it from the
`client-go` version in `go.mod` (`client-go v0.X.Y` => K8s `1.X`), matching the
existing `KIND_VERSION` / `GINKGO_VERSION` go.mod-parsing pattern, so the envtest
binaries stay in sync automatically.

With the current `k8s.io/client-go v0.35.3` this resolves to `1.35`. Verified
locally that `make envtest-path` derives `1.35` and `setup-envtest` provides a
matching `v1.35.0` binary.

Fixes #11500

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```
