### PR TITLE
fix: The controller owns the 'replicas' field of the proxy Deployment

### DIFF
--- a/api/v1alpha1/kgateway/gateway_parameters_types.go
+++ b/api/v1alpha1/kgateway/gateway_parameters_types.go
@@ -1,6 +1,9 @@
 package kgateway
 
 import (
+	"bytes"
+	"encoding/json"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -216,13 +219,34 @@ func (in *KubernetesProxyConfig) GetOmitDefaultSecurityContext() *bool {
 // ProxyDeployment configures the Proxy deployment in Kubernetes.
 type ProxyDeployment struct {
 	// The number of desired pods.
-	// If omitted, behavior will be managed by the K8s control plane, and will default to 1.
-	// If you are using an HPA, make sure to not explicitly define this.
+	//
+	// When omitted (and no horizontalPodAutoscaler is configured), kgateway
+	// defaults this to 1 and owns the field via server-side apply. This means
+	// the proxy Deployment is reconciled back to the desired count if it drifts,
+	// for example if it is scaled externally to 0.
+	//
+	// To let an external actor manage the replica count instead, either configure
+	// a horizontalPodAutoscaler, or set this field explicitly to null. An explicit
+	// null opts out of kgateway managing replicas entirely, leaving the field to
+	// the K8s control plane (which defaults a new Deployment to 1) or to an
+	// autoscaler. Note: an explicit null is only preserved when the
+	// GatewayParameters is applied with server-side apply (`kubectl apply
+	// --server-side`); client-side apply drops null fields, which kgateway then
+	// treats the same as omitting the field (defaulting to 1).
+	//
 	// K8s reference: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas
 	//
 	// +optional
+	// +nullable
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// replicasExplicitlyNull records whether the `replicas` key was present in
+	// the source with an explicit null value (as opposed to being omitted). It is
+	// used to distinguish an explicit `replicas: null` (opt out of kgateway
+	// managing replicas) from an omitted field (default to 1). It is populated by
+	// UnmarshalJSON and is never serialized or exposed in the CRD schema.
+	ReplicasExplicitlyNull bool `json:"-"`
 
 	// The deployment strategy to use to replace existing pods with new
 	// ones. The Kubernetes default is a RollingUpdate with 25% maxUnavailable,
@@ -241,11 +265,86 @@ type ProxyDeployment struct {
 	Strategy *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
 }
 
+// MarshalJSON implements json.Marshaler so that an explicit `replicas: null`
+// round-trips. Without this, the nil Replicas pointer is dropped by omitempty
+// when the object is re-serialized, which would lose the distinction (carried
+// by ReplicasExplicitlyNull, see UnmarshalJSON) between an explicit null and an
+// omitted field.
+//
+// How it is used:
+//   - The live consumer is conversion to unstructured
+//     (runtime.DefaultUnstructuredConverter.ToUnstructured, which honors
+//     json.Marshaler). This matters in tests that seed a GatewayParameters into
+//     an API server via the unstructured/dynamic client: without re-emitting the
+//     null, the explicit `replicas: null` would be stripped before reaching the
+//     server, making the test behave like client-side apply instead of the
+//     server-side apply it intends to model.
+//   - It is effectively inert in the controller at runtime: kgateway only ever
+//     reads GatewayParameters (decode -> UnmarshalJSON), never writes them, and
+//     the deployer applies the rendered Deployment, not this type. Real users
+//     supply `replicas: null` through their own server-side apply tooling, which
+//     sends the literal null directly.
+//
+// It is also safe by construction: the null is re-added only when
+// ReplicasExplicitlyNull was set by UnmarshalJSON (i.e. the source really had an
+// explicit null), so it can never fabricate a null; in every other case the
+// output is identical to default marshaling.
+func (in ProxyDeployment) MarshalJSON() ([]byte, error) {
+	type proxyDeploymentAlias ProxyDeployment
+	data, err := json.Marshal(proxyDeploymentAlias(in))
+	if err != nil {
+		return nil, err
+	}
+	// Only re-add the null when it was explicitly set and no value is present.
+	if !in.ReplicasExplicitlyNull || in.Replicas != nil {
+		return data, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	raw["replicas"] = json.RawMessage("null")
+	return json.Marshal(raw)
+}
+
+// UnmarshalJSON implements json.Unmarshaler so we can distinguish an explicit
+// `replicas: null` from an omitted `replicas` field. Both decode to a nil
+// Replicas pointer, but only the former sets ReplicasExplicitlyNull, which the
+// deployer uses to decide whether to default the replica count.
+func (in *ProxyDeployment) UnmarshalJSON(data []byte) error {
+	// Avoid infinite recursion by unmarshaling into an alias type that does not
+	// carry this UnmarshalJSON method.
+	type proxyDeploymentAlias ProxyDeployment
+	var alias proxyDeploymentAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*in = ProxyDeployment(alias)
+
+	// Inspect the raw object to detect an explicit `replicas: null`.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	v, present := raw["replicas"]
+	in.ReplicasExplicitlyNull = present && bytes.Equal(bytes.TrimSpace(v), []byte("null"))
+	return nil
+}
+
 func (in *ProxyDeployment) GetReplicas() *int32 {
 	if in == nil {
 		return nil
 	}
 	return in.Replicas
+}
+
+// IsReplicasExplicitlyNull reports whether the user set `replicas: null`
+// explicitly, which signals that kgateway should not manage the replica count.
+func (in *ProxyDeployment) IsReplicasExplicitlyNull() bool {
+	if in == nil {
+		return false
+	}
+	return in.ReplicasExplicitlyNull
 }
 
 func (in *ProxyDeployment) GetStrategy() *appsv1.DeploymentStrategy {

--- a/api/v1alpha1/kgateway/gateway_parameters_types_test.go
+++ b/api/v1alpha1/kgateway/gateway_parameters_types_test.go
@@ -1,0 +1,122 @@
+package kgateway
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// TestProxyDeploymentUnmarshalReplicas verifies that ProxyDeployment.UnmarshalJSON
+// distinguishes an explicit `replicas: null` from an omitted `replicas` field,
+// which the deployer relies on to decide whether to manage the replica count.
+func TestProxyDeploymentUnmarshalReplicas(t *testing.T) {
+	cases := []struct {
+		name             string
+		json             string
+		wantReplicas     *int32
+		wantExplicitNull bool
+	}{
+		{
+			name:             "omitted",
+			json:             `{}`,
+			wantReplicas:     nil,
+			wantExplicitNull: false,
+		},
+		{
+			name:             "explicit null",
+			json:             `{"replicas": null}`,
+			wantReplicas:     nil,
+			wantExplicitNull: true,
+		},
+		{
+			name:             "explicit value",
+			json:             `{"replicas": 3}`,
+			wantReplicas:     ptrInt32(3),
+			wantExplicitNull: false,
+		},
+		{
+			name:             "explicit zero",
+			json:             `{"replicas": 0}`,
+			wantReplicas:     ptrInt32(0),
+			wantExplicitNull: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var pd ProxyDeployment
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &pd))
+			assert.Equal(t, tc.wantReplicas, pd.GetReplicas())
+			assert.Equal(t, tc.wantExplicitNull, pd.IsReplicasExplicitlyNull())
+		})
+	}
+}
+
+// TestProxyDeploymentUnmarshalReplicasYAML exercises the same detection through
+// the YAML decode path (sigs.k8s.io/yaml -> JSON), which mirrors how manifests
+// are loaded.
+func TestProxyDeploymentUnmarshalReplicasYAML(t *testing.T) {
+	var explicit ProxyDeployment
+	require.NoError(t, yaml.Unmarshal([]byte("replicas: null\n"), &explicit))
+	assert.Nil(t, explicit.GetReplicas())
+	assert.True(t, explicit.IsReplicasExplicitlyNull(), "replicas: null should be detected as explicit null")
+
+	var omitted ProxyDeployment
+	require.NoError(t, yaml.Unmarshal([]byte("strategy: {}\n"), &omitted))
+	assert.Nil(t, omitted.GetReplicas())
+	assert.False(t, omitted.IsReplicasExplicitlyNull(), "omitted replicas should not be detected as explicit null")
+}
+
+// TestProxyDeploymentMarshalReplicas verifies that an explicit null round-trips
+// through marshaling (so it survives conversion to unstructured for server-side
+// apply) while omitted/valued replicas marshal normally.
+func TestProxyDeploymentMarshalReplicas(t *testing.T) {
+	t.Run("explicit null re-emitted", func(t *testing.T) {
+		pd := ProxyDeployment{ReplicasExplicitlyNull: true}
+		data, err := json.Marshal(pd)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"replicas": null}`, string(data))
+
+		// Round-trip restores the marker.
+		var back ProxyDeployment
+		require.NoError(t, json.Unmarshal(data, &back))
+		assert.True(t, back.IsReplicasExplicitlyNull())
+		assert.Nil(t, back.GetReplicas())
+	})
+
+	t.Run("omitted stays omitted", func(t *testing.T) {
+		data, err := json.Marshal(ProxyDeployment{})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{}`, string(data))
+	})
+
+	t.Run("explicit value marshals normally", func(t *testing.T) {
+		data, err := json.Marshal(ProxyDeployment{Replicas: ptrInt32(3)})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"replicas": 3}`, string(data))
+	})
+}
+
+// TestGatewayParametersUnmarshalNestedReplicasNull verifies the flag survives
+// decoding through the full GatewayParameters object.
+func TestGatewayParametersUnmarshalNestedReplicasNull(t *testing.T) {
+	raw := `{
+		"spec": {
+			"kube": {
+				"deployment": {"replicas": null}
+			}
+		}
+	}`
+	var gwp GatewayParameters
+	require.NoError(t, json.Unmarshal([]byte(raw), &gwp))
+	require.NotNil(t, gwp.Spec.Kube)
+	require.NotNil(t, gwp.Spec.Kube.Deployment)
+	assert.Nil(t, gwp.Spec.Kube.Deployment.GetReplicas())
+	assert.True(t, gwp.Spec.Kube.Deployment.IsReplicasExplicitlyNull())
+}
+
+//go:fix inline
+func ptrInt32(i int32) *int32 { return new(i) }

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayparameters.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayparameters.yaml
@@ -68,11 +68,25 @@ spec:
                       replicas:
                         description: |-
                           The number of desired pods.
-                          If omitted, behavior will be managed by the K8s control plane, and will default to 1.
-                          If you are using an HPA, make sure to not explicitly define this.
+
+                          When omitted (and no horizontalPodAutoscaler is configured), kgateway
+                          defaults this to 1 and owns the field via server-side apply. This means
+                          the proxy Deployment is reconciled back to the desired count if it drifts,
+                          for example if it is scaled externally to 0.
+
+                          To let an external actor manage the replica count instead, either configure
+                          a horizontalPodAutoscaler, or set this field explicitly to null. An explicit
+                          null opts out of kgateway managing replicas entirely, leaving the field to
+                          the K8s control plane (which defaults a new Deployment to 1) or to an
+                          autoscaler. Note: an explicit null is only preserved when the
+                          GatewayParameters is applied with server-side apply (`kubectl apply
+                          --server-side`); client-side apply drops null fields, which kgateway then
+                          treats the same as omitting the field (defaulting to 1).
+
                           K8s reference: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas
                         format: int32
                         minimum: 0
+                        nullable: true
                         type: integer
                       strategy:
                         description: |-

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -1244,7 +1244,8 @@ var _ = Describe("Deployer", func() {
 				By("verifying deployment inherited default replicas")
 				dep := objs.findDeployment(defaultDeploymentName)
 				Expect(dep).ToNot(BeNil())
-				Expect(dep.Spec.Replicas).To(BeNil())
+				Expect(dep.Spec.Replicas).ToNot(BeNil(), "kgateway should default and own replicas")
+				Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
 
 				By("verifying envoy container log level was overridden")
 				envoyContainer := dep.Spec.Template.Spec.Containers[0]
@@ -2235,7 +2236,32 @@ var _ = Describe("Deployer", func() {
 				validationFunc: func(objs clientObjects, inp *input) {
 					deployment := objs.findDeployment(defaultServiceName)
 					Expect(deployment).NotTo(BeNil())
-					Expect(deployment.Spec.Replicas).To(BeNil())
+					Expect(deployment.Spec.Replicas).ToNot(BeNil(), "kgateway should default and own replicas")
+					Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+				},
+			}),
+			Entry("Replicas explicitly null (unmanaged)", &input{
+				dInputs: defaultDeployerInputs(),
+				gw:      defaultGateway(),
+				defaultGwp: &kgateway.GatewayParameters{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wellknown.DefaultGatewayParametersName,
+						Namespace: defaultNamespace,
+						UID:       "1237",
+					},
+					Spec: kgateway.GatewayParametersSpec{
+						Kube: &kgateway.KubernetesProxyConfig{
+							Deployment: &kgateway.ProxyDeployment{ReplicasExplicitlyNull: true},
+						},
+					},
+				},
+				overrideGwp: &kgateway.GatewayParameters{},
+			}, &expectedOutput{
+				validationFunc: func(objs clientObjects, inp *input) {
+					deployment := objs.findDeployment(defaultServiceName)
+					Expect(deployment).NotTo(BeNil())
+					Expect(deployment.Spec.Replicas).To(BeNil(),
+						"explicit replicas: null should leave replicas unmanaged")
 				},
 			}),
 			Entry("have replicas set", &input{

--- a/pkg/deployer/merge.go
+++ b/pkg/deployer/merge.go
@@ -778,7 +778,20 @@ func deepMergeDeployment(dst, src *kgateway.ProxyDeployment) *kgateway.ProxyDepl
 		return src
 	}
 
-	dst.Replicas = MergePointers(dst.GetReplicas(), src.GetReplicas())
+	// Replicas precedence (most-specific layer wins). We must preserve the
+	// distinction between an explicit `replicas: null` and an omitted field so
+	// the deployer can decide whether to default the replica count:
+	//   - src sets an explicit value -> use it, clear the explicit-null marker
+	//   - src is explicitly null -> opt out of managing replicas
+	//   - src omits replicas -> inherit dst's value and marker
+	switch {
+	case src.GetReplicas() != nil:
+		dst.Replicas = src.GetReplicas()
+		dst.ReplicasExplicitlyNull = false
+	case src.IsReplicasExplicitlyNull():
+		dst.Replicas = nil
+		dst.ReplicasExplicitlyNull = true
+	}
 	dst.Strategy = MergePointers(dst.Strategy, src.Strategy)
 
 	return dst

--- a/pkg/deployer/merge_test.go
+++ b/pkg/deployer/merge_test.go
@@ -121,6 +121,66 @@ func TestDeepMergeGatewayParameters(t *testing.T) {
 			},
 		},
 		{
+			name: "should clear replicas when src is explicitly null",
+			dst: &kgateway.GatewayParameters{
+				Spec: kgateway.GatewayParametersSpec{
+					Kube: &kgateway.KubernetesProxyConfig{
+						Deployment: &kgateway.ProxyDeployment{
+							Replicas: new(int32(2)),
+						},
+					},
+				},
+			},
+			src: &kgateway.GatewayParameters{
+				Spec: kgateway.GatewayParametersSpec{
+					Kube: &kgateway.KubernetesProxyConfig{
+						Deployment: &kgateway.ProxyDeployment{
+							ReplicasExplicitlyNull: true,
+						},
+					},
+				},
+			},
+			want: &kgateway.GatewayParameters{
+				Spec: kgateway.GatewayParametersSpec{
+					Kube: &kgateway.KubernetesProxyConfig{
+						Deployment: &kgateway.ProxyDeployment{
+							ReplicasExplicitlyNull: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "explicit src replicas value overrides dst explicit null",
+			dst: &kgateway.GatewayParameters{
+				Spec: kgateway.GatewayParametersSpec{
+					Kube: &kgateway.KubernetesProxyConfig{
+						Deployment: &kgateway.ProxyDeployment{
+							ReplicasExplicitlyNull: true,
+						},
+					},
+				},
+			},
+			src: &kgateway.GatewayParameters{
+				Spec: kgateway.GatewayParametersSpec{
+					Kube: &kgateway.KubernetesProxyConfig{
+						Deployment: &kgateway.ProxyDeployment{
+							Replicas: new(int32(5)),
+						},
+					},
+				},
+			},
+			want: &kgateway.GatewayParameters{
+				Spec: kgateway.GatewayParametersSpec{
+					Kube: &kgateway.KubernetesProxyConfig{
+						Deployment: &kgateway.ProxyDeployment{
+							Replicas: new(int32(5)),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "merges maps",
 			dst: &kgateway.GatewayParameters{
 				Spec: kgateway.GatewayParametersSpec{

--- a/pkg/kgateway/deployer/gateway_parameters.go
+++ b/pkg/kgateway/deployer/gateway_parameters.go
@@ -408,8 +408,21 @@ func (k *kgatewayParameters) getValues(gw *gwv1.Gateway, gwParam *kgateway.Gatew
 	gateway := vals.Gateway
 
 	// deployment values
-	if deployConfig.GetReplicas() != nil {
+	//
+	// Default the replica count to 1 unless it is externally managed, so that
+	// kgateway owns the field via server-side apply and reconciles the proxy
+	// Deployment back to the desired count if it drifts (e.g. is scaled
+	// externally to 0). Replicas are considered externally managed when the user
+	// either sets `replicas: null` explicitly or configures a
+	// HorizontalPodAutoscaler, in which case the field is left unset.
+	// See https://github.com/kgateway-dev/kgateway/issues/14195
+	switch {
+	case deployConfig.GetReplicas() != nil:
 		gateway.ReplicaCount = new(uint32(*deployConfig.GetReplicas())) // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	case deployConfig.IsReplicasExplicitlyNull() || k.hasHorizontalPodAutoscaler(gw):
+		// leave gateway.ReplicaCount nil so kgateway does not manage replicas
+	default:
+		gateway.ReplicaCount = new(uint32(1))
 	}
 	gateway.Strategy = deployConfig.GetStrategy()
 
@@ -527,6 +540,23 @@ func (k *kgatewayParameters) resolveParametersForOverlays(gw *gwv1.Gateway) *res
 	}
 
 	return result
+}
+
+// hasHorizontalPodAutoscaler reports whether a HorizontalPodAutoscaler overlay
+// is configured for the Gateway, either via GatewayClass-level or Gateway-level
+// GatewayParameters. The HPA overlay is applied separately from the merged
+// GatewayParameters (see PostProcessObjects), so it is not present on the merged
+// object passed to getValues and must be resolved here. When an HPA is present
+// kgateway leaves the Deployment's replica count unmanaged so the autoscaler can
+// control it.
+func (k *kgatewayParameters) hasHorizontalPodAutoscaler(gw *gwv1.Gateway) bool {
+	resolved := k.resolveParametersForOverlays(gw)
+	for _, gwp := range []*kgateway.GatewayParameters{resolved.gatewayClassGWP, resolved.gatewayGWP} {
+		if gwp != nil && gwp.Spec.Kube != nil && gwp.Spec.Kube.HorizontalPodAutoscaler != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func getGatewayClassFromGateway(cli kclient.Client[*gwv1.GatewayClass], gw *gwv1.Gateway) (*gwv1.GatewayClass, error) {

--- a/test/deployer/internal_helm_test.go
+++ b/test/deployer/internal_helm_test.go
@@ -179,8 +179,13 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 			},
 		},
 		{
-			// This test case cares about SSA vs. client-side apply because it
-			// uses a null value. It'd be nice to test it both ways.
+			// An explicit `replicas: null` is the escape hatch for opting out of
+			// kgateway managing the replica count. It is preserved through
+			// server-side apply (which this harness models, including the
+			// ProxyDeployment.MarshalJSON round-trip), so the rendered Deployment
+			// omits replicas entirely, leaving it to the K8s control plane or an
+			// autoscaler. (Client-side apply would strip the null before it
+			// reached the API server, in which case kgateway defaults to 1.)
 			Name:      "gateway with null replicas GWP via GWC",
 			InputFile: "gwc-with-replicas-null",
 			Validate: func(t *testing.T, outputYaml string) {
@@ -188,7 +193,7 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 				assert.NotContains(t, outputYaml, "replicas: null",
 					"replicas: null should never appear in the output")
 				assert.NotRegexp(t, `(?m)^\s*replicas:`, outputYaml,
-					"replicas field should be omitted entirely when set to null")
+					"explicit replicas: null should opt out of management, omitting the field entirely")
 			},
 		},
 		{

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/base-gateway-tls-out.yaml
+++ b/test/deployer/testdata/base-gateway-tls-out.yaml
@@ -298,6 +298,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-dns-resolver-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
@@ -264,6 +264,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
+++ b/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-infrastructure-out.yaml
+++ b/test/deployer/testdata/envoy-infrastructure-out.yaml
@@ -293,6 +293,7 @@ metadata:
     my-label: my-value
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-log-json-out.yaml
+++ b/test/deployer/testdata/envoy-log-json-out.yaml
@@ -276,6 +276,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-log-text-out.yaml
+++ b/test/deployer/testdata/envoy-log-text-out.yaml
@@ -272,6 +272,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-overlay-ordering-out.yaml
+++ b/test/deployer/testdata/envoy-overlay-ordering-out.yaml
@@ -278,6 +278,7 @@ metadata:
     overlay-source: from-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-pdb-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-pdb-overlay-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
+++ b/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
@@ -274,6 +274,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -281,6 +281,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
+++ b/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
@@ -282,6 +282,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/envoy-vpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-vpa-overlay-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -281,6 +281,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -285,6 +285,7 @@ metadata:
     kgateway: kube-gateway
   name: waypoint
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: waypoint

--- a/test/deployer/testdata/loadbalancer-class-out.yaml
+++ b/test/deployer/testdata/loadbalancer-class-out.yaml
@@ -270,6 +270,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
@@ -272,6 +272,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
@@ -272,6 +272,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/loadbalancer-static-ip-out.yaml
+++ b/test/deployer/testdata/loadbalancer-static-ip-out.yaml
@@ -270,6 +270,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: very-long-gateway-name-that-is-exactly-sixty-three-characterslo

--- a/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/priority-class-name-out.yaml
+++ b/test/deployer/testdata/priority-class-name-out.yaml
@@ -269,6 +269,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/stats-matcher-exclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-exclusion-out.yaml
@@ -277,6 +277,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw

--- a/test/deployer/testdata/stats-matcher-inclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-inclusion-out.yaml
@@ -281,6 +281,7 @@ metadata:
     kgateway: kube-gateway
   name: gw
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: gw


### PR DESCRIPTION
# Description

The proxy `Deployment` that kgateway provisions for a `Gateway` was never reconciled back to its desired replica count after external scaling. If you ran `kubectl scale deploy/gateway-default --replicas=0`, the Deployment stayed at 0 indefinitely, and restarting the controller did not restore it either.

Root cause (as diagnosed on the issue): the deployer never set a default value for `replicas`, so the rendered Deployment omitted the field and kgateway never *owned* `spec.replicas` via server-side apply. The Deployment watch and on-startup reconcile already fired — they just couldn't restore a field kgateway didn't own.

This PR makes kgateway **default `replicas` to 1 and own the field**, so the existing watch + SSA (`Force: true`) reconcile the proxy Deployment back to the desired count whenever it drifts, and on controller startup. Two opt-outs preserve external management of replicas:

- Configure a `horizontalPodAutoscaler` overlay -> kgateway leaves `replicas` unset so the HPA controls it.
- Set `spec.kube.deployment.replicas` explicitly to `null` -> opts out of management entirely.

Because `null` and an omitted field both decode to a nil pointer in Go, `ProxyDeployment` now distinguishes them: `replicas` is marked `nullable`, and a custom `UnmarshalJSON`/`MarshalJSON` pair records and round-trips an explicit null. Note this only survives **server-side apply** (`kubectl apply --server-side`, Helm 4 default, Argo CD with `ServerSideApply: true`); client-side apply strips null before it reaches the API server, in which case kgateway treats it as omitted and defaults to 1.

## Backwards compatibility

- **Schema and Go-source compatible**: `nullable: true` only widens what's accepted (existing objects stay valid); all type additions are keyed/additive.
- **Intentional behavior change**: operators who scaled the proxy externally **without an HPA and without setting `replicas`** will now find kgateway reverts that scaling. They can opt back out with an HPA overlay or `replicas: null` (server-side apply). Existing installs otherwise self-heal on upgrade with no manual intervention — `Force: true` SSA lets the controller reclaim the previously-unowned field on the next reconcile.

Fixes #14195

# Change Type

/kind fix

# Changelog

```release-note
The proxy Deployment provisioned for a Gateway now defaults to 1 replica and is reconciled back to its desired count if it drifts (for example, if it is scaled externally to 0), including after a controller restart. To leave the replica count to an external actor, configure a `horizontalPodAutoscaler` in GatewayParameters, or set `spec.kube.deployment.replicas` explicitly to `null` (applied with server-side apply). Operators who previously scaled the proxy Deployment externally without an HPA should adopt one of these opt-outs.
```

# Additional Notes

- The `replicas: null` escape hatch only survives server-side apply; this is documented on the field and called out in the release note. The envtest golden harness models SSA (via the `MarshalJSON` round-trip), so the escape hatch is covered end-to-end in both the envtest and fake-client modes.
- HPA from 0 is still a Kubernetes limitation (the standard algorithm can't scale up from 0 replicas), as noted in the issue — that's orthogonal to this fix, which restores the configured/default count directly.
