### PR TITLE
fix: include group/kind in unknown backend kind status message

### DIFF
--- a/pkg/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/grpc-routing/invalid-backend.yaml
@@ -94,7 +94,7 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: unknown backend kind
+          message: unknown backend kind "ConfigMap"
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-routing-invalid-backend.yaml
@@ -94,7 +94,7 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: unknown backend kind
+          message: unknown backend kind "unknown" in group "unknown"
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs

--- a/pkg/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/tcp-routing/invalid-backend.yaml
@@ -72,7 +72,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: unknown backend kind
+          message: unknown backend kind "unknown" in group "unknown"
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs

--- a/pkg/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/tls-routing/invalid-backend.yaml
@@ -87,7 +87,7 @@ Statuses:
           status: "True"
           type: Accepted
         - lastTransitionTime: null
-          message: unknown backend kind
+          message: unknown backend kind "unknown" in group "unknown"
           reason: InvalidKind
           status: "False"
           type: ResolvedRefs

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -59,6 +59,25 @@ func (e *BackendPortNotAllowedError) Error() string {
 	return fmt.Sprintf("BackendRef to \"%s\" includes a port. Do not specify a port when referencing a Backend resource, as it defines its own port configuration", e.BackendName)
 }
 
+// UnknownBackendKindError indicates that a backend reference used a Group/Kind
+// that is not a supported backend type. It reports errors.Is true against
+// ErrUnknownBackendKind so existing error classification keeps working, while
+// carrying the referenced Group/Kind for a more descriptive status message.
+type UnknownBackendKindError struct {
+	GroupKind schema.GroupKind
+}
+
+func (e *UnknownBackendKindError) Error() string {
+	if e.GroupKind.Group == "" {
+		return fmt.Sprintf("unknown backend kind %q", e.GroupKind.Kind)
+	}
+	return fmt.Sprintf("unknown backend kind %q in group %q", e.GroupKind.Kind, e.GroupKind.Group)
+}
+
+func (e *UnknownBackendKindError) Is(target error) bool {
+	return target == ErrUnknownBackendKind
+}
+
 // ListenerCollection defines an interface that returns the listeners belonging to the implementing struct
 type ListenerCollection interface {
 	GetListeners() []gwv1.Listener
@@ -331,7 +350,7 @@ func (i *BackendIndex) getBackendFromAlias(kctx krt.HandlerContext, gk schema.Gr
 	}
 
 	if !didFetch {
-		return nil, ErrUnknownBackendKind
+		return nil, &UnknownBackendKindError{GroupKind: gk}
 	}
 
 	var out *ir.BackendObjectIR

--- a/pkg/krtcollections/policy_errors_test.go
+++ b/pkg/krtcollections/policy_errors_test.go
@@ -1,0 +1,27 @@
+package krtcollections
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestUnknownBackendKindError(t *testing.T) {
+	// The error classification in pkg/kgateway/query and pkg/kgateway/translator/irtranslator
+	// relies on errors.Is(err, ErrUnknownBackendKind), so the typed error must keep matching it.
+	t.Run("matches the ErrUnknownBackendKind sentinel", func(t *testing.T) {
+		err := &UnknownBackendKindError{GroupKind: schema.GroupKind{Group: "example.com", Kind: "Foo"}}
+		assert.ErrorIs(t, err, ErrUnknownBackendKind)
+	})
+
+	t.Run("message includes the kind and group", func(t *testing.T) {
+		err := &UnknownBackendKindError{GroupKind: schema.GroupKind{Group: "example.com", Kind: "Foo"}}
+		assert.Equal(t, `unknown backend kind "Foo" in group "example.com"`, err.Error())
+	})
+
+	t.Run("message omits the empty core group", func(t *testing.T) {
+		err := &UnknownBackendKindError{GroupKind: schema.GroupKind{Kind: "ConfigMap"}}
+		assert.Equal(t, `unknown backend kind "ConfigMap"`, err.Error())
+	})
+}


### PR DESCRIPTION
# Description

When an HTTPRoute `backendRef` references an unsupported backend type, the `ResolvedRefs` condition message was simply `unknown backend kind`, which didn't tell the user *which* Group/Kind was rejected. As noted on the issue, the problem is frequently the `group` field rather than the `kind`.

This introduces a typed `UnknownBackendKindError` that carries the referenced `GroupKind` and reports `errors.Is` true against the existing `ErrUnknownBackendKind` sentinel, so the error classification in `pkg/kgateway/query` and `pkg/kgateway/translator/irtranslator` is preserved. The `ResolvedRefs` status message now reads, for example:

- `unknown backend kind "ConfigMap"`
- `unknown backend kind "Foo" in group "example.com"`

Fixes #10619

# Change Type

/kind fix

# Changelog

```release-note
The HTTPRoute ResolvedRefs=False (InvalidKind) status message now names the referenced backend Group/Kind instead of a generic "unknown backend kind".
```

# Additional Notes

- A focused unit test (`pkg/krtcollections/policy_errors_test.go`) guards the `errors.Is` behavior and the message format.
- The affected golden translator outputs were regenerated.
- The same sentinel is also returned for unknown secret group/kinds in `secrets.go`; that path was intentionally left out of scope to keep this change focused on the backend-kind status message described in the issue.
