### PR TITLE
Support Gateway HTTP listener isolation

### DIFF
--- a/pkg/deployer/gatewayclass.go
+++ b/pkg/deployer/gatewayclass.go
@@ -33,7 +33,6 @@ func GetSupportedFeaturesForStandardGateway(enableExperimentalGatewayAPIFeatures
 	exemptFeatures := GetCommonExemptFeatures()
 	// backfill individual features that we don't support yet.
 	exemptFeatures.Insert(
-		features.GatewayHTTPListenerIsolationFeature,
 		// We do not yet implement the 421 misdirected-request behavior across HTTPS listeners
 		// sharing the same port.
 		features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature,

--- a/pkg/deployer/gatewayclass_test.go
+++ b/pkg/deployer/gatewayclass_test.go
@@ -29,6 +29,9 @@ func TestGetSupportedFeaturesForStandardGatewayExcludesKnownUnsupportedV15Featur
 	if _, ok := supportedNames[gwv1.FeatureName(features.SupportGatewayFrontendClientCertificateValidationInsecureFallback)]; !ok {
 		t.Fatalf("expected %q to remain supported", features.SupportGatewayFrontendClientCertificateValidationInsecureFallback)
 	}
+	if _, ok := supportedNames[gwv1.FeatureName(features.SupportGatewayHTTPListenerIsolation)]; !ok {
+		t.Fatalf("expected %q to be supported", features.SupportGatewayHTTPListenerIsolation)
+	}
 	if _, ok := supportedNames[gwv1.FeatureName(features.SupportGatewayBackendClientCertificate)]; !ok {
 		t.Fatalf("expected %q to remain supported once core BackendTLSPolicy support is advertised", features.SupportGatewayBackendClientCertificate)
 	}

--- a/pkg/kgateway/translator/listener/gateway_listener_translator.go
+++ b/pkg/kgateway/translator/listener/gateway_listener_translator.go
@@ -683,6 +683,66 @@ type httpFilterChainParent struct {
 	listenerReporter    reports.ListenerReporter
 }
 
+func filterHTTPListenerIsolationHostnames(parent httpFilterChainParent, parents []httpFilterChainParent, hostnames []string) []string {
+	filteredHostnames := make([]string, 0, len(hostnames))
+	for _, hostname := range hostnames {
+		if hostnameOwnedByMoreSpecificHTTPListener(parent, parents, hostname) {
+			continue
+		}
+		filteredHostnames = append(filteredHostnames, hostname)
+	}
+	return filteredHostnames
+}
+
+func hostnameOwnedByMoreSpecificHTTPListener(parent httpFilterChainParent, parents []httpFilterChainParent, routeHostname string) bool {
+	for _, candidate := range parents {
+		if candidate.gatewayListenerName == parent.gatewayListenerName {
+			continue
+		}
+		if !listenerHostnameCoversRouteHostname(candidate.gatewayListener.Hostname, routeHostname) {
+			continue
+		}
+		if listenerHostnamePrecedes(parent.gatewayListener.Hostname, candidate.gatewayListener.Hostname) {
+			return true
+		}
+	}
+	return false
+}
+
+func listenerHostnameCoversRouteHostname(listenerHostname *gwv1.Hostname, routeHostname string) bool {
+	if listenerHostname == nil || *listenerHostname == "" {
+		return true
+	}
+	if routeHostname == "*" {
+		return false
+	}
+
+	intersection, ok := query.IntersectHostnames(string(*listenerHostname), routeHostname)
+	return ok && intersection == routeHostname
+}
+
+func listenerHostnamePrecedes(current, candidate *gwv1.Hostname) bool {
+	currentRank, currentSpecificity := listenerHostnamePrecedence(current)
+	candidateRank, candidateSpecificity := listenerHostnamePrecedence(candidate)
+	if currentRank != candidateRank {
+		return candidateRank > currentRank
+	}
+	return candidateSpecificity > currentSpecificity
+}
+
+func listenerHostnamePrecedence(hostname *gwv1.Hostname) (int, int) {
+	if hostname == nil || *hostname == "" {
+		return 0, 0
+	}
+
+	hostnameString := string(*hostname)
+	if strings.HasPrefix(hostnameString, "*.") {
+		return 1, strings.Count(strings.TrimPrefix(hostnameString, "*."), ".")
+	}
+
+	return 2, 0
+}
+
 func (httpFilterChain *httpFilterChain) translateHttpFilterChain(
 	ctx context.Context,
 	parentName string,
@@ -690,11 +750,14 @@ func (httpFilterChain *httpFilterChain) translateHttpFilterChain(
 ) ir.HttpFilterChainIR {
 	routesByHost := map[string]routeutils.SortableRoutes{}
 	for _, parent := range httpFilterChain.parents {
-		buildRoutesPerHost(
+		buildRoutesPerHostWithHostnamesFilter(
 			ctx,
 			routesByHost,
 			parent.routesWithHosts,
 			reporter,
+			func(hostnames []string) []string {
+				return filterHTTPListenerIsolationHostnames(parent, httpFilterChain.parents, hostnames)
+			},
 		)
 	}
 
@@ -863,6 +926,18 @@ func buildRoutesPerHost(
 	routes []*query.RouteInfo,
 	reporter reports.Reporter,
 ) {
+	buildRoutesPerHostWithHostnamesFilter(ctx, routesByHost, routes, reporter, nil)
+}
+
+type routeHostnamesFilter func([]string) []string
+
+func buildRoutesPerHostWithHostnamesFilter(
+	ctx context.Context,
+	routesByHost map[string]routeutils.SortableRoutes,
+	routes []*query.RouteInfo,
+	reporter reports.Reporter,
+	filter routeHostnamesFilter,
+) {
 	for _, routeWithHosts := range routes {
 		parentRefReporter := reporter.Route(routeWithHosts.Object.GetSourceObject()).ParentRef(&routeWithHosts.ParentRef)
 		routes := route.TranslateGatewayHTTPRouteRules(
@@ -876,14 +951,25 @@ func buildRoutesPerHost(
 			continue
 		}
 
-		hostnames := routeWithHosts.Hostnames()
+		hostnames := routeHostnamesOrCatchAll(routeWithHosts)
+		if filter != nil {
+			hostnames = filter(hostnames)
+		}
 		if len(hostnames) == 0 {
-			hostnames = []string{"*"}
+			continue
 		}
 		for _, host := range hostnames {
 			routesByHost[host] = append(routesByHost[host], routeutils.ToSortable(routeWithHosts.Object.GetSourceObject(), routes)...)
 		}
 	}
+}
+
+func routeHostnamesOrCatchAll(routeWithHosts *query.RouteInfo) []string {
+	hostnames := routeWithHosts.Hostnames()
+	if len(hostnames) == 0 {
+		return []string{"*"}
+	}
+	return hostnames
 }
 
 // resolveFrontendTLSConfig resolves the FrontendTLSConfig for a specific port.

--- a/pkg/kgateway/translator/listener/gateway_listener_translator.go
+++ b/pkg/kgateway/translator/listener/gateway_listener_translator.go
@@ -736,8 +736,8 @@ func listenerHostnamePrecedence(hostname *gwv1.Hostname) (int, int) {
 	}
 
 	hostnameString := string(*hostname)
-	if strings.HasPrefix(hostnameString, "*.") {
-		return 1, strings.Count(strings.TrimPrefix(hostnameString, "*."), ".")
+	if after, ok := strings.CutPrefix(hostnameString, "*."); ok {
+		return 1, strings.Count(after, ".")
 	}
 
 	return 2, 0

--- a/pkg/kgateway/translator/listener/gateway_listener_translator_internal_test.go
+++ b/pkg/kgateway/translator/listener/gateway_listener_translator_internal_test.go
@@ -1,0 +1,228 @@
+package listener
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/query"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/routeutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+func TestFilterHTTPListenerIsolationHostnames(t *testing.T) {
+	tests := []struct {
+		name             string
+		currentHostname  *gwv1.Hostname
+		siblingHostnames []*gwv1.Hostname
+		inputHostnames   []string
+		wantHostnames    []string
+	}{
+		{
+			name:            "fallback listener keeps hostnames not covered by more specific listeners",
+			currentHostname: nil,
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("*.example.com"),
+				listenerIsolationHostname("*.foo.example.com"),
+				listenerIsolationHostname("abc.foo.example.com"),
+			},
+			inputHostnames: []string{
+				"bar.com",
+				"*.example.com",
+				"*.foo.example.com",
+				"abc.foo.example.com",
+			},
+			wantHostnames: []string{"bar.com"},
+		},
+		{
+			name:            "wildcard listener keeps its own wildcard and removes more specific hostnames",
+			currentHostname: listenerIsolationHostname("*.example.com"),
+			siblingHostnames: []*gwv1.Hostname{
+				nil,
+				listenerIsolationHostname("*.foo.example.com"),
+				listenerIsolationHostname("abc.foo.example.com"),
+			},
+			inputHostnames: []string{
+				"*.example.com",
+				"*.foo.example.com",
+				"abc.foo.example.com",
+			},
+			wantHostnames: []string{"*.example.com"},
+		},
+		{
+			name:            "more specific wildcard keeps wildcard when exact listener covers only a subspace",
+			currentHostname: listenerIsolationHostname("*.foo.example.com"),
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("abc.foo.example.com"),
+			},
+			inputHostnames: []string{
+				"*.foo.example.com",
+				"abc.foo.example.com",
+			},
+			wantHostnames: []string{"*.foo.example.com"},
+		},
+		{
+			name:            "exact listener beats wildcard listener",
+			currentHostname: listenerIsolationHostname("abc.foo.example.com"),
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("*.foo.example.com"),
+			},
+			inputHostnames: []string{"abc.foo.example.com"},
+			wantHostnames:  []string{"abc.foo.example.com"},
+		},
+		{
+			name:            "catch all route on fallback listener remains catch all",
+			currentHostname: nil,
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("*.example.com"),
+			},
+			inputHostnames: []string{"*"},
+			wantHostnames:  []string{"*"},
+		},
+		{
+			name:            "less specific wildcard is not removed by listener that covers only a subspace",
+			currentHostname: listenerIsolationHostname("*.example.com"),
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("*.foo.example.com"),
+			},
+			inputHostnames: []string{"*.example.com"},
+			wantHostnames:  []string{"*.example.com"},
+		},
+		{
+			name:            "exact route hostname is removed for a more specific wildcard listener",
+			currentHostname: listenerIsolationHostname("*.example.com"),
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("*.foo.example.com"),
+			},
+			inputHostnames: []string{"abc.foo.example.com"},
+			wantHostnames:  []string{},
+		},
+		{
+			name:            "fallback wildcard route is not removed by listener that covers only a subspace",
+			currentHostname: nil,
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("*.foo.example.com"),
+			},
+			inputHostnames: []string{"*.example.com"},
+			wantHostnames:  []string{"*.example.com"},
+		},
+		{
+			name:            "filtering can leave no hostnames",
+			currentHostname: nil,
+			siblingHostnames: []*gwv1.Hostname{
+				listenerIsolationHostname("*.example.com"),
+			},
+			inputHostnames: []string{"*.example.com"},
+			wantHostnames:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := listenerIsolationParent("current", tt.currentHostname)
+			parents := []httpFilterChainParent{current}
+			for i, hostname := range tt.siblingHostnames {
+				parents = append(parents, listenerIsolationParent(fmt.Sprintf("sibling-%d", i), hostname))
+			}
+
+			got := filterHTTPListenerIsolationHostnames(current, parents, tt.inputHostnames)
+			if diff := cmp.Diff(tt.wantHostnames, got); diff != "" {
+				t.Fatalf("filterHTTPListenerIsolationHostnames() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRoutesPerHostWithHostnamesFilter(t *testing.T) {
+	t.Run("defaults routes without hostnames to catch all", func(t *testing.T) {
+		reportMap := reports.NewReportMap()
+		reporter := reports.NewReporter(&reportMap)
+		routesByHost := map[string]routeutils.SortableRoutes{}
+
+		buildRoutesPerHost(
+			context.Background(),
+			routesByHost,
+			[]*query.RouteInfo{listenerIsolationRouteInfo(nil)},
+			reporter,
+		)
+
+		if _, ok := routesByHost["*"]; !ok {
+			t.Fatalf("expected route without hostnames to be added to catch-all host")
+		}
+	})
+
+	t.Run("does not fallback after filter removes all hostnames", func(t *testing.T) {
+		reportMap := reports.NewReportMap()
+		reporter := reports.NewReporter(&reportMap)
+		routesByHost := map[string]routeutils.SortableRoutes{}
+		var observedHostnames []string
+
+		buildRoutesPerHostWithHostnamesFilter(
+			context.Background(),
+			routesByHost,
+			[]*query.RouteInfo{listenerIsolationRouteInfo(nil)},
+			reporter,
+			func(hostnames []string) []string {
+				observedHostnames = append([]string{}, hostnames...)
+				return []string{}
+			},
+		)
+
+		if diff := cmp.Diff([]string{"*"}, observedHostnames); diff != "" {
+			t.Fatalf("hostnames passed to filter mismatch (-want +got):\n%s", diff)
+		}
+		if len(routesByHost) != 0 {
+			t.Fatalf("expected no routes after filter removed all hostnames, got %v", routesByHost)
+		}
+	})
+}
+
+func listenerIsolationParent(name string, hostname *gwv1.Hostname) httpFilterChainParent {
+	return httpFilterChainParent{
+		gatewayListenerName: name,
+		gatewayListener: ir.Listener{
+			Listener: gwv1.Listener{
+				Name:     gwv1.SectionName(name),
+				Protocol: gwv1.HTTPProtocolType,
+				Port:     80,
+				Hostname: hostname,
+			},
+		},
+	}
+}
+
+func listenerIsolationHostname(hostname string) *gwv1.Hostname {
+	h := gwv1.Hostname(hostname)
+	return &h
+}
+
+func listenerIsolationRouteInfo(hostnames []string) *query.RouteInfo {
+	source := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+		},
+	}
+	return &query.RouteInfo{
+		Object: &ir.HttpRouteIR{
+			ObjectSource: ir.ObjectSource{
+				Group:     gwv1.GroupVersion.Group,
+				Kind:      "HTTPRoute",
+				Namespace: "default",
+				Name:      "route",
+			},
+			SourceObject: source,
+			Hostnames:    hostnames,
+			ParentRefs: []gwv1.ParentReference{
+				{Name: "gw"},
+			},
+			Rules: []ir.HttpRouteRuleIR{{}},
+		},
+		ParentRef: gwv1.ParentReference{Name: "gw"},
+	}
+}


### PR DESCRIPTION
# Description
Adds HTTP listener isolation for same-port HTTP listeners by filtering route hostnames owned by more-specific sibling listeners before building shared virtual hosts. This lets kgateway advertise the GatewayHTTPListenerIsolation feature.

# Change Type
/kind feature

# Changelog
```release-note
Added support for GatewayHTTPListenerIsolation conformance behavior for HTTP listeners.
```

# Additional Notes
Tested with:
- `go test -tags e2e ./pkg/kgateway/translator/listener ./pkg/deployer`