### PR TITLE
perf: share per-client CLAs and precompute per-client resource names

### DIFF
--- a/pkg/kgateway/endpoints/prioritize.go
+++ b/pkg/kgateway/endpoints/prioritize.go
@@ -24,6 +24,50 @@ type EndpointsInputs struct {
 	PriorityInfo        *PriorityInfo
 }
 
+// ClaPerClient pairs a connected client with the ClusterLoadAssignment
+// translated for it. The Cla may be shared with other clients whose
+// load-balancing inputs are identical.
+type ClaPerClient struct {
+	Client ir.UniquelyConnectedClient
+	Cla    *envoyendpointv3.ClusterLoadAssignment
+	// AdditionalHash is the endpoint plugins' contribution to the CLA's
+	// equality hash for this client.
+	AdditionalHash uint64
+}
+
+// ClientLbInfoKey returns a key identifying the client attributes that influence
+// the ClusterLoadAssignment built by PrioritizeEndpoints: two clients with equal
+// keys receive identical CLAs for the same EndpointsInputs, so callers can share
+// one CLA among them instead of building one per client.
+func ClientLbInfoKey(ucc ir.UniquelyConnectedClient, inputs EndpointsInputs) string {
+	pi := inputs.PriorityInfo
+	if pi == nil {
+		pi = priorityInfoFromTrafficDistribution(inputs.EndpointsForBackend.TrafficDistribution)
+	}
+	if pi == nil {
+		// No priority or failover config: the CLA ignores client labels and locality.
+		return ""
+	}
+	if fp := pi.FailoverPriority; fp != nil {
+		// Endpoint priorities depend on the client's resolved values for the
+		// priority labels (see Prioritizer.GetPriority); locality failover is
+		// not applied in this mode.
+		var b strings.Builder
+		b.WriteString("labels:")
+		for _, priorityLabel := range fp.priorityLabels {
+			value, ok := fp.priorityLabelOverrides[priorityLabel]
+			if !ok {
+				value = ucc.Labels[priorityLabel]
+			}
+			b.WriteString(value)
+			b.WriteByte(0)
+		}
+		return b.String()
+	}
+	// Locality failover: priorities depend on the client's locality only.
+	return "locality:" + ucc.Locality.String()
+}
+
 // PrioritizeEndpoints converts EndpointsInputs into a ClusterLoadAssignment.
 func PrioritizeEndpoints(
 	logger *slog.Logger,

--- a/pkg/kgateway/endpoints/prioritize_test.go
+++ b/pkg/kgateway/endpoints/prioritize_test.go
@@ -1,0 +1,120 @@
+package endpoints
+
+import (
+	"testing"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+func testEndpoints(trafficDistribution wellknown.TrafficDistribution) ir.EndpointsForBackend {
+	return ir.EndpointsForBackend{
+		ClusterName:         "test-cluster",
+		TrafficDistribution: trafficDistribution,
+		LbEps: ir.LocalityLbMap{
+			{Region: "r1", Zone: "z1"}: []ir.EndpointWithMd{
+				{
+					LbEndpoint: &envoyendpointv3.LbEndpoint{
+						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
+							Endpoint: &envoyendpointv3.Endpoint{
+								Address: &envoycorev3.Address{
+									Address: &envoycorev3.Address_SocketAddress{
+										SocketAddress: &envoycorev3.SocketAddress{Address: "1.2.3.4"},
+									},
+								},
+							},
+						},
+					},
+					EndpointMd: ir.EndpointMetadata{
+						Labels: map[string]string{
+							corev1.LabelZoneRegion:   "r1",
+							corev1.LabelTopologyZone: "z1",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func client(zone string, labels map[string]string) ir.UniquelyConnectedClient {
+	return ir.UniquelyConnectedClient{
+		Labels:   labels,
+		Locality: ir.PodLocality{Region: "r1", Zone: zone},
+	}
+}
+
+func TestClientLbInfoKey_NoPriorityConfig(t *testing.T) {
+	inputs := EndpointsInputs{EndpointsForBackend: testEndpoints(wellknown.TrafficDistributionAny)}
+
+	a := ClientLbInfoKey(client("z1", map[string]string{"app": "gw1"}), inputs)
+	b := ClientLbInfoKey(client("z2", map[string]string{"app": "gw2"}), inputs)
+
+	if a != "" || b != "" {
+		t.Fatalf("expected empty (client-agnostic) keys without priority config, got %q and %q", a, b)
+	}
+}
+
+func TestClientLbInfoKey_FailoverPriority(t *testing.T) {
+	inputs := EndpointsInputs{
+		EndpointsForBackend: testEndpoints(wellknown.TrafficDistributionPreferSameZone),
+	}
+	// clientA and clientB are distinct gateways in the same zone; clientC is in
+	// another zone. Only the priority label values should influence the key.
+	clientA := client("z1", map[string]string{
+		corev1.LabelZoneRegion:   "r1",
+		corev1.LabelTopologyZone: "z1",
+		"app":                    "gw1",
+	})
+	clientB := client("z1", map[string]string{
+		corev1.LabelZoneRegion:   "r1",
+		corev1.LabelTopologyZone: "z1",
+		"app":                    "gw2",
+	})
+	clientC := client("z2", map[string]string{
+		corev1.LabelZoneRegion:   "r1",
+		corev1.LabelTopologyZone: "z2",
+	})
+
+	a := ClientLbInfoKey(clientA, inputs)
+	b := ClientLbInfoKey(clientB, inputs)
+	c := ClientLbInfoKey(clientC, inputs)
+
+	if a == "" {
+		t.Fatal("expected non-empty key with traffic distribution set")
+	}
+	if a != b {
+		t.Fatalf("expected equal keys for clients with equal priority label values, got %q and %q", a, b)
+	}
+	if a == c {
+		t.Fatalf("expected different keys for clients in different zones, got %q for both", a)
+	}
+
+	// clients with equal keys must produce identical CLAs
+	if !proto.Equal(PrioritizeEndpoints(nil, clientA, inputs), PrioritizeEndpoints(nil, clientB, inputs)) {
+		t.Fatal("expected identical CLAs for clients with equal lb info keys")
+	}
+}
+
+func TestClientLbInfoKey_LocalityFailover(t *testing.T) {
+	inputs := EndpointsInputs{
+		EndpointsForBackend: testEndpoints(wellknown.TrafficDistributionAny),
+		PriorityInfo:        &PriorityInfo{}, // locality failover mode: no FailoverPriority
+	}
+
+	a := ClientLbInfoKey(client("z1", map[string]string{"app": "gw1"}), inputs)
+	b := ClientLbInfoKey(client("z1", map[string]string{"app": "gw2"}), inputs)
+	c := ClientLbInfoKey(client("z2", nil), inputs)
+
+	if a != b {
+		t.Fatalf("expected equal keys for clients with equal locality, got %q and %q", a, b)
+	}
+	if a == c {
+		t.Fatalf("expected different keys for clients with different localities, got %q for both", a)
+	}
+}

--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -2,7 +2,6 @@ package proxy_syncer
 
 import (
 	"context"
-	"fmt"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"istio.io/istio/pkg/kube/krt"
@@ -29,10 +28,18 @@ type uccWithCluster struct {
 	BackendSource ir.ObjectSource
 	// BackendGeneration is the observed generation of the source Backend.
 	BackendGeneration int64
+	// resourceName is precomputed at construction: krt calls ResourceName
+	// repeatedly per object and these objects exist per (client, backend) pair.
+	// Derived from Client and Name, which are compared.
+	// +noKrtEquals
+	resourceName string
 }
 
 func (c uccWithCluster) ResourceName() string {
-	return fmt.Sprintf("%s/%s", c.Client.ResourceName(), c.Name)
+	if c.resourceName != "" {
+		return c.resourceName
+	}
+	return c.Client.ResourceName() + "/" + c.Name
 }
 
 func (c uccWithCluster) Equals(in uccWithCluster) bool {
@@ -91,6 +98,7 @@ func NewPerClientEnvoyClusters(
 				ClusterVersion:    utils.HashProto(c),
 				BackendSource:     backendObj.GetObjectSource(),
 				BackendGeneration: backendGeneration,
+				resourceName:      ucc.ResourceName() + "/" + c.GetName(),
 			})
 		}
 		return uccWithClusterRet

--- a/pkg/kgateway/proxy_syncer/backendtls_snapshot_test.go
+++ b/pkg/kgateway/proxy_syncer/backendtls_snapshot_test.go
@@ -161,7 +161,7 @@ func TestPerClientSnapshotUpdatesWhenBackendTLSPolicyConflictsAddedLater(t *test
 		krtopts,
 		uccs,
 		newFinalBackendEndpoints(krtopts, finalBackends, commoncol.Endpoints),
-		translator.TranslateEndpoints,
+		translator.TranslateEndpointsForClients,
 	)
 	clustersPerClient := NewPerClientEnvoyClusters(
 		ctx,
@@ -400,7 +400,7 @@ func TestPerClientSnapshotUsesSectionSpecificAndServiceWideBackendTLSPolicies(t 
 		krtopts,
 		uccs,
 		newFinalBackendEndpoints(krtopts, finalBackends, commoncol.Endpoints),
-		translator.TranslateEndpoints,
+		translator.TranslateEndpointsForClients,
 	)
 	clustersPerClient := NewPerClientEnvoyClusters(
 		ctx,

--- a/pkg/kgateway/proxy_syncer/cla.go
+++ b/pkg/kgateway/proxy_syncer/cla.go
@@ -1,11 +1,10 @@
 package proxy_syncer
 
 import (
-	"fmt"
-
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"istio.io/istio/pkg/kube/krt"
 
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/endpoints"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	krtutil "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
@@ -17,10 +16,18 @@ type UccWithEndpoints struct {
 	Endpoints     *envoyendpointv3.ClusterLoadAssignment
 	EndpointsHash uint64
 	endpointsName string
+	// resourceName is precomputed at construction: krt calls ResourceName
+	// repeatedly per object and these objects exist per (client, endpoints) pair.
+	// Derived from Client and endpointsName, which are compared.
+	// +noKrtEquals
+	resourceName string
 }
 
 func (c UccWithEndpoints) ResourceName() string {
-	return fmt.Sprintf("%s/%s", c.Client.ResourceName(), c.endpointsName)
+	if c.resourceName != "" {
+		return c.resourceName
+	}
+	return c.Client.ResourceName() + "/" + c.endpointsName
 }
 
 func (c UccWithEndpoints) Equals(in UccWithEndpoints) bool {
@@ -42,18 +49,19 @@ func NewPerClientEnvoyEndpoints(
 	krtopts krtutil.KrtOptions,
 	uccs krt.Collection[ir.UniquelyConnectedClient],
 	kgatewayEndpoints krt.Collection[ir.EndpointsForBackend],
-	translateEndpoints func(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) (*envoyendpointv3.ClusterLoadAssignment, uint64),
+	translateEndpoints func(kctx krt.HandlerContext, uccs []ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) []endpoints.ClaPerClient,
 ) PerClientEnvoyEndpoints {
 	eps := krt.NewManyCollection(kgatewayEndpoints, func(kctx krt.HandlerContext, ep ir.EndpointsForBackend) []UccWithEndpoints {
 		uccs := krt.Fetch(kctx, uccs)
+		epName := ep.ResourceName()
 		uccWithEndpointsRet := make([]UccWithEndpoints, 0, len(uccs))
-		for _, ucc := range uccs {
-			cla, additionalHash := translateEndpoints(kctx, ucc, ep)
+		for _, result := range translateEndpoints(kctx, uccs, ep) {
 			u := UccWithEndpoints{
-				Client:        ucc,
-				Endpoints:     cla,
-				EndpointsHash: ep.LbEpsEqualityHash ^ additionalHash,
-				endpointsName: ep.ResourceName(),
+				Client:        result.Client,
+				Endpoints:     result.Cla,
+				EndpointsHash: ep.LbEpsEqualityHash ^ result.AdditionalHash,
+				endpointsName: epName,
+				resourceName:  result.Client.ResourceName() + "/" + epName,
 			}
 			uccWithEndpointsRet = append(uccWithEndpointsRet, u)
 		}

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -308,7 +308,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 		krtopts,
 		s.uniqueClients,
 		newFinalBackendEndpoints(krtopts, finalBackends, allEndpoints),
-		s.translator.TranslateEndpoints,
+		s.translator.TranslateEndpointsForClients,
 	)
 	clustersPerClient := NewPerClientEnvoyClusters(
 		ctx,

--- a/pkg/kgateway/translator/translator.go
+++ b/pkg/kgateway/translator/translator.go
@@ -156,3 +156,39 @@ func (s *CombinedTranslator) TranslateEndpoints(kctx krt.HandlerContext, ucc ir.
 	}
 	return endpoints.PrioritizeEndpoints(s.logger, ucc, epInputs), hash
 }
+
+// TranslateEndpointsForClients translates ep into a ClusterLoadAssignment for
+// each client in uccs. Clients that produce identical CLAs — same endpoint
+// plugin contribution (captured by the plugins' hash, which is already relied
+// on for change detection) and same load-balancing inputs (locality / priority
+// label values, see endpoints.ClientLbInfoKey) — share a single CLA instead of
+// each retaining its own copy.
+func (s *CombinedTranslator) TranslateEndpointsForClients(kctx krt.HandlerContext, uccs []ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) []endpoints.ClaPerClient {
+	out := make([]endpoints.ClaPerClient, 0, len(uccs))
+	type claKey struct {
+		pluginHash uint64
+		lbKey      string
+	}
+	shared := map[claKey]*envoyendpointv3.ClusterLoadAssignment{}
+	for _, ucc := range uccs {
+		epInputs := endpoints.EndpointsInputs{
+			EndpointsForBackend: ep,
+		}
+		var hash uint64
+		for _, processEndpoints := range s.endpointPlugins {
+			hash ^= processEndpoints(kctx, context.TODO(), ucc, &epInputs)
+		}
+		key := claKey{pluginHash: hash, lbKey: endpoints.ClientLbInfoKey(ucc, epInputs)}
+		cla, ok := shared[key]
+		if !ok {
+			cla = endpoints.PrioritizeEndpoints(s.logger, ucc, epInputs)
+			shared[key] = cla
+		}
+		out = append(out, endpoints.ClaPerClient{
+			Client:         ucc,
+			Cla:            cla,
+			AdditionalHash: hash,
+		})
+	}
+	return out
+}


### PR DESCRIPTION
# Description

A memory profile of a large environment (1k Gateways, ~2.8k clusters per proxy, every proxy receiving all clusters) showed the controller's heap dominated by per-(client, backend) allocations in the per-client KRT collections. This PR addresses two of them:

**1. `fmt.Sprintf` resource-name keys (~13% of live heap).** `uccWithCluster.ResourceName` and `UccWithEndpoints.ResourceName` built their key with `fmt.Sprintf` on every call; krt calls `ResourceName` repeatedly per object, and these objects exist per (client, backend) pair, so the strings were both hot and retained. The name is now precomputed once at construction with plain concatenation and stored on the struct (with a lazy fallback for zero-value construction in tests). The fields are excluded from `Equals` via `+noKrtEquals` since they are derived from compared fields.

**2. Per-client `ClusterLoadAssignment` copies (~10-15% of live heap, growing to ~25% during reconciliation).** Every connected client received its own copy of each backend's CLA, but the output of `PrioritizeEndpoints` only varies with:
- the endpoint plugins' per-client contribution (already captured by the hash the plugins return, which change detection relies on), and
- the client's load-balancing inputs: nothing when no priority/failover config applies, the resolved priority-label values in failover-priority mode (e.g. `trafficDistribution`), or the client's locality in locality-failover mode.

`endpoints.ClientLbInfoKey` encodes that dependence, and the new `CombinedTranslator.TranslateEndpointsForClients` translates a backend's endpoints for all clients in one pass, sharing a single CLA among clients with equal keys. In the common case (no traffic distribution or failover policy) all clients share **one** CLA per backend; with `trafficDistribution: PreferSameZone`, clients dedupe per zone.

# Change Type

/kind cleanup

# Changelog

```release-note
Reduced controller memory usage by sharing ClusterLoadAssignments across connected clients with identical load-balancing inputs, and by precomputing per-client resource names.
```

# Additional Notes

`NewPerClientEnvoyEndpoints`'s `translateEndpoints` parameter changed from a per-client to a batched signature; `TranslateEndpoints` (single-client) is retained for compatibility. Unit tests cover the three `ClientLbInfoKey` modes, including that two clients with equal keys produce proto-equal CLAs.