### PR TITLE
replace PerRouteConfigName with FilterName

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin.go
@@ -102,8 +102,8 @@ func constructHttpACL(in *kgateway.TrafficPolicy, out *trafficPolicySpecIr) erro
 			DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 				Name: httpACLModuleName,
 			},
-			PerRouteConfigName: httpACLFilterName,
-			FilterConfig:       filterCfg,
+			FilterName:   httpACLFilterName,
+			FilterConfig: filterCfg,
 		},
 	}
 	return nil

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin_test.go
@@ -19,8 +19,8 @@ func TestHttpACLIREquals(t *testing.T) {
 			DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 				Name: httpACLModuleName,
 			},
-			PerRouteConfigName: httpACLFilterName,
-			FilterConfig:       filterCfg,
+			FilterName:   httpACLFilterName,
+			FilterConfig: filterCfg,
 		}
 	}
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
@@ -248,8 +248,8 @@ func mergeRustformation(
 				DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 					Name: RustformationModuleName,
 				},
-				PerRouteConfigName: RustformationFilterName,
-				FilterConfig:       filterCfg,
+				FilterName:   RustformationFilterName,
+				FilterConfig: filterCfg,
 			}}
 		}
 		p1Json, err := utils.AnyToJson(p1.spec.rustformation.config.FilterConfig)
@@ -696,8 +696,8 @@ func mergeHttpACL(
 				DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 					Name: httpACLModuleName,
 				},
-				PerRouteConfigName: httpACLFilterName,
-				FilterConfig:       filterCfg,
+				FilterName:   httpACLFilterName,
+				FilterConfig: filterCfg,
 			}}
 		}
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
@@ -85,8 +85,8 @@ func toRustFormationPerRouteConfig(t *kgateway.TransformationPolicy) (*dynamicmo
 		DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 			Name: RustformationModuleName,
 		},
-		PerRouteConfigName: RustformationFilterName,
-		FilterConfig:       filterCfg,
+		FilterName:   RustformationFilterName,
+		FilterConfig: filterCfg,
 	}
 
 	return rustCfg, nil
@@ -119,7 +119,7 @@ func GenerateBlankTransformationConfigPerRoute() *dynamicmodulesv3.DynamicModule
 		DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 			Name: RustformationModuleName,
 		},
-		PerRouteConfigName: RustformationFilterName,
+		FilterName: RustformationFilterName,
 		FilterConfig: utils.MustMessageToAny(&wrapperspb.StringValue{
 			Value: "{}",
 		}),
@@ -162,7 +162,7 @@ func generateDynamicMetadata(ns string, kv map[string]kgateway.InjaTemplate) *dy
 		DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 			Name: RustformationModuleName,
 		},
-		PerRouteConfigName: RustformationFilterName,
+		FilterName: RustformationFilterName,
 		FilterConfig: utils.MustMessageToAny(&wrapperspb.StringValue{
 			Value: string(b),
 		}),

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin_test.go
@@ -23,8 +23,8 @@ func TestRustformationIREquals(t *testing.T) {
 			DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 				Name: RustformationModuleName,
 			},
-			PerRouteConfigName: RustformationFilterName,
-			FilterConfig:       filterCfg,
+			FilterName:   RustformationFilterName,
+			FilterConfig: filterCfg,
 		}
 	}
 
@@ -90,7 +90,7 @@ func TestRustformationIREquals(t *testing.T) {
 				DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 					Name: RustformationModuleName,
 				},
-				PerRouteConfigName: RustformationFilterName,
+				FilterName: RustformationFilterName,
 			},
 		}
 		assert.True(t, transformation.Equals(transformation), "transformation should equal itself")

--- a/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
@@ -89,7 +89,7 @@ routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"x-foo-req","value":"abc"}]},"response":{"set":[{"name":"x-foo-resp","value":"xyz"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
   - domains:
     - www.example.com
     name: listener~8080~www_example_com
@@ -113,4 +113,4 @@ routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"x-foo-req","value":"abc"}]},"response":{"set":[{"name":"x-foo-resp","value":"xyz"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
@@ -88,7 +88,7 @@ routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}],"body":{"parseAs":"AsJson","value":"{{
           body }}"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example-gateway-only.com
@@ -124,4 +124,4 @@ routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"add":[{"name":"x-greatness","value":"{{ length(headers(\":path\"))
               }}"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
@@ -88,7 +88,7 @@ routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}],"body":{"parseAs":"AsJson","value":"{{
           body }}"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example.com

--- a/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
@@ -95,7 +95,7 @@ routes:
             value: '{"request":{"add":[{"name":"x-greatness","value":"{{ length(headers(\":path\"))
               }}"}],"body":{"parseAs":"AsString","value":"request-response"}},"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}],"body":{"parseAs":"AsJson","value":"{{
               body }}"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
   - domains:
     - www.example-request.com
     name: listener~8080~www_example-request_com
@@ -120,7 +120,7 @@ routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"x-greatness","value":"{{length(headers(\":path\"))
               }}"}],"body":{"parseAs":"AsJson","value":"requested"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
   - domains:
     - www.example-response.com
     name: listener~8080~www_example-response_com
@@ -144,4 +144,4 @@ routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation

--- a/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
@@ -90,4 +90,4 @@ routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"set":[{"name":"x-kgateway-response","value":"{{
               request_header(\"x-kgateway-request\") }}"}],"remove":["x-kgateway-request"]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/gateway-with-route-override.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/gateway-with-route-override.yaml
@@ -83,7 +83,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:
@@ -102,7 +102,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
       envoy.filters.http.basic_auth:
         '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
         users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/inline-users-route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/inline-users-route.yaml
@@ -78,7 +78,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/route-disable.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/route-disable.yaml
@@ -89,7 +89,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -102,7 +102,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
       envoy.filters.http.basic_auth:
         '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
         users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/secret-ref.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/secret-ref.yaml
@@ -78,7 +78,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -89,7 +89,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"a"},{"name":"source","value":"example"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /a/2
       metadata:
@@ -109,7 +109,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"example"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
   - domains:
     - foo.com
     name: listener~80~foo_com
@@ -134,7 +134,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"foo"},{"name":"source","value":"b"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /b/2
       metadata:
@@ -154,7 +154,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"foo"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -88,7 +88,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"x-foo-req","value":"abc"}]},"response":{"set":[{"name":"x-foo-resp","value":"xyz"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         prefix: /
       name: listener~80~example_com-route-2-httproute-example-route-infra-0-0-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -171,7 +171,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ext_proc/a/extproc-ext1:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -211,7 +211,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"def","value":"custom-value-def"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -88,7 +88,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         prefix: /
       metadata:
@@ -108,7 +108,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -88,7 +88,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         prefix: /
       metadata:
@@ -108,7 +108,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -95,7 +95,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:
@@ -130,7 +130,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -158,7 +158,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ext_proc/a/extproc-ext:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -196,7 +196,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -211,7 +211,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"a1","value":"a1"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ext_proc/a/extproc-ext:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -253,7 +253,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"mid","value":"mid"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ext_proc/b/extproc-ext:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -293,7 +293,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"example","value":"example"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -87,7 +87,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:
@@ -122,7 +122,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -85,7 +85,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/gateway-http-acl.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/gateway-http-acl.yaml
@@ -66,7 +66,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"allow","denyResponse":{"blockedByHeaderName":"X-Blocked-By","statusCode":403},"rules":[{"action":"deny","cidrs":["10.0.0.0/8"],"name":"block-internal-range"},{"action":"allow","cidrs":["10.1.0.0/16"],"name":"allow-trusted-subnet"},{"action":"deny","cidrs":["2001:db8::/32"],"name":"block-ipv6-range"},{"action":"deny","cidrs":["192.168.1.100"],"name":"block-single-ipv4"},{"action":"deny","cidrs":["2001:db8::1"],"name":"block-single-ipv6"}]}'
-      perRouteConfigName: http-acl
+      filterName: http-acl
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/httproute-http-acl.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/httproute-http-acl.yaml
@@ -72,7 +72,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["2001:db8::/32"]},{"action":"allow","cidrs":["192.168.1.100"]},{"action":"allow","cidrs":["2001:db8::1"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -92,7 +92,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["2001:db8::/32"]},{"action":"allow","cidrs":["192.168.1.100"]},{"action":"allow","cidrs":["2001:db8::1"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/route-http-acl.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/route-http-acl.yaml
@@ -78,7 +78,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["192.168.0.0/16"]},{"action":"deny","cidrs":["2001:db8::/32"]},{"action":"deny","cidrs":["192.168.1.100"]},{"action":"deny","cidrs":["2001:db8::1"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace-extension.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace-extension.yaml
@@ -132,7 +132,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace.yaml
@@ -152,7 +152,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
   - domains:
     - denied.example.com
     name: listener~80~denied_example_com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-and-route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-and-route.yaml
@@ -189,7 +189,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -217,7 +217,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -240,7 +240,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-configmap.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-configmap.yaml
@@ -128,7 +128,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-disable.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-disable.yaml
@@ -126,7 +126,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -154,7 +154,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -177,7 +177,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-listener.yaml
@@ -163,7 +163,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 - ignorePortInHostMatching: true
   name: listener~8081
   virtualHosts:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode.yaml
@@ -129,7 +129,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway.yaml
@@ -126,7 +126,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute-remote-jwks.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute-remote-jwks.yaml
@@ -164,7 +164,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute.yaml
@@ -134,7 +134,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -157,7 +157,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/listenerset.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/listenerset.yaml
@@ -257,7 +257,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 - ignorePortInHostMatching: true
   name: listener~8083
   virtualHosts:
@@ -293,7 +293,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/rbac.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/rbac.yaml
@@ -227,7 +227,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/gw:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/route.yaml
@@ -152,7 +152,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
@@ -114,7 +114,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -142,7 +142,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
@@ -129,7 +129,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - secure.example.com
@@ -168,7 +168,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 - ignorePortInHostMatching: true
   name: listener~8081
   virtualHosts:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
@@ -98,7 +98,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
   - domains:
     - api.a.example.com
     metadata:
@@ -123,7 +123,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
   - domains:
     - backend.b.example.com
     name: listener~8080~backend_b_example_com
@@ -158,7 +158,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
   - domains:
     - www.b.example.com
     name: listener~8080~www_b_example_com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
@@ -73,7 +73,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
               }"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /api
       metadata:
@@ -94,7 +94,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
               }"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
@@ -191,7 +191,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_gateway_template
           }"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -219,7 +219,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_gateway_template
           }"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -247,7 +247,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_gateway_template
           }"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
@@ -122,7 +122,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -163,7 +163,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
@@ -138,7 +138,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -73,7 +73,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
               }}"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -134,7 +134,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.cors:
           '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
           allowOriginStringMatch:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-conflict-fallback-to-shallow-merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-conflict-fallback-to-shallow-merge.yaml
@@ -68,7 +68,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["192.168.0.0/16"]}]}'
-      perRouteConfigName: http-acl
+      filterName: http-acl
   virtualHosts:
   - domains:
     - test.com
@@ -93,7 +93,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["172.16.0.0/12"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
     - match:
         pathSeparatedPrefix: /route-1
       metadata:
@@ -114,7 +114,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["138.16.0.0/12"]},{"action":"deny","cidrs":["11.11.0.0/16"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
     - match:
         pathSeparatedPrefix: /route-2
       name: listener~8080~test_com-route-2-httproute-test-default-2-0-rule2-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-default-deep-merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-default-deep-merge.yaml
@@ -70,7 +70,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["192.168.0.0/16"]}]}'
-      perRouteConfigName: http-acl
+      filterName: http-acl
   virtualHosts:
   - domains:
     - test.com
@@ -95,7 +95,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["172.16.0.0/12"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
     - match:
         pathSeparatedPrefix: /route-1
       name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-deep.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-deep.yaml
@@ -68,7 +68,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["192.168.0.0/16"]},{"action":"allow","cidrs":["10.0.0.0/8"]}]}'
-      perRouteConfigName: http-acl
+      filterName: http-acl
   virtualHosts:
   - domains:
     - test.com
@@ -94,7 +94,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["10.10.0.0/16"]},{"action":"deny","cidrs":["172.16.0.0/12"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
     - match:
         pathSeparatedPrefix: /route-1
       name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-shallow.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-shallow.yaml
@@ -66,7 +66,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"deny","rules":[{"cidrs":["192.168.0.0/16"],"action":"allow"}]}'
-      perRouteConfigName: http-acl
+      filterName: http-acl
   virtualHosts:
   - domains:
     - test.com
@@ -91,7 +91,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"cidrs":["10.10.0.0/16"],"action":"deny"}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
     - match:
         pathSeparatedPrefix: /route-1
       name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-route-delegation.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-route-delegation.yaml
@@ -73,7 +73,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["192.168.0.0/16"]},{"action":"allow","cidrs":["10.0.0.0/8"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
   - domains:
     - dpp.test.com
     name: listener~8080~dpp_test_com
@@ -98,7 +98,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["192.168.0.0/16"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
   - domains:
     - spc.test.com
     name: listener~8080~spc_test_com
@@ -122,7 +122,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["192.168.0.0/16"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
   - domains:
     - spp.test.com
     name: listener~8080~spp_test_com
@@ -146,7 +146,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]}]}'
-          perRouteConfigName: http-acl
+          filterName: http-acl
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-gateway.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-gateway.yaml
@@ -70,7 +70,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
     envoy.filters.http.api_key_auth:
       '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
       credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-httproute.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-httproute.yaml
@@ -76,7 +76,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:
@@ -107,7 +107,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override-section.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override-section.yaml
@@ -70,7 +70,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
     envoy.filters.http.api_key_auth:
       '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
       credentials:
@@ -112,7 +112,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override.yaml
@@ -70,7 +70,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
     envoy.filters.http.api_key_auth:
       '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
       credentials:
@@ -106,7 +106,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:
@@ -136,7 +136,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-route.yaml
@@ -76,7 +76,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref-with-refgrant.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref-with-refgrant.yaml
@@ -76,7 +76,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref.yaml
@@ -76,7 +76,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-selector-with-refgrant.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-selector-with-refgrant.yaml
@@ -76,7 +76,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-cross-namespace.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-cross-namespace.yaml
@@ -170,7 +170,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - allowed.example.com
@@ -198,7 +198,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
   - domains:
     - denied.example.com
     name: listener~80~denied_example_com
@@ -239,7 +239,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - listener.example.com
@@ -267,7 +267,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -217,7 +217,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - test.com
@@ -255,7 +255,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-1
       metadata:
@@ -275,7 +275,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         global_disable/ext_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -299,7 +299,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc-full-config.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc-full-config.yaml
@@ -141,7 +141,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /example-route
       metadata:
@@ -168,7 +168,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc.yaml
@@ -308,7 +308,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -341,7 +341,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-0
       metadata:
@@ -366,7 +366,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-1
       metadata:
@@ -386,7 +386,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         global_disable/ext_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -401,7 +401,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
   - domains:
     - no-auth.example.com
     name: listener~80~no-auth_example_com
@@ -430,7 +430,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - tls.example.com
@@ -459,7 +459,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /example-route-tls-section-name
       metadata:
@@ -482,7 +482,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /example-tls-sibling-route
       name: tls1~tls_example_com-route-2-httproute-example-tls-sibling-route-infra-0-0-matcher-0
@@ -511,7 +511,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 - ignorePortInHostMatching: true
   metadata:
     filterMetadata:
@@ -530,7 +530,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - no-auth-tls.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http-full-config.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http-full-config.yaml
@@ -159,7 +159,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /example-route
       metadata:
@@ -186,7 +186,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http.yaml
@@ -320,7 +320,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -353,7 +353,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-0
       metadata:
@@ -378,7 +378,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-1
       metadata:
@@ -398,7 +398,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         global_disable/ext_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -413,7 +413,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
   - domains:
     - no-auth.example.com
     name: listener~80~no-auth_example_com
@@ -442,7 +442,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - tls.example.com
@@ -471,7 +471,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /example-route-tls-section-name
       metadata:
@@ -494,7 +494,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /example-tls-sibling-route
       name: tls1~tls_example_com-route-2-httproute-example-tls-sibling-route-infra-0-0-matcher-0
@@ -523,7 +523,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 - ignorePortInHostMatching: true
   metadata:
     filterMetadata:
@@ -542,7 +542,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - no-auth-tls.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -122,7 +122,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -128,7 +128,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.cors:
           '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
           allowOriginStringMatch:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -85,7 +85,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
         envoy.filters.http.cors:
           '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
           allowOriginStringMatch:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2-jwks-backend.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2-jwks-backend.yaml
@@ -176,7 +176,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Secrets:
 - genericSecret:
     secret:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2.yaml
@@ -351,7 +351,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - test.com
@@ -384,7 +384,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-1
       metadata:
@@ -410,7 +410,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-2
       name: listener~8080~test_com-route-2-httproute-test-default-2-0-rule2-matcher-0
@@ -431,7 +431,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Secrets:
 - genericSecret:
     secret:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -68,7 +68,7 @@ Routes:
       filterConfig:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"set":[{"name":"source","value":"gateway-attachment-1"},{"name":"source","value":"gateway-attachment-2"}]},"response":{"set":[{"name":"source","value":"gateway-attachment-1"},{"name":"source","value":"gateway-attachment-2"}]}}'
-      perRouteConfigName: rustformation
+      filterName: rustformation
   virtualHosts:
   - domains:
     - test.com
@@ -100,7 +100,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"source","value":"route-attachment-2"},{"name":"source","value":"route-attachment-1"}]},"response":{"set":[{"name":"source","value":"route-attachment-2"},{"name":"source","value":"route-attachment-1"}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
     - match:
         pathSeparatedPrefix: /route-1
       name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0
@@ -121,7 +121,7 @@ Routes:
         filterConfig:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"set":[{"name":"source","value":"listener-attachment-1"},{"name":"source","value":"listener-attachment-2"}]},"response":{"set":[{"name":"source","value":"listener-attachment-1"},{"name":"source","value":"listener-attachment-2"}]}}'
-        perRouteConfigName: rustformation
+        filterName: rustformation
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-set-metadata.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-set-metadata.yaml
@@ -76,7 +76,7 @@ Routes:
               header(\"x-user-id\") }}"}}]},"response":{"set":[{"name":"x-user-response","value":"{{
               header(\"x-user-id\") }}"}],"dynamicMetadata":[{"namespace":"com.example.auth","key":"user-id-response","value":{"stringValue":"{{
               header(\"x-user-id\") }}"}}]}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-skip-body-buffering.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-skip-body-buffering.yaml
@@ -72,7 +72,7 @@ Routes:
           filterConfig:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"source","value":"route-attachment-1"}],"body":{"parseAs":"None"}},"response":{"set":[{"name":"source","value":"route-attachment-1"}],"body":{"parseAs":"None"}}}'
-          perRouteConfigName: rustformation
+          filterName: rustformation
 Statuses:
   gateways:
     default/test:


### PR DESCRIPTION
# Description

Implemented the dynamic module migration from deprecated per_route_config_name to filter_name.

Changed:

- HTTP ACL per-route dynamic module configs now set FilterName.
- Rustformation/transformation per-route configs now set FilterName.
- Merge default configs and unit test fixtures updated.
- Golden YAML outputs updated from perRouteConfigName to filterName.


# Change Type

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
