### PR TITLE
feat: add translation metrics for BackendConfigPolicy and TrafficPolicy

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/metrics"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
@@ -306,6 +307,19 @@ func translate(
 	pol *kgateway.BackendConfigPolicy,
 ) (*BackendConfigPolicyIR, []error) {
 	var errs []error
+	finishMetrics := metrics.CollectTranslationMetrics(metrics.TranslatorMetricLabels{
+		Name:       pol.Name,
+		Namespace:  pol.Namespace,
+		Translator: "BackendConfigPolicy",
+	})
+	defer func() {
+		var err error
+		if len(errs) > 0 {
+			err = errs[0]
+		}
+		finishMetrics(err)
+	}()
+
 	ir := BackendConfigPolicyIR{
 		ct: pol.CreationTimestamp.Time,
 	}

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
@@ -24,8 +24,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	translatorMetrics "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/metrics"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics/metricstest"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
@@ -554,4 +557,34 @@ func mustMessageToAny(t *testing.T, msg proto.Message) *anypb.Any {
 	a, err := utils.MessageToAny(msg)
 	require.NoError(t, err, "failed to convert message to Any")
 	return a
+}
+
+func TestCollectTranslationMetrics_BackendConfigPolicy(t *testing.T) {
+	translatorMetrics.ResetMetrics()
+
+	policy := &kgateway.BackendConfigPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "test-namespace",
+		},
+		Spec: kgateway.BackendConfigPolicySpec{},
+	}
+
+	policyIR, errs := translate(nil, nil, policy)
+	require.Empty(t, errs, "translation should not produce errors")
+	assert.NotNil(t, policyIR, "translation should return a non-nil IR")
+
+	currentMetrics := metricstest.MustGatherMetrics(t)
+
+	currentMetrics.AssertMetricsInclude("kgateway_translator_translations_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetric{
+			Labels: []metrics.Label{
+				{Name: "name", Value: "test-policy"},
+				{Name: "namespace", Value: "test-namespace"},
+				{Name: "result", Value: "success"},
+				{Name: "translator", Value: "BackendConfigPolicy"},
+			},
+			Value: 1,
+		},
+	})
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/pluginutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/metrics"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
@@ -48,12 +49,24 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 	krtctx krt.HandlerContext,
 	policyCR *kgateway.TrafficPolicy,
 ) (*TrafficPolicy, []error) {
+	var errors []error
+	finishMetrics := metrics.CollectTranslationMetrics(metrics.TranslatorMetricLabels{
+		Name:       policyCR.Name,
+		Namespace:  policyCR.Namespace,
+		Translator: "TrafficPolicy",
+	})
+	defer func() {
+		var err error
+		if len(errors) > 0 {
+			err = errors[0]
+		}
+		finishMetrics(err)
+	}()
+
 	policyIr := TrafficPolicy{
 		ct: policyCR.CreationTimestamp.Time,
 	}
 	outSpec := trafficPolicySpecIr{}
-
-	var errors []error
 
 	// Construct rustformation specific IR
 	if err := constructRustformation(policyCR, &outSpec); err != nil {

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor_test.go
@@ -1,0 +1,49 @@
+package trafficpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	translatorMetrics "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics/metricstest"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+)
+
+func TestCollectTranslationMetrics_TrafficPolicy(t *testing.T) {
+	translatorMetrics.ResetMetrics()
+
+	policy := &kgateway.TrafficPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-traffic-policy",
+			Namespace: "test-namespace",
+		},
+		Spec: kgateway.TrafficPolicySpec{},
+	}
+
+	constructor := &TrafficPolicyConstructor{
+		commoncol: &collections.CommonCollections{},
+	}
+
+	policyIR, errs := constructor.ConstructIR(nil, policy)
+	require.Empty(t, errs, "translation should not produce errors")
+	assert.NotNil(t, policyIR, "translation should return a non-nil IR")
+
+	currentMetrics := metricstest.MustGatherMetrics(t)
+
+	currentMetrics.AssertMetricsInclude("kgateway_translator_translations_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetric{
+			Labels: []metrics.Label{
+				{Name: "name", Value: "test-traffic-policy"},
+				{Name: "namespace", Value: "test-namespace"},
+				{Name: "result", Value: "success"},
+				{Name: "translator", Value: "TrafficPolicy"},
+			},
+			Value: 1,
+		},
+	})
+}


### PR DESCRIPTION
# Description

Adds translation lifecycle metrics to `BackendConfigPolicy` and `TrafficPolicy`, enabling better control plane scale testing and system observability.

Wraps the respective `translate` and `ConstructIR` functions with the `CollectTranslationMetrics` API, emitting the `kgateway_translator_translations_total` metric with accurate `success` or `error` results. Follows the same defer pattern used by existing translators (`TranslateGateway`, `TranslateListeners`, `TranslateHTTPRoute`).

Previous attempts (#13366, #13317) stalled due to missing tests and CI failures. This PR includes dedicated unit tests for both policies.

Fixes #13282

# Change Type

/kind feature

# Changelog

```release-note
Added translation metrics (kgateway_translator_translations_total, kgateway_translations_running, kgateway_translator_translation_duration_seconds) for BackendConfigPolicy and TrafficPolicy.
```
