### PR TITLE
feat: add translation metrics for ListenerPolicy and HTTPListenerPolicy

### DIFF
--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/plugins/backendconfigpolicy"
+	metrics "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/metrics"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	kgwwellknown "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
@@ -213,10 +214,23 @@ func NewListenerPolicyIR(
 	spec *kgateway.ListenerPolicySpec,
 	objSrc ir.ObjectSource,
 ) (*ListenerPolicyIR, []error) {
+	// A nil spec means no translation is requested; intentionally skip metrics.
 	if spec == nil {
 		return nil, nil
 	}
-	errs := []error{}
+	var errs []error
+	finishMetrics := metrics.CollectTranslationMetrics(metrics.TranslatorMetricLabels{
+		Name:       objSrc.Name,
+		Namespace:  objSrc.Namespace,
+		Translator: objSrc.Kind,
+	})
+	defer func() {
+		var err error
+		if len(errs) > 0 {
+			err = errs[0]
+		}
+		finishMetrics(err)
+	}()
 	perPort := map[uint32]listenerPolicy{}
 	for _, portConfig := range spec.PerPort {
 		pol, errs2 := newListenerPolicy(krtctx, commoncol, objSrc, &portConfig.Listener)

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin_test.go
@@ -1,0 +1,79 @@
+package listenerpolicy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	translatorMetrics "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics/metricstest"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+func TestCollectTranslationMetrics_ListenerPolicy(t *testing.T) {
+	translatorMetrics.ResetMetrics()
+	t.Cleanup(translatorMetrics.ResetMetrics)
+
+	spec := &kgateway.ListenerPolicySpec{}
+
+	objSrc := ir.ObjectSource{
+		Group:     "gateway.kgateway.dev",
+		Kind:      "ListenerPolicy",
+		Namespace: "test-namespace",
+		Name:      "test-listener-policy",
+	}
+
+	policyIR, errs := NewListenerPolicyIR(nil, nil, time.Now(), spec, objSrc)
+	require.Empty(t, errs, "translation should not produce errors")
+	assert.NotNil(t, policyIR, "translation should return a non-nil IR")
+
+	currentMetrics := metricstest.MustGatherMetrics(t)
+
+	currentMetrics.AssertMetricsInclude("kgateway_translator_translations_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetric{
+			Labels: []metrics.Label{
+				{Name: "name", Value: "test-listener-policy"},
+				{Name: "namespace", Value: "test-namespace"},
+				{Name: "result", Value: "success"},
+				{Name: "translator", Value: "ListenerPolicy"},
+			},
+			Value: 1,
+		},
+	})
+}
+
+func TestCollectTranslationMetrics_HTTPListenerPolicy(t *testing.T) {
+	translatorMetrics.ResetMetrics()
+	t.Cleanup(translatorMetrics.ResetMetrics)
+
+	spec := &kgateway.ListenerPolicySpec{}
+
+	objSrc := ir.ObjectSource{
+		Group:     "gateway.kgateway.dev",
+		Kind:      "HTTPListenerPolicy",
+		Namespace: "test-namespace",
+		Name:      "test-httplistener-policy",
+	}
+
+	policyIR, errs := NewListenerPolicyIR(nil, nil, time.Now(), spec, objSrc)
+	require.Empty(t, errs, "translation should not produce errors")
+	assert.NotNil(t, policyIR, "translation should return a non-nil IR")
+
+	currentMetrics := metricstest.MustGatherMetrics(t)
+
+	currentMetrics.AssertMetricsInclude("kgateway_translator_translations_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetric{
+			Labels: []metrics.Label{
+				{Name: "name", Value: "test-httplistener-policy"},
+				{Name: "namespace", Value: "test-namespace"},
+				{Name: "result", Value: "success"},
+				{Name: "translator", Value: "HTTPListenerPolicy"},
+			},
+			Value: 1,
+		},
+	})
+}


### PR DESCRIPTION
# Description

Adds translation lifecycle metrics to `ListenerPolicy` and `HTTPListenerPolicy`, ensuring full observability parity across all Kgateway-owned policy CRDs.

This updates the shared `NewListenerPolicyIR` constructor (used by both listener policies) to wrap its translation logic with the `CollectTranslationMetrics` API. By utilizing the `objSrc.Kind`, the emitted `kgateway_translator_translations_total` metric accurately tags the specific translator in use (`ListenerPolicy` or `HTTPListenerPolicy`).

Follows the same defer pattern and testing rigorousness established in #14240 for `BackendConfigPolicy` and `TrafficPolicy`.

Fixes #14249

# Change Type

/kind feature

# Changelog

```release-note
Added translation metrics (kgateway_translator_translations_total, kgateway_translations_running, kgateway_translator_translation_duration_seconds) for ListenerPolicy and HTTPListenerPolicy.
```
