### PR TITLE
perf: stop cloning static backend protos per client

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backend/static.go
+++ b/pkg/kgateway/extensions2/plugins/backend/static.go
@@ -28,22 +28,26 @@ type StaticIr struct {
 	// +noKrtEquals
 	loadAssignment *envoyendpointv3.ClusterLoadAssignment
 
-	// namedLAOnce/namedLA memoize loadAssignment with the cluster name applied.
-	// The name is backend-derived, so all per-client clusters translated from
-	// this backend share one copy instead of cloning per client.
-	namedLAOnce sync.Once
-	namedLA     *envoyendpointv3.ClusterLoadAssignment
+	// namedLAs memoizes loadAssignment clones with the cluster name applied,
+	// keyed by cluster name. This IR can be translated under multiple names —
+	// gateway-scoped backend variants (e.g. CloneForGatewayBackendClientCertificate)
+	// share the IR but derive their own cluster name — so each name gets its own
+	// clone, shared by every client of that variant instead of cloned per client.
+	// Bounded by the number of variants of this backend; lives as long as the IR.
+	namedLAs sync.Map // map[string]*envoyendpointv3.ClusterLoadAssignment
 }
 
 // namedLoadAssignment returns loadAssignment with the cluster name set, cloning
-// it once per backend rather than once per (client, backend) pair.
+// it once per (backend, cluster name) rather than once per (client, backend).
 func (u *StaticIr) namedLoadAssignment(clusterName string) *envoyendpointv3.ClusterLoadAssignment {
-	u.namedLAOnce.Do(func() {
-		la := proto.Clone(u.loadAssignment).(*envoyendpointv3.ClusterLoadAssignment)
-		la.ClusterName = clusterName
-		u.namedLA = la
-	})
-	return u.namedLA
+	if cached, ok := u.namedLAs.Load(clusterName); ok {
+		return cached.(*envoyendpointv3.ClusterLoadAssignment)
+	}
+	la := proto.Clone(u.loadAssignment).(*envoyendpointv3.ClusterLoadAssignment)
+	la.ClusterName = clusterName
+	// LoadOrStore keeps one canonical instance if two translations race.
+	actual, _ := u.namedLAs.LoadOrStore(clusterName, la)
+	return actual.(*envoyendpointv3.ClusterLoadAssignment)
 }
 
 // Equals checks if two StaticIr objects are equal.

--- a/pkg/kgateway/extensions2/plugins/backend/static.go
+++ b/pkg/kgateway/extensions2/plugins/backend/static.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"fmt"
 	"net/netip"
+	"sync"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -26,6 +27,23 @@ type StaticIr struct {
 	clusterTypeConfig *anypb.Any
 	// +noKrtEquals
 	loadAssignment *envoyendpointv3.ClusterLoadAssignment
+
+	// namedLAOnce/namedLA memoize loadAssignment with the cluster name applied.
+	// The name is backend-derived, so all per-client clusters translated from
+	// this backend share one copy instead of cloning per client.
+	namedLAOnce sync.Once
+	namedLA     *envoyendpointv3.ClusterLoadAssignment
+}
+
+// namedLoadAssignment returns loadAssignment with the cluster name set, cloning
+// it once per backend rather than once per (client, backend) pair.
+func (u *StaticIr) namedLoadAssignment(clusterName string) *envoyendpointv3.ClusterLoadAssignment {
+	u.namedLAOnce.Do(func() {
+		la := proto.Clone(u.loadAssignment).(*envoyendpointv3.ClusterLoadAssignment)
+		la.ClusterName = clusterName
+		u.namedLA = la
+	})
+	return u.namedLA
 }
 
 // Equals checks if two StaticIr objects are equal.
@@ -115,8 +133,11 @@ func processStatic(ir *StaticIr, out *envoyclusterv3.Cluster) {
 	if ir.clusterTypeConfig != nil {
 		out.ClusterDiscoveryType = &envoyclusterv3.Cluster_ClusterType{
 			ClusterType: &envoyclusterv3.Cluster_CustomClusterType{
-				Name:        dnsClusterExtensionName,
-				TypedConfig: proto.Clone(ir.clusterTypeConfig).(*anypb.Any),
+				Name: dnsClusterExtensionName,
+				// Shared, not cloned: consumers that adjust the DNS config
+				// (processDnsLookupFamily, BackendConfigPolicy) replace the
+				// Any on the cluster rather than mutating it in place.
+				TypedConfig: ir.clusterTypeConfig,
 			},
 		}
 	} else {
@@ -126,8 +147,6 @@ func processStatic(ir *StaticIr, out *envoyclusterv3.Cluster) {
 	}
 
 	if ir.loadAssignment != nil {
-		// clone needed to avoid adding cluster name to original object in the IR.
-		out.LoadAssignment = proto.Clone(ir.loadAssignment).(*envoyendpointv3.ClusterLoadAssignment)
-		out.LoadAssignment.ClusterName = out.GetName()
+		out.LoadAssignment = ir.namedLoadAssignment(out.GetName())
 	}
 }

--- a/pkg/kgateway/extensions2/plugins/backend/static_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/static_test.go
@@ -60,3 +60,33 @@ func TestProcessStaticUsesCustomDnsCluster(t *testing.T) {
 	assert.Equal(t, "example.com", endpoint.GetAddress().GetSocketAddress().GetAddress())
 	assert.Equal(t, uint32(8080), endpoint.GetAddress().GetSocketAddress().GetPortValue())
 }
+
+// One StaticIr can be translated under multiple cluster names: gateway-scoped
+// backend variants (e.g. CloneForGatewayBackendClientCertificate) share the IR
+// but derive their own cluster name. Each name must get a load assignment with
+// the matching name, while repeated translations of the same name share one copy.
+func TestProcessStaticLoadAssignmentPerClusterName(t *testing.T) {
+	ir, err := buildStaticIr(&kgateway.StaticBackend{
+		Hosts: []kgateway.Host{{
+			Host: "example.com",
+			Port: 8080,
+		}},
+	})
+	require.NoError(t, err)
+
+	base := &envoyclusterv3.Cluster{Name: "base-cluster"}
+	processStatic(ir, base)
+	variant := &envoyclusterv3.Cluster{Name: "gateway-variant-cluster"}
+	processStatic(ir, variant)
+	baseAgain := &envoyclusterv3.Cluster{Name: "base-cluster"}
+	processStatic(ir, baseAgain)
+
+	assert.Equal(t, "base-cluster", base.GetLoadAssignment().GetClusterName())
+	assert.Equal(t, "gateway-variant-cluster", variant.GetLoadAssignment().GetClusterName())
+	assert.Same(t, base.GetLoadAssignment(), baseAgain.GetLoadAssignment(),
+		"clusters with the same name should share one load assignment")
+	assert.NotSame(t, base.GetLoadAssignment(), variant.GetLoadAssignment(),
+		"clusters with different names must not share a load assignment")
+	assert.Empty(t, ir.loadAssignment.GetClusterName(),
+		"the IR's original load assignment must not be mutated")
+}


### PR DESCRIPTION
# Description

A memory profile of a large environment (1k Gateways, ~2k static Backends, every proxy receiving all clusters) showed ~12-14% of the controller's live heap in `proto.Clone` called from `processStatic`. During per-client cluster translation, the static backend plugin cloned the IR's `ClusterLoadAssignment` and DNS cluster typed config for every (client, backend) pair — with 1,000 connected clients that is 1,000 identical clones per backend, all retained in the per-client cluster collection.

This PR:
- Clones the load assignment **once per backend** instead of once per (client, backend). The clone existed only to set `ClusterName`, which is backend-derived and therefore identical for every client, so the named copy is memoized on the `StaticIr` via `sync.Once` and shared by all clients.
- Shares the DNS cluster typed config (`anypb.Any`) directly instead of cloning it. The consumers that adjust the DNS config (`processDnsLookupFamily`, `BackendConfigPolicy`'s DNS settings) unmarshal it and assign a **new** Any to the cluster rather than mutating the shared one in place, so sharing is safe.

The emitted Envoy configuration is unchanged.

# Change Type

/kind cleanup

# Changelog

```release-note
Reduced controller memory usage by sharing static Backend cluster protos across connected clients instead of cloning them per client.
```

# Additional Notes

`go vet`'s copylocks check passes, confirming the `sync.Once` on `StaticIr` is never copied (the IR is used by pointer throughout).