### PR TITLE
fixes an issue where unhealthy endpoints for service entries are not removed from routing

### DIFF
--- a/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
@@ -327,6 +327,10 @@ func selectedWorkloadFromEntry(
 			Locality:        locality,
 			AugmentedLabels: labels,
 			Addresses:       []string{weSpec.GetAddress()},
+			// WorkloadEntry / inline endpoints have no pod readiness concept; their
+			// health is managed by the remote cluster (e.g. cross-network endpoints),
+			// so treat them as ready and never filter them on readiness.
+			Ready: true,
 		},
 
 		weight:      weSpec.GetWeight(),

--- a/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
@@ -118,6 +118,16 @@ func endpointsFromWorkloads(
 
 	eps := ir.NewEndpointsForBackend(be)
 	for _, workload := range workloads {
+		// Skip NotReady pod-backed workloads so that ingress (and any other
+		// ServiceEntry consumer) does not send traffic to pods that Kubernetes has
+		// marked NotReady. This mirrors the EndpointSlice-based Service path, which
+		// skips endpoints whose Ready condition is not true, and lets locality
+		// failover promote endpoints in a peer cluster when all local pods are
+		// NotReady. WorkloadEntry and inline endpoints set Ready=true.
+		if !workload.Ready {
+			continue
+		}
+
 		address := workload.Address()
 
 		// for static, it must be an IP

--- a/pkg/kgateway/extensions2/plugins/serviceentry/endpoints_test.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/endpoints_test.go
@@ -1,0 +1,76 @@
+package serviceentry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networking "istio.io/api/networking/v1alpha3"
+	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
+	"istio.io/istio/pkg/kube/krt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+)
+
+// TestEndpointsFromWorkloads_SkipsNotReadyPods verifies that endpointsFromWorkloads
+// excludes pod-backed workloads that are NotReady (mirroring the EndpointSlice/Service
+// path) while keeping Ready pods and WorkloadEntry/inline endpoints (which are always
+// treated as Ready). This is the behavior that lets ingress traffic to a global service
+// fail over to a peer cluster when all local pods go NotReady.
+func TestEndpointsFromWorkloads_SkipsNotReadyPods(t *testing.T) {
+	se := &networkingclient.ServiceEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "autogen.server.server", Namespace: "istio-system"},
+		Spec: networking.ServiceEntry{
+			Hosts:      []string{"server.server.mesh.internal"},
+			Location:   networking.ServiceEntry_MESH_INTERNAL,
+			Resolution: networking.ServiceEntry_STATIC,
+			Ports: []*networking.ServicePort{
+				{Name: "http", Number: 80, Protocol: "HTTP", TargetPort: 9898},
+			},
+		},
+	}
+	be := BuildServiceEntryBackendObjectIR(se, "server.server.mesh.internal", 80, "HTTP", nil)
+
+	podWorkload := func(name, ip string, ready bool) selectedWorkload {
+		return selectedWorkload{
+			LocalityPod: krtcollections.LocalityPod{
+				Named:           krt.Named{Name: name, Namespace: "server"},
+				Addresses:       []string{ip},
+				AugmentedLabels: map[string]string{"app": "server"},
+				Ready:           ready,
+			},
+		}
+	}
+
+	// A WorkloadEntry-backed workload (e.g. a cross-cluster endpoint). These have no
+	// pod readiness concept and selectedWorkloadFromEntry marks them Ready=true.
+	weWorkload := selectedWorkloadFromEntry(
+		"cross-cluster", "server",
+		nil, nil, nil,
+		&networking.WorkloadEntry{Address: "10.0.0.3"},
+		nil,
+	)
+	assert.True(t, weWorkload.Ready, "WorkloadEntry-backed workloads must be treated as Ready")
+
+	workloads := []selectedWorkload{
+		podWorkload("ready-pod", "10.0.0.1", true),
+		podWorkload("notready-pod", "10.0.0.2", false),
+		weWorkload,
+	}
+
+	eps := endpointsFromWorkloads(se, be, workloads)
+	assert.NotNil(t, eps)
+
+	got := map[string]bool{}
+	for _, lbeps := range eps.LbEps {
+		for _, emd := range lbeps {
+			addr := emd.GetEndpoint().GetAddress().GetSocketAddress().GetAddress()
+			got[addr] = true
+		}
+	}
+
+	assert.True(t, got["10.0.0.1"], "Ready pod endpoint should be included")
+	assert.True(t, got["10.0.0.3"], "WorkloadEntry endpoint should be included")
+	assert.False(t, got["10.0.0.2"], "NotReady pod endpoint should be excluded")
+	assert.Len(t, got, 2, "exactly the Ready pod and the WorkloadEntry endpoint should remain")
+}

--- a/pkg/kgateway/extensions2/plugins/serviceentry/endpoints_test.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/endpoints_test.go
@@ -15,8 +15,9 @@ import (
 // TestEndpointsFromWorkloads_SkipsNotReadyPods verifies that endpointsFromWorkloads
 // excludes pod-backed workloads that are NotReady (mirroring the EndpointSlice/Service
 // path) while keeping Ready pods and WorkloadEntry/inline endpoints (which are always
-// treated as Ready). This is the behavior that lets ingress traffic to a global service
-// fail over to a peer cluster when all local pods go NotReady.
+// treated as Ready). This is the behavior that lets traffic to a ServiceEntry cluster
+// with workloadSelector-backed pod endpoints fail over to a peer cluster when all
+// locally selected pods go NotReady.
 func TestEndpointsFromWorkloads_SkipsNotReadyPods(t *testing.T) {
 	se := &networkingclient.ServiceEntry{
 		ObjectMeta: metav1.ObjectMeta{Name: "autogen.server.server", Namespace: "istio-system"},

--- a/pkg/kgateway/setup/testdata/setup_yaml/pods.yaml
+++ b/pkg/kgateway/setup/testdata/setup_yaml/pods.yaml
@@ -98,6 +98,9 @@ spec:
   serviceAccount: default
   serviceAccountName: default
 status:
+  conditions:
+  - type: Ready
+    status: "True"
   podIP: 10.244.1.11
 ---
 apiVersion: v1
@@ -119,6 +122,9 @@ spec:
   serviceAccount: default
   serviceAccountName: default
 status:
+  conditions:
+  - type: Ready
+    status: "True"
   podIP: 10.244.2.14
 ---
 apiVersion: v1
@@ -138,6 +144,9 @@ spec:
   serviceAccount: default
   serviceAccountName: default
 status:
+  conditions:
+  - type: Ready
+    status: "True"
   podIP: 10.244.3.3
 ---
 ## while cross regional nodes is usually not a valid k8s setup, we'll add one here for testing purposes
@@ -179,4 +188,7 @@ spec:
   serviceAccount: default
   serviceAccountName: default
 status:
+  conditions:
+  - type: Ready
+    status: "True"
   podIP: 10.244.4.4

--- a/pkg/krtcollections/pods.go
+++ b/pkg/krtcollections/pods.go
@@ -127,6 +127,12 @@ type LocalityPod struct {
 	Locality        ir.PodLocality
 	AugmentedLabels map[string]string
 	Addresses       []string
+	// Ready reflects the pod's Kubernetes readiness (the Ready condition is True).
+	// It is used to exclude NotReady pods from ServiceEntry-derived endpoints,
+	// mirroring the EndpointSlice-based Service path which skips NotReady endpoints.
+	// Synthetic LocalityPods built from WorkloadEntries / inline endpoints set this
+	// to true, since pod readiness does not apply to them.
+	Ready bool
 }
 
 // Addresses returns the first address if there are any.
@@ -140,6 +146,7 @@ func (c LocalityPod) Address() string {
 func (c LocalityPod) Equals(in LocalityPod) bool {
 	return c.Named == in.Named &&
 		c.Locality == in.Locality &&
+		c.Ready == in.Ready &&
 		maps.Equal(c.AugmentedLabels, in.AugmentedLabels) &&
 		slices.Equal(c.Addresses, in.Addresses)
 }
@@ -293,6 +300,7 @@ func augmentPodLabels(nodes krt.Collection[NodeMetadata]) func(kctx krt.HandlerC
 			AugmentedLabels: labels,
 			Locality:        l,
 			Addresses:       extractPodIPs(pod),
+			Ready:           isPodReadyConditionTrue(pod.Status),
 		}
 	}
 }


### PR DESCRIPTION
# Description
ServiceEntry clusters that select pod endpoints via `workloadSelector` now respect pod readiness: pod-backed endpoints whose Kubernetes `Ready` condition is not `True` are excluded from the cluster's EDS, mirroring the EndpointSlice-based Service path. This lets locality failover promote endpoints in a peer cluster when all local pods for a selected workload go NotReady (e.g. during graceful termination, where kubelet flips the pod's `Ready` condition to `False`).

Scope:
- Only ServiceEntries with `workloadSelector`-backed **pod** endpoints are affected.
- `WorkloadEntry` and inline `ServiceEntry` endpoints are treated as always Ready and are never filtered, since pod readiness does not apply to them (their health is managed by the remote/owning system).

# Change Type
/kind fix

# Changelog

```release-note
ServiceEntry clusters with workloadSelector-backed pod endpoints now respect pod readiness: NotReady pods are excluded from routing, matching the EndpointSlice-based Service behavior and enabling locality failover when all locally selected pods are NotReady. WorkloadEntry and inline ServiceEntry endpoints are unaffected.
```
