### PR TITLE
fix: Equals mutation-test harness for IR types; fix Listener and GatewayExtension equality

### DIFF
--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -426,11 +426,11 @@ func parentRefEquals(a, b client.Object) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	gvkA := a.GetObjectKind().GroupVersionKind()
-	gvkB := b.GetObjectKind().GroupVersionKind()
-	// Objects from informers often have an empty TypeMeta/GVK. When both are
-	// empty, fall back to the concrete Go type so that two same-kind parents
-	// from the same collection still compare correctly.
+	gvkA := parentGVK(a)
+	gvkB := parentGVK(b)
+	// Unknown parent kind with no TypeMeta on either side: fall back to the
+	// concrete Go type so that two same-kind parents from the same collection
+	// still compare correctly.
 	if gvkA.Empty() && gvkB.Empty() {
 		if reflect.TypeOf(a) != reflect.TypeOf(b) {
 			return false
@@ -440,6 +440,22 @@ func parentRefEquals(a, b client.Object) bool {
 	}
 	return a.GetNamespace() == b.GetNamespace() &&
 		a.GetName() == b.GetName()
+}
+
+// parentGVK returns the object's GVK, normalizing the empty TypeMeta that
+// typed informers leave behind for known parent kinds, so a parent built with
+// TypeMeta set compares equal to the same parent from an informer.
+// ListenerSet is deliberately not normalized: the same Go type serves both the
+// standard ListenerSetGVK and the legacy XListenerSetGVK, so its GVK cannot be
+// inferred from the type, and in practice it always arrives populated.
+func parentGVK(obj client.Object) schema.GroupVersionKind {
+	if gvk := obj.GetObjectKind().GroupVersionKind(); !gvk.Empty() {
+		return gvk
+	}
+	if _, ok := obj.(*gwv1.Gateway); ok {
+		return wellknown.GatewayGVK
+	}
+	return schema.GroupVersionKind{}
 }
 
 type GatewayForDeployer struct {

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -412,50 +412,22 @@ func (listener Listener) GetParentReporter(reporter reporter.Reporter) reporter.
 }
 
 func (c Listener) Equals(in Listener) bool {
-	return reflect.DeepEqual(c.Listener, in.Listener) && // plain gwv1 API struct, no protos
-		parentRefEquals(c.Parent, in.Parent) &&
-		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
-		reflect.DeepEqual(c.PolicyAncestorRef, in.PolicyAncestorRef) // plain gwv1 API struct
-}
-
-// parentRefEquals compares the parent by identity (GVK + namespace/name).
-// Content changes to the parent are detected by versionEquals on Gateway.Obj /
-// ListenerSet.Obj in the enclosing Equals, so comparing content here would only
-// re-add spurious inequality (e.g. resourceVersion bumps from status writes).
-func parentRefEquals(a, b client.Object) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	gvkA := parentGVK(a)
-	gvkB := parentGVK(b)
-	// Unknown parent kind with no TypeMeta on either side: fall back to the
-	// concrete Go type so that two same-kind parents from the same collection
-	// still compare correctly.
-	if gvkA.Empty() && gvkB.Empty() {
-		if reflect.TypeOf(a) != reflect.TypeOf(b) {
-			return false
-		}
-	} else if gvkA != gvkB {
+	// Use versionEquals for Parent (raw *gwv1.Gateway or *gwv1.ListenerSet) so that
+	// status-only writes (which bump resourceVersion but not generation) do not cause
+	// reflect.DeepEqual to return false and trigger unnecessary re-translations.
+	if (c.Parent == nil) != (in.Parent == nil) {
 		return false
 	}
-	return a.GetNamespace() == b.GetNamespace() &&
-		a.GetName() == b.GetName()
-}
-
-// parentGVK returns the object's GVK, normalizing the empty TypeMeta that
-// typed informers leave behind for known parent kinds, so a parent built with
-// TypeMeta set compares equal to the same parent from an informer.
-// ListenerSet is deliberately not normalized: the same Go type serves both the
-// standard ListenerSetGVK and the legacy XListenerSetGVK, so its GVK cannot be
-// inferred from the type, and in practice it always arrives populated.
-func parentGVK(obj client.Object) schema.GroupVersionKind {
-	if gvk := obj.GetObjectKind().GroupVersionKind(); !gvk.Empty() {
-		return gvk
+	// Currently, only Gateway and ListenerSet's Equals() calls Listener.Equals(),
+	// and both of those check versionEquals on the Parent before calling Listener.Equals(),
+	// so, this versionEquals check is somewhat redundant, but it's safer to have it here in
+	// case Listener.Equals() is called directly in the future without a Parent version check.
+	if c.Parent != nil && !versionEquals(c.Parent, in.Parent) {
+		return false
 	}
-	if _, ok := obj.(*gwv1.Gateway); ok {
-		return wellknown.GatewayGVK
-	}
-	return schema.GroupVersionKind{}
+	return reflect.DeepEqual(c.Listener, in.Listener) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		reflect.DeepEqual(c.PolicyAncestorRef, in.PolicyAncestorRef)
 }
 
 type GatewayForDeployer struct {

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -397,11 +397,8 @@ func (l Secret) MarshalJSON() ([]byte, error) {
 // TODO: why is this in backend.go?
 type Listener struct {
 	gwv1.Listener
-	// +krtEqualsTodo compare parent reference in listener equality
-	Parent client.Object
-	// +krtEqualsTodo include attached listener policies in equality
-	AttachedPolicies AttachedPolicies
-	// +krtEqualsTodo include policy ancestor reference in equality
+	Parent            client.Object
+	AttachedPolicies  AttachedPolicies
 	PolicyAncestorRef gwv1.ParentReference
 }
 
@@ -414,9 +411,35 @@ func (listener Listener) GetParentReporter(reporter reporter.Reporter) reporter.
 	}
 }
 
-// TODO: need to reevaluate DeepEqual usage
 func (c Listener) Equals(in Listener) bool {
-	return reflect.DeepEqual(c, in)
+	return reflect.DeepEqual(c.Listener, in.Listener) && // plain gwv1 API struct, no protos
+		parentRefEquals(c.Parent, in.Parent) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		reflect.DeepEqual(c.PolicyAncestorRef, in.PolicyAncestorRef) // plain gwv1 API struct
+}
+
+// parentRefEquals compares the parent by identity (GVK + namespace/name).
+// Content changes to the parent are detected by versionEquals on Gateway.Obj /
+// ListenerSet.Obj in the enclosing Equals, so comparing content here would only
+// re-add spurious inequality (e.g. resourceVersion bumps from status writes).
+func parentRefEquals(a, b client.Object) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	gvkA := a.GetObjectKind().GroupVersionKind()
+	gvkB := b.GetObjectKind().GroupVersionKind()
+	// Objects from informers often have an empty TypeMeta/GVK. When both are
+	// empty, fall back to the concrete Go type so that two same-kind parents
+	// from the same collection still compare correctly.
+	if gvkA.Empty() && gvkB.Empty() {
+		if reflect.TypeOf(a) != reflect.TypeOf(b) {
+			return false
+		}
+	} else if gvkA != gvkB {
+		return false
+	}
+	return a.GetNamespace() == b.GetNamespace() &&
+		a.GetName() == b.GetName()
 }
 
 type GatewayForDeployer struct {

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -487,5 +487,128 @@ func TestHarnessGatewayExtensionEquals(t *testing.T) {
 	)
 }
 
+// baseHarnessFullListener returns a fully-populated Listener for the
+// TestHarnessListenerEquals test. It is separate from baseHarnessListener (which
+// is minimal and used by Gateway/ListenerSet tests) so that adding fields here
+// does not break those tests.
+func baseHarnessFullListener() Listener {
+	hostname := gwv1.Hostname("example.com")
+	port := gwv1.PortNumber(443)
+	proto := gwv1.HTTPSProtocolType
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+	return Listener{
+		Listener: gwv1.Listener{
+			Name:     "https",
+			Hostname: &hostname,
+			Port:     port,
+			Protocol: proto,
+		},
+		Parent: &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "my-gateway",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+		},
+		AttachedPolicies: AttachedPolicies{
+			Policies: map[schema.GroupKind][]PolicyAtt{
+				gk: {baseHarnessPolicyAtt()},
+			},
+		},
+		PolicyAncestorRef: gwv1.ParentReference{
+			Group:     new(gwv1.Group("gateway.networking.k8s.io")),
+			Kind:      new(gwv1.Kind("Gateway")),
+			Name:      gwv1.ObjectName("my-gateway"),
+			Namespace: new(gwv1.Namespace("default")),
+		},
+	}
+}
+
+func TestHarnessListenerEquals(t *testing.T) {
+	cases := []equalstest.Case[Listener]{
+		{
+			// The embedded gwv1.Listener contributes flattened field names (Name,
+			// Hostname, Port, Protocol, TLS, AllowedRoutes) plus the embedding name
+			// "Listener". Cover the embedding via a Port mutation; the flattened
+			// names are exempted below.
+			Field: "Listener",
+			Mutate: func(l *Listener) {
+				l.Listener.Port = gwv1.PortNumber(80)
+			},
+		},
+		{
+			// Replace parent with a Gateway of a different name → unequal.
+			Field: "Parent",
+			Mutate: func(l *Listener) {
+				l.Parent = &gwv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "other-gateway",
+						Namespace:       "default",
+						ResourceVersion: "1",
+					},
+				}
+			},
+		},
+		{
+			// Add a policy to AttachedPolicies → unequal.
+			Field: "AttachedPolicies",
+			Mutate: func(l *Listener) {
+				gk2 := schema.GroupKind{Group: "other.io", Kind: "OtherPolicy"}
+				l.AttachedPolicies.Policies[gk2] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			// Change PolicyAncestorRef.Name → unequal.
+			Field: "PolicyAncestorRef",
+			Mutate: func(l *Listener) {
+				l.PolicyAncestorRef = gwv1.ParentReference{
+					Group:     new(gwv1.Group("gateway.networking.k8s.io")),
+					Kind:      new(gwv1.Kind("Gateway")),
+					Name:      gwv1.ObjectName("other-gateway"),
+					Namespace: new(gwv1.Namespace("default")),
+				}
+			},
+		},
+	}
+
+	// gwv1.Listener is embedded; the harness flattens its exported field names
+	// (Name, Hostname, Port, Protocol, TLS, AllowedRoutes) plus the embedding
+	// name "Listener". We cover the embedding via the "Listener" case above;
+	// exempt the individual flattened names to avoid requiring redundant cases.
+	equalstest.Run(
+		t,
+		baseHarnessFullListener,
+		func(a, b Listener) bool { return a.Equals(b) },
+		cases,
+		[]string{"Name", "Hostname", "Port", "Protocol", "TLS", "AllowedRoutes"}, // embedded gwv1.Listener fields covered by "Listener" case
+		// Suppress the gk field from the AttachedPolicies map closure; the
+		// "AttachedPolicies" case above exercises it at the struct level.
+	)
+}
+
+// TestListenerEqualsIgnoresParentVersion verifies that two Listeners whose
+// parents differ ONLY in ResourceVersion (i.e. same identity: name, namespace,
+// type) compare as EQUAL. This is the core semantic of the field-wise Equals:
+// parent content changes are detected by versionEquals on Gateway.Obj /
+// ListenerSet.Obj in the enclosing Equals; duplicating that check here would
+// only add spurious false-inequality from status writes.
+func TestListenerEqualsIgnoresParentVersion(t *testing.T) {
+	base := baseHarnessFullListener()
+
+	// Make a copy whose parent has a different ResourceVersion but same identity.
+	other := baseHarnessFullListener()
+	other.Parent = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			ResourceVersion: "999", // only difference
+		},
+	}
+
+	if !base.Equals(other) {
+		t.Error("Listener.Equals returned false for parents that differ only in ResourceVersion; expected true (identity comparison only)")
+	}
+}
+
 //go:fix inline
 func uint32ptr(v uint32) *uint32 { return new(v) }

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -94,7 +94,8 @@ func TestHarnessPolicyAttEquals(t *testing.T) {
 			Mutate: func(p *PolicyAtt) { p.PrecedenceWeight = 99 },
 		},
 	}
-	equalstest.Run(t, baseHarnessPolicyAtt, func(a, b PolicyAtt) bool { return a.Equals(b) }, cases,
+	equalstest.Run(
+		t, baseHarnessPolicyAtt, func(a, b PolicyAtt) bool { return a.Equals(b) }, cases,
 		[]string{"MergeOrigins"}, // +noKrtEquals, gw.go:105
 	)
 }
@@ -607,6 +608,46 @@ func TestListenerEqualsIgnoresParentVersion(t *testing.T) {
 
 	if !base.Equals(other) {
 		t.Error("Listener.Equals returned false for parents that differ only in ResourceVersion; expected true (identity comparison only)")
+	}
+}
+
+// TestListenerEqualsNormalizesParentTypeMeta verifies that a Gateway parent
+// with TypeMeta populated compares equal to the same Gateway without it (as
+// typed informers leave TypeMeta empty), and that a populated TypeMeta still
+// distinguishes genuinely different GVKs.
+func TestListenerEqualsNormalizesParentTypeMeta(t *testing.T) {
+	base := baseHarnessFullListener()
+
+	withTypeMeta := baseHarnessFullListener()
+	withTypeMeta.Parent = &gwv1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gwv1.GroupVersion.String(),
+			Kind:       "Gateway",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+	if !base.Equals(withTypeMeta) {
+		t.Error("Listener.Equals returned false for identical Gateway parents that differ only in TypeMeta presence; expected true")
+	}
+
+	wrongKind := baseHarnessFullListener()
+	wrongKind.Parent = &gwv1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gwv1.GroupVersion.String(),
+			Kind:       "NotAGateway",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+	if base.Equals(wrongKind) {
+		t.Error("Listener.Equals returned true for parents with different GVKs; expected false")
 	}
 }
 

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
 )
 
-// MARK: PolicyAtt
-
 // harnessTestPolicyIR is a minimal PolicyIR for harness tests.
 // (gw_test.go defines mockPolicyIR for its own tests; this is a separate type
 // to avoid confusion and allow independent evolution.)
@@ -101,8 +99,6 @@ func TestHarnessPolicyAttEquals(t *testing.T) {
 	)
 }
 
-// MARK: AttachedPolicies
-
 func baseHarnessAttachedPolicies() AttachedPolicies {
 	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
 	return AttachedPolicies{
@@ -146,8 +142,6 @@ func TestHarnessAttachedPoliciesEquals(t *testing.T) {
 	// All cases target it; no exempt fields needed.
 	equalstest.Run(t, baseHarnessAttachedPolicies, func(a, b AttachedPolicies) bool { return a.Equals(b) }, cases, nil)
 }
-
-// MARK: Gateway
 
 func baseGatewayObj() *gwv1.Gateway {
 	return &gwv1.Gateway{
@@ -307,8 +301,6 @@ func TestHarnessGatewayEquals(t *testing.T) {
 	)
 }
 
-// MARK: ListenerSet
-
 func TestHarnessListenerSetEquals(t *testing.T) {
 	cases := []equalstest.Case[ListenerSet]{
 		{
@@ -355,8 +347,6 @@ func TestHarnessListenerSetEquals(t *testing.T) {
 	)
 }
 
-// MARK: BackendRefIR
-
 func baseHarnessBackendRefIR() BackendRefIR {
 	backend := NewBackendObjectIR(ObjectSource{
 		Namespace: "default",
@@ -401,8 +391,6 @@ func TestHarnessBackendRefIREquals(t *testing.T) {
 
 	equalstest.Run(t, baseHarnessBackendRefIR, func(a, b BackendRefIR) bool { return a.Equals(b) }, cases, nil)
 }
-
-// MARK: GatewayExtension
 
 func baseHarnessGatewayExtension() GatewayExtension {
 	grpcSvcName := gwv1.ObjectName("ext-auth-svc")
@@ -498,8 +486,6 @@ func TestHarnessGatewayExtensionEquals(t *testing.T) {
 		[]string{"Group", "Kind", "Namespace", "Name"}, // embedded ObjectSource fields
 	)
 }
-
-// MARK: helpers
 
 //go:fix inline
 func uint32ptr(v uint32) *uint32 { return new(v) }

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -1,0 +1,505 @@
+package ir
+
+// equality_harness_test.go verifies that the Equals() implementations on core
+// IR types detect every exported field mutation. This enforces that adding a
+// field without updating Equals fails here instead of silently dropping Envoy
+// config updates.
+//
+// See test/testutils/equalstest for the harness API.
+// Plan 003 must add Listener coverage using this harness once Listener.Equals
+// is rewritten (Listener is skipped here per plan 002 scope).
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+// MARK: PolicyAtt
+
+// harnessTestPolicyIR is a minimal PolicyIR for harness tests.
+// (gw_test.go defines mockPolicyIR for its own tests; this is a separate type
+// to avoid confusion and allow independent evolution.)
+type harnessTestPolicyIR struct {
+	val string
+}
+
+func (f *harnessTestPolicyIR) CreationTime() time.Time { return time.Time{} }
+func (f *harnessTestPolicyIR) Equals(in any) bool {
+	other, ok := in.(*harnessTestPolicyIR)
+	if !ok {
+		return false
+	}
+	return f.val == other.val
+}
+
+func baseHarnessPolicyAtt() PolicyAtt {
+	return PolicyAtt{
+		GroupKind:  schema.GroupKind{Group: "example.com", Kind: "MyPolicy"},
+		Generation: 1,
+		PolicyIr:   &harnessTestPolicyIR{val: "base"},
+		PolicyRef: &AttachedPolicyRef{
+			Group:     "example.com",
+			Kind:      "MyPolicy",
+			Name:      "my-policy",
+			Namespace: "default",
+		},
+		InheritedPolicyPriority: apiannotations.ShallowMergePreferParent,
+		Errors:                  []error{errors.New("base error")},
+		HierarchicalPriority:    5,
+		PrecedenceWeight:        10,
+		// MergeOrigins is +noKrtEquals and listed as exempt below.
+	}
+}
+
+func TestHarnessPolicyAttEquals(t *testing.T) {
+	cases := []equalstest.Case[PolicyAtt]{
+		{
+			Field:  "GroupKind",
+			Mutate: func(p *PolicyAtt) { p.GroupKind = schema.GroupKind{Group: "other.io", Kind: "Other"} },
+		},
+		{
+			Field:  "Generation",
+			Mutate: func(p *PolicyAtt) { p.Generation = 99 },
+		},
+		{
+			Field:  "PolicyIr",
+			Mutate: func(p *PolicyAtt) { p.PolicyIr = &harnessTestPolicyIR{val: "mutated"} },
+		},
+		{
+			Field:  "PolicyRef",
+			Mutate: func(p *PolicyAtt) { p.PolicyRef = &AttachedPolicyRef{Name: "other-policy"} },
+		},
+		{
+			Field:  "InheritedPolicyPriority",
+			Mutate: func(p *PolicyAtt) { p.InheritedPolicyPriority = apiannotations.DeepMergePreferChild },
+		},
+		{
+			Field:  "Errors",
+			Mutate: func(p *PolicyAtt) { p.Errors = []error{errors.New("different error")} },
+		},
+		{
+			Field:  "HierarchicalPriority",
+			Mutate: func(p *PolicyAtt) { p.HierarchicalPriority = 99 },
+		},
+		{
+			Field:  "PrecedenceWeight",
+			Mutate: func(p *PolicyAtt) { p.PrecedenceWeight = 99 },
+		},
+	}
+	equalstest.Run(t, baseHarnessPolicyAtt, func(a, b PolicyAtt) bool { return a.Equals(b) }, cases,
+		[]string{"MergeOrigins"}, // +noKrtEquals, gw.go:105
+	)
+}
+
+// MARK: AttachedPolicies
+
+func baseHarnessAttachedPolicies() AttachedPolicies {
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+	return AttachedPolicies{
+		Policies: map[schema.GroupKind][]PolicyAtt{
+			gk: {baseHarnessPolicyAtt()},
+		},
+	}
+}
+
+func TestHarnessAttachedPoliciesEquals(t *testing.T) {
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+	gk2 := schema.GroupKind{Group: "other.io", Kind: "OtherPolicy"}
+
+	cases := []equalstest.Case[AttachedPolicies]{
+		{
+			Field: "Policies",
+			// Add a new entry under a different GroupKind.
+			Mutate: func(a *AttachedPolicies) {
+				a.Policies[gk2] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			Field: "Policies",
+			// Change a PolicyAtt within an existing slice.
+			Mutate: func(a *AttachedPolicies) {
+				pa := baseHarnessPolicyAtt()
+				pa.Generation = 99
+				a.Policies[gk] = []PolicyAtt{pa}
+			},
+		},
+		{
+			Field: "Policies",
+			// Remove an entry.
+			Mutate: func(a *AttachedPolicies) {
+				delete(a.Policies, gk)
+			},
+		},
+	}
+
+	// AttachedPolicies has a single exported field: Policies (map).
+	// All cases target it; no exempt fields needed.
+	equalstest.Run(t, baseHarnessAttachedPolicies, func(a, b AttachedPolicies) bool { return a.Equals(b) }, cases, nil)
+}
+
+// MARK: Gateway
+
+func baseGatewayObj() *gwv1.Gateway {
+	return &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			ResourceVersion: "1",
+			UID:             "uid-1",
+		},
+	}
+}
+
+func baseHarnessListener() Listener {
+	port := gwv1.PortNumber(80)
+	return Listener{
+		Listener: gwv1.Listener{
+			Name:     "http",
+			Port:     port,
+			Protocol: gwv1.HTTPProtocolType,
+		},
+	}
+}
+
+func baseHarnessListenerSet() ListenerSet {
+	return ListenerSet{
+		ObjectSource: ObjectSource{
+			Group:     "gateway.networking.k8s.io",
+			Kind:      "ListenerSet",
+			Namespace: "default",
+			Name:      "my-listenerset",
+		},
+		Listeners: Listeners{baseHarnessListener()},
+		Obj: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "1",
+				UID:             "ls-uid-1",
+			},
+		},
+		Err: nil,
+	}
+}
+
+func baseHarnessGateway() Gateway {
+	ls := baseHarnessListenerSet()
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "ListenerSet"}
+	return Gateway{
+		ObjectSource: ObjectSource{
+			Group:     "gateway.networking.k8s.io",
+			Kind:      "Gateway",
+			Namespace: "default",
+			Name:      "my-gateway",
+		},
+		Listeners:           Listeners{baseHarnessListener()},
+		AllowedListenerSets: GVKListenerSets{gvk: ListenerSets{ls}},
+		DeniedListenerSets:  GVKListenerSets{},
+		Obj:                 baseGatewayObj(),
+		AttachedListenerPolicies: AttachedPolicies{
+			Policies: map[schema.GroupKind][]PolicyAtt{},
+		},
+		AttachedHttpPolicies: AttachedPolicies{
+			Policies: map[schema.GroupKind][]PolicyAtt{},
+		},
+		PerConnectionBufferLimitBytes: uint32ptr(65535),
+		FrontendTLSConfig:             nil,
+		BackendTLSConfig:              nil,
+	}
+}
+
+func TestHarnessGatewayEquals(t *testing.T) {
+	gvk2 := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "OtherSet"}
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+
+	cases := []equalstest.Case[Gateway]{
+		{
+			// ObjectSource is embedded; cover it by mutating one of its fields.
+			Field: "ObjectSource",
+			Mutate: func(g *Gateway) {
+				g.ObjectSource.Name = "other-gateway"
+			},
+		},
+		{
+			// Listeners: length change (field mutations inside a Listener are plan 003's territory).
+			Field: "Listeners",
+			Mutate: func(g *Gateway) {
+				g.Listeners = append(g.Listeners, baseHarnessListener())
+			},
+		},
+		{
+			Field: "AllowedListenerSets",
+			Mutate: func(g *Gateway) {
+				g.AllowedListenerSets[gvk2] = ListenerSets{baseHarnessListenerSet()}
+			},
+		},
+		{
+			Field: "DeniedListenerSets",
+			Mutate: func(g *Gateway) {
+				ls := baseHarnessListenerSet()
+				ls.ObjectSource.Name = "denied-set"
+				g.DeniedListenerSets[gvk2] = ListenerSets{ls}
+			},
+		},
+		{
+			// Obj: mutate ResourceVersion so versionEquals (backend.go:523) detects the change.
+			// versionEquals uses ResourceVersion when Generation == 0.
+			Field: "Obj",
+			Mutate: func(g *Gateway) {
+				obj := baseGatewayObj()
+				obj.ResourceVersion = "999"
+				g.Obj = obj
+			},
+		},
+		{
+			Field: "AttachedListenerPolicies",
+			Mutate: func(g *Gateway) {
+				g.AttachedListenerPolicies.Policies[gk] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			Field: "AttachedHttpPolicies",
+			Mutate: func(g *Gateway) {
+				g.AttachedHttpPolicies.Policies[gk] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			Field: "PerConnectionBufferLimitBytes",
+			Mutate: func(g *Gateway) {
+				g.PerConnectionBufferLimitBytes = uint32ptr(32768)
+			},
+		},
+		{
+			Field: "FrontendTLSConfig",
+			Mutate: func(g *Gateway) {
+				g.FrontendTLSConfig = &FrontendTLSConfigIR{}
+			},
+		},
+		{
+			Field: "BackendTLSConfig",
+			Mutate: func(g *Gateway) {
+				ref := gwv1.SecretObjectReference{Name: "my-secret"}
+				g.BackendTLSConfig = &GatewayBackendTLSConfigIR{
+					ClientCertificateRef: &ref,
+				}
+			},
+		},
+	}
+
+	// ObjectSource is an embedded struct; the harness flattens its exported
+	// fields (Group, Kind, Namespace, Name) plus adds the embedding name itself.
+	// We cover the embedding via the "ObjectSource" case above; exempt the four
+	// individual flattened names to avoid requiring redundant cases.
+	equalstest.Run(
+		t,
+		baseHarnessGateway,
+		func(a, b Gateway) bool { return a.Equals(b) },
+		cases,
+		[]string{"Group", "Kind", "Namespace", "Name"}, // embedded ObjectSource fields covered by "ObjectSource" case
+	)
+}
+
+// MARK: ListenerSet
+
+func TestHarnessListenerSetEquals(t *testing.T) {
+	cases := []equalstest.Case[ListenerSet]{
+		{
+			// ObjectSource embedding — cover via name mutation.
+			Field: "ObjectSource",
+			Mutate: func(ls *ListenerSet) {
+				ls.ObjectSource.Name = "other-listenerset"
+			},
+		},
+		{
+			// Listeners: length change only (per plan 002 scope).
+			Field: "Listeners",
+			Mutate: func(ls *ListenerSet) {
+				ls.Listeners = append(ls.Listeners, baseHarnessListener())
+			},
+		},
+		{
+			// Obj: mutate ResourceVersion so versionEquals detects the change.
+			// versionEquals uses ResourceVersion when Generation == 0.
+			Field: "Obj",
+			Mutate: func(ls *ListenerSet) {
+				ls.Obj = &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "999",
+						UID:             "ls-uid-1",
+					},
+				}
+			},
+		},
+		{
+			Field: "Err",
+			Mutate: func(ls *ListenerSet) {
+				ls.Err = errors.New("construction failed")
+			},
+		},
+	}
+
+	equalstest.Run(
+		t,
+		baseHarnessListenerSet,
+		func(a, b ListenerSet) bool { return a.Equals(b) },
+		cases,
+		[]string{"Group", "Kind", "Namespace", "Name"}, // embedded ObjectSource fields covered by "ObjectSource" case
+	)
+}
+
+// MARK: BackendRefIR
+
+func baseHarnessBackendRefIR() BackendRefIR {
+	backend := NewBackendObjectIR(ObjectSource{
+		Namespace: "default",
+		Name:      "my-service",
+		Kind:      "Service",
+	}, 8080, "", "")
+	backend.Obj = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-service",
+			Namespace:       "default",
+			UID:             "svc-uid-1",
+			ResourceVersion: "1",
+		},
+	}
+	return BackendRefIR{
+		ClusterName:   "service_default_my-service_8080",
+		Weight:        1,
+		BackendObject: &backend,
+		Err:           nil,
+	}
+}
+
+func TestHarnessBackendRefIREquals(t *testing.T) {
+	cases := []equalstest.Case[BackendRefIR]{
+		{
+			Field:  "ClusterName",
+			Mutate: func(b *BackendRefIR) { b.ClusterName = "other_cluster" },
+		},
+		{
+			Field:  "Weight",
+			Mutate: func(b *BackendRefIR) { b.Weight = 50 },
+		},
+		{
+			Field:  "BackendObject",
+			Mutate: func(b *BackendRefIR) { b.BackendObject = nil },
+		},
+		{
+			Field:  "Err",
+			Mutate: func(b *BackendRefIR) { b.Err = errors.New("backend not found") },
+		},
+	}
+
+	equalstest.Run(t, baseHarnessBackendRefIR, func(a, b BackendRefIR) bool { return a.Equals(b) }, cases, nil)
+}
+
+// MARK: GatewayExtension
+
+func baseHarnessGatewayExtension() GatewayExtension {
+	grpcSvcName := gwv1.ObjectName("ext-auth-svc")
+	return GatewayExtension{
+		ObjectSource: ObjectSource{
+			Group:     "gateway.kgateway.io",
+			Kind:      "GatewayExtension",
+			Namespace: "default",
+			Name:      "my-extension",
+		},
+		ExtAuth: &kgateway.ExtAuthProvider{
+			GrpcService: &kgateway.ExtGrpcService{
+				BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Name: grpcSvcName,
+					},
+				},
+			},
+		},
+		ExtProc: nil,
+		RateLimit: &kgateway.RateLimitProvider{
+			Domain: "my-domain",
+		},
+		JWT:              nil,
+		OAuth2:           nil,
+		PrecedenceWeight: 5,
+	}
+}
+
+// TestHarnessGatewayExtensionEquals drives the ObjectSource fix in Step 4.
+// The "ObjectSource" mutation case will FAIL until Step 4 adds the comparison.
+func TestHarnessGatewayExtensionEquals(t *testing.T) {
+	differentSvcName := gwv1.ObjectName("different-svc")
+	cases := []equalstest.Case[GatewayExtension]{
+		{
+			// ObjectSource: mutate Name. This case passes only after Step 4.
+			Field: "ObjectSource",
+			Mutate: func(e *GatewayExtension) {
+				e.ObjectSource.Name = "other-extension"
+			},
+		},
+		{
+			Field: "ExtAuth",
+			Mutate: func(e *GatewayExtension) {
+				e.ExtAuth = &kgateway.ExtAuthProvider{
+					GrpcService: &kgateway.ExtGrpcService{
+						BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: differentSvcName,
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			Field: "ExtProc",
+			Mutate: func(e *GatewayExtension) {
+				e.ExtProc = &kgateway.ExtProcProvider{}
+			},
+		},
+		{
+			Field: "RateLimit",
+			Mutate: func(e *GatewayExtension) {
+				e.RateLimit = &kgateway.RateLimitProvider{Domain: "other-domain"}
+			},
+		},
+		{
+			Field: "JWT",
+			Mutate: func(e *GatewayExtension) {
+				e.JWT = &kgateway.JWT{}
+			},
+		},
+		{
+			Field: "OAuth2",
+			Mutate: func(e *GatewayExtension) {
+				e.OAuth2 = &kgateway.OAuth2Provider{}
+			},
+		},
+		{
+			Field:  "PrecedenceWeight",
+			Mutate: func(e *GatewayExtension) { e.PrecedenceWeight = 99 },
+		},
+	}
+
+	// ObjectSource is embedded; exempt its flattened field names since we cover
+	// them via the "ObjectSource" case.
+	equalstest.Run(
+		t,
+		baseHarnessGatewayExtension,
+		func(a, b GatewayExtension) bool { return a.Equals(b) },
+		cases,
+		[]string{"Group", "Kind", "Namespace", "Name"}, // embedded ObjectSource fields
+	)
+}
+
+// MARK: helpers
+
+//go:fix inline
+func uint32ptr(v uint32) *uint32 { return new(v) }

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
@@ -538,14 +539,16 @@ func TestHarnessListenerEquals(t *testing.T) {
 			},
 		},
 		{
-			// Replace parent with a Gateway of a different name → unequal.
+			// Bump the parent's ResourceVersion → versionEquals detects a change
+			// (the base parent has Generation 0, so versionEquals falls back to
+			// ResourceVersion + UID).
 			Field: "Parent",
 			Mutate: func(l *Listener) {
 				l.Parent = &gwv1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            "other-gateway",
+						Name:            "my-gateway",
 						Namespace:       "default",
-						ResourceVersion: "1",
+						ResourceVersion: "2",
 					},
 				}
 			},
@@ -587,67 +590,51 @@ func TestHarnessListenerEquals(t *testing.T) {
 	)
 }
 
-// TestListenerEqualsIgnoresParentVersion verifies that two Listeners whose
-// parents differ ONLY in ResourceVersion (i.e. same identity: name, namespace,
-// type) compare as EQUAL. This is the core semantic of the field-wise Equals:
-// parent content changes are detected by versionEquals on Gateway.Obj /
-// ListenerSet.Obj in the enclosing Equals; duplicating that check here would
-// only add spurious false-inequality from status writes.
-func TestListenerEqualsIgnoresParentVersion(t *testing.T) {
+// TestListenerEqualsIgnoresStatusOnlyParentUpdates verifies that a status-only
+// write to the parent (which bumps ResourceVersion but not Generation) does NOT
+// make two Listeners compare unequal, while a spec change (which bumps
+// Generation) does. This mirrors the versionEquals semantics used in
+// Listener.Equals to avoid spurious re-translations on status writes.
+func TestListenerEqualsIgnoresStatusOnlyParentUpdates(t *testing.T) {
 	base := baseHarnessFullListener()
-
-	// Make a copy whose parent has a different ResourceVersion but same identity.
-	other := baseHarnessFullListener()
-	other.Parent = &gwv1.Gateway{
+	base.Parent = &gwv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "my-gateway",
 			Namespace:       "default",
-			ResourceVersion: "999", // only difference
-		},
-	}
-
-	if !base.Equals(other) {
-		t.Error("Listener.Equals returned false for parents that differ only in ResourceVersion; expected true (identity comparison only)")
-	}
-}
-
-// TestListenerEqualsNormalizesParentTypeMeta verifies that a Gateway parent
-// with TypeMeta populated compares equal to the same Gateway without it (as
-// typed informers leave TypeMeta empty), and that a populated TypeMeta still
-// distinguishes genuinely different GVKs.
-func TestListenerEqualsNormalizesParentTypeMeta(t *testing.T) {
-	base := baseHarnessFullListener()
-
-	withTypeMeta := baseHarnessFullListener()
-	withTypeMeta.Parent = &gwv1.Gateway{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: gwv1.GroupVersion.String(),
-			Kind:       "Gateway",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "my-gateway",
-			Namespace:       "default",
+			UID:             types.UID("my-gateway-uid"),
 			ResourceVersion: "1",
+			Generation:      1,
 		},
-	}
-	if !base.Equals(withTypeMeta) {
-		t.Error("Listener.Equals returned false for identical Gateway parents that differ only in TypeMeta presence; expected true")
 	}
 
-	wrongKind := baseHarnessFullListener()
-	wrongKind.Parent = &gwv1.Gateway{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: gwv1.GroupVersion.String(),
-			Kind:       "NotAGateway",
-		},
+	// Status-only write: ResourceVersion bumps, Generation does not → equal.
+	statusOnly := baseHarnessFullListener()
+	statusOnly.Parent = &gwv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "my-gateway",
 			Namespace:       "default",
-			ResourceVersion: "1",
+			UID:             types.UID("my-gateway-uid"),
+			ResourceVersion: "2",
+			Generation:      1,
 		},
 	}
-	if base.Equals(wrongKind) {
-		t.Error("Listener.Equals returned true for parents with different GVKs; expected false")
+	if !base.Equals(statusOnly) {
+		t.Error("Listener.Equals returned false for a status-only parent update (ResourceVersion bumped, Generation unchanged); expected true")
+	}
+
+	// Spec change: Generation bumps → unequal.
+	specChange := baseHarnessFullListener()
+	specChange.Parent = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			UID:             types.UID("my-gateway-uid"),
+			ResourceVersion: "3",
+			Generation:      2,
+		},
+	}
+	if base.Equals(specChange) {
+		t.Error("Listener.Equals returned true for a parent spec change (Generation bumped); expected false")
 	}
 }
 

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -6,8 +6,6 @@ package ir
 // config updates.
 //
 // See test/testutils/equalstest for the harness API.
-// Plan 003 must add Listener coverage using this harness once Listener.Equals
-// is rewritten (Listener is skipped here per plan 002 scope).
 
 import (
 	"errors"
@@ -224,7 +222,8 @@ func TestHarnessGatewayEquals(t *testing.T) {
 			},
 		},
 		{
-			// Listeners: length change (field mutations inside a Listener are plan 003's territory).
+			// Listeners: length change only; per-field Listener mutations are
+			// covered by TestHarnessListenerEquals.
 			Field: "Listeners",
 			Mutate: func(g *Gateway) {
 				g.Listeners = append(g.Listeners, baseHarnessListener())
@@ -312,7 +311,8 @@ func TestHarnessListenerSetEquals(t *testing.T) {
 			},
 		},
 		{
-			// Listeners: length change only (per plan 002 scope).
+			// Listeners: length change only; per-field Listener mutations are
+			// covered by TestHarnessListenerEquals.
 			Field: "Listeners",
 			Mutate: func(ls *ListenerSet) {
 				ls.Listeners = append(ls.Listeners, baseHarnessListener())

--- a/pkg/pluginsdk/ir/gatewayextension.go
+++ b/pkg/pluginsdk/ir/gatewayextension.go
@@ -46,6 +46,9 @@ func (e GatewayExtension) ResourceName() string {
 }
 
 func (e GatewayExtension) Equals(other GatewayExtension) bool {
+	if e.ObjectSource != other.ObjectSource {
+		return false
+	}
 	if !reflect.DeepEqual(e.ExtAuth, other.ExtAuth) {
 		return false
 	}

--- a/test/testutils/equalstest/equalstest.go
+++ b/test/testutils/equalstest/equalstest.go
@@ -1,0 +1,123 @@
+// Package equalstest verifies that an IR type's Equals method detects a
+// change in every exported field, so KRT collections never miss an update.
+package equalstest
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// Case mutates one logical field of T and states whether Equals must
+// report inequality afterwards.
+type Case[T any] struct {
+	// Field is the exported Go field name this case covers (e.g. "Listeners").
+	// Used to satisfy the completeness check.
+	Field string
+	// Mutate changes that field on the given instance.
+	Mutate func(*T)
+}
+
+// Run builds two fresh instances via base() for each case, applies
+// Mutate to one, and asserts:
+//  1. base().Equals(base()) is true (reflexivity on identical values)
+//  2. after mutation, Equals is false in both directions (detection + symmetry)
+//
+// It then reflects over T's exported fields (flattening embedded structs one
+// level) and fails if any field name is neither covered by a Case nor listed
+// in exempt — that is how "new field, forgot Equals" becomes a test failure.
+func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []Case[T], exempt []string) {
+	t.Helper()
+
+	// 1. Reflexivity check: two identical base instances must be equal.
+	t.Run("reflexivity", func(t *testing.T) {
+		t.Helper()
+		a := base()
+		b := base()
+		if !equals(a, b) {
+			t.Errorf("Equals(base(), base()) returned false; two identical instances must be equal")
+		}
+	})
+
+	// 2. Mutation cases: each mutation must cause Equals to return false.
+	for _, c := range cases {
+		t.Run("mutation/"+c.Field, func(t *testing.T) {
+			t.Helper()
+			orig := base()
+			mutated := base()
+			c.Mutate(&mutated)
+
+			if equals(orig, mutated) {
+				t.Errorf("Equals returned true after mutating field %q; Equals must detect this change", c.Field)
+			}
+			// Symmetry: a.Equals(b) must equal b.Equals(a)
+			if equals(mutated, orig) {
+				t.Errorf("Equals is not symmetric: Equals(orig, mutated)=false but Equals(mutated, orig)=true for field %q", c.Field)
+			}
+		})
+	}
+
+	// 3. Completeness check: every exported field of T must appear in a Case or in exempt.
+	covered := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		covered[c.Field] = true
+	}
+	exemptSet := make(map[string]bool, len(exempt))
+	for _, e := range exempt {
+		exemptSet[e] = true
+	}
+
+	typ := reflect.TypeOf(*new(T))
+	if typ.Kind() != reflect.Struct {
+		t.Fatalf("equalstest.Run: type %s is not a struct", typ.Name())
+	}
+
+	var uncovered []string
+	for _, field := range exportedFields(typ) {
+		if !covered[field] && !exemptSet[field] {
+			uncovered = append(uncovered, field)
+		}
+	}
+	if len(uncovered) > 0 {
+		t.Errorf(
+			"completeness check failed for %s: exported field(s) %v are neither covered by a mutation Case nor listed as exempt — add a Case or add the field name to exempt",
+			typeName(typ),
+			uncovered,
+		)
+	}
+}
+
+// exportedFields returns all exported field names of a struct type, flattening
+// anonymous (embedded) struct fields one level deep.
+func exportedFields(t reflect.Type) []string {
+	var names []string
+	for f := range t.Fields() {
+		f := f
+		if !f.IsExported() {
+			continue
+		}
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			// Flatten embedded struct fields one level.
+			embedded := f.Type
+			for ef := range embedded.Fields() {
+				ef := ef
+				if ef.IsExported() {
+					names = append(names, ef.Name)
+				}
+			}
+			// Also add the embedded type's own name so the test can explicitly
+			// target the whole embedding as a single field (e.g. "ObjectSource").
+			names = append(names, f.Name)
+			continue
+		}
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func typeName(t reflect.Type) string {
+	if t.PkgPath() != "" {
+		return fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
+	}
+	return t.Name()
+}

--- a/test/testutils/equalstest/equalstest.go
+++ b/test/testutils/equalstest/equalstest.go
@@ -72,19 +72,27 @@ func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []C
 		t.Fatalf("equalstest.Run: type %s is not a struct", typ.Name())
 	}
 
-	var uncovered []string
-	for _, field := range exportedFields(typ) {
-		if !covered[field] && !exemptSet[field] {
-			uncovered = append(uncovered, field)
-		}
-	}
-	if len(uncovered) > 0 {
+	missing := uncoveredFields(typ, covered, exemptSet)
+	if len(missing) > 0 {
 		t.Errorf(
 			"completeness check failed for %s: exported field(s) %v are neither covered by a mutation Case nor listed as exempt — add a Case or add the field name to exempt",
 			typeName(typ),
-			uncovered,
+			missing,
 		)
 	}
+}
+
+// uncoveredFields returns the exported field names of typ that are not present
+// in covered or exempt. It flattens anonymous (embedded) struct fields one
+// level deep, matching the same logic used by Run's completeness check.
+func uncoveredFields(typ reflect.Type, covered map[string]bool, exempt map[string]bool) []string {
+	var missing []string
+	for _, field := range exportedFields(typ) {
+		if !covered[field] && !exempt[field] {
+			missing = append(missing, field)
+		}
+	}
+	return missing
 }
 
 // exportedFields returns all exported field names of a struct type, flattening
@@ -92,7 +100,6 @@ func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []C
 func exportedFields(t reflect.Type) []string {
 	var names []string
 	for f := range t.Fields() {
-		f := f
 		if !f.IsExported() {
 			continue
 		}
@@ -100,7 +107,6 @@ func exportedFields(t reflect.Type) []string {
 			// Flatten embedded struct fields one level.
 			embedded := f.Type
 			for ef := range embedded.Fields() {
-				ef := ef
 				if ef.IsExported() {
 					names = append(names, ef.Name)
 				}

--- a/test/testutils/equalstest/equalstest.go
+++ b/test/testutils/equalstest/equalstest.go
@@ -26,6 +26,9 @@ type Case[T any] struct {
 // It then reflects over T's exported fields (flattening embedded structs one
 // level) and fails if any field name is neither covered by a Case nor listed
 // in exempt — that is how "new field, forgot Equals" becomes a test failure.
+//
+// T must be a struct or a pointer to a struct; pointers are dereferenced one
+// level before field reflection.
 func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []Case[T], exempt []string) {
 	t.Helper()
 
@@ -67,9 +70,12 @@ func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []C
 		exemptSet[e] = true
 	}
 
-	typ := reflect.TypeOf(*new(T))
+	typ := reflect.TypeFor[T]()
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
 	if typ.Kind() != reflect.Struct {
-		t.Fatalf("equalstest.Run: type %s is not a struct", typ.Name())
+		t.Fatalf("equalstest.Run: type %s is not a struct or pointer to struct", typ)
 	}
 
 	missing := uncoveredFields(typ, covered, exemptSet)

--- a/test/testutils/equalstest/equalstest_internal_test.go
+++ b/test/testutils/equalstest/equalstest_internal_test.go
@@ -20,7 +20,7 @@ type internalFixture struct {
 }
 
 func TestUncoveredFields_UncoveredFieldIsFlagged(t *testing.T) {
-	typ := reflect.TypeOf(internalFixture{})
+	typ := reflect.TypeFor[internalFixture]()
 	// Cover Plain and the embedding name EmbeddedBase, but not the flattened field Embedded.
 	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
 	exempt := map[string]bool{}
@@ -33,7 +33,7 @@ func TestUncoveredFields_UncoveredFieldIsFlagged(t *testing.T) {
 }
 
 func TestUncoveredFields_ExemptFieldIsNotFlagged(t *testing.T) {
-	typ := reflect.TypeOf(internalFixture{})
+	typ := reflect.TypeFor[internalFixture]()
 	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
 	exempt := map[string]bool{"Embedded": true}
 
@@ -44,7 +44,7 @@ func TestUncoveredFields_ExemptFieldIsNotFlagged(t *testing.T) {
 }
 
 func TestUncoveredFields_EmbeddedStructNameAlsoReturned(t *testing.T) {
-	typ := reflect.TypeOf(internalFixture{})
+	typ := reflect.TypeFor[internalFixture]()
 	// Cover the flattened field but leave the embedding name itself uncovered.
 	covered := map[string]bool{"Plain": true, "Embedded": true}
 	exempt := map[string]bool{}
@@ -59,7 +59,7 @@ func TestUncoveredFields_EmbeddedStructNameAlsoReturned(t *testing.T) {
 }
 
 func TestUncoveredFields_AllCoveredReturnsEmpty(t *testing.T) {
-	typ := reflect.TypeOf(internalFixture{})
+	typ := reflect.TypeFor[internalFixture]()
 	// Cover every name that exportedFields produces for internalFixture.
 	covered := map[string]bool{"Plain": true, "Embedded": true, "EmbeddedBase": true}
 	exempt := map[string]bool{}

--- a/test/testutils/equalstest/equalstest_internal_test.go
+++ b/test/testutils/equalstest/equalstest_internal_test.go
@@ -1,0 +1,71 @@
+// Package equalstest white-box tests for unexported helpers.
+package equalstest
+
+import (
+	"reflect"
+	"testing"
+)
+
+// EmbeddedBase is an exported struct embedded inside internalFixture to test
+// that uncoveredFields flattens one level of anonymous embedding.
+type EmbeddedBase struct {
+	Embedded string
+}
+
+// internalFixture is a local fixture struct with a plain field and an exported
+// embedded struct, used exclusively for testing uncoveredFields.
+type internalFixture struct {
+	Plain string
+	EmbeddedBase
+}
+
+func TestUncoveredFields_UncoveredFieldIsFlagged(t *testing.T) {
+	typ := reflect.TypeOf(internalFixture{})
+	// Cover Plain and the embedding name EmbeddedBase, but not the flattened field Embedded.
+	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
+	exempt := map[string]bool{}
+
+	// "Embedded" comes from flattening EmbeddedBase; it is not in covered or exempt.
+	missing := uncoveredFields(typ, covered, exempt)
+	if len(missing) != 1 || missing[0] != "Embedded" {
+		t.Errorf("expected [Embedded] to be uncovered, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_ExemptFieldIsNotFlagged(t *testing.T) {
+	typ := reflect.TypeOf(internalFixture{})
+	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
+	exempt := map[string]bool{"Embedded": true}
+
+	missing := uncoveredFields(typ, covered, exempt)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields when Embedded is exempt, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_EmbeddedStructNameAlsoReturned(t *testing.T) {
+	typ := reflect.TypeOf(internalFixture{})
+	// Cover the flattened field but leave the embedding name itself uncovered.
+	covered := map[string]bool{"Plain": true, "Embedded": true}
+	exempt := map[string]bool{}
+
+	// exportedFields emits both "Embedded" (flattened) and "EmbeddedBase" (the
+	// embedding name itself). With covered containing only "Embedded",
+	// "EmbeddedBase" must appear as uncovered.
+	missing := uncoveredFields(typ, covered, exempt)
+	if len(missing) != 1 || missing[0] != "EmbeddedBase" {
+		t.Errorf("expected [EmbeddedBase] to be uncovered, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_AllCoveredReturnsEmpty(t *testing.T) {
+	typ := reflect.TypeOf(internalFixture{})
+	// Cover every name that exportedFields produces for internalFixture.
+	covered := map[string]bool{"Plain": true, "Embedded": true, "EmbeddedBase": true}
+	exempt := map[string]bool{}
+
+	missing := uncoveredFields(typ, covered, exempt)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields, got %v", missing)
+	}
+}

--- a/test/testutils/equalstest/equalstest_test.go
+++ b/test/testutils/equalstest/equalstest_test.go
@@ -1,0 +1,149 @@
+package equalstest_test
+
+import (
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+// fixture is a tiny struct used exclusively for testing the harness itself.
+type fixture struct {
+	A string
+	B int
+	// C is deliberately ignored by fixtureEqualsMissingC to simulate a bug.
+	C string
+}
+
+// fixtureEqualsMissingC is a buggy Equals that misses field C.
+func fixtureEqualsMissingC(a, b fixture) bool {
+	return a.A == b.A && a.B == b.B
+}
+
+// fixtureEqualsCorrect compares all fields.
+func fixtureEqualsCorrect(a, b fixture) bool {
+	return a.A == b.A && a.B == b.B && a.C == b.C
+}
+
+func baseFixture() fixture {
+	return fixture{A: "hello", B: 42, C: "world"}
+}
+
+// TestHarnessSelfTest_CorrectEquals verifies that a complete case list over a
+// correct Equals implementation passes without any failures.
+func TestHarnessSelfTest_CorrectEquals(t *testing.T) {
+	cases := []equalstest.Case[fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f *fixture) { f.A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f *fixture) { f.B = 99 },
+		},
+		{
+			Field:  "C",
+			Mutate: func(f *fixture) { f.C = "changed" },
+		},
+	}
+	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, nil)
+}
+
+// TestHarnessSelfTest_ExemptField verifies that listing an uncovered field as
+// exempt prevents the completeness failure.
+func TestHarnessSelfTest_ExemptField(t *testing.T) {
+	cases := []equalstest.Case[fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f *fixture) { f.A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f *fixture) { f.B = 99 },
+		},
+	}
+	// C is listed as exempt; the completeness check must pass without a C Case.
+	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, []string{"C"})
+}
+
+// TestHarnessSelfTest_MutationDetection directly verifies the core logic that
+// Run uses internally: that Equals(orig, mutated) == false for each mutation.
+// This avoids the need to invert a test-framework failure.
+func TestHarnessSelfTest_MutationDetection(t *testing.T) {
+	// A buggy Equals that ignores C.
+	equals := fixtureEqualsMissingC
+
+	t.Run("A_is_detected", func(t *testing.T) {
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.A = "changed"
+		if equals(orig, mutated) {
+			t.Error("expected Equals to detect change in A, but it returned true")
+		}
+	})
+
+	t.Run("B_is_detected", func(t *testing.T) {
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.B = 99
+		if equals(orig, mutated) {
+			t.Error("expected Equals to detect change in B, but it returned true")
+		}
+	})
+
+	t.Run("C_is_NOT_detected_by_buggy_equals", func(t *testing.T) {
+		// This verifies the fixture correctly models the bug:
+		// fixtureEqualsMissingC returns true even when C differs.
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.C = "changed"
+		if !equals(orig, mutated) {
+			t.Error("expected the buggy Equals to miss the C change, but it detected it")
+		}
+	})
+
+	t.Run("C_IS_detected_by_correct_equals", func(t *testing.T) {
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.C = "changed"
+		if fixtureEqualsCorrect(orig, mutated) {
+			t.Error("expected fixtureEqualsCorrect to detect change in C, but it returned true")
+		}
+	})
+}
+
+// TestHarnessSelfTest_CompletenessLogic directly verifies the field-coverage
+// completeness logic without relying on test-failure inversion.
+func TestHarnessSelfTest_CompletenessLogic(t *testing.T) {
+	// Cases cover only A and B, C is neither covered nor exempt — should be caught.
+	t.Run("uncovered_field_is_flagged", func(t *testing.T) {
+		covered := map[string]bool{"A": true, "B": true}
+		exempt := map[string]bool{}
+		fields := []string{"A", "B", "C"} // exported fields of fixture
+
+		var uncovered []string
+		for _, f := range fields {
+			if !covered[f] && !exempt[f] {
+				uncovered = append(uncovered, f)
+			}
+		}
+		if len(uncovered) != 1 || uncovered[0] != "C" {
+			t.Errorf("expected [C] uncovered, got %v", uncovered)
+		}
+	})
+
+	t.Run("exempt_field_is_not_flagged", func(t *testing.T) {
+		covered := map[string]bool{"A": true, "B": true}
+		exempt := map[string]bool{"C": true}
+		fields := []string{"A", "B", "C"}
+
+		var uncovered []string
+		for _, f := range fields {
+			if !covered[f] && !exempt[f] {
+				uncovered = append(uncovered, f)
+			}
+		}
+		if len(uncovered) != 0 {
+			t.Errorf("expected no uncovered fields when C is exempt, got %v", uncovered)
+		}
+	})
+}

--- a/test/testutils/equalstest/equalstest_test.go
+++ b/test/testutils/equalstest/equalstest_test.go
@@ -65,6 +65,31 @@ func TestHarnessSelfTest_ExemptField(t *testing.T) {
 	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, []string{"C"})
 }
 
+// TestHarnessSelfTest_PointerToStruct verifies the harness accepts a
+// pointer-to-struct type parameter, dereferencing it for the completeness check.
+func TestHarnessSelfTest_PointerToStruct(t *testing.T) {
+	base := func() *fixture {
+		f := baseFixture()
+		return &f
+	}
+	equals := func(a, b *fixture) bool { return fixtureEqualsCorrect(*a, *b) }
+	cases := []equalstest.Case[*fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f **fixture) { (*f).A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f **fixture) { (*f).B = 99 },
+		},
+		{
+			Field:  "C",
+			Mutate: func(f **fixture) { (*f).C = "changed" },
+		},
+	}
+	equalstest.Run(t, base, equals, cases, nil)
+}
+
 // TestHarnessSelfTest_FixtureSanity validates the fixture functions themselves
 // so that higher-level tests can rely on them. In particular it confirms that
 // fixtureEqualsMissingC genuinely misses field C (modelling the bug) and that

--- a/test/testutils/equalstest/equalstest_test.go
+++ b/test/testutils/equalstest/equalstest_test.go
@@ -65,85 +65,26 @@ func TestHarnessSelfTest_ExemptField(t *testing.T) {
 	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, []string{"C"})
 }
 
-// TestHarnessSelfTest_MutationDetection directly verifies the core logic that
-// Run uses internally: that Equals(orig, mutated) == false for each mutation.
-// This avoids the need to invert a test-framework failure.
-func TestHarnessSelfTest_MutationDetection(t *testing.T) {
-	// A buggy Equals that ignores C.
-	equals := fixtureEqualsMissingC
-
-	t.Run("A_is_detected", func(t *testing.T) {
-		orig := baseFixture()
-		mutated := baseFixture()
-		mutated.A = "changed"
-		if equals(orig, mutated) {
-			t.Error("expected Equals to detect change in A, but it returned true")
-		}
-	})
-
-	t.Run("B_is_detected", func(t *testing.T) {
-		orig := baseFixture()
-		mutated := baseFixture()
-		mutated.B = 99
-		if equals(orig, mutated) {
-			t.Error("expected Equals to detect change in B, but it returned true")
-		}
-	})
-
-	t.Run("C_is_NOT_detected_by_buggy_equals", func(t *testing.T) {
-		// This verifies the fixture correctly models the bug:
-		// fixtureEqualsMissingC returns true even when C differs.
+// TestHarnessSelfTest_FixtureSanity validates the fixture functions themselves
+// so that higher-level tests can rely on them. In particular it confirms that
+// fixtureEqualsMissingC genuinely misses field C (modelling the bug) and that
+// fixtureEqualsCorrect catches it.
+func TestHarnessSelfTest_FixtureSanity(t *testing.T) {
+	t.Run("buggy_equals_misses_C", func(t *testing.T) {
 		orig := baseFixture()
 		mutated := baseFixture()
 		mutated.C = "changed"
-		if !equals(orig, mutated) {
-			t.Error("expected the buggy Equals to miss the C change, but it detected it")
+		if !fixtureEqualsMissingC(orig, mutated) {
+			t.Error("expected fixtureEqualsMissingC to miss the C change, but it detected it")
 		}
 	})
 
-	t.Run("C_IS_detected_by_correct_equals", func(t *testing.T) {
+	t.Run("correct_equals_detects_C", func(t *testing.T) {
 		orig := baseFixture()
 		mutated := baseFixture()
 		mutated.C = "changed"
 		if fixtureEqualsCorrect(orig, mutated) {
 			t.Error("expected fixtureEqualsCorrect to detect change in C, but it returned true")
-		}
-	})
-}
-
-// TestHarnessSelfTest_CompletenessLogic directly verifies the field-coverage
-// completeness logic without relying on test-failure inversion.
-func TestHarnessSelfTest_CompletenessLogic(t *testing.T) {
-	// Cases cover only A and B, C is neither covered nor exempt — should be caught.
-	t.Run("uncovered_field_is_flagged", func(t *testing.T) {
-		covered := map[string]bool{"A": true, "B": true}
-		exempt := map[string]bool{}
-		fields := []string{"A", "B", "C"} // exported fields of fixture
-
-		var uncovered []string
-		for _, f := range fields {
-			if !covered[f] && !exempt[f] {
-				uncovered = append(uncovered, f)
-			}
-		}
-		if len(uncovered) != 1 || uncovered[0] != "C" {
-			t.Errorf("expected [C] uncovered, got %v", uncovered)
-		}
-	})
-
-	t.Run("exempt_field_is_not_flagged", func(t *testing.T) {
-		covered := map[string]bool{"A": true, "B": true}
-		exempt := map[string]bool{"C": true}
-		fields := []string{"A", "B", "C"}
-
-		var uncovered []string
-		for _, f := range fields {
-			if !covered[f] && !exempt[f] {
-				uncovered = append(uncovered, f)
-			}
-		}
-		if len(uncovered) != 0 {
-			t.Errorf("expected no uncovered fields when C is exempt, got %v", uncovered)
 		}
 	})
 }


### PR DESCRIPTION
# Description

IR types consumed by KRT collections must implement `Equals()` covering all fields; a missed field can silently suppress updates and leave stale Envoy config. Today nothing enforces coverage when a field is added to an existing IR type.

This PR has two parts:

**1. Equals mutation-test harness.** Adds a generic harness (`test/testutils/equalstest`) that verifies every exported field of an IR type is covered by a mutation case proving `Equals()` detects the change. Any uncovered, non-exempt field fails the test, so adding a field without updating `Equals` becomes a build-time failure instead of a silent stale-config bug. The harness supports struct and pointer-to-struct type parameters via `reflect.TypeFor`, flattens embedded structs one level for coverage checks, and is applied to seven core IR types: `PolicyAtt`, `AttachedPolicies`, `Gateway`, `Listener`, `ListenerSet`, `BackendRefIR`, and `GatewayExtension`.

**2. Equals fixes the harness and follow-up review drove out.**
- `GatewayExtension.Equals` now includes the embedded `ObjectSource` comparison.
- `Listener.Equals` no longer uses whole-struct `reflect.DeepEqual`, which compared the `Parent client.Object` by content and made parent metadata churn (for example, `resourceVersion` bumps from status writes) dirty every listener. It now compares the embedded `gwv1.Listener`, `AttachedPolicies`, and `PolicyAncestorRef` explicitly, and compares `Parent` with `versionEquals`. That keeps status-only parent writes from triggering unnecessary re-translation while still detecting meaningful parent version changes if `Listener.Equals` is called directly in the future.

# Change Type

/kind fix
/kind cleanup

# Changelog

```release-note
Fixed GatewayExtension equality to include the object source, and Listener equality to ignore parent object metadata churn (e.g. resourceVersion bumps from status writes), preventing missed updates and spurious recomputation.
```

# Additional Notes

The harness completeness check is exercised through its real code path in `equalstest_internal_test.go`, so a regression in field-coverage detection also fails tests. The Listener parent comparison follows the `versionEquals` approach discussed in kgateway-dev/kgateway#14265.