### PR TITLE
fix: stabilize delegated route status parent ordering

### DIFF
--- a/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
@@ -103,6 +103,27 @@ func TestIsRouteStatusEqual(t *testing.T) {
 			},
 		},
 	}
+	// Same as status1, but with reversed parent order.
+	status2Reordered := &gwv1.RouteStatus{
+		Parents: []gwv1.RouteParentStatus{
+			{
+				ParentRef: gwv1.ParentReference{
+					Group:     new(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      new(gwv1.Kind(wellknown.TCPRouteKind)),
+					Name:      "parent",
+					Namespace: new(gwv1.Namespace("default")),
+				},
+			},
+			{
+				ParentRef: gwv1.ParentReference{
+					Group:     new(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      new(gwv1.Kind(wellknown.HTTPRouteKind)),
+					Name:      "parent",
+					Namespace: new(gwv1.Namespace("default")),
+				},
+			},
+		},
+	}
 	// Different from status1
 	status3 := &gwv1.RouteStatus{
 		Parents: []gwv1.RouteParentStatus{
@@ -132,6 +153,7 @@ func TestIsRouteStatusEqual(t *testing.T) {
 		want bool
 	}{
 		{"EqualStatus", status1, status2, true},
+		{"EqualStatusReorderedParents", status1, status2Reordered, true},
 		{"DifferentStatus", status1, status3, false},
 	}
 

--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -819,6 +820,9 @@ var opts = cmp.Options{
 	cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 		return k == "lastTransitionTime"
 	}),
+	cmpopts.SortSlices(func(a, b gwv1.RouteParentStatus) bool {
+		return lessRouteParentStatus(a, b)
+	}),
 }
 
 func isGatewayStatusEqual(objA, objB *gwv1.GatewayStatus) bool {
@@ -836,4 +840,11 @@ func isBackendStatusEqual(objA, objB *kgateway.BackendStatus) bool {
 // isRouteStatusEqual compares two RouteStatus objects directly
 func isRouteStatusEqual(objA, objB *gwv1.RouteStatus) bool {
 	return cmp.Equal(objA, objB, opts)
+}
+
+func lessRouteParentStatus(a, b gwv1.RouteParentStatus) bool {
+	if cmp := strings.Compare(reports.ParentString(a.ParentRef), reports.ParentString(b.ParentRef)); cmp != 0 {
+		return cmp < 0
+	}
+	return strings.Compare(string(a.ControllerName), string(b.ControllerName)) < 0
 }

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -3,6 +3,8 @@ package reports
 import (
 	"fmt"
 	"log/slog"
+	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -506,6 +508,9 @@ func (r *RouteReport) parentRefs() []gwv1.ParentReference {
 		}
 		refs = append(refs, parentRef)
 	}
+	slices.SortStableFunc(refs, func(a, b gwv1.ParentReference) int {
+		return strings.Compare(ParentString(a), ParentString(b))
+	})
 	return refs
 }
 


### PR DESCRIPTION
# Description
This fixes delegated child-route status churn when `spec.parentRefs` is omitted. The route report now emits inferred parent refs in deterministic order, and route status equality treats parent slices as order-insensitive so equivalent status does not get rewritten on every sync.

# Change Type

/kind fix

# Changelog
```release-note
NONE
```
