### PR TITLE
fix: make Envoy bootstrap listeners bind to :: for IPv6 support

### DIFF
--- a/pkg/kgateway/helm/envoy/templates/configmap.yaml
+++ b/pkg/kgateway/helm/envoy/templates/configmap.yaml
@@ -92,7 +92,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
 {{- if $gateway.enableReadinessProbeProxyProtocol }}
         listener_filters:
           - name: envoy.filters.listener.proxy_protocol
@@ -141,8 +141,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/base-gateway-tls-out.yaml
+++ b/test/deployer/testdata/base-gateway-tls-out.yaml
@@ -56,7 +56,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -95,8 +95,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-all-autoscalers-out.yaml
+++ b/test/deployer/testdata/envoy-all-autoscalers-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-dns-resolver-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-hpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-hpa-overlay-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
+++ b/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-infrastructure-out.yaml
+++ b/test/deployer/testdata/envoy-infrastructure-out.yaml
@@ -40,7 +40,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -79,8 +79,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-log-json-out.yaml
+++ b/test/deployer/testdata/envoy-log-json-out.yaml
@@ -41,7 +41,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -80,8 +80,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-log-text-out.yaml
+++ b/test/deployer/testdata/envoy-log-text-out.yaml
@@ -37,7 +37,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -76,8 +76,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-overlay-ordering-out.yaml
+++ b/test/deployer/testdata/envoy-overlay-ordering-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-pdb-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-pdb-overlay-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
+++ b/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         listener_filters:
           - name: envoy.filters.listener.proxy_protocol
             typed_config:
@@ -78,8 +78,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
+++ b/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
@@ -37,7 +37,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -76,8 +76,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/envoy-vpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-vpa-overlay-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/gwc-with-replicas-null-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-null-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/gwc-with-replicas-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/loadbalancer-class-out.yaml
+++ b/test/deployer/testdata/loadbalancer-class-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/loadbalancer-static-ip-out.yaml
+++ b/test/deployer/testdata/loadbalancer-static-ip-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/openshift-two-params-security-context-out.yaml
+++ b/test/deployer/testdata/openshift-two-params-security-context-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/priority-class-name-out.yaml
+++ b/test/deployer/testdata/priority-class-name-out.yaml
@@ -34,7 +34,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -73,8 +73,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/stats-matcher-exclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-exclusion-out.yaml
@@ -42,7 +42,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -81,8 +81,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager

--- a/test/deployer/testdata/stats-matcher-inclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-inclusion-out.yaml
@@ -46,7 +46,7 @@ data:
       listeners:
       - name: readiness_listener
         address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
+          socket_address: { address: "::", port_value: 8082, ipv4_compat: true }
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -85,8 +85,9 @@ data:
       - name: prometheus_listener
         address:
           socket_address:
-            address: 0.0.0.0
+            address: "::"
             port_value: 9091
+            ipv4_compat: true
         filter_chains:
           - filters:
             - name: envoy.filters.network.http_connection_manager


### PR DESCRIPTION
# Description

The Envoy bootstrap config hardcodes `0.0.0.0` for the readiness and prometheus listeners, which causes startup probe failures in IPv6-only Kubernetes clusters. When kubelet connects via the pod's IPv6 address, the connection is refused and pods enter CrashLoopBackOff.

**Motivation:** kgateway is completely non-viable for IPv6-only clusters. The `KGW_LISTENER_BIND_IPV6=true` env var only affects dynamic listeners (ports 80/443 from Gateway API HTTPRoutes), not the static bootstrap config.

I don't know if this will be enough to make kgateway usable in IPv6-only environments, but it's the first issue I encountered when trying to set up a Gateway CR.

**What changed:**
- `readiness_listener`: `0.0.0.0:8082` -> `::` with `ipv4_compat: true`
- `prometheus_listener`: `0.0.0.0:9091` -> `::` with `ipv4_compat: true`

Admin (`127.0.0.1:19000`), xDS cluster endpoint, and Istio SDS endpoint are left unchanged as they are pod-internal loopback traffic that should work on all IP families.

**Related issues:** Related to #12074, #13339. Similar fix in agentgateay: https://github.com/agentgateway/agentgateway/pull/821/changes

# Change Type

```
/kind fix
```

# Changelog

```release-note
Fix Envoy bootstrap readiness and prometheus listeners to support IPv6-only clusters by binding to :: with ipv4_compat: true, ensuring startup probes and metrics scraping work on dual-stack and IPv6-only nodes.
```

# Additional Notes
I have not been able to verify this on an IPv4-only system. `::` should bind correctly on most systems but I'm sure there is a risk this breaks some systems where IPv6 is strictly disabled.