### PR TITLE
fixed duplicated translation when gateway status is updated

### DIFF
--- a/pkg/kgateway/proxy_syncer/merge_proxy_reports_test.go
+++ b/pkg/kgateway/proxy_syncer/merge_proxy_reports_test.go
@@ -1,0 +1,81 @@
+package proxy_syncer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+// routeReportWithParent builds a per-proxy ReportMap containing a single HTTPRoute
+// report whose only parent is the Gateway named gwName.
+func routeReportWithParent(routeName, gwName string) reports.ReportMap {
+	rm := reports.NewReportMap()
+	r := reports.NewReporter(&rm)
+	route := &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: routeName, Generation: 1}}
+	parent := gwv1.ParentReference{
+		Group:     new(gwv1.Group("gateway.networking.k8s.io")),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      gwv1.ObjectName(gwName),
+		Namespace: new(gwv1.Namespace("default")),
+	}
+	r.Route(route).ParentRef(&parent).SetCondition(reporter.RouteCondition{
+		Type:    gwv1.RouteConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.RouteReasonAccepted,
+		Message: "accepted",
+	})
+	return rm
+}
+
+// TestMergeProxyReportsDoesNotMutateProxyReports ensures that merging two proxies
+// that report the same route under different parents does not mutate either
+// per-proxy report. Those reports are owned by the mostXdsSnapshots collection and
+// are read concurrently for equality checks, so mergeProxyReports must produce
+// owned copies before merging parents.
+func TestMergeProxyReportsDoesNotMutateProxyReports(t *testing.T) {
+	routeKey := types.NamespacedName{Namespace: "default", Name: "route"}
+
+	proxyA := GatewayXdsResources{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "gw-a"},
+		reports:        routeReportWithParent("route", "gw-a"),
+	}
+	proxyB := GatewayXdsResources{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "gw-b"},
+		reports:        routeReportWithParent("route", "gw-b"),
+	}
+
+	// Snapshot the original parent pointers and counts for proxyA's report.
+	aReport := proxyA.reports.HTTPRoutes[routeKey]
+	if got := len(aReport.Parents); got != 1 {
+		t.Fatalf("precondition: expected proxyA route report to have 1 parent, got %d", got)
+	}
+
+	merged := mergeProxyReports([]GatewayXdsResources{proxyA, proxyB})
+
+	// The merged report must contain both parents.
+	mergedRoute := merged.HTTPRoutes[routeKey]
+	if mergedRoute == nil {
+		t.Fatal("expected merged report to contain the route")
+	}
+	if got := len(mergedRoute.Parents); got != 2 {
+		t.Fatalf("expected merged route report to have 2 parents, got %d", got)
+	}
+
+	// The per-proxy reports must be untouched.
+	if got := len(proxyA.reports.HTTPRoutes[routeKey].Parents); got != 1 {
+		t.Fatalf("proxyA report was mutated: expected 1 parent, got %d", got)
+	}
+	if got := len(proxyB.reports.HTTPRoutes[routeKey].Parents); got != 1 {
+		t.Fatalf("proxyB report was mutated: expected 1 parent, got %d", got)
+	}
+
+	// The merged route report must be a distinct object from the per-proxy reports.
+	if mergedRoute == proxyA.reports.HTTPRoutes[routeKey] {
+		t.Fatal("merged route report aliases proxyA's per-proxy report")
+	}
+}

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"reflect"
+	"slices"
 	"sync/atomic"
 
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/query"
@@ -199,12 +200,12 @@ func (r report) ResourceName() string {
 
 // do we really need this for a singleton?
 func (r report) Equals(in report) bool {
-	if !maps.EqualFunc(r.reportMap.Gateways, in.reportMap.Gateways, reportValueEqual[reports.GatewayReport]) {
+	if !maps.EqualFunc(r.reportMap.Gateways, in.reportMap.Gateways, gatewayReportEqual) {
 		return false
 	}
 	if !maps.EqualFunc(r.reportMap.ListenerSets, in.reportMap.ListenerSets,
 		func(a, b map[types.NamespacedName]*reports.ListenerSetReport) bool {
-			return maps.EqualFunc(a, b, reportValueEqual[reports.ListenerSetReport])
+			return maps.EqualFunc(a, b, listenerSetReportEqual)
 		}) {
 		return false
 	}
@@ -229,13 +230,51 @@ func (r report) Equals(in report) bool {
 	return true
 }
 
-// reportValueEqual compares two non-nil pointers by value (reflect.DeepEqual on the
-// dereferenced structs). Reports contain unexported fields so we must use reflect.
-func reportValueEqual[T any](a, b *T) bool {
+// gatewayReportEqual reports whether two GatewayReports hold the same listener
+// reports, observed generation, attached ListenerSet count, and semantic
+// conditions (ignoring LastTransitionTime).
+func gatewayReportEqual(a, b *reports.GatewayReport) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	return reflect.DeepEqual(*a, *b)
+	return a.GetObservedGeneration() == b.GetObservedGeneration() &&
+		a.GetAttachedListenerSets() == b.GetAttachedListenerSets() &&
+		conditionsEqual(a.GetConditions(), b.GetConditions()) &&
+		listenerStatusesEqual(a.GetListenerStatuses(), b.GetListenerStatuses())
+}
+
+// listenerSetReportEqual reports whether two ListenerSetReports hold the same
+// listener reports, observed generation, and semantic conditions (ignoring
+// LastTransitionTime).
+func listenerSetReportEqual(a, b *reports.ListenerSetReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.GetObservedGeneration() == b.GetObservedGeneration() &&
+		conditionsEqual(a.GetConditions(), b.GetConditions()) &&
+		listenerStatusesEqual(a.GetListenerStatuses(), b.GetListenerStatuses())
+}
+
+func listenerStatusesEqual(a, b map[string]gwv1.ListenerStatus) bool {
+	return maps.EqualFunc(a, b, listenerStatusEqual)
+}
+
+func listenerStatusEqual(a, b gwv1.ListenerStatus) bool {
+	return a.Name == b.Name &&
+		slices.EqualFunc(a.SupportedKinds, b.SupportedKinds, routeGroupKindEqual) &&
+		a.AttachedRoutes == b.AttachedRoutes &&
+		conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func routeGroupKindEqual(a, b gwv1.RouteGroupKind) bool {
+	return ptrValueEqual(a.Group, b.Group) && a.Kind == b.Kind
+}
+
+func ptrValueEqual[T comparable](a, b *T) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // backendReportEqual reports whether two BackendReports hold the same conditions and observed generation.

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 	"sync/atomic"
 
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -197,31 +198,43 @@ func (r report) ResourceName() string {
 
 // do we really need this for a singleton?
 func (r report) Equals(in report) bool {
-	if !maps.Equal(r.reportMap.Gateways, in.reportMap.Gateways) {
+	if !maps.EqualFunc(r.reportMap.Gateways, in.reportMap.Gateways, reportValueEqual[reports.GatewayReport]) {
 		return false
 	}
 	if !maps.EqualFunc(r.reportMap.ListenerSets, in.reportMap.ListenerSets,
 		func(a, b map[types.NamespacedName]*reports.ListenerSetReport) bool {
-			return maps.Equal(a, b)
+			return maps.EqualFunc(a, b, reportValueEqual[reports.ListenerSetReport])
 		}) {
 		return false
 	}
-	if !maps.Equal(r.reportMap.HTTPRoutes, in.reportMap.HTTPRoutes) {
+	if !maps.EqualFunc(r.reportMap.HTTPRoutes, in.reportMap.HTTPRoutes, reportValueEqual[reports.RouteReport]) {
 		return false
 	}
-	if !maps.Equal(r.reportMap.TCPRoutes, in.reportMap.TCPRoutes) {
+	if !maps.EqualFunc(r.reportMap.GRPCRoutes, in.reportMap.GRPCRoutes, reportValueEqual[reports.RouteReport]) {
 		return false
 	}
-	if !maps.Equal(r.reportMap.TLSRoutes, in.reportMap.TLSRoutes) {
+	if !maps.EqualFunc(r.reportMap.TCPRoutes, in.reportMap.TCPRoutes, reportValueEqual[reports.RouteReport]) {
 		return false
 	}
-	if !maps.Equal(r.reportMap.Policies, in.reportMap.Policies) {
+	if !maps.EqualFunc(r.reportMap.TLSRoutes, in.reportMap.TLSRoutes, reportValueEqual[reports.RouteReport]) {
+		return false
+	}
+	if !maps.EqualFunc(r.reportMap.Policies, in.reportMap.Policies, reportValueEqual[reports.PolicyReport]) {
 		return false
 	}
 	if !maps.EqualFunc(r.reportMap.Backends, in.reportMap.Backends, backendReportEqual) {
 		return false
 	}
 	return true
+}
+
+// reportValueEqual compares two non-nil pointers by value (reflect.DeepEqual on the
+// dereferenced structs). Reports contain unexported fields so we must use reflect.
+func reportValueEqual[T any](a, b *T) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return reflect.DeepEqual(*a, *b)
 }
 
 // backendReportEqual reports whether two BackendReports hold the same conditions and observed generation.

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -14,6 +14,7 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -207,19 +208,19 @@ func (r report) Equals(in report) bool {
 		}) {
 		return false
 	}
-	if !maps.EqualFunc(r.reportMap.HTTPRoutes, in.reportMap.HTTPRoutes, reportValueEqual[reports.RouteReport]) {
+	if !maps.EqualFunc(r.reportMap.HTTPRoutes, in.reportMap.HTTPRoutes, routeReportEqual) {
 		return false
 	}
-	if !maps.EqualFunc(r.reportMap.GRPCRoutes, in.reportMap.GRPCRoutes, reportValueEqual[reports.RouteReport]) {
+	if !maps.EqualFunc(r.reportMap.GRPCRoutes, in.reportMap.GRPCRoutes, routeReportEqual) {
 		return false
 	}
-	if !maps.EqualFunc(r.reportMap.TCPRoutes, in.reportMap.TCPRoutes, reportValueEqual[reports.RouteReport]) {
+	if !maps.EqualFunc(r.reportMap.TCPRoutes, in.reportMap.TCPRoutes, routeReportEqual) {
 		return false
 	}
-	if !maps.EqualFunc(r.reportMap.TLSRoutes, in.reportMap.TLSRoutes, reportValueEqual[reports.RouteReport]) {
+	if !maps.EqualFunc(r.reportMap.TLSRoutes, in.reportMap.TLSRoutes, routeReportEqual) {
 		return false
 	}
-	if !maps.EqualFunc(r.reportMap.Policies, in.reportMap.Policies, reportValueEqual[reports.PolicyReport]) {
+	if !maps.EqualFunc(r.reportMap.Policies, in.reportMap.Policies, policyReportEqual) {
 		return false
 	}
 	if !maps.EqualFunc(r.reportMap.Backends, in.reportMap.Backends, backendReportEqual) {
@@ -245,17 +246,65 @@ func backendReportEqual(a, b *reports.BackendReport) bool {
 	if a.GetObservedGeneration() != b.GetObservedGeneration() {
 		return false
 	}
-	ac, bc := a.GetConditions(), b.GetConditions()
-	if len(ac) != len(bc) {
+	return conditionsEqual(a.GetConditions(), b.GetConditions())
+}
+
+// routeReportEqual reports whether two RouteReports hold the same parent refs,
+// observed generation, and semantic conditions (ignoring LastTransitionTime).
+func routeReportEqual(a, b *reports.RouteReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.GetObservedGeneration() != b.GetObservedGeneration() {
 		return false
 	}
-	for i := range ac {
-		other := meta.FindStatusCondition(bc, ac[i].Type)
+	if len(a.Parents) != len(b.Parents) {
+		return false
+	}
+	for key, aParent := range a.Parents {
+		bParent, ok := b.Parents[key]
+		if !ok || !conditionsEqual(aParent.Conditions, bParent.Conditions) {
+			return false
+		}
+	}
+	return true
+}
+
+// policyReportEqual reports whether two PolicyReports hold the same ancestor refs,
+// attachment state, observed generation, and semantic conditions (ignoring LastTransitionTime).
+func policyReportEqual(a, b *reports.PolicyReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.GetObservedGeneration() != b.GetObservedGeneration() {
+		return false
+	}
+	if len(a.Ancestors) != len(b.Ancestors) {
+		return false
+	}
+	for key, aAncestor := range a.Ancestors {
+		bAncestor, ok := b.Ancestors[key]
+		if !ok || aAncestor.AttachmentState != bAncestor.AttachmentState ||
+			!conditionsEqual(aAncestor.Conditions, bAncestor.Conditions) {
+			return false
+		}
+	}
+	return true
+}
+
+// conditionsEqual compares conditions by type and semantic fields, intentionally
+// ignoring LastTransitionTime to avoid false diffs on timestamp-only updates.
+func conditionsEqual(a, b []metav1.Condition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		other := meta.FindStatusCondition(b, a[i].Type)
 		if other == nil ||
-			ac[i].Status != other.Status ||
-			ac[i].Reason != other.Reason ||
-			ac[i].Message != other.Message ||
-			ac[i].ObservedGeneration != other.ObservedGeneration {
+			a[i].Status != other.Status ||
+			a[i].Reason != other.Reason ||
+			a[i].Message != other.Message ||
+			a[i].ObservedGeneration != other.ObservedGeneration {
 			return false
 		}
 	}

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -512,10 +512,13 @@ func mergeProxyReports(
 
 		// 3. merge httproute parentRefs into RouteReports
 		for rnn, rr := range p.reports.HTTPRoutes {
-			// if we haven't encountered this route, just copy it over completely
+			// if we haven't encountered this route, clone it so the merged report owns
+			// its Parents map; subsequent merges must not mutate the per-proxy report,
+			// which is held by the mostXdsSnapshots collection and read concurrently
+			// for equality checks.
 			old := merged.HTTPRoutes[rnn]
 			if old == nil {
-				merged.HTTPRoutes[rnn] = rr
+				merged.HTTPRoutes[rnn] = rr.Clone()
 				continue
 			}
 			// else, this route has already been seen for a proxy, merge this proxy's parents
@@ -525,10 +528,10 @@ func mergeProxyReports(
 
 		// 4. merge tcproute parentRefs into RouteReports
 		for rnn, rr := range p.reports.TCPRoutes {
-			// if we haven't encountered this route, just copy it over completely
+			// if we haven't encountered this route, clone it (see HTTPRoutes above)
 			old := merged.TCPRoutes[rnn]
 			if old == nil {
-				merged.TCPRoutes[rnn] = rr
+				merged.TCPRoutes[rnn] = rr.Clone()
 				continue
 			}
 			// else, this route has already been seen for a proxy, merge this proxy's parents
@@ -537,10 +540,10 @@ func mergeProxyReports(
 		}
 
 		for rnn, rr := range p.reports.TLSRoutes {
-			// if we haven't encountered this route, just copy it over completely
+			// if we haven't encountered this route, clone it (see HTTPRoutes above)
 			old := merged.TLSRoutes[rnn]
 			if old == nil {
-				merged.TLSRoutes[rnn] = rr
+				merged.TLSRoutes[rnn] = rr.Clone()
 				continue
 			}
 			// else, this route has already been seen for a proxy, merge this proxy's parents
@@ -549,10 +552,10 @@ func mergeProxyReports(
 		}
 
 		for rnn, rr := range p.reports.GRPCRoutes {
-			// if we haven't encountered this route, just copy it over completely
+			// if we haven't encountered this route, clone it (see HTTPRoutes above)
 			old := merged.GRPCRoutes[rnn]
 			if old == nil {
-				merged.GRPCRoutes[rnn] = rr
+				merged.GRPCRoutes[rnn] = rr.Clone()
 				continue
 			}
 			// else, this route has already been seen for a proxy, merge this proxy's parents
@@ -561,10 +564,11 @@ func mergeProxyReports(
 		}
 
 		for key, report := range p.reports.Policies {
-			// if we haven't encountered this policy, just copy it over completely
+			// if we haven't encountered this policy, clone it so the merged report owns
+			// its Ancestors map (see HTTPRoutes above)
 			old := merged.Policies[key]
 			if old == nil {
-				merged.Policies[key] = report
+				merged.Policies[key] = report.Clone()
 				continue
 			}
 			// else, let's merge our parentRefs into the existing map

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -240,7 +240,7 @@ func gatewayReportEqual(a, b *reports.GatewayReport) bool {
 	return a.GetObservedGeneration() == b.GetObservedGeneration() &&
 		a.GetAttachedListenerSets() == b.GetAttachedListenerSets() &&
 		conditionsEqual(a.GetConditions(), b.GetConditions()) &&
-		listenerStatusesEqual(a.GetListenerStatuses(), b.GetListenerStatuses())
+		listenerReportsEqual(a.GetListenerReports(), b.GetListenerReports())
 }
 
 // listenerSetReportEqual reports whether two ListenerSetReports hold the same
@@ -252,11 +252,20 @@ func listenerSetReportEqual(a, b *reports.ListenerSetReport) bool {
 	}
 	return a.GetObservedGeneration() == b.GetObservedGeneration() &&
 		conditionsEqual(a.GetConditions(), b.GetConditions()) &&
-		listenerStatusesEqual(a.GetListenerStatuses(), b.GetListenerStatuses())
+		listenerReportsEqual(a.GetListenerReports(), b.GetListenerReports())
 }
 
-func listenerStatusesEqual(a, b map[string]gwv1.ListenerStatus) bool {
-	return maps.EqualFunc(a, b, listenerStatusEqual)
+// listenerReportsEqual compares listener reports in place (no cloning) for read-only
+// equality, since report.Equals is called frequently by KRT.
+func listenerReportsEqual(a, b map[string]*reports.ListenerReport) bool {
+	return maps.EqualFunc(a, b, listenerReportEqual)
+}
+
+func listenerReportEqual(a, b *reports.ListenerReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return listenerStatusEqual(a.Status, b.Status)
 }
 
 func listenerStatusEqual(a, b gwv1.ListenerStatus) bool {

--- a/pkg/kgateway/proxy_syncer/report_equal_test.go
+++ b/pkg/kgateway/proxy_syncer/report_equal_test.go
@@ -155,8 +155,9 @@ func TestPolicyReportEqual(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func localPtr[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 func setFirstParentConditionTime(r *reports.RouteReport, ts metav1.Time) {

--- a/pkg/kgateway/proxy_syncer/report_equal_test.go
+++ b/pkg/kgateway/proxy_syncer/report_equal_test.go
@@ -1,0 +1,178 @@
+package proxy_syncer
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+func TestBackendReportEqual(t *testing.T) {
+	mk := func(generation int64, conditionMsg string) *reports.BackendReport {
+		rm := reports.NewReportMap()
+		r := reports.NewReporter(&rm)
+		backend := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "backend", Generation: generation}}
+		r.Backend(backend).SetCondition(reporter.BackendCondition{
+			Type:    "Accepted",
+			Status:  metav1.ConditionTrue,
+			Reason:  "Accepted",
+			Message: conditionMsg,
+		})
+		return rm.Backends[types.NamespacedName{Namespace: "default", Name: "backend"}]
+	}
+
+	t.Run("ignores LastTransitionTime", func(t *testing.T) {
+		a := mk(1, "same")
+		b := mk(1, "same")
+		a.Conditions[0].LastTransitionTime = metav1.NewTime(time.Unix(1, 0))
+		b.Conditions[0].LastTransitionTime = metav1.NewTime(time.Unix(2, 0))
+		if !backendReportEqual(a, b) {
+			t.Fatal("expected backend reports to be equal when only LastTransitionTime differs")
+		}
+	})
+
+	t.Run("detects semantic condition changes", func(t *testing.T) {
+		a := mk(1, "msg-a")
+		b := mk(1, "msg-b")
+		if backendReportEqual(a, b) {
+			t.Fatal("expected backend reports to differ when condition message differs")
+		}
+	})
+
+	t.Run("detects observed generation changes", func(t *testing.T) {
+		a := mk(1, "same")
+		b := mk(2, "same")
+		if backendReportEqual(a, b) {
+			t.Fatal("expected backend reports to differ when observed generation differs")
+		}
+	})
+}
+
+func TestRouteReportEqual(t *testing.T) {
+	mk := func(generation int64) *reports.RouteReport {
+		rm := reports.NewReportMap()
+		r := reports.NewReporter(&rm)
+		route := &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route", Generation: generation}}
+		parent := gwv1.ParentReference{
+			Group:     localPtr(gwv1.Group("gateway.networking.k8s.io")),
+			Kind:      localPtr(gwv1.Kind("Gateway")),
+			Name:      gwv1.ObjectName("gw"),
+			Namespace: localPtr(gwv1.Namespace("default")),
+		}
+		r.Route(route).ParentRef(&parent).SetCondition(reporter.RouteCondition{
+			Type:    gwv1.RouteConditionAccepted,
+			Status:  metav1.ConditionTrue,
+			Reason:  gwv1.RouteReasonAccepted,
+			Message: "accepted",
+		})
+		return rm.HTTPRoutes[types.NamespacedName{Namespace: "default", Name: "route"}]
+	}
+
+	t.Run("ignores LastTransitionTime", func(t *testing.T) {
+		a := mk(1)
+		b := mk(1)
+		setFirstParentConditionTime(a, metav1.NewTime(time.Unix(1, 0)))
+		setFirstParentConditionTime(b, metav1.NewTime(time.Unix(2, 0)))
+		if !routeReportEqual(a, b) {
+			t.Fatal("expected route reports to be equal when only LastTransitionTime differs")
+		}
+	})
+
+	t.Run("detects observed generation changes", func(t *testing.T) {
+		a := mk(1)
+		b := mk(2)
+		if routeReportEqual(a, b) {
+			t.Fatal("expected route reports to differ when observed generation differs")
+		}
+	})
+
+	t.Run("detects parent mismatch", func(t *testing.T) {
+		a := mk(1)
+		b := mk(1)
+		for k := range b.Parents {
+			delete(b.Parents, k)
+			break
+		}
+		if routeReportEqual(a, b) {
+			t.Fatal("expected route reports to differ when parent refs differ")
+		}
+	})
+}
+
+func TestPolicyReportEqual(t *testing.T) {
+	mk := func(generation int64, state reporter.PolicyAttachmentState) *reports.PolicyReport {
+		rm := reports.NewReportMap()
+		r := reports.NewReporter(&rm)
+		key := reporter.PolicyKey{Group: "g", Kind: "k", Namespace: "default", Name: "policy"}
+		ancestor := gwv1.ParentReference{
+			Group:     localPtr(gwv1.Group("gateway.networking.k8s.io")),
+			Kind:      localPtr(gwv1.Kind("Gateway")),
+			Name:      gwv1.ObjectName("gw"),
+			Namespace: localPtr(gwv1.Namespace("default")),
+		}
+		ar := r.Policy(key, generation).AncestorRef(ancestor)
+		ar.SetCondition(reporter.PolicyCondition{
+			Type:               "Accepted",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Accepted",
+			Message:            "accepted",
+			ObservedGeneration: generation,
+		})
+		ar.SetAttachmentState(state)
+		return rm.Policies[key]
+	}
+
+	t.Run("ignores LastTransitionTime", func(t *testing.T) {
+		a := mk(1, reporter.PolicyAttachmentStateAttached)
+		b := mk(1, reporter.PolicyAttachmentStateAttached)
+		setFirstAncestorConditionTime(a, metav1.NewTime(time.Unix(1, 0)))
+		setFirstAncestorConditionTime(b, metav1.NewTime(time.Unix(2, 0)))
+		if !policyReportEqual(a, b) {
+			t.Fatal("expected policy reports to be equal when only LastTransitionTime differs")
+		}
+	})
+
+	t.Run("detects attachment state changes", func(t *testing.T) {
+		a := mk(1, reporter.PolicyAttachmentStateAttached)
+		b := mk(1, reporter.PolicyAttachmentStateMerged)
+		if policyReportEqual(a, b) {
+			t.Fatal("expected policy reports to differ when attachment state differs")
+		}
+	})
+
+	t.Run("detects observed generation changes", func(t *testing.T) {
+		a := mk(1, reporter.PolicyAttachmentStateAttached)
+		b := mk(2, reporter.PolicyAttachmentStateAttached)
+		if policyReportEqual(a, b) {
+			t.Fatal("expected policy reports to differ when observed generation differs")
+		}
+	})
+}
+
+func localPtr[T any](v T) *T {
+	return &v
+}
+
+func setFirstParentConditionTime(r *reports.RouteReport, ts metav1.Time) {
+	for _, parent := range r.Parents {
+		if len(parent.Conditions) > 0 {
+			parent.Conditions[0].LastTransitionTime = ts
+		}
+		return
+	}
+}
+
+func setFirstAncestorConditionTime(r *reports.PolicyReport, ts metav1.Time) {
+	for _, ancestor := range r.Ancestors {
+		if len(ancestor.Conditions) > 0 {
+			ancestor.Conditions[0].LastTransitionTime = ts
+		}
+		return
+	}
+}

--- a/pkg/kgateway/proxy_syncer/report_equal_test.go
+++ b/pkg/kgateway/proxy_syncer/report_equal_test.go
@@ -60,10 +60,10 @@ func TestRouteReportEqual(t *testing.T) {
 		r := reports.NewReporter(&rm)
 		route := &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route", Generation: generation}}
 		parent := gwv1.ParentReference{
-			Group:     localPtr(gwv1.Group("gateway.networking.k8s.io")),
-			Kind:      localPtr(gwv1.Kind("Gateway")),
+			Group:     new(gwv1.Group("gateway.networking.k8s.io")),
+			Kind:      new(gwv1.Kind("Gateway")),
 			Name:      gwv1.ObjectName("gw"),
-			Namespace: localPtr(gwv1.Namespace("default")),
+			Namespace: new(gwv1.Namespace("default")),
 		}
 		r.Route(route).ParentRef(&parent).SetCondition(reporter.RouteCondition{
 			Type:    gwv1.RouteConditionAccepted,
@@ -111,10 +111,10 @@ func TestPolicyReportEqual(t *testing.T) {
 		r := reports.NewReporter(&rm)
 		key := reporter.PolicyKey{Group: "g", Kind: "k", Namespace: "default", Name: "policy"}
 		ancestor := gwv1.ParentReference{
-			Group:     localPtr(gwv1.Group("gateway.networking.k8s.io")),
-			Kind:      localPtr(gwv1.Kind("Gateway")),
+			Group:     new(gwv1.Group("gateway.networking.k8s.io")),
+			Kind:      new(gwv1.Kind("Gateway")),
 			Name:      gwv1.ObjectName("gw"),
-			Namespace: localPtr(gwv1.Namespace("default")),
+			Namespace: new(gwv1.Namespace("default")),
 		}
 		ar := r.Policy(key, generation).AncestorRef(ancestor)
 		ar.SetCondition(reporter.PolicyCondition{
@@ -153,11 +153,6 @@ func TestPolicyReportEqual(t *testing.T) {
 			t.Fatal("expected policy reports to differ when observed generation differs")
 		}
 	})
-}
-
-//go:fix inline
-func localPtr[T any](v T) *T {
-	return new(v)
 }
 
 func setFirstParentConditionTime(r *reports.RouteReport, ts metav1.Time) {

--- a/pkg/kgateway/proxy_syncer/report_equal_test.go
+++ b/pkg/kgateway/proxy_syncer/report_equal_test.go
@@ -9,9 +9,92 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
 )
+
+func TestGatewayReportEqual(t *testing.T) {
+	t.Run("ignores LastTransitionTime", func(t *testing.T) {
+		a := makeGatewayReport(1, true)
+		b := makeGatewayReport(1, false)
+		if !gatewayReportEqual(a, b) {
+			t.Fatal("expected gateway reports to be equal when only LastTransitionTime differs")
+		}
+	})
+
+	t.Run("detects observed generation changes", func(t *testing.T) {
+		a := makeGatewayReport(1, false)
+		b := makeGatewayReport(2, false)
+		if gatewayReportEqual(a, b) {
+			t.Fatal("expected gateway reports to differ when observed generation differs")
+		}
+	})
+
+	t.Run("detects attached listener set changes", func(t *testing.T) {
+		a := makeGatewayReport(1, false)
+		b := makeGatewayReport(1, false)
+		b.SetAttachedListenerSets(2)
+		if gatewayReportEqual(a, b) {
+			t.Fatal("expected gateway reports to differ when attached ListenerSet count differs")
+		}
+	})
+
+	t.Run("detects listener status changes", func(t *testing.T) {
+		a := makeGatewayReport(1, false)
+		b := makeGatewayReport(1, false)
+		b.ListenerName("http").SetAttachedRoutes(3)
+		if gatewayReportEqual(a, b) {
+			t.Fatal("expected gateway reports to differ when listener status differs")
+		}
+	})
+}
+
+func TestListenerSetReportEqual(t *testing.T) {
+	t.Run("ignores LastTransitionTime", func(t *testing.T) {
+		a := makeListenerSetReport(1, true)
+		b := makeListenerSetReport(1, false)
+		if !listenerSetReportEqual(a, b) {
+			t.Fatal("expected ListenerSet reports to be equal when only LastTransitionTime differs")
+		}
+	})
+
+	t.Run("detects observed generation changes", func(t *testing.T) {
+		a := makeListenerSetReport(1, false)
+		b := makeListenerSetReport(2, false)
+		if listenerSetReportEqual(a, b) {
+			t.Fatal("expected ListenerSet reports to differ when observed generation differs")
+		}
+	})
+
+	t.Run("detects top-level condition changes", func(t *testing.T) {
+		a := makeListenerSetReport(1, false)
+		b := makeListenerSetReport(1, false)
+		b.SetCondition(reporter.GatewayCondition{
+			Type:    gwv1.GatewayConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.GatewayReasonListenersNotValid,
+			Message: "listener rejected",
+		})
+		if listenerSetReportEqual(a, b) {
+			t.Fatal("expected ListenerSet reports to differ when top-level condition differs")
+		}
+	})
+
+	t.Run("detects listener condition changes", func(t *testing.T) {
+		a := makeListenerSetReport(1, false)
+		b := makeListenerSetReport(1, false)
+		b.ListenerName("http").SetCondition(reporter.ListenerCondition{
+			Type:    gwv1.ListenerConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.ListenerReasonInvalid,
+			Message: "listener invalid",
+		})
+		if listenerSetReportEqual(a, b) {
+			t.Fatal("expected ListenerSet reports to differ when listener condition differs")
+		}
+	})
+}
 
 func TestBackendReportEqual(t *testing.T) {
 	mk := func(generation int64, conditionMsg string) *reports.BackendReport {
@@ -162,6 +245,118 @@ func setFirstParentConditionTime(r *reports.RouteReport, ts metav1.Time) {
 		}
 		return
 	}
+}
+
+func makeGatewayReport(generation int64, forceTransition bool) *reports.GatewayReport {
+	rm := reports.NewReportMap()
+	statusReporter := reports.NewReporter(&rm)
+	listener := gwv1.Listener{Name: "http"}
+	gateway := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "gw",
+			Generation: generation,
+		},
+		Spec: gwv1.GatewaySpec{
+			Listeners: []gwv1.Listener{listener},
+		},
+	}
+
+	gatewayReporter := statusReporter.Gateway(gateway)
+	if forceTransition {
+		gatewayReporter.SetCondition(reporter.GatewayCondition{
+			Type:    gwv1.GatewayConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.GatewayReasonListenersNotValid,
+			Message: "before",
+		})
+		time.Sleep(time.Millisecond)
+	}
+	gatewayReporter.SetCondition(reporter.GatewayCondition{
+		Type:    gwv1.GatewayConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.GatewayReasonAccepted,
+		Message: "accepted",
+	})
+	gatewayReporter.SetAttachedListenerSets(1)
+
+	listenerReporter := gatewayReporter.Listener(&listener)
+	if forceTransition {
+		listenerReporter.SetCondition(reporter.ListenerCondition{
+			Type:    gwv1.ListenerConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.ListenerReasonInvalid,
+			Message: "before",
+		})
+		time.Sleep(time.Millisecond)
+	}
+	listenerReporter.SetCondition(reporter.ListenerCondition{
+		Type:    gwv1.ListenerConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.ListenerReasonAccepted,
+		Message: "accepted",
+	})
+	listenerReporter.SetSupportedKinds([]gwv1.RouteGroupKind{{
+		Group: new(gwv1.Group(wellknown.HTTPRouteGVK.Group)),
+		Kind:  gwv1.Kind(wellknown.HTTPRouteGVK.Kind),
+	}})
+	listenerReporter.SetAttachedRoutes(2)
+
+	return rm.Gateways[types.NamespacedName{Namespace: "default", Name: "gw"}]
+}
+
+func makeListenerSetReport(generation int64, forceTransition bool) *reports.ListenerSetReport {
+	rm := reports.NewReportMap()
+	statusReporter := reports.NewReporter(&rm)
+	listener := gwv1.Listener{Name: "http"}
+	listenerSet := &gwv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "ls",
+			Generation: generation,
+		},
+	}
+
+	listenerSetReporter := statusReporter.ListenerSet(listenerSet)
+	if forceTransition {
+		listenerSetReporter.SetCondition(reporter.GatewayCondition{
+			Type:    gwv1.GatewayConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.GatewayReasonListenersNotValid,
+			Message: "before",
+		})
+		time.Sleep(time.Millisecond)
+	}
+	listenerSetReporter.SetCondition(reporter.GatewayCondition{
+		Type:    gwv1.GatewayConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.GatewayReasonAccepted,
+		Message: "accepted",
+	})
+
+	listenerReporter := listenerSetReporter.Listener(&listener)
+	if forceTransition {
+		listenerReporter.SetCondition(reporter.ListenerCondition{
+			Type:    gwv1.ListenerConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.ListenerReasonInvalid,
+			Message: "before",
+		})
+		time.Sleep(time.Millisecond)
+	}
+	listenerReporter.SetCondition(reporter.ListenerCondition{
+		Type:    gwv1.ListenerConditionAccepted,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.ListenerReasonAccepted,
+		Message: "accepted",
+	})
+	listenerReporter.SetSupportedKinds([]gwv1.RouteGroupKind{{
+		Group: new(gwv1.Group(wellknown.HTTPRouteGVK.Group)),
+		Kind:  gwv1.Kind(wellknown.HTTPRouteGVK.Kind),
+	}})
+	listenerReporter.SetAttachedRoutes(2)
+
+	return rm.ListenerSet(listenerSet)
 }
 
 func setFirstAncestorConditionTime(r *reports.PolicyReport, ts metav1.Time) {

--- a/pkg/kgateway/proxy_syncer/status_syncer_gateway_test.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer_gateway_test.go
@@ -1,0 +1,110 @@
+package proxy_syncer
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+func TestSyncGatewayStatusPreservesControllerInvalidParameters(t *testing.T) {
+	ctx := context.Background()
+	const controllerName = "kgateway.dev/kgateway"
+	gatewayKey := types.NamespacedName{Namespace: "default", Name: "gw"}
+
+	gateway := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  gatewayKey.Namespace,
+			Name:       gatewayKey.Name,
+			Generation: 2,
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "kgateway",
+			Listeners: []gwv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+		Status: gwv1.GatewayStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(gwv1.GatewayConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(gwv1.GatewayReasonInvalidParameters),
+				Message:            "invalid gateway parameters",
+				ObservedGeneration: 2,
+			}},
+		},
+	}
+	gatewayClass := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "kgateway"},
+		Spec: gwv1.GatewayClassSpec{
+			ControllerName: gwv1.GatewayController(controllerName),
+		},
+	}
+
+	kubeClient := newFakeGatewayStatusClient(t, gateway, gatewayClass)
+
+	rm := reports.NewReportMap()
+	translatedGateway := gateway.DeepCopy()
+	translatedGateway.Status = gwv1.GatewayStatus{}
+	gwReporter := reports.NewReporter(&rm).Gateway(translatedGateway)
+	gwReporter.SetCondition(reporter.GatewayCondition{
+		Type:    gwv1.GatewayConditionProgrammed,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.GatewayReasonProgrammed,
+		Message: reports.GatewayProgrammedMessage,
+	})
+
+	syncer := &StatusSyncer{
+		mgr:            statusSyncerTestManager{client: kubeClient},
+		controllerName: controllerName,
+	}
+	syncer.syncGatewayStatus(ctx, slog.New(slog.DiscardHandler), rm)
+
+	updated := &gwv1.Gateway{}
+	require.NoError(t, kubeClient.Get(ctx, gatewayKey, updated))
+	accepted := apimeta.FindStatusCondition(updated.Status.Conditions, string(gwv1.GatewayConditionAccepted))
+	require.NotNil(t, accepted)
+	require.Equal(t, metav1.ConditionFalse, accepted.Status)
+	require.Equal(t, string(gwv1.GatewayReasonInvalidParameters), accepted.Reason)
+	require.Equal(t, "invalid gateway parameters", accepted.Message)
+
+	programmed := apimeta.FindStatusCondition(updated.Status.Conditions, string(gwv1.GatewayConditionProgrammed))
+	require.NotNil(t, programmed)
+	require.Equal(t, metav1.ConditionTrue, programmed.Status)
+	require.Equal(t, string(gwv1.GatewayReasonProgrammed), programmed.Reason)
+}
+
+func newFakeGatewayStatusClient(t *testing.T, objs ...ctrlclient.Object) ctrlclient.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gwv1.Install(scheme))
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&gwv1.Gateway{}).
+		WithObjects(objs...).
+		Build()
+}
+
+type statusSyncerTestManager struct {
+	manager.Manager
+	client ctrlclient.Client
+}
+
+func (m statusSyncerTestManager) GetClient() ctrlclient.Client {
+	return m.client
+}

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -418,6 +418,10 @@ func (c Listener) Equals(in Listener) bool {
 	if (c.Parent == nil) != (in.Parent == nil) {
 		return false
 	}
+	// Currently, only Gateway and ListenerSet's Equals() calls Listener.Equals(),
+	// and both of those check versionEquals on the Parent before calling Listener.Equals(),
+	// so, this versionEquals check is somewhat redundant, but it's safer to have it here in
+	// case Listener.Equals() is called directly in the future without a Parent version check.
 	if c.Parent != nil && !versionEquals(c.Parent, in.Parent) {
 		return false
 	}

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -397,11 +397,8 @@ func (l Secret) MarshalJSON() ([]byte, error) {
 // TODO: why is this in backend.go?
 type Listener struct {
 	gwv1.Listener
-	// +krtEqualsTodo compare parent reference in listener equality
-	Parent client.Object
-	// +krtEqualsTodo include attached listener policies in equality
-	AttachedPolicies AttachedPolicies
-	// +krtEqualsTodo include policy ancestor reference in equality
+	Parent            client.Object
+	AttachedPolicies  AttachedPolicies
 	PolicyAncestorRef gwv1.ParentReference
 }
 
@@ -414,9 +411,19 @@ func (listener Listener) GetParentReporter(reporter reporter.Reporter) reporter.
 	}
 }
 
-// TODO: need to reevaluate DeepEqual usage
 func (c Listener) Equals(in Listener) bool {
-	return reflect.DeepEqual(c, in)
+	// Use versionEquals for Parent (raw *gwv1.Gateway or *gwv1.ListenerSet) so that
+	// status-only writes (which bump resourceVersion but not generation) do not cause
+	// reflect.DeepEqual to return false and trigger unnecessary re-translations.
+	if (c.Parent == nil) != (in.Parent == nil) {
+		return false
+	}
+	if c.Parent != nil && !versionEquals(c.Parent, in.Parent) {
+		return false
+	}
+	return reflect.DeepEqual(c.Listener, in.Listener) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		reflect.DeepEqual(c.PolicyAncestorRef, in.PolicyAncestorRef)
 }
 
 type GatewayForDeployer struct {

--- a/pkg/pluginsdk/ir/backend_test.go
+++ b/pkg/pluginsdk/ir/backend_test.go
@@ -9,6 +9,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 )
@@ -88,6 +90,80 @@ func createTestBackendObjectIR(trafficDist wellknown.TrafficDistribution) Backen
 	}
 	backend.TrafficDistribution = trafficDist
 	return backend
+}
+
+func makeGatewayForEquality(resourceVersion string) *gwv1.Gateway {
+	return &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-gateway",
+			Namespace:       "default",
+			UID:             types.UID("test-gateway-uid"),
+			ResourceVersion: resourceVersion,
+			Generation:      1,
+			Labels: map[string]string{
+				"policy": "enabled",
+			},
+			Annotations: map[string]string{
+				"kgateway.dev/test": "true",
+			},
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: gwv1.ObjectName("kgateway"),
+			Listeners: []gwv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+	}
+}
+
+func makeGatewayIRForEquality(gatewayObject *gwv1.Gateway) Gateway {
+	return Gateway{
+		ObjectSource: ObjectSource{
+			Group:     gwv1.GroupVersion.Group,
+			Kind:      wellknown.GatewayKind,
+			Namespace: gatewayObject.Namespace,
+			Name:      gatewayObject.Name,
+		},
+		Obj: gatewayObject,
+		Listeners: Listeners{{
+			Listener: gatewayObject.Spec.Listeners[0],
+			Parent:   gatewayObject,
+		}},
+		AllowedListenerSets: map[schema.GroupVersionKind]ListenerSets{},
+		DeniedListenerSets:  map[schema.GroupVersionKind]ListenerSets{},
+	}
+}
+
+func TestGatewayEqualsIgnoresStatusOnlyParentUpdates(t *testing.T) {
+	baseGateway := makeGatewayForEquality("1")
+	statusUpdatedGateway := baseGateway.DeepCopy()
+	statusUpdatedGateway.ResourceVersion = "2"
+	statusUpdatedGateway.Status = gwv1.GatewayStatus{
+		Conditions: []metav1.Condition{{
+			Type:               string(gwv1.GatewayConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gwv1.GatewayReasonAccepted),
+			ObservedGeneration: baseGateway.Generation,
+			LastTransitionTime: metav1.Now(),
+		}},
+	}
+
+	baseGatewayIR := makeGatewayIRForEquality(baseGateway)
+	statusUpdatedGatewayIR := makeGatewayIRForEquality(statusUpdatedGateway)
+	require.True(t, baseGatewayIR.Equals(statusUpdatedGatewayIR))
+
+	labelUpdatedGateway := baseGateway.DeepCopy()
+	labelUpdatedGateway.ResourceVersion = "3"
+	labelUpdatedGateway.Labels["policy"] = "disabled"
+	require.False(t, baseGatewayIR.Equals(makeGatewayIRForEquality(labelUpdatedGateway)))
+
+	specUpdatedGateway := baseGateway.DeepCopy()
+	specUpdatedGateway.ResourceVersion = "4"
+	specUpdatedGateway.Generation = 2
+	specUpdatedGateway.Spec.Listeners[0].Port = 8080
+	require.False(t, baseGatewayIR.Equals(makeGatewayIRForEquality(specUpdatedGateway)))
 }
 
 func TestBackendObjectIREquals(t *testing.T) {

--- a/pkg/reports/observed_generation_test.go
+++ b/pkg/reports/observed_generation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
@@ -148,6 +149,44 @@ func TestRouteStatusRefreshesObservedGenerationFromCurrentObject(t *testing.T) {
 	}
 }
 
+func TestBuildRouteStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := reports.NewReportMap()
+	statusReporter := reports.NewReporter(&rm)
+
+	parentRef := gwv1.ParentReference{
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      "example-gateway",
+		Namespace: new(gwv1.Namespace("default")),
+	}
+	route := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "example-route",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{parentRef}},
+		},
+	}
+
+	statusReporter.Route(route).ParentRef(&parentRef).SetCondition(pluginreporter.RouteCondition{
+		Type:   gwv1.RouteConditionAccepted,
+		Status: metav1.ConditionFalse,
+		Reason: gwv1.RouteReasonNoMatchingParent,
+	})
+
+	rr := rm.HTTPRoutes[types.NamespacedName{Namespace: route.Namespace, Name: route.Name}]
+	require.NotNil(t, rr)
+	before := cloneParentConditions(rr)
+
+	status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
+	require.NotNil(t, status)
+
+	after := cloneParentConditions(rr)
+	require.Equal(t, before, after, "BuildRouteStatus must not mutate RouteReport condition slices")
+}
+
 func TestPolicyStatusRefreshesObservedGenerationOnReporterReuse(t *testing.T) {
 	rm := reports.NewReportMap()
 	statusReporter := reports.NewReporter(&rm)
@@ -180,6 +219,30 @@ func TestPolicyStatusRefreshesObservedGenerationOnReporterReuse(t *testing.T) {
 	requireCondition(t, status.Ancestors[0].Conditions, string(shared.PolicyConditionAttached), metav1.ConditionFalse, string(shared.PolicyReasonPending))
 }
 
+func TestBuildPolicyStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := reports.NewReportMap()
+	statusReporter := reports.NewReporter(&rm)
+
+	key := pluginreporter.PolicyKey{Group: "example.com", Kind: "Policy", Namespace: "default", Name: "example"}
+	ancestorRef := gwv1.ParentReference{
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      "example-gateway",
+		Namespace: new(gwv1.Namespace("default")),
+	}
+	statusReporter.Policy(key, 1).AncestorRef(ancestorRef)
+
+	pr := rm.Policies[key]
+	require.NotNil(t, pr)
+	before := cloneAncestorConditions(pr)
+
+	status := rm.BuildPolicyStatus(context.Background(), key, "kgateway.dev/kgateway", gwv1.PolicyStatus{})
+	require.NotNil(t, status)
+
+	after := cloneAncestorConditions(pr)
+	require.Equal(t, before, after, "BuildPolicyStatus must not mutate PolicyReport condition slices")
+}
+
 func requireCondition(
 	t *testing.T,
 	conditions []metav1.Condition,
@@ -202,4 +265,20 @@ func metaFindStatusCondition(conditions []metav1.Condition, conditionType string
 		}
 	}
 	return nil
+}
+
+func cloneParentConditions(rr *reports.RouteReport) map[string][]metav1.Condition {
+	out := map[string][]metav1.Condition{}
+	for k, p := range rr.Parents {
+		out[k.String()] = append([]metav1.Condition(nil), p.Conditions...)
+	}
+	return out
+}
+
+func cloneAncestorConditions(pr *reports.PolicyReport) map[string][]metav1.Condition {
+	out := map[string][]metav1.Condition{}
+	for k, a := range pr.Ancestors {
+		out[k.String()] = append([]metav1.Condition(nil), a.Conditions...)
+	}
+	return out
 }

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -24,6 +24,13 @@ type PolicyReport struct {
 	observedGeneration int64
 }
 
+func (r *PolicyReport) GetObservedGeneration() int64 {
+	if r == nil {
+		return 0
+	}
+	return r.observedGeneration
+}
+
 func (r *PolicyReport) AncestorRef(ref gwv1.ParentReference) reporter.AncestorRefReporter {
 	return r.ancestorRef(ref)
 }

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -133,6 +133,13 @@ func (r *ReportMap) BuildPolicyStatus(
 			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)
 			continue
 		}
+
+		// Work on a clone to avoid mutating the shared report map entry while
+		// other goroutines may be reading it for KRT equality checks.
+		parentStatusReport = &AncestorRefReport{
+			Conditions:      slices.Clone(parentStatusReport.Conditions),
+			AttachmentState: parentStatusReport.AttachmentState,
+		}
 		addMissingAncestorRefConditions(parentStatusReport)
 
 		// Get the status of the current parentRef conditions if they exist

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -31,6 +31,24 @@ func (r *PolicyReport) GetObservedGeneration() int64 {
 	return r.observedGeneration
 }
 
+// Clone returns a copy of the PolicyReport with its own (non-nil) Ancestors map,
+// so that merging additional ancestors into the clone does not mutate the
+// original. The AncestorRefReport values are shared; they are treated as
+// read-only after translation (status building clones them before mutation).
+func (r *PolicyReport) Clone() *PolicyReport {
+	if r == nil {
+		return nil
+	}
+	ancestors := make(map[ParentRefKey]*AncestorRefReport, len(r.Ancestors))
+	for k, v := range r.Ancestors {
+		ancestors[k] = v
+	}
+	return &PolicyReport{
+		Ancestors:          ancestors,
+		observedGeneration: r.observedGeneration,
+	}
+}
+
 func (r *PolicyReport) AncestorRef(ref gwv1.ParentReference) reporter.AncestorRefReporter {
 	return r.ancestorRef(ref)
 }

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -216,9 +216,9 @@ func (r *ReportMap) BuildPolicyStatus(
 // If no report is found, nil is returned, signaling this parentRef is unknown to the report
 func (r *PolicyReport) getAncestorRefOrNil(parentRef *gwv1.ParentReference) *AncestorRefReport {
 	key := getParentRefKey(parentRef)
-	if r.Ancestors == nil {
-		r.Ancestors = make(map[ParentRefKey]*AncestorRefReport)
-	}
+	// This is a pure read: indexing a nil map returns the zero value. Do not lazily
+	// initialize r.Ancestors here, as the report pointer is shared with the KRT report
+	// singleton and may be read concurrently for equality checks (see policyReportEqual).
 	return r.Ancestors[key]
 }
 

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -51,6 +51,13 @@ type RouteReport struct {
 	observedGeneration int64
 }
 
+func (r *RouteReport) GetObservedGeneration() int64 {
+	if r == nil {
+		return 0
+	}
+	return r.observedGeneration
+}
+
 // TODO: rename to e.g. RouteParentRefReport
 type ParentRefReport struct {
 	Conditions []metav1.Condition

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -182,40 +182,26 @@ func (r *ReportMap) newListenerSetReport(listenerSet client.Object) *ListenerSet
 // * TCPRoute
 // * TLSRoute
 // * GRPCRoute
+// route is a pure lookup that returns the RouteReport for the provided route object,
+// or nil if a report is not present. It must not mutate the report: the returned
+// pointer is shared with the KRT report singleton, which may be read concurrently by
+// other goroutines for equality checks (see routeReportEqual). The observedGeneration
+// is set at report creation time (newRouteReport) and when the route is (re)translated
+// (statusReporter.Route).
 func (r *ReportMap) route(obj metav1.Object) *RouteReport {
 	key := key(obj)
 
 	switch obj.(type) {
 	case *gwv1.HTTPRoute:
-		report := r.HTTPRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.HTTPRoutes[key]
 	case *gwv1a2.TCPRoute:
-		report := r.TCPRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.TCPRoutes[key]
 	case *gwv1.TLSRoute:
-		report := r.TLSRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.TLSRoutes[key]
 	case *gwv1a2.TLSRoute:
-		report := r.TLSRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.TLSRoutes[key]
 	case *gwv1.GRPCRoute:
-		report := r.GRPCRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.GRPCRoutes[key]
 	default:
 		slog.Warn("unsupported route type", "route_type", fmt.Sprintf("%T", obj))
 		return nil
@@ -428,6 +414,8 @@ func (r *statusReporter) Route(obj metav1.Object) reporter.RouteReporter {
 	rr := r.report.route(obj)
 	if rr == nil {
 		rr = r.report.newRouteReport(obj)
+	} else {
+		rr.observedGeneration = obj.GetGeneration()
 	}
 	return rr
 }

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -58,6 +58,24 @@ func (r *RouteReport) GetObservedGeneration() int64 {
 	return r.observedGeneration
 }
 
+// Clone returns a copy of the RouteReport with its own (non-nil) Parents map, so
+// that merging additional parents into the clone does not mutate the original.
+// The ParentRefReport values are shared; they are treated as read-only after
+// translation (status building clones them before mutation).
+func (r *RouteReport) Clone() *RouteReport {
+	if r == nil {
+		return nil
+	}
+	parents := make(map[ParentRefKey]*ParentRefReport, len(r.Parents))
+	for k, v := range r.Parents {
+		parents[k] = v
+	}
+	return &RouteReport{
+		Parents:            parents,
+		observedGeneration: r.observedGeneration,
+	}
+}
+
 // TODO: rename to e.g. RouteParentRefReport
 type ParentRefReport struct {
 	Conditions []metav1.Condition

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -305,19 +305,14 @@ func (g *GatewayReport) GetAttachedListenerSets() int32 {
 	return g.attachedListenerSets
 }
 
-func (g *GatewayReport) GetListenerStatuses() map[string]gwv1.ListenerStatus {
-	if g == nil || g.listeners == nil {
+// GetListenerReports returns the report's listener reports keyed by listener name.
+// The internal map is returned directly (not cloned) for read-only use such as
+// equality checks; callers must not mutate it.
+func (g *GatewayReport) GetListenerReports() map[string]*ListenerReport {
+	if g == nil {
 		return nil
 	}
-	statuses := make(map[string]gwv1.ListenerStatus, len(g.listeners))
-	for name, listener := range g.listeners {
-		if listener == nil {
-			statuses[name] = gwv1.ListenerStatus{}
-			continue
-		}
-		statuses[name] = cloneListenerStatus(listener.Status)
-	}
-	return statuses
+	return g.listeners
 }
 
 func (g *GatewayReport) SetCondition(gc reporter.GatewayCondition) {
@@ -365,19 +360,14 @@ func (g *ListenerSetReport) GetConditions() []metav1.Condition {
 	return g.conditions
 }
 
-func (g *ListenerSetReport) GetListenerStatuses() map[string]gwv1.ListenerStatus {
-	if g == nil || g.listeners == nil {
+// GetListenerReports returns the report's listener reports keyed by listener name.
+// The internal map is returned directly (not cloned) for read-only use such as
+// equality checks; callers must not mutate it.
+func (g *ListenerSetReport) GetListenerReports() map[string]*ListenerReport {
+	if g == nil {
 		return nil
 	}
-	statuses := make(map[string]gwv1.ListenerStatus, len(g.listeners))
-	for name, listener := range g.listeners {
-		if listener == nil {
-			statuses[name] = gwv1.ListenerStatus{}
-			continue
-		}
-		statuses[name] = cloneListenerStatus(listener.Status)
-	}
-	return statuses
+	return g.listeners
 }
 
 func (g *ListenerSetReport) SetCondition(gc reporter.GatewayCondition) {
@@ -424,12 +414,6 @@ func (l *ListenerReport) SetSupportedKinds(rgks []gwv1.RouteGroupKind) {
 
 func (l *ListenerReport) SetAttachedRoutes(n uint) {
 	l.Status.AttachedRoutes = int32(n) //nolint:gosec // G115: route count is always non-negative
-}
-
-func cloneListenerStatus(status gwv1.ListenerStatus) gwv1.ListenerStatus {
-	status.SupportedKinds = append([]gwv1.RouteGroupKind(nil), status.SupportedKinds...)
-	status.Conditions = append([]metav1.Condition(nil), status.Conditions...)
-	return status
 }
 
 type statusReporter struct {

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -174,14 +174,6 @@ func (r *ReportMap) newListenerSetReport(listenerSet client.Object) *ListenerSet
 	return lsr
 }
 
-// route returns a RouteReport for the provided route object, nil if a report is not present.
-// This is different than the Reporter.Route() method, as we need to understand when
-// reports are not generated for a route that has been translated. Supported object types are:
-//
-// * HTTPRoute
-// * TCPRoute
-// * TLSRoute
-// * GRPCRoute
 // route is a pure lookup that returns the RouteReport for the provided route object,
 // or nil if a report is not present. It must not mutate the report: the returned
 // pointer is shared with the KRT report singleton, which may be read concurrently by
@@ -299,6 +291,35 @@ func (g *GatewayReport) GetConditions() []metav1.Condition {
 	return g.conditions
 }
 
+func (g *GatewayReport) GetObservedGeneration() int64 {
+	if g == nil {
+		return 0
+	}
+	return g.observedGeneration
+}
+
+func (g *GatewayReport) GetAttachedListenerSets() int32 {
+	if g == nil {
+		return 0
+	}
+	return g.attachedListenerSets
+}
+
+func (g *GatewayReport) GetListenerStatuses() map[string]gwv1.ListenerStatus {
+	if g == nil || g.listeners == nil {
+		return nil
+	}
+	statuses := make(map[string]gwv1.ListenerStatus, len(g.listeners))
+	for name, listener := range g.listeners {
+		if listener == nil {
+			statuses[name] = gwv1.ListenerStatus{}
+			continue
+		}
+		statuses[name] = cloneListenerStatus(listener.Status)
+	}
+	return statuses
+}
+
 func (g *GatewayReport) SetCondition(gc reporter.GatewayCondition) {
 	condition := metav1.Condition{
 		Type:    string(gc.Type),
@@ -342,6 +363,21 @@ func (g *ListenerSetReport) GetConditions() []metav1.Condition {
 		return []metav1.Condition{}
 	}
 	return g.conditions
+}
+
+func (g *ListenerSetReport) GetListenerStatuses() map[string]gwv1.ListenerStatus {
+	if g == nil || g.listeners == nil {
+		return nil
+	}
+	statuses := make(map[string]gwv1.ListenerStatus, len(g.listeners))
+	for name, listener := range g.listeners {
+		if listener == nil {
+			statuses[name] = gwv1.ListenerStatus{}
+			continue
+		}
+		statuses[name] = cloneListenerStatus(listener.Status)
+	}
+	return statuses
 }
 
 func (g *ListenerSetReport) SetCondition(gc reporter.GatewayCondition) {
@@ -388,6 +424,12 @@ func (l *ListenerReport) SetSupportedKinds(rgks []gwv1.RouteGroupKind) {
 
 func (l *ListenerReport) SetAttachedRoutes(n uint) {
 	l.Status.AttachedRoutes = int32(n) //nolint:gosec // G115: route count is always non-negative
+}
+
+func cloneListenerStatus(status gwv1.ListenerStatus) gwv1.ListenerStatus {
+	status.SupportedKinds = append([]gwv1.RouteGroupKind(nil), status.SupportedKinds...)
+	status.Conditions = append([]metav1.Condition(nil), status.Conditions...)
+	return status
 }
 
 type statusReporter struct {

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -504,9 +504,9 @@ func getParentRefKey(parentRef *gwv1.ParentReference) ParentRefKey {
 // If no report is found, nil is returned, signaling this parentRef is unknown to the report
 func (r *RouteReport) getParentRefOrNil(parentRef *gwv1.ParentReference) *ParentRefReport {
 	key := getParentRefKey(parentRef)
-	if r.Parents == nil {
-		r.Parents = make(map[ParentRefKey]*ParentRefReport)
-	}
+	// This is a pure read: indexing a nil map returns the zero value. Do not lazily
+	// initialize r.Parents here, as the report pointer is shared with the KRT report
+	// singleton and may be read concurrently for equality checks (see routeReportEqual).
 	return r.Parents[key]
 }
 

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -458,6 +458,12 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)
 			continue
 		}
+
+		// Work on a clone to avoid mutating the shared report map entry while
+		// other goroutines may be reading it for KRT equality checks.
+		parentStatusReport = &ParentRefReport{
+			Conditions: slices.Clone(parentStatusReport.Conditions),
+		}
 		addMissingParentRefConditions(parentStatusReport)
 
 		// Get the status of the current parentRef conditions if they exist

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -468,6 +468,11 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 		return nil
 	}
 
+	// Use the generation of the route object being status-updated rather than reading
+	// it off the shared RouteReport, which other goroutines may read concurrently for
+	// KRT equality checks. This mirrors BuildBackendStatus / BuildGWStatus.
+	observedGeneration := obj.GetGeneration()
+
 	slog.Debug("building status", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
 
 	var existingStatus gwv1.RouteStatus
@@ -543,7 +548,7 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 
 		finalConditions := make([]metav1.Condition, 0, len(parentStatusReport.Conditions))
 		for _, pCondition := range parentStatusReport.Conditions {
-			pCondition.ObservedGeneration = routeReport.observedGeneration
+			pCondition.ObservedGeneration = observedGeneration
 
 			// Copy old condition to preserve LastTransitionTime, if it exists
 			if cond := meta.FindStatusCondition(currentParentRefConditions, pCondition.Type); cond != nil {

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -11,6 +11,7 @@ import (
 	"istio.io/istio/pkg/slices"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -41,10 +42,14 @@ const (
 // TODO: refactor this struct + methods to better reflect the usage now in proxy_syncer
 
 func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attachedRoutes map[string]uint) *gwv1.GatewayStatus {
-	gwReport := r.Gateway(&gw)
+	gwReport := r.GatewayNamespaceName(types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name})
 	if gwReport == nil {
 		return nil
 	}
+
+	// Work on a clone to avoid mutating the shared report map entry while
+	// other goroutines may be reading it for KRT equality checks.
+	gwReport = cloneGatewayReport(gwReport)
 
 	finalListeners := make([]gwv1.ListenerStatus, 0, len(gw.Spec.Listeners))
 	var invalidListeners []string
@@ -65,7 +70,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 			return l.Name == lis.Name
 		})
 		for _, lisCondition := range lisReport.Status.Conditions {
-			lisCondition.ObservedGeneration = gwReport.observedGeneration
+			lisCondition.ObservedGeneration = gw.Generation
 
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 			if oldLisStatusIndex != -1 {
@@ -106,11 +111,11 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 	handleInvalidAddresses(gwReport, &gw)
 	handleInsecureFrontendValidationMode(gwReport, &gw)
 
-	addMissingGatewayConditions(r.Gateway(&gw), &gw)
+	addMissingGatewayConditions(gwReport, &gw)
 
 	finalConditions := make([]metav1.Condition, 0)
 	for _, gwCondition := range gwReport.GetConditions() {
-		gwCondition.ObservedGeneration = gwReport.observedGeneration
+		gwCondition.ObservedGeneration = gw.Generation
 
 		// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(gw.Status.Conditions, gwCondition.Type); cond != nil {
@@ -223,10 +228,22 @@ func shouldPreserveGatewayCondition(condition metav1.Condition, finalConditions 
 }
 
 func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.ListenerSet) *gwv1.ListenerSetStatus {
-	lsReport := r.ListenerSet(&ls)
+	gvk := ls.GroupVersionKind()
+	if gvk.Empty() {
+		gvk = wellknown.ListenerSetGVK
+	}
+	lsByGVK := r.ListenerSets[gvk]
+	var lsReport *ListenerSetReport
+	if lsByGVK != nil {
+		lsReport = lsByGVK[types.NamespacedName{Namespace: ls.Namespace, Name: ls.Name}]
+	}
 	if lsReport == nil {
 		return nil
 	}
+
+	// Work on a clone to avoid mutating the shared report map entry while
+	// other goroutines may be reading it for KRT equality checks.
+	lsReport = cloneListenerSetReport(lsReport)
 
 	finalListeners := make([]gwv1.ListenerStatus, 0, len(ls.Spec.Listeners))
 	var invalidListeners []string
@@ -251,7 +268,7 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 				return l.Name == lis.Name
 			})
 			for _, lisCondition := range lisReport.Status.Conditions {
-				lisCondition.ObservedGeneration = lsReport.observedGeneration
+				lisCondition.ObservedGeneration = ls.Generation
 
 				// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
 				if oldLisStatusIndex != -1 {
@@ -307,11 +324,11 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 		}
 	}
 
-	AddMissingListenerSetConditions(r.ListenerSet(&ls))
+	AddMissingListenerSetConditions(lsReport)
 
 	finalConditions := make([]metav1.Condition, 0)
 	for _, lsCondition := range lsReport.GetConditions() {
-		lsCondition.ObservedGeneration = lsReport.observedGeneration
+		lsCondition.ObservedGeneration = ls.Generation
 
 		// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(ls.Status.Conditions, lsCondition.Type); cond != nil {
@@ -340,6 +357,55 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 	}
 	finalLsStatus.Listeners = fl
 	return &finalLsStatus
+}
+
+func cloneGatewayReport(in *GatewayReport) *GatewayReport {
+	if in == nil {
+		return nil
+	}
+	out := &GatewayReport{
+		conditions:           slices.Clone(in.conditions),
+		observedGeneration:   in.observedGeneration,
+		attachedListenerSets: in.attachedListenerSets,
+	}
+	if in.listeners != nil {
+		out.listeners = make(map[string]*ListenerReport, len(in.listeners))
+		for k, v := range in.listeners {
+			if v == nil {
+				out.listeners[k] = nil
+				continue
+			}
+			cloned := *v
+			cloned.Status.Conditions = slices.Clone(v.Status.Conditions)
+			cloned.Status.SupportedKinds = slices.Clone(v.Status.SupportedKinds)
+			out.listeners[k] = &cloned
+		}
+	}
+	return out
+}
+
+func cloneListenerSetReport(in *ListenerSetReport) *ListenerSetReport {
+	if in == nil {
+		return nil
+	}
+	out := &ListenerSetReport{
+		conditions:         slices.Clone(in.conditions),
+		observedGeneration: in.observedGeneration,
+	}
+	if in.listeners != nil {
+		out.listeners = make(map[string]*ListenerReport, len(in.listeners))
+		for k, v := range in.listeners {
+			if v == nil {
+				out.listeners[k] = nil
+				continue
+			}
+			cloned := *v
+			cloned.Status.Conditions = slices.Clone(v.Status.Conditions)
+			cloned.Status.SupportedKinds = slices.Clone(v.Status.SupportedKinds)
+			out.listeners[k] = &cloned
+		}
+	}
+	return out
 }
 
 // BuildBackendStatus builds the Backend's status from its report, preserving the

--- a/pkg/reports/status_mutation_test.go
+++ b/pkg/reports/status_mutation_test.go
@@ -1,0 +1,79 @@
+package reports
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestBuildGWStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "gw",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gwv1.GatewaySpec{
+			Listeners: []gwv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+	}
+
+	rep.Gateway(gw).Listener(&gw.Spec.Listeners[0])
+	gr := rm.GatewayNamespaceName(key(gw))
+	require.NotNil(t, gr)
+	beforeCond := append([]metav1.Condition(nil), gr.conditions...)
+	beforeListenerCond := append([]metav1.Condition(nil), gr.listeners["http"].Status.Conditions...)
+
+	status := rm.BuildGWStatus(context.Background(), *gw, nil)
+	require.NotNil(t, status)
+
+	afterCond := append([]metav1.Condition(nil), gr.conditions...)
+	afterListenerCond := append([]metav1.Condition(nil), gr.listeners["http"].Status.Conditions...)
+	require.Equal(t, beforeCond, afterCond, "BuildGWStatus must not mutate GatewayReport conditions")
+	require.Equal(t, beforeListenerCond, afterListenerCond, "BuildGWStatus must not mutate ListenerReport conditions")
+}
+
+func TestBuildListenerSetStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	ls := &gwv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "ls",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gwv1.ListenerSetSpec{
+			Listeners: []gwv1.ListenerEntry{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+	}
+	ls.SetGroupVersionKind(gwv1.SchemeGroupVersion.WithKind("ListenerSet"))
+
+	rep.ListenerSet(ls).ListenerName("http")
+	lsr := rm.ListenerSet(ls)
+	require.NotNil(t, lsr)
+	beforeCond := append([]metav1.Condition(nil), lsr.conditions...)
+	beforeListenerCond := append([]metav1.Condition(nil), lsr.listeners["http"].Status.Conditions...)
+
+	status := rm.BuildListenerSetStatus(context.Background(), *ls)
+	require.NotNil(t, status)
+
+	afterCond := append([]metav1.Condition(nil), lsr.conditions...)
+	afterListenerCond := append([]metav1.Condition(nil), lsr.listeners["http"].Status.Conditions...)
+	require.Equal(t, beforeCond, afterCond, "BuildListenerSetStatus must not mutate ListenerSetReport conditions")
+	require.Equal(t, beforeListenerCond, afterListenerCond, "BuildListenerSetStatus must not mutate listener conditions")
+}

--- a/pkg/reports/status_mutation_test.go
+++ b/pkg/reports/status_mutation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -61,7 +62,11 @@ func TestBuildListenerSetStatusDoesNotMutateReportMapEntry(t *testing.T) {
 			}},
 		},
 	}
-	ls.SetGroupVersionKind(gwv1.SchemeGroupVersion.WithKind("ListenerSet"))
+	ls.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   gwv1.GroupVersion.Group,
+		Version: gwv1.GroupVersion.Version,
+		Kind:    "ListenerSet",
+	})
 
 	rep.ListenerSet(ls).ListenerName("http")
 	lsr := rm.ListenerSet(ls)


### PR DESCRIPTION
# Description

fixed duplicated translation when gateway status is updated. After the 1st translation, we update status of the gateway which triggered callback from KRT that Gateway has changed and in our Listener.Equals() we deepEqual() which also compares the parent's status, so we triggered another translation. The only saving grace is that the 2nd translation then try to update status again with the exact same status and become no-op and stopped the cycle.

Changes:
- ignore Listener's parent (Gateway or ListenerSet) status change (the main cause of this bug) when comparing Listener.
- fix report.Equals() where it was using maps.Equals() to compare maps that contains pointers and the pointers are always different even the actual objects are the same. Also created specific routeReportEqual() and policyReportEqual() to ignore timestamp diff. 
- added tests

fixes https://github.com/kgateway-dev/kgateway/issues/12278
# Change Type

/kind fix

# Changelog

```release-note
fixed duplicated translation when gateway status is updated
```
