### PR TITLE
perf: share marshaled typed filter config Anys across routes

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -53,16 +53,24 @@ const (
 
 var logger = logging.New("plugin/trafficpolicy")
 
+// Shared across all routes; callers must not mutate the returned messages.
+// Sharing one instance lets the translator's marshaling cache emit a single
+// *anypb.Any for every route that enables/disables a filter.
+var (
+	enableFilterPerRoute  = &envoyroutev3.FilterConfig{Config: &anypb.Any{}}
+	disableFilterPerRoute = &envoyroutev3.FilterConfig{Config: &anypb.Any{}, Disabled: true}
+)
+
 // from envoy code:
 // If the field `config` is configured but is empty, we treat the filter is enabled
 // explicitly.
 // see: https://github.com/envoyproxy/envoy/blob/8ed93ef372f788456b708fc93a7e54e17a013aa7/source/common/router/config_impl.cc#L2552
 func EnableFilterPerRoute() *envoyroutev3.FilterConfig {
-	return &envoyroutev3.FilterConfig{Config: &anypb.Any{}}
+	return enableFilterPerRoute
 }
 
 func DisableFilterPerRoute() *envoyroutev3.FilterConfig {
-	return &envoyroutev3.FilterConfig{Config: &anypb.Any{}, Disabled: true}
+	return disableFilterPerRoute
 }
 
 // PolicySubIR documents the expected interface that all policy sub-IRs should implement.

--- a/pkg/kgateway/translator/irtranslator/gateway.go
+++ b/pkg/kgateway/translator/irtranslator/gateway.go
@@ -139,6 +139,7 @@ func (t *Translator) ComputeListener(
 			logger:                   logger.With("route_config_name", hfc.FilterChainName),
 			validationLevel:          t.ValidationLevel,
 			validator:                t.Validator,
+			anyCache:                 ir.ProtoAnyCache{},
 		}
 		rc := hr.ComputeRouteConfiguration(ctx, hfc.Vhosts)
 		if rc != nil {

--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -41,6 +41,11 @@ type httpRouteConfigurationTranslator struct {
 	logger                   *slog.Logger
 	validationLevel          apisettings.ValidationMode
 	validator                validator.Validator
+
+	// anyCache deduplicates typed filter config marshaling across the routes of
+	// this route configuration: routes sharing a policy IR proto share a single
+	// marshaled *anypb.Any in the output instead of one copy per route.
+	anyCache ir.ProtoAnyCache
 }
 
 const (
@@ -112,7 +117,7 @@ func (h *httpRouteConfigurationTranslator) ComputeRouteConfiguration(
 		cfg.VirtualHosts = []*envoyroutev3.VirtualHost{setFallBackConfig("default", "*")}
 		return cfg
 	}
-	cfg.TypedPerFilterConfig = typedPerFilterConfigRoute.ToAnyMap()
+	cfg.TypedPerFilterConfig = typedPerFilterConfigRoute.ToAnyMapCached(h.anyCache)
 
 	return cfg
 }
@@ -185,7 +190,7 @@ func (h *httpRouteConfigurationTranslator) computeVirtualHost(
 		// replace the computed vhost with a fallback that preserves the original vhost identity
 		return setFallBackConfig(sanitizedName, domains[0])
 	}
-	out.TypedPerFilterConfig = typedPerFilterConfigRoute.ToAnyMap()
+	out.TypedPerFilterConfig = typedPerFilterConfigRoute.ToAnyMapCached(h.anyCache)
 
 	return out
 }
@@ -246,7 +251,7 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 	routeProcessingErr := h.runRoutePlugins(in, out, backendConfigCtx.typedPerFilterConfigRoute)
 
 	// Apply typed per filter config from translating route action and route plugins
-	typedPerFilterConfig := backendConfigCtx.typedPerFilterConfigRoute.ToAnyMap()
+	typedPerFilterConfig := backendConfigCtx.typedPerFilterConfigRoute.ToAnyMapCached(h.anyCache)
 	if out.GetTypedPerFilterConfig() == nil {
 		out.TypedPerFilterConfig = typedPerFilterConfig
 	} else {
@@ -556,7 +561,7 @@ func (h *httpRouteConfigurationTranslator) translateRouteAction(
 		backendConfigCtx.ResponseHeadersToRemove = pCtx.ResponseHeadersToRemove
 
 		// Translating weighted clusters needs the typed per filter config on each cluster
-		cw.TypedPerFilterConfig = backendConfigCtx.typedPerFilterConfigRoute.ToAnyMap()
+		cw.TypedPerFilterConfig = backendConfigCtx.typedPerFilterConfigRoute.ToAnyMapCached(h.anyCache)
 		cw.RequestHeadersToAdd = backendConfigCtx.RequestHeadersToAdd
 		cw.RequestHeadersToRemove = backendConfigCtx.RequestHeadersToRemove
 		cw.ResponseHeadersToAdd = backendConfigCtx.ResponseHeadersToAdd

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -76,16 +76,36 @@ func (r *TypedFilterConfigMap) GetTypedConfig(key string) proto.Message {
 }
 
 func (r *TypedFilterConfigMap) ToAnyMap() map[string]*anypb.Any {
-	typedPerFilterConfigAny := map[string]*anypb.Any{}
+	return r.ToAnyMapCached(nil)
+}
+
+// ProtoAnyCache memoizes proto.Message to anypb.Any marshaling by message
+// identity. It allows a config shared across many routes (e.g. a proto held on
+// a PolicyIR) to be marshaled once, with all routes sharing one *anypb.Any in
+// the final config. It is not safe for concurrent use, so it must not be
+// shared across translations.
+type ProtoAnyCache map[proto.Message]*anypb.Any
+
+// ToAnyMapCached is ToAnyMap with memoization through cache (which may be nil).
+// Messages must not be mutated after being added to the config map.
+func (r *TypedFilterConfigMap) ToAnyMapCached(cache ProtoAnyCache) map[string]*anypb.Any {
+	typedPerFilterConfigAny := make(map[string]*anypb.Any, len(*r))
 	for k, v := range *r {
 		if anyMsg, ok := v.(*anypb.Any); ok {
 			typedPerFilterConfigAny[k] = anyMsg
+			continue
+		}
+		if config, ok := cache[v]; ok {
+			typedPerFilterConfigAny[k] = config
 			continue
 		}
 		config, err := utils.MessageToAny(v)
 		if err != nil {
 			logger.Error("unexpected marshalling error", "error", err)
 			continue
+		}
+		if cache != nil {
+			cache[v] = config
 		}
 		typedPerFilterConfigAny[k] = config
 	}


### PR DESCRIPTION
# Description

A memory profile of a large production environment showed ~12.6% of the controller's live heap attributed to `TypedFilterConfigMap.ToAnyMap` / `MessageToAny`: every route marshals its policy protos into `anypb.Any` independently, even though routes sharing a policy reference the same proto instance held on the `PolicyIR`. Each marshaled copy is then retained in the xDS snapshot.

This PR:
- Adds `TypedFilterConfigMap.ToAnyMapCached` with a `ProtoAnyCache` keyed by message identity. `ToAnyMap` delegates to it with a nil cache, so existing callers are unaffected.
- Gives each `httpRouteConfigurationTranslator` a cache used at all four typed-filter-config marshal sites (route config, vhost, route, weighted cluster). The cache is scoped to a single route configuration translation, so it is single-goroutine (no locking) and cannot retain memory across translations.
- Makes `EnableFilterPerRoute`/`DisableFilterPerRoute` return shared singletons. These enable/disable markers are emitted on a large fraction of routes (extauth, extproc, JWT, compression, oauth2), and as fresh per-route allocations they both missed the cache and were retained once per route.

Routes sharing a policy now share one marshaled `*anypb.Any` in the retained snapshot instead of one copy per route. The emitted Envoy configuration is byte-identical; translator golden tests pass without regeneration.

# Change Type

/kind cleanup

# Changelog

```release-note
Reduced controller memory usage by marshaling typed filter configs shared across routes once per route configuration instead of once per route.
```

# Additional Notes

The cache relies on plugins not mutating protos after handing them to `AddTypedConfig`. This is an existing invariant: policy IR protos are already shared across concurrent gateway translations, so mutating them during a translation pass would already be racy.