### PR TITLE
Perform deep merge of listenerset reports to prevent some status sync…

### DIFF
--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -398,7 +398,12 @@ func mergeProxyReports(
 		maps.Copy(merged.Gateways, p.reports.Gateways)
 
 		// 2. merge LS Reports for all Proxies' status reports
-		maps.Copy(merged.ListenerSets, p.reports.ListenerSets)
+		for gvk, listenerSetsForGVK := range p.reports.ListenerSets {
+			if merged.ListenerSets[gvk] == nil {
+				merged.ListenerSets[gvk] = make(map[types.NamespacedName]*reports.ListenerSetReport)
+			}
+			maps.Copy(merged.ListenerSets[gvk], listenerSetsForGVK)
+		}
 
 		// 3. merge httproute parentRefs into RouteReports
 		for rnn, rr := range p.reports.HTTPRoutes {

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -399,6 +399,9 @@ func mergeProxyReports(
 
 		// 2. merge LS Reports for all Proxies' status reports
 		for gvk, listenerSetsForGVK := range p.reports.ListenerSets {
+			if merged.ListenerSets == nil {
+				merged.ListenerSets = make(map[schema.GroupVersionKind]map[types.NamespacedName]*reports.ListenerSetReport)
+			}
 			if merged.ListenerSets[gvk] == nil {
 				merged.ListenerSets[gvk] = make(map[types.NamespacedName]*reports.ListenerSetReport)
 			}

--- a/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
@@ -328,7 +328,7 @@ func TestMergeProxyReports(t *testing.T) {
 					reports: reports.ReportMap{
 						ListenerSets: map[schema.GroupVersionKind]map[types.NamespacedName]*reports.ListenerSetReport{
 							wellknown.ListenerSetGVK: {
-								{Name: "ls-1", Namespace: "default"}: {},
+								{Name: "ls-1", Namespace: "default"}: &reports.ListenerSetReport{},
 							},
 						},
 					},
@@ -337,7 +337,7 @@ func TestMergeProxyReports(t *testing.T) {
 					reports: reports.ReportMap{
 						ListenerSets: map[schema.GroupVersionKind]map[types.NamespacedName]*reports.ListenerSetReport{
 							wellknown.ListenerSetGVK: {
-								{Name: "ls-2", Namespace: "default"}: {},
+								{Name: "ls-2", Namespace: "default"}: &reports.ListenerSetReport{},
 							},
 						},
 					},
@@ -346,8 +346,8 @@ func TestMergeProxyReports(t *testing.T) {
 			expected: reports.ReportMap{
 				ListenerSets: map[schema.GroupVersionKind]map[types.NamespacedName]*reports.ListenerSetReport{
 					wellknown.ListenerSetGVK: {
-						{Name: "ls-1", Namespace: "default"}: {},
-						{Name: "ls-2", Namespace: "default"}: {},
+						{Name: "ls-1", Namespace: "default"}: &reports.ListenerSetReport{},
+						{Name: "ls-2", Namespace: "default"}: &reports.ListenerSetReport{},
 					},
 				},
 			},

--- a/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -320,6 +321,37 @@ func TestMergeProxyReports(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Merge ListenerSet reports for same GVK",
+			proxies: []GatewayXdsResources{
+				{
+					reports: reports.ReportMap{
+						ListenerSets: map[schema.GroupVersionKind]map[types.NamespacedName]*reports.ListenerSetReport{
+							wellknown.ListenerSetGVK: {
+								{Name: "ls-1", Namespace: "default"}: {},
+							},
+						},
+					},
+				},
+				{
+					reports: reports.ReportMap{
+						ListenerSets: map[schema.GroupVersionKind]map[types.NamespacedName]*reports.ListenerSetReport{
+							wellknown.ListenerSetGVK: {
+								{Name: "ls-2", Namespace: "default"}: {},
+							},
+						},
+					},
+				},
+			},
+			expected: reports.ReportMap{
+				ListenerSets: map[schema.GroupVersionKind]map[types.NamespacedName]*reports.ListenerSetReport{
+					wellknown.ListenerSetGVK: {
+						{Name: "ls-1", Namespace: "default"}: {},
+						{Name: "ls-2", Namespace: "default"}: {},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -338,6 +370,9 @@ func TestMergeProxyReports(t *testing.T) {
 			}
 			if tt.expected.Policies != nil {
 				a.Equal(tt.expected.Policies, actual.Policies)
+			}
+			if tt.expected.ListenerSets != nil {
+				a.Equal(tt.expected.ListenerSets, actual.ListenerSets)
 			}
 		})
 	}


### PR DESCRIPTION
…'s being dropped/lost

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Fixes https://github.com/kgateway-dev/kgateway/issues/13969

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fixes ListenerSet status updates being dropped
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
