### PR TITLE
fix: deterministic policy ordering for delegated route merging

### DIFF
--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -917,9 +917,9 @@ func (p *PolicyIndex) getTargetingPoliciesMaybeForBackends(
 		})
 	}
 
-	slices.SortFunc(ret, func(a, b ir.PolicyAtt) int {
+	slices.SortStableFunc(ret, func(a, b ir.PolicyAtt) int {
 		// Sort policies by their PrecedenceWeight for the same kind if the weights are different,
-		// otherwise sort by creation time
+		// then by creation time.
 		if a.GroupKind == b.GroupKind {
 			if a.PrecedenceWeight > b.PrecedenceWeight {
 				return -1
@@ -927,9 +927,26 @@ func (p *PolicyIndex) getTargetingPoliciesMaybeForBackends(
 				return 1
 			}
 		}
-		return a.PolicyIr.CreationTime().Compare(b.PolicyIr.CreationTime())
+		if c := a.PolicyIr.CreationTime().Compare(b.PolicyIr.CreationTime()); c != 0 {
+			return c
+		}
+		// Kubernetes creationTimestamp only has second granularity, so policies applied
+		// together (e.g. via a single `kubectl apply`) routinely tie on weight and creation
+		// time. Without a final deterministic tiebreaker the order would depend on upstream
+		// map iteration, which is randomized per process and produces nondeterministic merge
+		// results across control-plane restarts. Break ties on the policy identity.
+		return strings.Compare(policyAttSortKey(a), policyAttSortKey(b))
 	})
 	return ret
+}
+
+// policyAttSortKey returns a stable identity key for a PolicyAtt, used as the final
+// tiebreaker when ordering policies that are otherwise equal (same weight and creation time).
+func policyAttSortKey(a ir.PolicyAtt) string {
+	if a.PolicyRef != nil {
+		return a.PolicyRef.IDWithSectionName()
+	}
+	return a.GroupKind.String()
 }
 
 func (p *PolicyIndex) fetchPolicy(kctx krt.HandlerContext, policyRef ir.ObjectSource) *ir.PolicyWrapper {

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -230,10 +230,16 @@ func (a *AttachedPolicies) AppendWithPriority(HierarchicalPriority int, l ...Att
 	}
 	for _, l := range l {
 		for k, v := range l.Policies {
-			for j := range v {
-				v[j].HierarchicalPriority = HierarchicalPriority
+			// Copy before mutating: v aliases the source AttachedPolicies, which is
+			// KRT collection output shared across translations (e.g. a delegating parent
+			// route shared by all its delegatee children). Mutating it in place corrupts
+			// that shared state and races with other consumers.
+			cp := make([]PolicyAtt, len(v))
+			copy(cp, v)
+			for j := range cp {
+				cp[j].HierarchicalPriority = HierarchicalPriority
 			}
-			a.Policies[k] = append(a.Policies[k], v...)
+			a.Policies[k] = append(a.Policies[k], cp...)
 		}
 	}
 }
@@ -246,10 +252,14 @@ func (a *AttachedPolicies) Prepend(hierarchicalPriority int, l ...AttachedPolici
 	// iterate in the reverse order so that the input order in l is preserved at the end
 	for i := len(l) - 1; i >= 0; i-- {
 		for k, v := range l[i].Policies {
-			for j := range v {
-				v[j].HierarchicalPriority = hierarchicalPriority
+			// Copy before mutating: see AppendWithPriority. v also backs the result, so
+			// without a copy the append below could write into the shared source's array.
+			cp := make([]PolicyAtt, len(v))
+			copy(cp, v)
+			for j := range cp {
+				cp[j].HierarchicalPriority = hierarchicalPriority
 			}
-			a.Policies[k] = append(v, a.Policies[k]...)
+			a.Policies[k] = append(cp, a.Policies[k]...)
 		}
 	}
 }


### PR DESCRIPTION
# Description

This addresses two related sources of nondeterminism in delegated-route policy merging that contribute to the flaky transformation-merge behavior tracked in #13314.

1. **Non-deterministic policy ordering.** `GetTargetingPolicies` sorted policies with a non-stable `slices.SortFunc` whose final tiebreaker was `CreationTime()`. Kubernetes `creationTimestamp` only has **second** granularity, so policies applied together (e.g. via a single `kubectl apply`) tie on both `PrecedenceWeight` and creation time. With an unstable sort and no further tiebreaker, the order fell back to randomized Go map iteration — which is randomized per process, so the merged config changed on every control-plane restart. Fixed by using `SortStableFunc` with a final deterministic tiebreaker on the policy identity.

2. **Mutation of shared KRT state.** `AppendWithPriority`/`Prepend` stamped `HierarchicalPriority` directly into the *source* `PolicyAtt` slices. Those slices are KRT collection output shared across translations — a delegating parent route is shared by all of its delegatee children — so the in-place write corrupted shared state and could race with other consumers. Fixed by copying each `PolicyAtt` before mutating.

This is the first of two PRs. It is a pure determinism/safety fix with no intended behavior change. A follow-up makes the transformation `set` merge dedup-by-header-name (and re-enables the disabled e2e test); that part touches DeepMerge semantics flagged `needs-design`, so it is split out for separate review.

Related to #13314

# Change Type

/kind fix

# Changelog
```release-note
NONE
```