### PR TITLE
Advertise BackendTLSPolicy SAN validation

### DIFF
--- a/pkg/deployer/gatewayclass.go
+++ b/pkg/deployer/gatewayclass.go
@@ -47,10 +47,6 @@ func GetSupportedFeaturesForStandardGateway(enableExperimentalGatewayAPIFeatures
 		)
 	}
 
-	// Support only the core BackendTLSPolicy feature set for now.
-	for _, feature := range features.BackendTLSPolicyExtendedFeatures.UnsortedList() {
-		exemptFeatures.Insert(feature)
-	}
 	return getSupportedFeatures(exemptFeatures)
 }
 

--- a/pkg/deployer/gatewayclass_test.go
+++ b/pkg/deployer/gatewayclass_test.go
@@ -32,6 +32,9 @@ func TestGetSupportedFeaturesForStandardGatewayExcludesKnownUnsupportedV15Featur
 	if _, ok := supportedNames[gwv1.FeatureName(features.SupportGatewayBackendClientCertificate)]; !ok {
 		t.Fatalf("expected %q to remain supported once core BackendTLSPolicy support is advertised", features.SupportGatewayBackendClientCertificate)
 	}
+	if _, ok := supportedNames[gwv1.FeatureName(features.SupportBackendTLSPolicySANValidation)]; !ok {
+		t.Fatalf("expected %q to be supported", features.SupportBackendTLSPolicySANValidation)
+	}
 }
 
 func TestGetSupportedFeaturesForStandardGatewayIncludesStandardTLSRouteWhenExperimentalDisabled(t *testing.T) {


### PR DESCRIPTION
# Description

Advertise `BackendTLSPolicySANValidation` now that kgateway supports BackendTLSPolicy SAN matching behavior.

Fixes: #11142

# Change Type

/kind fix

# Changelog

```release-note
Advertise support for the Gateway API BackendTLSPolicySANValidation conformance feature.
```

# Additional Notes

Tested:
- `go test ./pkg/deployer`
- Gateway API `BackendTLSPolicySANValidation` conformance test on kind with kgateway `v1.0.1-dev`
