### PR TITLE
perf: intern AttachedPolicyRef ID strings

### DIFF
--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"unique"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,7 +50,9 @@ type AttachedPolicyRef struct {
 }
 
 func (ref *AttachedPolicyRef) ID() string {
-	return ref.Group + delimiter + ref.Kind + delimiter + ref.Namespace + delimiter + ref.Name
+	// The ID is retained for every route a policy attaches to (e.g. in MergeOrigins),
+	// so intern it to share a single backing string across all copies.
+	return unique.Make(ref.Group + delimiter + ref.Kind + delimiter + ref.Namespace + delimiter + ref.Name).Value()
 }
 
 // IDWithSectionName returns ID() with SectionName appended when set.

--- a/pkg/pluginsdk/ir/merge.go
+++ b/pkg/pluginsdk/ir/merge.go
@@ -74,9 +74,10 @@ func (m MergeOrigins) GetRefCount(
 		return MergeOriginsRefCountNone
 	}
 
+	id := policyRef.ID()
 	forRef := 0
 	for _, field := range m {
-		if field != nil && field.Has(policyRef.ID()) {
+		if field != nil && field.Has(id) {
 			forRef++
 		}
 	}


### PR DESCRIPTION
# Description

A memory profile of a large production environment showed ~6.6% of the controller's live heap attributed to `AttachedPolicyRef.ID`. The concatenated ID string is retained in `MergeOrigins` sets for every route a policy attaches to, so a policy attached to many routes retains many identical copies of the same string.

This PR:
- Interns the ID via Go's `unique` package, so all retained copies share a single canonical backing string. The interning map is weakly held, so entries are garbage collected once the policy refs go away.
- Hoists the `policyRef.ID()` computation out of the per-field loop in `MergeOrigins.GetRefCount`, which recomputed the concatenation once per merged field.

The emitted Envoy configuration and status reporting are unchanged; only the memory sharing changes.

# Change Type

/kind cleanup

# Changelog

```release-note
Reduced controller memory usage by interning policy ref ID strings retained in policy merge tracking.
```

# Additional Notes

An alternative considered was caching the computed ID on the `AttachedPolicyRef` struct, but a lazily-written field would be a data race under concurrent gateway translations; interning achieves the same retained-memory deduplication without changing struct semantics.