### PR TITLE
fix: update the ownership check in the deployer

### DIFF
--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -396,10 +396,17 @@ func (d *Deployer) hasMatchingGatewayServiceMetadata(existingObj, desiredObj cli
 	}
 
 	if desiredGatewayLabel, desiredHasGatewayLabel := desiredLabels[wellknown.GatewayNameLabel]; desiredHasGatewayLabel {
-		return existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
+		existingGatewayLabel := existingLabels[wellknown.GatewayNameLabel]
+		if existingGatewayLabel == desiredGatewayLabel {
+			return true
+		}
+		// If the existing Service already has a gateway-name label (and it doesn't match), it likely belongs to a different Gateway.
+		if existingGatewayLabel != "" {
+			return false
+		}
 	}
 
-	// Down to the last option. Does any label contain `kgateway` ?
+	// Down to the last option. Does any label contain the managed-by value?
 	// This can happen if it is an upgrade from an older version
 	for _, v := range existingLabels {
 		if strings.Contains(v, d.managedBy) {

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -395,8 +395,7 @@ func (d *Deployer) hasMatchingGatewayServiceMetadata(existingObj, desiredObj cli
 		}
 	}
 
-	desiredGatewayLabel, desiredHasGatewayLabel := desiredLabels[wellknown.GatewayNameLabel]
-	if desiredHasGatewayLabel {
+	if desiredGatewayLabel, desiredHasGatewayLabel := desiredLabels[wellknown.GatewayNameLabel]; desiredHasGatewayLabel {
 		return existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
 	}
 

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -395,9 +396,18 @@ func (d *Deployer) hasMatchingGatewayServiceMetadata(existingObj, desiredObj cli
 	}
 
 	desiredGatewayLabel, desiredHasGatewayLabel := desiredLabels[wellknown.GatewayNameLabel]
-	// Down to the last option. If the GatewayNameLabel is missing, there's really no way to know for sure so return true
+	if desiredHasGatewayLabel {
+		return existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
+	}
+
+	// Down to the last option. Does any label contain `kgateway` ?
 	// This can happen if it is an upgrade from an older version
-	return !desiredHasGatewayLabel || existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
+	for _, v := range existingLabels {
+		if strings.Contains(v, d.managedBy) {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *Deployer) gvkToGVR(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -33,7 +33,6 @@ var logger = logging.New("deployer")
 
 const (
 	appKubernetesManagedByLabel = "app.kubernetes.io/managed-by"
-	kgatewayManagedByValue      = "kgateway"
 )
 
 type ControlPlaneInfo struct {
@@ -55,6 +54,7 @@ type Patcher func(ctx context.Context, client apiclient.Client, fieldManager str
 // A Deployer is responsible for deploying proxies.
 type Deployer struct {
 	controllerName                       string
+	managedBy                            string
 	chart                                *chart.Chart
 	scheme                               *runtime.Scheme
 	client                               apiclient.Client
@@ -78,6 +78,12 @@ func WithGVKToGVRMapper(m map[schema.GroupVersionKind]schema.GroupVersionResourc
 	}
 }
 
+func WithManagedBy(managedBy string) Option {
+	return func(d *Deployer) {
+		d.managedBy = managedBy
+	}
+}
+
 // NewDeployer creates a new deployer for managed resources.
 func NewDeployer(
 	controllerName string,
@@ -90,6 +96,7 @@ func NewDeployer(
 ) *Deployer {
 	d := &Deployer{
 		controllerName:                       controllerName,
+		managedBy:                            controllerName,
 		scheme:                               scheme,
 		client:                               client,
 		chart:                                chart,
@@ -285,7 +292,7 @@ func (d *Deployer) DeployObjsWithSource(ctx context.Context, objs []client.Objec
 		// If the object doesn't exist or there's an error other than "not found", proceed with patching
 		switch {
 		case err == nil:
-			if err := validateExistingServiceOwnership(sourceObj, obj, existing); err != nil {
+			if err := d.validateExistingServiceOwnership(sourceObj, obj, existing); err != nil {
 				return err
 			}
 			// zero out fields that api server changes
@@ -335,12 +342,12 @@ func (d *Deployer) DeployObjsWithSource(ctx context.Context, objs []client.Objec
 	return nil
 }
 
-func validateExistingServiceOwnership(sourceObj, desiredObj client.Object, existingObj *unstructured.Unstructured) error {
+func (d *Deployer) validateExistingServiceOwnership(sourceObj, desiredObj client.Object, existingObj *unstructured.Unstructured) error {
 	if sourceObj == nil || desiredObj.GetObjectKind().GroupVersionKind() != wellknown.ServiceGVK {
 		return nil
 	}
 
-	if hasControllerOwnerRef(existingObj, sourceObj) || hasMatchingGatewayServiceMetadata(existingObj, desiredObj) {
+	if hasControllerOwnerRef(existingObj, sourceObj) || d.hasMatchingGatewayServiceMetadata(existingObj, desiredObj) {
 		return nil
 	}
 
@@ -370,12 +377,14 @@ func hasControllerOwnerRef(obj client.Object, sourceObj client.Object) bool {
 	return controller.Name == sourceObj.GetName()
 }
 
-func hasMatchingGatewayServiceMetadata(existingObj, desiredObj client.Object) bool {
+func (d *Deployer) hasMatchingGatewayServiceMetadata(existingObj, desiredObj client.Object) bool {
 	existingLabels := existingObj.GetLabels()
 	desiredLabels := desiredObj.GetLabels()
-	if existingLabels[appKubernetesManagedByLabel] != kgatewayManagedByValue ||
-		desiredLabels[appKubernetesManagedByLabel] != kgatewayManagedByValue {
-		return false
+	if existingManagedByLabel, existingHasManagedByLabel := existingLabels[appKubernetesManagedByLabel]; existingHasManagedByLabel {
+		if existingManagedByLabel != d.managedBy ||
+			desiredLabels[appKubernetesManagedByLabel] != d.managedBy {
+			return false
+		}
 	}
 
 	if desiredClassName, ok := desiredLabels[wellknown.GatewayClassNameLabel]; ok {
@@ -385,7 +394,7 @@ func hasMatchingGatewayServiceMetadata(existingObj, desiredObj client.Object) bo
 	}
 
 	desiredGatewayLabel, desiredHasGatewayLabel := desiredLabels[wellknown.GatewayNameLabel]
-	return desiredHasGatewayLabel && existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
+	return !desiredHasGatewayLabel && existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
 }
 
 func (d *Deployer) gvkToGVR(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -32,10 +32,6 @@ import (
 
 var logger = logging.New("deployer")
 
-const (
-	appKubernetesManagedByLabel = "app.kubernetes.io/managed-by"
-)
-
 type ControlPlaneInfo struct {
 	XdsHost      string
 	XdsPort      uint32
@@ -382,9 +378,9 @@ func hasControllerOwnerRef(obj client.Object, sourceObj client.Object) bool {
 func (d *Deployer) hasMatchingGatewayServiceMetadata(existingObj, desiredObj client.Object) bool {
 	existingLabels := existingObj.GetLabels()
 	desiredLabels := desiredObj.GetLabels()
-	if existingManagedByLabel, existingHasManagedByLabel := existingLabels[appKubernetesManagedByLabel]; existingHasManagedByLabel {
+	if existingManagedByLabel, existingHasManagedByLabel := existingLabels[wellknown.ManagedByLabel]; existingHasManagedByLabel {
 		if existingManagedByLabel != d.managedBy ||
-			desiredLabels[appKubernetesManagedByLabel] != d.managedBy {
+			desiredLabels[wellknown.ManagedByLabel] != d.managedBy {
 			return false
 		}
 	}

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -395,6 +395,8 @@ func (d *Deployer) hasMatchingGatewayServiceMetadata(existingObj, desiredObj cli
 	}
 
 	desiredGatewayLabel, desiredHasGatewayLabel := desiredLabels[wellknown.GatewayNameLabel]
+	// Down to the last option. If the GatewayNameLabel is missing, there's really no way to know for sure so return true
+	// This can happen if it is an upgrade from an older version
 	return !desiredHasGatewayLabel || existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
 }
 

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -374,6 +374,7 @@ func hasControllerOwnerRef(obj client.Object, sourceObj client.Object) bool {
 		return false
 	}
 
+	// sourceObj should be the gateway - so if the owner name matches the gateway name, it should be updated
 	return controller.Name == sourceObj.GetName()
 }
 

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -394,7 +394,7 @@ func (d *Deployer) hasMatchingGatewayServiceMetadata(existingObj, desiredObj cli
 	}
 
 	desiredGatewayLabel, desiredHasGatewayLabel := desiredLabels[wellknown.GatewayNameLabel]
-	return !desiredHasGatewayLabel && existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
+	return !desiredHasGatewayLabel || existingLabels[wellknown.GatewayNameLabel] == desiredGatewayLabel
 }
 
 func (d *Deployer) gvkToGVR(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2605,7 +2605,7 @@ var _ = Describe("DeployObjs", func() {
 				Name:      name,
 				Namespace: ns,
 				Labels: map[string]string{
-					wellknown.ManagedByLabel:  wellknown.DefaultManagedByValue,
+					wellknown.ManagedByLabel:        wellknown.DefaultManagedByValue,
 					wellknown.GatewayClassNameLabel: wellknown.DefaultGatewayClassName,
 					wellknown.GatewayNameLabel:      name,
 				},

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2604,7 +2604,7 @@ var _ = Describe("DeployObjs", func() {
 				Name:      name,
 				Namespace: ns,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by":  "kgateway",
+					"app.kubernetes.io/managed-by":  wellknown.DefaultGatewayControllerName,
 					wellknown.GatewayClassNameLabel: wellknown.DefaultGatewayClassName,
 					wellknown.GatewayNameLabel:      name,
 				},

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2574,6 +2574,7 @@ var _ = Describe("DeployObjs", func() {
 			fc,
 			nil,
 			deployer.WithPatcher(patcher),
+			deployer.WithManagedBy(wellknown.DefaultManagedByValue),
 		)
 		Expect(err).ToNot(HaveOccurred())
 		return d
@@ -2604,7 +2605,7 @@ var _ = Describe("DeployObjs", func() {
 				Name:      name,
 				Namespace: ns,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by":  wellknown.DefaultGatewayControllerName,
+					"app.kubernetes.io/managed-by":  wellknown.DefaultManagedByValue,
 					wellknown.GatewayClassNameLabel: wellknown.DefaultGatewayClassName,
 					wellknown.GatewayNameLabel:      name,
 				},

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2605,7 +2605,7 @@ var _ = Describe("DeployObjs", func() {
 				Name:      name,
 				Namespace: ns,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by":  wellknown.DefaultManagedByValue,
+					wellknown.ManagedByLabel:  wellknown.DefaultManagedByValue,
 					wellknown.GatewayClassNameLabel: wellknown.DefaultGatewayClassName,
 					wellknown.GatewayNameLabel:      name,
 				},

--- a/pkg/deployer/deployer_test.go
+++ b/pkg/deployer/deployer_test.go
@@ -2604,7 +2604,7 @@ var _ = Describe("DeployObjs", func() {
 				Name:      name,
 				Namespace: ns,
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by":  wellknown.DefaultGatewayControllerName,
+					"app.kubernetes.io/managed-by":  "kgateway",
 					wellknown.GatewayClassNameLabel: wellknown.DefaultGatewayClassName,
 					wellknown.GatewayNameLabel:      name,
 				},

--- a/pkg/kgateway/controller/controller.go
+++ b/pkg/kgateway/controller/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
 	internaldeployer "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/deployer"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 )
@@ -110,6 +111,7 @@ func watchGw(
 		cfg.Mgr.GetScheme(),
 		cfg.Client,
 		gwParams,
+		deployer.WithManagedBy(wellknown.DefaultManagedByValue),
 	)
 	if err != nil {
 		return err

--- a/pkg/kgateway/wellknown/controller.go
+++ b/pkg/kgateway/wellknown/controller.go
@@ -15,6 +15,9 @@ const (
 	// parametersRef to the GatewayClass.
 	DefaultGatewayParametersName = "kgateway"
 
+	// ManagedByLabel is the label key for the tool being used to manage the operation of an application
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+
 	// GatewayNameLabel is a label on GW pods to indicate the name of the gateway
 	// they are associated with. For gateway names > 63 chars, this contains a
 	// truncated name with hash suffix. Use GatewayNameAnnotation for the full name.

--- a/pkg/kgateway/wellknown/controller.go
+++ b/pkg/kgateway/wellknown/controller.go
@@ -29,4 +29,7 @@ const (
 
 	// LeaderElectionID is the name of the lease that leader election will use for holding the leader lock.
 	LeaderElectionID = "kgateway-envoy"
+
+	// DefaultManagedByValue represents the default value of the app.kubernetes.io/managed-by label
+	DefaultManagedByValue = "kgateway"
 )


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Fixes the ownership check to rely on a managed by string rather than the controller name in the deployer
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind cleanup
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
