### PR TITLE
[2.3.x] Fix: Hostname/ServiceEntry with multi-port hosts (#14212)

### DIFF
--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
@@ -1,0 +1,133 @@
+clusters:
+- connectTimeout: 5s
+  loadAssignment:
+    clusterName: istio-se_gwtest_example-se_se.example.com_443
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.1.1.1
+              portValue: 18443
+        loadBalancingWeight: 1
+      loadBalancingWeight: 1
+      locality:
+        region: r1
+        subZone: r1z2s4
+        zone: r1z2
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 2.2.2.2
+              portValue: 18443
+        loadBalancingWeight: 1
+      loadBalancingWeight: 1
+      locality:
+        region: r1
+        subZone: r1z3s4
+        zone: r1z3
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 3.3.3.3
+              portValue: 18443
+        loadBalancingWeight: 1
+      loadBalancingWeight: 1
+      locality:
+        region: r2
+        subZone: r2z1s1
+        zone: r2z1
+  name: istio-se_gwtest_example-se_se.example.com_443
+  type: STATIC
+- connectTimeout: 5s
+  loadAssignment:
+    clusterName: istio-se_gwtest_example-se_se.example.com_80
+    endpoints:
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 1.1.1.1
+              portValue: 18080
+        loadBalancingWeight: 1
+      loadBalancingWeight: 1
+      locality:
+        region: r1
+        subZone: r1z2s4
+        zone: r1z2
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 2.2.2.2
+              portValue: 18080
+        loadBalancingWeight: 1
+      loadBalancingWeight: 1
+      locality:
+        region: r1
+        subZone: r1z3s4
+        zone: r1z3
+    - lbEndpoints:
+      - endpoint:
+          address:
+            socketAddress:
+              address: 3.3.3.3
+              portValue: 18080
+        loadBalancingWeight: 1
+      loadBalancingWeight: 1
+      locality:
+        region: r2
+        subZone: r2z1s1
+        zone: r2z1
+  name: istio-se_gwtest_example-se_se.example.com_80
+  type: STATIC
+- connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_kubernetes_443
+  type: EDS
+listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - se.example.com
+    name: listener~8080~se_example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~8080~se_example_com-route-0-httproute-route-to-upstream-gwtest-0-0-matcher-0
+      route:
+        cluster: istio-se_gwtest_example-se_se.example.com_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
@@ -39,6 +39,7 @@ clusters:
         region: r2
         subZone: r2z1s1
         zone: r2z1
+  metadata: {}
   name: istio-se_gwtest_example-se_se.example.com_443
   type: STATIC
 - connectTimeout: 5s
@@ -81,6 +82,7 @@ clusters:
         region: r2
         subZone: r2z1s1
         zone: r2z1
+  metadata: {}
   name: istio-se_gwtest_example-se_se.example.com_80
   type: STATIC
 - connectTimeout: 5s
@@ -89,6 +91,7 @@ clusters:
       ads: {}
       resourceApiVersion: V3
   ignoreHealthOnHostRemoval: true
+  metadata: {}
   name: kube_default_kubernetes_443
   type: EDS
 listeners:

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport.yaml
@@ -1,0 +1,65 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: http-gw-for-test
+  namespace: gwtest
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: route-to-upstream
+  namespace: gwtest
+spec:
+  parentRefs:
+  - name: http-gw-for-test
+  hostnames:
+  - "se.example.com"
+  rules:
+  - backendRefs:
+    - name: se.example.com
+      port: 80
+      kind: Hostname
+      group: networking.istio.io
+---
+# Multi-port ServiceEntry sharing one host. A Hostname backendRef with an
+# explicit port (80 above) must resolve to that exact port's cluster
+# (..._se.example.com_80) and not to any other port (e.g. ..._443) defined on
+# the same host.
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: example-se
+  namespace: gwtest
+spec:
+  hosts:
+  - se.example.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+    targetPort: 18080
+  - number: 443
+    name: https
+    protocol: HTTPS
+    targetPort: 18443
+  resolution: STATIC
+  location: MESH_INTERNAL
+  endpoints:
+
+  - address: 1.1.1.1
+    locality: r1/r1z2/r1z2s4
+
+  - address: 2.2.2.2
+    locality: r1/r1z3/r1z3s4
+
+  - address: 3.3.3.3
+    locality: r2/r2z1/r2z1s1

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -3,6 +3,7 @@ package krtcollections
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"istio.io/istio/pkg/config/labels"
@@ -93,6 +94,12 @@ type BackendIndex struct {
 type backendKey struct {
 	ir.ObjectSource
 	port int32
+}
+
+// String must include the port; otherwise the embedded ir.ObjectSource.String()
+// is promoted and all ports of a multi-port host collapse into one index bucket.
+func (b backendKey) String() string {
+	return b.ObjectSource.String() + ":" + strconv.Itoa(int(b.port))
 }
 
 func NewBackendIndex(


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Backport #14212 

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fixed route Hostname/ServiceEntry backendRefs to the requested port on multi-port hosts
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
