### PR TITLE
[WIP] [2.3] fix: bound the first per-client xDS publish so new proxies can't crash-loop

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -67,7 +67,7 @@ jobs:
           # May 29, 2026: ~4 minutes
           - cluster-name: 'cluster-seven'
             go-test-args: '-timeout=25m'
-            go-test-run-regex: '^TestAPIValidation$$|^TestKgateway$$/^OAuth$$|^TestKgateway$$/^TrafficPolicyStatus$$|^TestKgateway$$/^AttachedRoutes$$'
+            go-test-run-regex: '^TestAPIValidation$$|^TestKgateway$$/^OAuth$$|^TestKgateway$$/^TrafficPolicyStatus$$|^TestKgateway$$/^AttachedRoutes$$|^TestKgateway$$/^StrictChurn$$'
             localstack: 'false'
           # May 29, 2026: ~5 minutes
           - cluster-name: 'cluster-eight'

--- a/Makefile
+++ b/Makefile
@@ -1063,6 +1063,11 @@ run-load-tests-production: ## Run production load tests (5000 routes)
 	SKIP_INSTALL=true CLUSTER_NAME=$(CLUSTER_NAME) INSTALL_NAMESPACE=$(INSTALL_NAMESPACE) \
 	go test -tags=e2e -v ./test/e2e/tests -run "^TestKgateway$$/^AttachedRoutes$$/^TestAttachedRoutesProduction$$"
 
+.PHONY: run-load-tests-strict-churn
+run-load-tests-strict-churn: ## Run strict-validation churn convergence test (mutates the controller deployment; requires existing cluster and installation)
+	SKIP_INSTALL=true KGW_ENABLE_STRICT_CHURN=true CLUSTER_NAME=$(CLUSTER_NAME) INSTALL_NAMESPACE=$(INSTALL_NAMESPACE) \
+	go test -tags=e2e -v -timeout 30m ./test/e2e/tests -run "^TestKgateway$$/^StrictChurn$$"
+
 #----------------------------------------------------------------------------------
 # MARK: Conformance
 # Targets for running Kubernetes Gateway API conformance tests

--- a/pkg/kgateway/controller/start.go
+++ b/pkg/kgateway/controller/start.go
@@ -83,6 +83,7 @@ type StartConfig struct {
 	CommonCollections *collections.CommonCollections
 	AugmentedPods     krt.Collection[krtcollections.LocalityPod]
 	UniqueClients     krt.Collection[ir.UniqlyConnectedClient]
+	XDSClientState    krtcollections.XDSClientState
 
 	KrtOptions krtutil.KrtOptions
 
@@ -158,6 +159,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 			cfg.CommonCollections,
 			cfg.SetupOpts.Cache,
 			cfg.Validator,
+			cfg.XDSClientState,
 		)
 		proxySyncer.Init(ctx, cfg.KrtOptions)
 		if err := cfg.Manager.Add(proxySyncer); err != nil {

--- a/pkg/kgateway/proxy_syncer/firstpublish_test.go
+++ b/pkg/kgateway/proxy_syncer/firstpublish_test.go
@@ -1,0 +1,201 @@
+package proxy_syncer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics/metricstest"
+)
+
+// deferredWrapper is a deferred wrapper carrying a defer reason for the metric.
+func deferredWrapper(version, reason string) XdsSnapWrapper {
+	w := wrapper(version, true)
+	w.deferReasons = []string{reason}
+	return w
+}
+
+const testClientKey = "c1"
+
+func newTestTranslator() *ProxyTranslator {
+	pt := NewProxyTranslator(envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil))
+	return &pt
+}
+
+func shortenBudget(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := perClientFirstPublishBudget
+	perClientFirstPublishBudget = d
+	t.Cleanup(func() { perClientFirstPublishBudget = orig })
+}
+
+// wrapper builds a wrapper whose listener version identifies it in assertions.
+func wrapper(version string, deferred bool) XdsSnapWrapper {
+	snap := &envoycache.Snapshot{}
+	snap.Resources[envoycachetypes.Listener] = envoycache.NewResources(version, nil)
+	return XdsSnapWrapper{snap: snap, proxyKey: testClientKey, deferred: deferred}
+}
+
+func publishedVersion(t *testing.T, pt *ProxyTranslator) (string, bool) {
+	t.Helper()
+	snap, err := pt.xdsCache.GetSnapshot(testClientKey)
+	if err != nil {
+		return "", false
+	}
+	return snap.GetVersion(resourcev3.ListenerType), true
+}
+
+func TestSyncXds_CoherentPublishesImmediately(t *testing.T) {
+	pt := newTestTranslator()
+	pt.syncXds(context.Background(), wrapper("v1", false))
+	v, ok := publishedVersion(t, pt)
+	require.True(t, ok)
+	assert.Equal(t, "v1", v)
+}
+
+// A never-published client is withheld within the budget, then published.
+func TestSyncXds_NeverPublishedDeferredPublishesAtBudget(t *testing.T) {
+	shortenBudget(t, 50*time.Millisecond)
+	pt := newTestTranslator()
+
+	pt.syncXds(context.Background(), wrapper("v1", true))
+
+	_, ok := publishedVersion(t, pt)
+	assert.False(t, ok, "deferred snapshot must not publish before the budget expires")
+
+	require.Eventually(t, func() bool {
+		_, ok := publishedVersion(t, pt)
+		return ok
+	}, 2*time.Second, 5*time.Millisecond, "deferred snapshot must publish after the budget expires")
+	v, _ := publishedVersion(t, pt)
+	assert.Equal(t, "v1", v)
+}
+
+// The latest deferred snapshot is the one published at budget expiry.
+func TestSyncXds_LatestDeferredWins(t *testing.T) {
+	shortenBudget(t, 80*time.Millisecond)
+	pt := newTestTranslator()
+
+	pt.syncXds(context.Background(), wrapper("v1", true))
+	pt.syncXds(context.Background(), wrapper("v2", true))
+
+	require.Eventually(t, func() bool {
+		_, ok := publishedVersion(t, pt)
+		return ok
+	}, 2*time.Second, 5*time.Millisecond)
+	v, _ := publishedVersion(t, pt)
+	assert.Equal(t, "v2", v)
+}
+
+// A coherent snapshot supersedes a pending first-publish and the canceled
+// timer must never overwrite it.
+func TestSyncXds_CoherentSupersedesPending(t *testing.T) {
+	shortenBudget(t, 100*time.Millisecond)
+	pt := newTestTranslator()
+
+	pt.syncXds(context.Background(), wrapper("deferred", true))
+	pt.syncXds(context.Background(), wrapper("coherent", false))
+
+	v, ok := publishedVersion(t, pt)
+	require.True(t, ok)
+	assert.Equal(t, "coherent", v)
+
+	time.Sleep(200 * time.Millisecond)
+	v, _ = publishedVersion(t, pt)
+	assert.Equal(t, "coherent", v, "a canceled first-publish timer must not overwrite a coherent snapshot")
+}
+
+// A warm client (already published) is never sent a deferred snapshot — and is
+// not bounded by the budget. This is the make-before-break guarantee.
+func TestSyncXds_WarmClientNeverReceivesDeferred(t *testing.T) {
+	shortenBudget(t, 50*time.Millisecond)
+	pt := newTestTranslator()
+
+	pt.syncXds(context.Background(), wrapper("coherent", false))
+	pt.syncXds(context.Background(), wrapper("deferred", true))
+
+	time.Sleep(150 * time.Millisecond) // well past the budget
+	v, ok := publishedVersion(t, pt)
+	require.True(t, ok)
+	assert.Equal(t, "coherent", v, "warm clients keep their last coherent snapshot, with no time bound")
+}
+
+// A never-published deferred client increments defers_total{reason} and, at
+// budget expiry, bounded_publishes_total{mode=first_publish}.
+func TestMetrics_DeferAndBoundedPublish(t *testing.T) {
+	ResetMetrics()
+	shortenBudget(t, 30*time.Millisecond)
+	pt := newTestTranslator()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	pt.syncXds(ctx, deferredWrapper("v1", deferReasonMissingClusters))
+	require.Eventually(t, func() bool { _, ok := publishedVersion(t, pt); return ok },
+		2*time.Second, 5*time.Millisecond)
+
+	g := metricstest.MustGatherMetricsContext(ctx, t,
+		"kgateway_xds_snapshot_perclient_defers_total",
+		"kgateway_xds_snapshot_perclient_bounded_publishes_total")
+	g.AssertMetricsInclude("kgateway_xds_snapshot_perclient_defers_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetricValueTest{
+			Labels: []metrics.Label{
+				{Name: "gateway", Value: "unknown"},
+				{Name: "namespace", Value: "unknown"},
+				{Name: "reason", Value: deferReasonMissingClusters},
+			},
+			Test: metricstest.GreaterOrEqual(1),
+		},
+	})
+	g.AssertMetricsInclude("kgateway_xds_snapshot_perclient_bounded_publishes_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetricValueTest{
+			Labels: []metrics.Label{
+				{Name: "gateway", Value: "unknown"},
+				{Name: "namespace", Value: "unknown"},
+				{Name: "mode", Value: boundedPublishFirstPublish},
+			},
+			Test: metricstest.Equal(1),
+		},
+	})
+}
+
+// A defer followed by a coherent publish increments recoveries_total.
+func TestMetrics_Recovery(t *testing.T) {
+	ResetMetrics()
+	pt := newTestTranslator()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	pt.syncXds(ctx, deferredWrapper("v1", deferReasonMissingEndpoints)) // never-published defer
+	pt.syncXds(ctx, wrapper("v2", false))                               // coherent -> recovery
+
+	g := metricstest.MustGatherMetricsContext(ctx, t, "kgateway_xds_snapshot_perclient_recoveries_total")
+	g.AssertMetricsInclude("kgateway_xds_snapshot_perclient_recoveries_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetricValueTest{
+			Labels: []metrics.Label{
+				{Name: "gateway", Value: "unknown"},
+				{Name: "namespace", Value: "unknown"},
+			},
+			Test: metricstest.GreaterOrEqual(1),
+		},
+	})
+}
+
+// A departed client's pending first publish must not fire.
+func TestSyncXds_DepartureCancelsPending(t *testing.T) {
+	shortenBudget(t, 50*time.Millisecond)
+	pt := newTestTranslator()
+
+	pt.syncXds(context.Background(), wrapper("v1", true))
+	pt.firstPublish.clientDeparted(testClientKey)
+
+	time.Sleep(150 * time.Millisecond)
+	_, ok := publishedVersion(t, pt)
+	assert.False(t, ok, "a departed client's pending first publish must not fire")
+}

--- a/pkg/kgateway/proxy_syncer/firstpublish_test.go
+++ b/pkg/kgateway/proxy_syncer/firstpublish_test.go
@@ -24,8 +24,22 @@ func deferredWrapper(version, reason string) XdsSnapWrapper {
 
 const testClientKey = "c1"
 
+type testXDSClientState map[string]bool
+
+func (s testXDSClientState) HasPriorXDSVersion(resourceName string) bool {
+	return s[resourceName]
+}
+
 func newTestTranslator() *ProxyTranslator {
-	pt := NewProxyTranslator(envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil))
+	pt := NewProxyTranslator(envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil), nil)
+	return &pt
+}
+
+func newTestTranslatorWithPriorVersion() *ProxyTranslator {
+	pt := NewProxyTranslator(
+		envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil),
+		testXDSClientState{testClientKey: true},
+	)
 	return &pt
 }
 
@@ -127,6 +141,39 @@ func TestSyncXds_WarmClientNeverReceivesDeferred(t *testing.T) {
 	assert.Equal(t, "coherent", v, "warm clients keep their last coherent snapshot, with no time bound")
 }
 
+// A reconnecting Envoy may be warm even when this controller's local cache has
+// no snapshot for it. Its prior xDS version is the protocol-level signal that
+// partial SotW would remove live config, so keep #13868's make-before-break
+// behavior and do not budget-publish.
+func TestSyncXds_PriorXDSVersionNeverReceivesDeferred(t *testing.T) {
+	shortenBudget(t, 50*time.Millisecond)
+	pt := newTestTranslatorWithPriorVersion()
+
+	pt.syncXds(context.Background(), wrapper("deferred", true))
+
+	time.Sleep(150 * time.Millisecond) // well past the budget
+	_, ok := publishedVersion(t, pt)
+	assert.False(t, ok, "clients that report a prior xDS version must not receive deferred snapshots")
+}
+
+// Prior xDS version only blocks deferred snapshots. A coherent snapshot is still
+// published immediately and clears the stale-risk state.
+func TestSyncXds_PriorXDSVersionPublishesCoherentImmediately(t *testing.T) {
+	shortenBudget(t, 50*time.Millisecond)
+	pt := newTestTranslatorWithPriorVersion()
+
+	pt.syncXds(context.Background(), wrapper("deferred", true))
+	pt.syncXds(context.Background(), wrapper("coherent", false))
+
+	v, ok := publishedVersion(t, pt)
+	require.True(t, ok)
+	assert.Equal(t, "coherent", v)
+
+	time.Sleep(150 * time.Millisecond) // well past the budget
+	v, _ = publishedVersion(t, pt)
+	assert.Equal(t, "coherent", v, "a prior-version deferred event must not arm a timer that overwrites coherent config")
+}
+
 // A never-published deferred client increments defers_total{reason} and, at
 // budget expiry, bounded_publishes_total{mode=first_publish}.
 func TestMetrics_DeferAndBoundedPublish(t *testing.T) {
@@ -161,6 +208,41 @@ func TestMetrics_DeferAndBoundedPublish(t *testing.T) {
 				{Name: "mode", Value: boundedPublishFirstPublish},
 			},
 			Test: metricstest.Equal(1),
+		},
+	})
+}
+
+func TestMetrics_DeferredWithheldWarmReasons(t *testing.T) {
+	ResetMetrics()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	localWarm := newTestTranslator()
+	localWarm.syncXds(ctx, wrapper("coherent", false))
+	localWarm.syncXds(ctx, deferredWrapper("deferred", deferReasonMissingClusters))
+
+	priorVersionWarm := newTestTranslatorWithPriorVersion()
+	priorVersionWarm.syncXds(ctx, deferredWrapper("deferred", deferReasonMissingEndpoints))
+
+	g := metricstest.MustGatherMetricsContext(ctx, t, "kgateway_xds_snapshot_perclient_deferred_withheld_total")
+	g.AssertMetricsInclude("kgateway_xds_snapshot_perclient_deferred_withheld_total", []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetricValueTest{
+			Labels: []metrics.Label{
+				{Name: "gateway", Value: "unknown"},
+				{Name: "namespace", Value: "unknown"},
+				{Name: "reason", Value: deferReasonMissingClusters},
+				{Name: "warm_reason", Value: warmReasonLocalCache},
+			},
+			Test: metricstest.GreaterOrEqual(1),
+		},
+		&metricstest.ExpectedMetricValueTest{
+			Labels: []metrics.Label{
+				{Name: "gateway", Value: "unknown"},
+				{Name: "namespace", Value: "unknown"},
+				{Name: "reason", Value: deferReasonMissingEndpoints},
+				{Name: "warm_reason", Value: warmReasonPriorXDSVersion},
+			},
+			Test: metricstest.GreaterOrEqual(1),
 		},
 	})
 }

--- a/pkg/kgateway/proxy_syncer/firstpublish_test.go
+++ b/pkg/kgateway/proxy_syncer/firstpublish_test.go
@@ -2,6 +2,7 @@ package proxy_syncer
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +29,14 @@ type testXDSClientState map[string]bool
 
 func (s testXDSClientState) HasPriorXDSVersion(resourceName string) bool {
 	return s[resourceName]
+}
+
+type mutableTestXDSClientState struct {
+	hasPrior atomic.Bool
+}
+
+func (s *mutableTestXDSClientState) HasPriorXDSVersion(resourceName string) bool {
+	return resourceName == testClientKey && s.hasPrior.Load()
 }
 
 func newTestTranslator() *ProxyTranslator {
@@ -154,6 +163,22 @@ func TestSyncXds_PriorXDSVersionNeverReceivesDeferred(t *testing.T) {
 	time.Sleep(150 * time.Millisecond) // well past the budget
 	_, ok := publishedVersion(t, pt)
 	assert.False(t, ok, "clients that report a prior xDS version must not receive deferred snapshots")
+}
+
+// A client can reveal prior accepted config after the first-publish timer has
+// already been armed, for example on a later ADS DiscoveryRequest. The timer
+// must recheck that state before publishing the deferred snapshot.
+func TestSyncXds_PriorXDSVersionDiscoveredBeforeBudgetPreventsPublish(t *testing.T) {
+	shortenBudget(t, 50*time.Millisecond)
+	state := &mutableTestXDSClientState{}
+	pt := NewProxyTranslator(envoycache.NewSnapshotCache(true, envoycache.IDHash{}, nil), state)
+
+	pt.syncXds(context.Background(), deferredWrapper("deferred", deferReasonMissingClusters))
+	state.hasPrior.Store(true)
+
+	time.Sleep(150 * time.Millisecond) // well past the budget
+	_, ok := publishedVersion(t, &pt)
+	assert.False(t, ok, "a deferred timer must not publish after the client reports a prior xDS version")
 }
 
 // Prior xDS version only blocks deferred snapshots. A coherent snapshot is still

--- a/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
+++ b/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
@@ -2,29 +2,165 @@ package proxy_syncer
 
 import (
 	"context"
+	"sync"
+	"time"
+
+	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 )
 
+// perClientFirstPublishBudget bounds how long a client that has NEVER been
+// published a snapshot waits for its per-client inputs to become coherent.
+// Within the budget a deferred snapshot is withheld (inputs usually converge
+// within a recompute or two). Once it expires the latest deferred snapshot is
+// published anyway: a client with no config at all serves nothing — its pod
+// never reports Ready and crash-loops, re-triggering the per-client fan-out on
+// every restart — so a bounded, incomplete snapshot beats an unbounded outage.
+//
+// Clients that already hold a published snapshot are never sent a deferred one
+// (no time bound): keeping the last coherent config is the correct degradation
+// for a warm proxy, and publishing an incomplete snapshot would remove
+// resources it is using. This is the #13868 make-before-break guarantee,
+// unchanged.
+//
+// Unexported var (not a setting) so tests can shorten it; there is
+// deliberately no operator-facing knob in this minimal bound.
+var perClientFirstPublishBudget = 15 * time.Second
+
+// firstPublishGate bounds the first publish for never-published clients. It is
+// shared by reference across ProxyTranslator copies.
+type firstPublishGate struct {
+	mu      sync.Mutex
+	pending map[string]*pendingFirstPublish
+	// deferredSince marks clients that have had an update withheld since their
+	// last coherent publish, so the next coherent publish counts as a recovery.
+	deferredSince map[string]struct{}
+}
+
+type pendingFirstPublish struct {
+	snap  *envoycache.Snapshot
+	timer *time.Timer
+}
+
+func newFirstPublishGate() *firstPublishGate {
+	return &firstPublishGate{
+		pending:       make(map[string]*pendingFirstPublish),
+		deferredSince: make(map[string]struct{}),
+	}
+}
+
+// syncXds applies the publication policy for one wrapper event.
 func (s *ProxyTranslator) syncXds(
 	ctx context.Context,
 	snapWrap XdsSnapWrapper,
 ) {
-	snap := snapWrap.snap
 	proxyKey := snapWrap.proxyKey
-
-	// TODO: handle errored clusters by fetching them from the previous snapshot and using the old cluster
-
-	// stringifying the snapshot may be an expensive operation, so we'd like to avoid building the large
-	// string if we're not even going to log it anyway
-	logger.Debug("syncing xds snapshot", "proxy_key", proxyKey)
-
+	logger.Debug("syncing xds snapshot", "proxy_key", proxyKey, "deferred", snapWrap.deferred)
 	logger.Log(ctx, logging.LevelTrace, "syncing xds snapshot", "proxy_key", proxyKey)
 
-	// if the snapshot is not consistent, make it so
-	// TODO: me may need to copy this to not change krt cache.
-	// TODO: this is also may not be needed now that envoy has
-	// a default initial fetch timeout
-	// snap.MakeConsistent()
-	s.xdsCache.SetSnapshot(ctx, proxyKey, snap)
+	if !snapWrap.deferred {
+		// Coherent: publish, and cancel any pending first-publish under the
+		// gate lock so a concurrently-firing timer cannot overwrite it.
+		if s.firstPublish.publishCoherent(ctx, s.xdsCache, proxyKey, snapWrap.snap) {
+			recordSnapshotRecovery(proxyKey)
+		}
+		return
+	}
+
+	recordSnapshotDefer(proxyKey, snapWrap.deferReasons)
+	s.firstPublish.markDeferred(proxyKey)
+
+	if _, err := s.xdsCache.GetSnapshot(proxyKey); err == nil {
+		// Warm client: withhold, unbounded (keep last-good).
+		return
+	}
+
+	// Never-published client: hold up to the budget, then publish.
+	s.firstPublish.offer(ctx, s.xdsCache, proxyKey, snapWrap.snap)
+}
+
+// publishCoherent publishes a coherent snapshot, cancels any pending
+// first-publish, and reports whether the client had deferred since its last
+// coherent publish (so the caller can count a recovery).
+func (g *firstPublishGate) publishCoherent(ctx context.Context, cache envoycache.SnapshotCache, proxyKey string, snap *envoycache.Snapshot) (recovered bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if st := g.pending[proxyKey]; st != nil {
+		if st.timer != nil {
+			st.timer.Stop()
+		}
+		delete(g.pending, proxyKey)
+	}
+	if _, ok := g.deferredSince[proxyKey]; ok {
+		recovered = true
+		delete(g.deferredSince, proxyKey)
+	}
+	cache.SetSnapshot(ctx, proxyKey, snap)
+	return recovered
+}
+
+// markDeferred records that a client had an update withheld, so its next
+// coherent publish counts as a recovery.
+func (g *firstPublishGate) markDeferred(proxyKey string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.deferredSince[proxyKey] = struct{}{}
+}
+
+// offer records the latest deferred snapshot for a never-published client and
+// arms the budget timer once; the timer publishes whatever is latest.
+func (g *firstPublishGate) offer(ctx context.Context, cache envoycache.SnapshotCache, proxyKey string, snap *envoycache.Snapshot) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	st := g.pending[proxyKey]
+	if st == nil {
+		st = &pendingFirstPublish{}
+		g.pending[proxyKey] = st
+		logger.Info("withholding first publish until per-client inputs converge or the budget expires",
+			"client", proxyKey, "budget", perClientFirstPublishBudget)
+	}
+	st.snap = snap
+	if st.timer != nil {
+		return // already armed; it will publish the latest snap
+	}
+	st.timer = time.AfterFunc(perClientFirstPublishBudget, func() {
+		g.firePending(ctx, cache, proxyKey)
+	})
+}
+
+// firePending runs at budget expiry: publish the latest deferred snapshot
+// unless a coherent snapshot won the race. The check and publish happen under
+// the lock, so they cannot interleave with a coherent publish.
+func (g *firstPublishGate) firePending(ctx context.Context, cache envoycache.SnapshotCache, proxyKey string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	st := g.pending[proxyKey]
+	if st == nil || st.snap == nil {
+		return
+	}
+	snap := st.snap
+	delete(g.pending, proxyKey)
+	if _, err := cache.GetSnapshot(proxyKey); err == nil {
+		return // a coherent snapshot was published while the timer was in flight
+	}
+	logger.Warn("first-publish budget expired; publishing deferred snapshot so the client can start",
+		"client", proxyKey)
+	cache.SetSnapshot(ctx, proxyKey, snap)
+	recordBoundedPublish(proxyKey)
+}
+
+// clientDeparted cancels any pending first publish for a client whose wrapper
+// row was deleted (disconnected, or its gateway snapshot went away), so a
+// timer cannot publish to a key after its client left.
+func (g *firstPublishGate) clientDeparted(proxyKey string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if st := g.pending[proxyKey]; st != nil {
+		if st.timer != nil {
+			st.timer.Stop()
+		}
+		delete(g.pending, proxyKey)
+	}
+	delete(g.deferredSince, proxyKey)
 }

--- a/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
+++ b/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
@@ -2,6 +2,7 @@ package proxy_syncer
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -11,22 +12,24 @@ import (
 )
 
 // perClientFirstPublishBudget bounds how long a client that has NEVER been
-// published a snapshot waits for its per-client inputs to become coherent.
-// Within the budget a deferred snapshot is withheld (inputs usually converge
-// within a recompute or two). Once it expires the latest deferred snapshot is
-// published anyway: a client with no config at all serves nothing — its pod
-// never reports Ready and crash-loops, re-triggering the per-client fan-out on
-// every restart — so a bounded, incomplete snapshot beats an unbounded outage.
+// published a snapshot and has not reported a prior xDS version waits for its
+// per-client inputs to become coherent. Within the budget a deferred snapshot
+// is withheld (inputs usually converge within a recompute or two). Once it
+// expires the latest deferred snapshot is published anyway: an Envoy that has
+// not reported any accepted config is likely still starting, and keeping it at
+// no listeners can leave the pod unable to report Ready and crash-looping.
 //
-// Clients that already hold a published snapshot are never sent a deferred one
-// (no time bound): keeping the last coherent config is the correct degradation
-// for a warm proxy, and publishing an incomplete snapshot would remove
-// resources it is using. This is the #13868 make-before-break guarantee,
-// unchanged.
+// Clients that either already hold a published snapshot in this controller or
+// report a prior accepted xDS version are never sent a deferred one (no time
+// bound): keeping the last coherent config is the correct degradation for a
+// warm proxy, and publishing an incomplete snapshot would remove resources it
+// is using. This is the #13868 make-before-break guarantee, unchanged.
 //
 // Unexported var (not a setting) so tests can shorten it; there is
 // deliberately no operator-facing knob in this minimal bound.
 var perClientFirstPublishBudget = 15 * time.Second
+
+const perClientWarmWithheldLogInterval = 5 * time.Minute
 
 // firstPublishGate bounds the first publish for never-published clients. It is
 // shared by reference across ProxyTranslator copies.
@@ -36,6 +39,10 @@ type firstPublishGate struct {
 	// deferredSince marks clients that have had an update withheld since their
 	// last coherent publish, so the next coherent publish counts as a recovery.
 	deferredSince map[string]struct{}
+	// warmWithheld tracks deferred snapshots withheld from clients that may
+	// already be serving traffic. It is intentionally in-memory and per-client;
+	// Prometheus metrics stay aggregate to avoid high-cardinality UCC labels.
+	warmWithheld map[string]*warmWithheldDeferred
 }
 
 type pendingFirstPublish struct {
@@ -43,10 +50,18 @@ type pendingFirstPublish struct {
 	timer *time.Timer
 }
 
+type warmWithheldDeferred struct {
+	since      time.Time
+	lastLog    time.Time
+	reasons    []string
+	warmReason string
+}
+
 func newFirstPublishGate() *firstPublishGate {
 	return &firstPublishGate{
 		pending:       make(map[string]*pendingFirstPublish),
 		deferredSince: make(map[string]struct{}),
+		warmWithheld:  make(map[string]*warmWithheldDeferred),
 	}
 }
 
@@ -71,13 +86,30 @@ func (s *ProxyTranslator) syncXds(
 	recordSnapshotDefer(proxyKey, snapWrap.deferReasons)
 	s.firstPublish.markDeferred(proxyKey)
 
+	// Safety/liveness split: without a real KRT quiescence signal, publishing a
+	// deferred snapshot to a client that may already be serving can regress
+	// #13868. Only clients with no evidence of prior config get the bounded
+	// first-publish liveness escape hatch below.
 	if _, err := s.xdsCache.GetSnapshot(proxyKey); err == nil {
 		// Warm client: withhold, unbounded (keep last-good).
+		s.firstPublish.withholdWarm(proxyKey, snapWrap.deferReasons, warmReasonLocalCache)
+		return
+	}
+	if s.hasPriorXDSVersion(proxyKey) {
+		// Warm reconnect to this controller: the local cache has no snapshot,
+		// but Envoy's initial xDS request carried a prior accepted version.
+		// Treat it as already serving and preserve #13868's make-before-break
+		// behavior by withholding deferred snapshots indefinitely.
+		s.firstPublish.withholdWarm(proxyKey, snapWrap.deferReasons, warmReasonPriorXDSVersion)
 		return
 	}
 
-	// Never-published client: hold up to the budget, then publish.
+	// Never-published, no-prior-version client: hold up to the budget, then publish.
 	s.firstPublish.offer(ctx, s.xdsCache, proxyKey, snapWrap.snap)
+}
+
+func (s *ProxyTranslator) hasPriorXDSVersion(proxyKey string) bool {
+	return s.xdsClientState != nil && s.xdsClientState.HasPriorXDSVersion(proxyKey)
 }
 
 // publishCoherent publishes a coherent snapshot, cancels any pending
@@ -96,6 +128,7 @@ func (g *firstPublishGate) publishCoherent(ctx context.Context, cache envoycache
 		recovered = true
 		delete(g.deferredSince, proxyKey)
 	}
+	delete(g.warmWithheld, proxyKey)
 	cache.SetSnapshot(ctx, proxyKey, snap)
 	return recovered
 }
@@ -106,6 +139,37 @@ func (g *firstPublishGate) markDeferred(proxyKey string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.deferredSince[proxyKey] = struct{}{}
+}
+
+func (g *firstPublishGate) withholdWarm(proxyKey string, reasons []string, warmReason string) {
+	recordDeferredSnapshotWithheld(proxyKey, reasons, warmReason)
+
+	now := time.Now()
+	g.mu.Lock()
+	st := g.warmWithheld[proxyKey]
+	if st == nil {
+		st = &warmWithheldDeferred{since: now}
+		g.warmWithheld[proxyKey] = st
+	}
+	reasonsChanged := st.warmReason != warmReason || !slices.Equal(st.reasons, reasons)
+	shouldLog := st.lastLog.IsZero() || reasonsChanged || now.Sub(st.lastLog) >= perClientWarmWithheldLogInterval
+	st.warmReason = warmReason
+	st.reasons = slices.Clone(reasons)
+	if shouldLog {
+		st.lastLog = now
+	}
+	since := st.since
+	g.mu.Unlock()
+
+	if shouldLog {
+		logger.Warn("withholding deferred snapshot for warm xDS client; keeping last coherent config",
+			"client", proxyKey,
+			"warm_reason", warmReason,
+			"defer_reasons", reasons,
+			"deferred_since", since,
+			"deferred_for", now.Sub(since),
+		)
+	}
 }
 
 // offer records the latest deferred snapshot for a never-published client and
@@ -163,4 +227,5 @@ func (g *firstPublishGate) clientDeparted(proxyKey string) {
 		delete(g.pending, proxyKey)
 	}
 	delete(g.deferredSince, proxyKey)
+	delete(g.warmWithheld, proxyKey)
 }

--- a/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
+++ b/pkg/kgateway/proxy_syncer/kube_gw_translator_syncer.go
@@ -46,8 +46,9 @@ type firstPublishGate struct {
 }
 
 type pendingFirstPublish struct {
-	snap  *envoycache.Snapshot
-	timer *time.Timer
+	snap    *envoycache.Snapshot
+	reasons []string
+	timer   *time.Timer
 }
 
 type warmWithheldDeferred struct {
@@ -105,7 +106,7 @@ func (s *ProxyTranslator) syncXds(
 	}
 
 	// Never-published, no-prior-version client: hold up to the budget, then publish.
-	s.firstPublish.offer(ctx, s.xdsCache, proxyKey, snapWrap.snap)
+	s.firstPublish.offer(ctx, s.xdsCache, proxyKey, snapWrap.snap, snapWrap.deferReasons, s.hasPriorXDSVersion)
 }
 
 func (s *ProxyTranslator) hasPriorXDSVersion(proxyKey string) bool {
@@ -174,7 +175,14 @@ func (g *firstPublishGate) withholdWarm(proxyKey string, reasons []string, warmR
 
 // offer records the latest deferred snapshot for a never-published client and
 // arms the budget timer once; the timer publishes whatever is latest.
-func (g *firstPublishGate) offer(ctx context.Context, cache envoycache.SnapshotCache, proxyKey string, snap *envoycache.Snapshot) {
+func (g *firstPublishGate) offer(
+	ctx context.Context,
+	cache envoycache.SnapshotCache,
+	proxyKey string,
+	snap *envoycache.Snapshot,
+	reasons []string,
+	hasPriorXDSVersion func(string) bool,
+) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	st := g.pending[proxyKey]
@@ -185,18 +193,24 @@ func (g *firstPublishGate) offer(ctx context.Context, cache envoycache.SnapshotC
 			"client", proxyKey, "budget", perClientFirstPublishBudget)
 	}
 	st.snap = snap
+	st.reasons = slices.Clone(reasons)
 	if st.timer != nil {
 		return // already armed; it will publish the latest snap
 	}
 	st.timer = time.AfterFunc(perClientFirstPublishBudget, func() {
-		g.firePending(ctx, cache, proxyKey)
+		g.firePending(ctx, cache, proxyKey, hasPriorXDSVersion)
 	})
 }
 
 // firePending runs at budget expiry: publish the latest deferred snapshot
 // unless a coherent snapshot won the race. The check and publish happen under
 // the lock, so they cannot interleave with a coherent publish.
-func (g *firstPublishGate) firePending(ctx context.Context, cache envoycache.SnapshotCache, proxyKey string) {
+func (g *firstPublishGate) firePending(
+	ctx context.Context,
+	cache envoycache.SnapshotCache,
+	proxyKey string,
+	hasPriorXDSVersion func(string) bool,
+) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	st := g.pending[proxyKey]
@@ -207,6 +221,12 @@ func (g *firstPublishGate) firePending(ctx context.Context, cache envoycache.Sna
 	delete(g.pending, proxyKey)
 	if _, err := cache.GetSnapshot(proxyKey); err == nil {
 		return // a coherent snapshot was published while the timer was in flight
+	}
+	if hasPriorXDSVersion != nil && hasPriorXDSVersion(proxyKey) {
+		logger.Warn("first-publish budget expired, but client reported a prior xDS version; withholding deferred snapshot",
+			"client", proxyKey)
+		recordDeferredSnapshotWithheld(proxyKey, st.reasons, warmReasonPriorXDSVersion)
+		return
 	}
 	logger.Warn("first-publish budget expired; publishing deferred snapshot so the client can start",
 		"client", proxyKey)

--- a/pkg/kgateway/proxy_syncer/metrics.go
+++ b/pkg/kgateway/proxy_syncer/metrics.go
@@ -18,6 +18,7 @@ const (
 	resourceLabel     = "resource"
 	reasonLabel       = "reason"
 	modeLabel         = "mode"
+	warmReasonLabel   = "warm_reason"
 )
 
 var (
@@ -107,11 +108,30 @@ var (
 		},
 		[]string{gatewayLabel, namespaceLabel, modeLabel},
 	)
+	snapshotPerClientDeferredWithheldTotal = metrics.NewCounter(
+		metrics.CounterOpts{
+			Subsystem: snapshotSubsystem,
+			Name:      "perclient_deferred_withheld_total",
+			Help: "Total deferred per-client XDS snapshots withheld indefinitely " +
+				"because the client may already be serving traffic. warm_reason " +
+				"identifies whether the safety signal was this controller's local " +
+				"snapshot cache or Envoy reporting a prior accepted xDS version. " +
+				"Nonzero prior_xds_version counts mean kgateway preserved last-good " +
+				"config after reconnect/controller restart instead of risking a " +
+				"partial SotW publish (#13868).",
+		},
+		[]string{gatewayLabel, namespaceLabel, reasonLabel, warmReasonLabel},
+	)
 )
 
 // boundedPublishFirstPublish is the only bounded-publish mode this minimal
 // bound emits (carry_forward publishes are a main-only follow-up).
 const boundedPublishFirstPublish = "first_publish"
+
+const (
+	warmReasonLocalCache      = "local_cache"
+	warmReasonPriorXDSVersion = "prior_xds_version"
+)
 
 // recordSnapshotDefer counts one withheld publication for the client's gateway,
 // per reason.
@@ -168,6 +188,23 @@ func (r snapshotResourcesMetricLabels) toMetricsLabels() []metrics.Label {
 		{Name: gatewayLabel, Value: r.Gateway},
 		{Name: namespaceLabel, Value: r.Namespace},
 		{Name: resourceLabel, Value: r.Resource},
+	}
+}
+
+// recordDeferredSnapshotWithheld counts deferred snapshots that are withheld
+// indefinitely for a warm client.
+func recordDeferredSnapshotWithheld(proxyKey string, reasons []string, warmReason string) {
+	if !metrics.Active() {
+		return
+	}
+	cd := getDetailsFromXDSClientResourceName(proxyKey)
+	for _, reason := range reasons {
+		snapshotPerClientDeferredWithheldTotal.Inc(
+			metrics.Label{Name: gatewayLabel, Value: cd.Gateway},
+			metrics.Label{Name: namespaceLabel, Value: cd.Namespace},
+			metrics.Label{Name: reasonLabel, Value: reason},
+			metrics.Label{Name: warmReasonLabel, Value: warmReason},
+		)
 	}
 }
 
@@ -286,4 +323,5 @@ func ResetMetrics() {
 	snapshotPerClientDefersTotal.Reset()
 	snapshotPerClientRecoveriesTotal.Reset()
 	snapshotPerClientBoundedPublishesTotal.Reset()
+	snapshotPerClientDeferredWithheldTotal.Reset()
 }

--- a/pkg/kgateway/proxy_syncer/metrics.go
+++ b/pkg/kgateway/proxy_syncer/metrics.go
@@ -16,6 +16,8 @@ const (
 	namespaceLabel    = "namespace"
 	resultLabel       = "result"
 	resourceLabel     = "resource"
+	reasonLabel       = "reason"
+	modeLabel         = "mode"
 )
 
 var (
@@ -70,7 +72,89 @@ var (
 		},
 		[]string{gatewayLabel, namespaceLabel, resourceLabel},
 	)
+	snapshotPerClientDefersTotal = metrics.NewCounter(
+		metrics.CounterOpts{
+			Subsystem: snapshotSubsystem,
+			Name:      "perclient_defers_total",
+			Help: "Total per-client XDS snapshot publication deferrals, by reason. " +
+				"Every increment means an update was withheld: the client kept its " +
+				"last published snapshot, or — before first publish — kept waiting " +
+				"up to the first-publish budget. A sustained rate for a gateway " +
+				"means a connected client's per-client inputs are not becoming " +
+				"consistent (#14184).",
+		},
+		[]string{gatewayLabel, namespaceLabel, reasonLabel},
+	)
+	snapshotPerClientRecoveriesTotal = metrics.NewCounter(
+		metrics.CounterOpts{
+			Subsystem: snapshotSubsystem,
+			Name:      "perclient_recoveries_total",
+			Help: "Total times a per-client XDS snapshot resumed coherent publishing " +
+				"after one or more deferrals.",
+		},
+		[]string{gatewayLabel, namespaceLabel},
+	)
+	snapshotPerClientBoundedPublishesTotal = metrics.NewCounter(
+		metrics.CounterOpts{
+			Subsystem: snapshotSubsystem,
+			Name:      "perclient_bounded_publishes_total",
+			Help: "Total deferred snapshots published because the first-publish " +
+				"budget expired (mode=first_publish), i.e. a never-published client " +
+				"started on incomplete config instead of waiting indefinitely. " +
+				"Nonzero means a gateway pod would otherwise have crash-looped " +
+				"(#14184). The mode label is forward-compatible with carry-forward " +
+				"publishes, which this minimal bound does not perform.",
+		},
+		[]string{gatewayLabel, namespaceLabel, modeLabel},
+	)
 )
+
+// boundedPublishFirstPublish is the only bounded-publish mode this minimal
+// bound emits (carry_forward publishes are a main-only follow-up).
+const boundedPublishFirstPublish = "first_publish"
+
+// recordSnapshotDefer counts one withheld publication for the client's gateway,
+// per reason.
+func recordSnapshotDefer(proxyKey string, reasons []string) {
+	if !metrics.Active() {
+		return
+	}
+	cd := getDetailsFromXDSClientResourceName(proxyKey)
+	for _, reason := range reasons {
+		snapshotPerClientDefersTotal.Inc(
+			metrics.Label{Name: gatewayLabel, Value: cd.Gateway},
+			metrics.Label{Name: namespaceLabel, Value: cd.Namespace},
+			metrics.Label{Name: reasonLabel, Value: reason},
+		)
+	}
+}
+
+// recordSnapshotRecovery counts a client resuming coherent publication after a
+// prior deferral.
+func recordSnapshotRecovery(proxyKey string) {
+	if !metrics.Active() {
+		return
+	}
+	cd := getDetailsFromXDSClientResourceName(proxyKey)
+	snapshotPerClientRecoveriesTotal.Inc(
+		metrics.Label{Name: gatewayLabel, Value: cd.Gateway},
+		metrics.Label{Name: namespaceLabel, Value: cd.Namespace},
+	)
+}
+
+// recordBoundedPublish counts a deferred snapshot published because the
+// first-publish budget expired.
+func recordBoundedPublish(proxyKey string) {
+	if !metrics.Active() {
+		return
+	}
+	cd := getDetailsFromXDSClientResourceName(proxyKey)
+	snapshotPerClientBoundedPublishesTotal.Inc(
+		metrics.Label{Name: gatewayLabel, Value: cd.Gateway},
+		metrics.Label{Name: namespaceLabel, Value: cd.Namespace},
+		metrics.Label{Name: modeLabel, Value: boundedPublishFirstPublish},
+	)
+}
 
 // snapshotResourcesMetricLabels defines the labels for XDS snapshot resources metrics.
 type snapshotResourcesMetricLabels struct {
@@ -199,4 +283,7 @@ func ResetMetrics() {
 	snapshotTransformsTotal.Reset()
 	snapshotTransformDuration.Reset()
 	snapshotResources.Reset()
+	snapshotPerClientDefersTotal.Reset()
+	snapshotPerClientRecoveriesTotal.Reset()
+	snapshotPerClientBoundedPublishesTotal.Reset()
 }

--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -24,6 +24,13 @@ import (
 	krtutil "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 )
 
+// Defer reasons, attached to a deferred snapshot for the defer metric.
+const (
+	deferReasonEndpointsNotReady = "endpoints_not_ready"
+	deferReasonMissingClusters   = "missing_clusters"
+	deferReasonMissingEndpoints  = "missing_endpoints"
+)
+
 type clustersWithErrors struct {
 	// +noKrtEquals
 	clusters envoycache.Resources
@@ -168,21 +175,31 @@ func snapshotPerClient(
 		//     CDS/RDS/LDS before EDS catches up can make Envoy drop all hosts for
 		//     a route that was healthy before a controller restart.
 		//
-		// Returning nil removes this UCC's entry from the output collection,
-		// which surfaces as a Delete event in proxy_syncer.go's xDS
-		// subscriber. That Delete branch is intentionally a no-op so the
-		// xDS snapshot cache retains the last-published Snapshot for this
-		// client. Envoy therefore keeps serving its previous, coherent
-		// config until a new coherent snapshot overwrites it. This is what
-		// prevents an unresolvable reference — a user BackendRef typo, a
-		// plugin bug — from stranding Envoy: there is no error response on
-		// valid traffic during the defer window, only continuity.
+		// A failed guard no longer withholds the row (return nil). The
+		// snapshot is still BUILT and marked deferred; the publication policy
+		// lives in syncXds:
+		//
+		//   - a client that already holds a published snapshot never receives
+		//     a deferred one — Envoy keeps its last coherent config, with no
+		//     deadline (make-before-break, unchanged from #13868);
+		//   - a client that has NEVER been published anything receives the
+		//     deferred snapshot once the first-publish budget expires, because
+		//     for that client the alternative is no listeners at all — the pod
+		//     never reports Ready and crash-loops, re-triggering the whole
+		//     per-client fan-out each restart.
+		//
+		// This deliberately keeps the warm-client behavior identical to the
+		// gate it replaces, and does NOT add carry-forward, a usable-endpoint
+		// check, or synthesized empty CLAs (see #14237 / #14257 for those):
+		// it is the minimal bound that stops a never-published client from
+		// waiting forever.
 		//
 		// BackendRef typos never reach this gate as real cluster names:
 		// IR-time resolution substitutes wellknown.BlackholeClusterName,
 		// which findMissingReferencedClusters explicitly skips.
 		//
 		// Historical context: https://github.com/solo-io/gloo/pull/10611.
+		var deferReasons []string
 		if clustersForUcc == nil {
 			clustersForUcc = &clustersWithErrors{
 				clusters: envoycache.Resources{
@@ -192,7 +209,11 @@ func snapshotPerClient(
 		}
 		if clientEndpointResources == nil {
 			logger.Info("per-client endpoints not ready; deferring snapshot", "client", ucc.ResourceName())
-			return nil
+			deferReasons = append(deferReasons, deferReasonEndpointsNotReady)
+			clientEndpointResources = &endpointsWithUccName{
+				endpoints:    envoycache.Resources{Items: map[string]envoycachetypes.ResourceWithTTL{}},
+				resourceName: ucc.ResourceName(),
+			}
 		}
 
 		logger.Debug("found perclient clusters", "client", ucc.ResourceName(), "clusters", len(clustersForUcc.clusters.Items))
@@ -218,7 +239,7 @@ func snapshotPerClient(
 				"client", ucc.ResourceName(),
 				"missing_clusters", missingClusters,
 			)
-			return nil
+			deferReasons = append(deferReasons, deferReasonMissingClusters)
 		}
 		// Exclude CLAs for STATIC clusters so ADS snapshot only contains resources Envoy will request.
 		endpointRes := filterEndpointResourcesForStaticClusters(clusterResources, clientEndpointResources.endpoints)
@@ -233,9 +254,11 @@ func snapshotPerClient(
 				"client", ucc.ResourceName(),
 				"missing_endpoint_clusters", missingEndpointClusters,
 			)
-			return nil
+			deferReasons = append(deferReasons, deferReasonMissingEndpoints)
 		}
 
+		snap.deferred = len(deferReasons) > 0
+		snap.deferReasons = deferReasons
 		snap.erroredClusters = clustersForUcc.erroredClusters
 		snap.proxyKey = ucc.ResourceName()
 		snapshot := &envoycache.Snapshot{}

--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -182,11 +182,12 @@ func snapshotPerClient(
 		//   - a client that already holds a published snapshot never receives
 		//     a deferred one — Envoy keeps its last coherent config, with no
 		//     deadline (make-before-break, unchanged from #13868);
-		//   - a client that has NEVER been published anything receives the
-		//     deferred snapshot once the first-publish budget expires, because
-		//     for that client the alternative is no listeners at all — the pod
-		//     never reports Ready and crash-loops, re-triggering the whole
-		//     per-client fan-out each restart.
+		//   - a client that has NEVER been published anything by this
+		//     controller, and has not reported a prior accepted xDS version,
+		//     receives the deferred snapshot once the first-publish budget
+		//     expires, because the alternative may be no listeners at all —
+		//     the pod never reports Ready and crash-loops, re-triggering the
+		//     whole per-client fan-out each restart.
 		//
 		// This deliberately keeps the warm-client behavior identical to the
 		// gate it replaces, and does NOT add carry-forward, a usable-endpoint

--- a/pkg/kgateway/proxy_syncer/perclient_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_test.go
@@ -226,9 +226,13 @@ func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T)
 		},
 	)
 
-	g.Consistently(func() int {
-		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
+	// While cluster-b is missing the wrapper is built but marked deferred; the
+	// publication policy in syncXds is what withholds it.
+	g.Eventually(func() bool {
+		l := snapshots.List()
+		return len(l) == 1 && l[0].deferred
+	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue(),
+		"snapshot should be built but deferred while a referenced cluster is missing")
 
 	clusterCol.UpdateObject(uccWithCluster{
 		Client:         ucc,
@@ -237,9 +241,11 @@ func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T)
 		ClusterVersion: 2,
 	})
 
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+	g.Eventually(func() bool {
+		l := snapshots.List()
+		return len(l) == 1 && !l[0].deferred
+	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue(),
+		"snapshot should become coherent once all referenced clusters exist")
 
 	snap := snapshots.List()[0].snap
 	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
@@ -314,9 +320,15 @@ func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testi
 		},
 	)
 
-	g.Consistently(func() int {
-		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
+	// While the referenced EDS cluster has no CLA the wrapper is built but
+	// marked deferred (the minimal bound keeps the base predicate: a present
+	// CLA — even empty — satisfies the gate; the usable-endpoint check is
+	// #14257, deliberately not included here).
+	g.Eventually(func() bool {
+		l := snapshots.List()
+		return len(l) == 1 && l[0].deferred
+	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue(),
+		"snapshot should be built but deferred while a referenced EDS cluster has no CLA")
 
 	endpointCol.UpdateObject(UccWithEndpoints{
 		Client: ucc,
@@ -327,9 +339,11 @@ func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testi
 		endpointsName: "cluster-a",
 	})
 
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+	g.Eventually(func() bool {
+		l := snapshots.List()
+		return len(l) == 1 && !l[0].deferred
+	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue(),
+		"snapshot should become coherent once the CLA arrives")
 
 	snap := snapshots.List()[0].snap
 	g.Expect(snap.Resources[envoycachetypes.Endpoint].Items).To(gomega.HaveKey("cluster-a"))

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -174,11 +174,16 @@ func NewProxySyncer(
 
 type ProxyTranslator struct {
 	xdsCache envoycache.SnapshotCache
+	// firstPublish bounds the first publish for never-published clients (see
+	// kube_gw_translator_syncer.go). Pointer so the state is shared across
+	// ProxyTranslator copies.
+	firstPublish *firstPublishGate
 }
 
 func NewProxyTranslator(xdsCache envoycache.SnapshotCache) ProxyTranslator {
 	return ProxyTranslator{
-		xdsCache: xdsCache,
+		xdsCache:     xdsCache,
+		firstPublish: newFirstPublishGate(),
 	}
 }
 
@@ -465,25 +470,21 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 				snapWrap := e.Latest()
 				s.proxyTranslator.syncXds(ctx, snapWrap)
 			} else {
-				// Intentional no-op. When snapshotPerClient returns nil (its
-				// readiness guards deferred publishing), KRT surfaces a Delete
-				// for this UCC. Clearing the xDS cache here would withdraw
-				// Envoy's last coherent Snapshot for the duration of the defer,
-				// causing 500/NC on valid routes. Leaving the cache alone means
-				// Envoy keeps serving its previously-published config until a
-				// new coherent snapshot overwrites it — the "retain last good"
-				// behavior that prevents unresolvable cluster references from
-				// stranding live traffic.
+				// A Delete here means the client's wrapper row is gone: the
+				// UCC departed, or its gateway snapshot is missing. (Readiness
+				// deferral no longer produces Deletes — deferred snapshots are
+				// emitted and the publication policy in syncXds withholds
+				// them.) Cancel any pending first-publish timer so it cannot
+				// fire for a departed client; leave the xDS snapshot cache
+				// alone so a still-connected Envoy keeps its last coherent
+				// config.
 				//
-				// Known leak: this branch also fires when a UCC truly goes
-				// away (Envoy pod replaced on rollout, scaled down, etc.),
-				// and we cannot distinguish that from the "defer" case here.
-				// The SnapshotCache entry for that UCC is therefore never
-				// cleared and accumulates over the controller's lifetime.
-				// Pre-existing behavior (the prior ClearSnapshot call was
-				// already commented out); reclaiming these entries requires
-				// a separate signal — e.g. cross-referencing uccCol
-				// membership — and is left to a follow-up.
+				// Known leak: the SnapshotCache entry for a truly-departed UCC
+				// is never cleared and accumulates over the controller's
+				// lifetime. Pre-existing behavior (the prior ClearSnapshot call
+				// was already commented out); reclaiming these entries is a
+				// separate follow-up.
+				s.proxyTranslator.firstPublish.clientDeparted(e.Latest().ResourceName())
 			}
 
 			kmetrics.EndResourceXDSSync(kmetrics.ResourceSyncDetails{

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -157,13 +157,14 @@ func NewProxySyncer(
 	commonCols *collections.CommonCollections,
 	xdsCache envoycache.SnapshotCache,
 	validator validator.Validator,
+	xdsClientState priorXDSVersionReader,
 ) *ProxySyncer {
 	return &ProxySyncer{
 		controllerName:           controllerName,
 		commonCols:               commonCols,
 		mgr:                      mgr,
 		apiClient:                client,
-		proxyTranslator:          NewProxyTranslator(xdsCache),
+		proxyTranslator:          NewProxyTranslator(xdsCache, xdsClientState),
 		uniqueClients:            uniqueClients,
 		translator:               translator.NewCombinedTranslator(ctx, mergedPlugins, commonCols, validator),
 		plugins:                  mergedPlugins,
@@ -172,18 +173,24 @@ func NewProxySyncer(
 	}
 }
 
+type priorXDSVersionReader interface {
+	HasPriorXDSVersion(resourceName string) bool
+}
+
 type ProxyTranslator struct {
-	xdsCache envoycache.SnapshotCache
+	xdsCache       envoycache.SnapshotCache
+	xdsClientState priorXDSVersionReader
 	// firstPublish bounds the first publish for never-published clients (see
 	// kube_gw_translator_syncer.go). Pointer so the state is shared across
 	// ProxyTranslator copies.
 	firstPublish *firstPublishGate
 }
 
-func NewProxyTranslator(xdsCache envoycache.SnapshotCache) ProxyTranslator {
+func NewProxyTranslator(xdsCache envoycache.SnapshotCache, xdsClientState priorXDSVersionReader) ProxyTranslator {
 	return ProxyTranslator{
-		xdsCache:     xdsCache,
-		firstPublish: newFirstPublishGate(),
+		xdsCache:       xdsCache,
+		xdsClientState: xdsClientState,
+		firstPublish:   newFirstPublishGate(),
 	}
 }
 

--- a/pkg/kgateway/proxy_syncer/xdswrapper.go
+++ b/pkg/kgateway/proxy_syncer/xdswrapper.go
@@ -3,6 +3,7 @@ package proxy_syncer
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	udpaannontations "github.com/cncf/xds/go/udpa/annotations"
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -29,6 +30,19 @@ type XdsSnapWrapper struct {
 	erroredClusters []string
 	// +noKrtEquals
 	proxyKey string
+	// deferred marks a snapshot built while its per-client inputs were not yet
+	// coherent (see snapshotPerClient's guards). A deferred snapshot is
+	// withheld from a client that already holds a published snapshot — Envoy
+	// keeps its last coherent config — and is published to a never-published
+	// client only after the first-publish budget expires (see syncXds), since
+	// for a client with no config at all an incomplete snapshot beats no
+	// listeners (the pod never goes Ready and crash-loops). Warm-client
+	// make-before-break is unchanged from #13868: deferral keeps last-good
+	// with no deadline.
+	deferred bool
+	// deferReasons lists which guards were not satisfied, for the defer
+	// metric. Empty when not deferred.
+	deferReasons []string
 }
 
 func (p XdsSnapWrapper) WithSnapshot(snap *envoycache.Snapshot) XdsSnapWrapper {
@@ -39,6 +53,9 @@ func (p XdsSnapWrapper) WithSnapshot(snap *envoycache.Snapshot) XdsSnapWrapper {
 var _ krt.ResourceNamer = XdsSnapWrapper{}
 
 func (p XdsSnapWrapper) Equals(in XdsSnapWrapper) bool {
+	if p.deferred != in.deferred || !slices.Equal(p.deferReasons, in.deferReasons) {
+		return false
+	}
 	// check that all the versions are the equal
 	for i, r := range p.snap.Resources {
 		if r.Version != in.snap.Resources[i].Version {

--- a/pkg/kgateway/proxy_syncer/xdswrapper.go
+++ b/pkg/kgateway/proxy_syncer/xdswrapper.go
@@ -32,11 +32,12 @@ type XdsSnapWrapper struct {
 	proxyKey string
 	// deferred marks a snapshot built while its per-client inputs were not yet
 	// coherent (see snapshotPerClient's guards). A deferred snapshot is
-	// withheld from a client that already holds a published snapshot — Envoy
-	// keeps its last coherent config — and is published to a never-published
-	// client only after the first-publish budget expires (see syncXds), since
-	// for a client with no config at all an incomplete snapshot beats no
-	// listeners (the pod never goes Ready and crash-loops). Warm-client
+	// withheld from a warm client — one that either already holds a published
+	// snapshot in this controller's cache or reported a prior accepted xDS
+	// version — so Envoy keeps its last coherent config. It is published only
+	// after the first-publish budget expires for a client with no local
+	// snapshot and no prior-version signal (see syncXds), since that client
+	// may otherwise sit at no listeners and never go Ready. Warm-client
 	// make-before-break is unchanged from #13868: deferral keeps last-good
 	// with no deadline.
 	deferred bool

--- a/pkg/kgateway/setup/setup.go
+++ b/pkg/kgateway/setup/setup.go
@@ -298,7 +298,7 @@ func (s *setup) Start(ctx context.Context) error {
 		return err
 	}
 
-	uniqueClientCallbacks, uccBuilder := krtcollections.NewUniquelyConnectedClients(s.extraXDSCallbacks, s.globalSettings.XdsAuth)
+	uniqueClientCallbacks, uccBuilder, xdsClientState := krtcollections.NewUniquelyConnectedClients(s.extraXDSCallbacks, s.globalSettings.XdsAuth)
 
 	authenticators := []security.Authenticator{
 		NewKubeJWTAuthenticator(s.apiClient.Kube()),
@@ -371,7 +371,7 @@ func (s *setup) Start(ctx context.Context) error {
 		}
 	}
 
-	err = s.buildKgatewayWithConfig(ctx, mgr, setupOpts, commoncol, uccBuilder)
+	err = s.buildKgatewayWithConfig(ctx, mgr, setupOpts, commoncol, uccBuilder, xdsClientState)
 	if err != nil {
 		return err
 	}
@@ -394,6 +394,7 @@ func (s *setup) buildKgatewayWithConfig(
 	setupOpts *controller.SetupOpts,
 	commonCollections *collections.CommonCollections,
 	uccBuilder krtcollections.UniquelyConnectedClientsBulider,
+	xdsClientState krtcollections.XDSClientState,
 ) error {
 	slog.Info("creating krt collections")
 	krtOpts := krtutil.NewKrtOptions(ctx.Done(), setupOpts.KrtDebugger)
@@ -429,6 +430,7 @@ func (s *setup) buildKgatewayWithConfig(
 		Client:                      s.apiClient,
 		AugmentedPods:               augmentedPods,
 		UniqueClients:               ucc,
+		XDSClientState:              xdsClientState,
 		Dev:                         logging.MustGetLevel(logging.DefaultComponent) <= logging.LevelTrace,
 		KrtOptions:                  krtOpts,
 		CommonCollections:           commonCollections,

--- a/pkg/krtcollections/uniqueclients.go
+++ b/pkg/krtcollections/uniqueclients.go
@@ -47,6 +47,7 @@ type callbacksCollection struct {
 	clients          map[int64]ConnectedClient
 	uniqClientsCount map[string]uint64
 	uniqClients      map[string]ir.UniqlyConnectedClient
+	priorXDSVersions map[string]struct{}
 	stateLock        sync.RWMutex
 
 	trigger *krt.RecomputeTrigger
@@ -97,13 +98,17 @@ func (x *callbacks) getPeerInfo(sid int64, r *envoy_service_discovery_v3.Discove
 // If augmentedPods is nil, we won't use the pod locality info, and all pods for the same gateway will receive the same config.
 type UniquelyConnectedClientsBulider func(ctx context.Context, krtOpts krtutil.KrtOptions, augmentedPods krt.Collection[LocalityPod]) krt.Collection[ir.UniqlyConnectedClient]
 
+type XDSClientState interface {
+	HasPriorXDSVersion(resourceName string) bool
+}
+
 // THIS IS THE SET OF THINGS WE RUN TRANSLATION FOR
 // add returned callbacks to the xds server.
 
 func NewUniquelyConnectedClients(
 	extraXDSCallbacks xdsserver.Callbacks,
 	xdsAuth bool,
-) (xdsserver.Callbacks, UniquelyConnectedClientsBulider) {
+) (xdsserver.Callbacks, UniquelyConnectedClientsBulider, XDSClientState) {
 	cb := &callbacks{
 		extraXDSCallbacks: extraXDSCallbacks,
 		xdsAuth:           xdsAuth,
@@ -115,7 +120,7 @@ func NewUniquelyConnectedClients(
 		StreamRequestFunc: cb.OnStreamRequest,
 		FetchRequestFunc:  cb.OnFetchRequest,
 	}
-	return envoycb, buildCollection(cb)
+	return envoycb, buildCollection(cb), cb
 }
 
 func buildCollection(callbacks *callbacks) UniquelyConnectedClientsBulider {
@@ -127,6 +132,7 @@ func buildCollection(callbacks *callbacks) UniquelyConnectedClientsBulider {
 			clients:          make(map[int64]ConnectedClient),
 			uniqClientsCount: make(map[string]uint64),
 			uniqClients:      make(map[string]ir.UniqlyConnectedClient),
+			priorXDSVersions: make(map[string]struct{}),
 			trigger:          trigger,
 		}
 
@@ -190,6 +196,7 @@ func (x *callbacksCollection) del(sid int64) *ir.UniqlyConnectedClient {
 			ucc := x.uniqClients[resourceName]
 			delete(x.uniqClientsCount, resourceName)
 			delete(x.uniqClients, resourceName)
+			delete(x.priorXDSVersions, resourceName)
 			return &ucc
 		}
 	}
@@ -298,6 +305,9 @@ func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3
 	if ucc == "" {
 		return fmt.Errorf("got empty unique client name for sid %d", sid)
 	}
+	if hasPriorXDSVersion(r) {
+		x.markPriorXDSVersion(ucc)
+	}
 
 	nodeMd := r.GetNode().GetMetadata()
 	if nodeMd == nil {
@@ -317,6 +327,31 @@ func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3
 		x.trigger.TriggerRecomputation()
 	}
 	return nil
+}
+
+func hasPriorXDSVersion(r *envoy_service_discovery_v3.DiscoveryRequest) bool {
+	return r.GetResponseNonce() == "" && r.GetVersionInfo() != ""
+}
+
+func (x *callbacksCollection) markPriorXDSVersion(resourceName string) {
+	x.stateLock.Lock()
+	defer x.stateLock.Unlock()
+	x.priorXDSVersions[resourceName] = struct{}{}
+}
+
+func (x *callbacks) HasPriorXDSVersion(resourceName string) bool {
+	c := x.collection.Load()
+	if c == nil {
+		return false
+	}
+	return c.hasPriorXDSVersion(resourceName)
+}
+
+func (x *callbacksCollection) hasPriorXDSVersion(resourceName string) bool {
+	x.stateLock.RLock()
+	defer x.stateLock.RUnlock()
+	_, ok := x.priorXDSVersions[resourceName]
+	return ok
 }
 
 func (x *callbacksCollection) getClients() []ir.UniqlyConnectedClient {

--- a/pkg/krtcollections/uniqueclients_test.go
+++ b/pkg/krtcollections/uniqueclients_test.go
@@ -7,6 +7,7 @@ import (
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoyresource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"istio.io/istio/pkg/kube/krt"
@@ -189,7 +190,7 @@ func TestUniqueClients(t *testing.T) {
 				pods.WaitUntilSynced(context.Background().Done())
 			}
 
-			cb, uccBuilder := NewUniquelyConnectedClients(nil, false)
+			cb, uccBuilder, _ := NewUniquelyConnectedClients(nil, false)
 			ucc := uccBuilder(context.Background(), krtutil.KrtOptions{}, pods)
 			ucc.WaitUntilSynced(context.Background().Done())
 
@@ -242,6 +243,57 @@ func TestUniqueClients(t *testing.T) {
 			}, "5s").Should(BeEmpty())
 		})
 	}
+}
+
+func TestUniqueClientsTracksPriorXDSVersion(t *testing.T) {
+	g := NewWithT(t)
+	cb, uccBuilder, clientState := NewUniquelyConnectedClients(nil, false)
+	ucc := uccBuilder(context.Background(), krtutil.KrtOptions{}, nil)
+	ucc.WaitUntilSynced(context.Background().Done())
+
+	req := &envoy_service_discovery_v3.DiscoveryRequest{
+		TypeUrl:     envoyresource.ListenerType,
+		VersionInfo: "already-accepted",
+		Node: &envoycorev3.Node{
+			Metadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					xds.RoleKey: structpb.NewStringValue(wellknown.GatewayApiProxyValue + "~warm-proxy"),
+				},
+			},
+		},
+	}
+	g.Expect(cb.OnStreamRequest(1, req)).To(Succeed())
+	clientKey := req.GetNode().GetMetadata().GetFields()[xds.RoleKey].GetStringValue()
+	g.Expect(clientState.HasPriorXDSVersion(clientKey)).To(BeTrue())
+
+	cb.OnStreamClosed(1, nil)
+	g.Eventually(ucc.List, "5s").Should(BeEmpty())
+	g.Expect(clientState.HasPriorXDSVersion(clientKey)).To(BeFalse())
+}
+
+func TestUniqueClientsDoesNotTrackCurrentStreamACKAsPriorXDSVersion(t *testing.T) {
+	g := NewWithT(t)
+	cb, uccBuilder, clientState := NewUniquelyConnectedClients(nil, false)
+	ucc := uccBuilder(context.Background(), krtutil.KrtOptions{}, nil)
+	ucc.WaitUntilSynced(context.Background().Done())
+
+	req := &envoy_service_discovery_v3.DiscoveryRequest{
+		TypeUrl:       envoyresource.ListenerType,
+		VersionInfo:   "acked-on-this-stream",
+		ResponseNonce: "nonce",
+		Node: &envoycorev3.Node{
+			Metadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					xds.RoleKey: structpb.NewStringValue(wellknown.GatewayApiProxyValue + "~cold-proxy"),
+				},
+			},
+		},
+	}
+	g.Expect(cb.OnStreamRequest(1, req)).To(Succeed())
+	clientKey := req.GetNode().GetMetadata().GetFields()[xds.RoleKey].GetStringValue()
+	g.Expect(clientState.HasPriorXDSVersion(clientKey)).To(BeFalse())
+
+	cb.OnStreamClosed(1, nil)
 }
 
 func TestNormalizeGatewayRole(t *testing.T) {

--- a/test/e2e/features/loadtesting/strictchurn_suite.go
+++ b/test/e2e/features/loadtesting/strictchurn_suite.go
@@ -1,0 +1,726 @@
+//go:build e2e
+
+package loadtesting
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
+	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
+)
+
+// StrictChurn is a control-plane convergence test for the per-client xDS
+// pipeline under its worst-case field shape (#14184): strict validation
+// (every translated cluster pays an external envoy invocation), a few hundred
+// backends, sustained route/Service churn including a dangling backend
+// reference, and a controller restart mid-churn. It asserts the properties
+// the per-client liveness work guarantees:
+//
+//   - stable routes keep serving throughout churn and across the restart
+//     (connected clients are never stranded on stale or withheld config);
+//   - new config still converges after the churn stops (a route created
+//     post-churn becomes routable within a bound);
+//   - per-client snapshot deferrals plateau once inputs are consistent
+//     (kgateway_xds_snapshot_perclient_defers_total stops increasing), and
+//     any deferral episode is followed by a recovery
+//     (kgateway_xds_snapshot_perclient_recoveries_total).
+//
+// The suite mutates the controller deployment (KGW_VALIDATION_MODE=STRICT)
+// and restores it on teardown, so it must not share a cluster with suites that
+// assume a steady controller. It is registered with the suite runner but
+// excluded from shared CI e2e clusters; run it via the dedicated nightly job or
+// `make run-load-tests-strict-churn`.
+
+// Scale and timing knobs. The scale is sized so a full per-client fan-out is
+// hundreds of strict validations per connected client — large enough that a
+// wedged or backlogged pipeline fails the convergence bounds, small enough to
+// run on a laptop kind cluster in a few minutes.
+const (
+	strictChurnCycles  = 8
+	churnCycleInterval = 5 * time.Second
+	// endpointChurnInterval paces the background EndpointSlice rewriter that
+	// keeps the fleet's endpoints from ever quiescing during phases 4-5.
+	endpointChurnInterval = 250 * time.Millisecond
+	// gatewayRolloutBound is how long a rolling-restarted gateway Envoy has to
+	// come back Ready. A fresh Envoy is a brand-new xDS client with no
+	// fallback config: if its first snapshot is withheld indefinitely, the
+	// pod never reports Ready and the rollout wedges ("gateways are unable to
+	// spawn"). Generous enough to absorb one full per-client rebuild on a
+	// healthy control plane.
+	gatewayRolloutBound = "180s"
+
+	// stableRouteBound is how quickly the stable route must answer 200 at
+	// every checkpoint during churn. It was reachable before churn started,
+	// so any sustained failure means the data plane lost working config.
+	stableRouteBound = 30 * time.Second
+	// convergenceBound is how quickly a route created after the churn stops
+	// must become routable end to end. This is the liveness property: the
+	// per-client pipeline still publishes after churn plus a restart.
+	convergenceBound = 90 * time.Second
+	// plateauWindow and plateauTimeout bound the defers-stop-increasing
+	// assertion: two samples plateauWindow apart must be equal within
+	// plateauTimeout of churn ending.
+	plateauWindow  = 10 * time.Second
+	plateauTimeout = 3 * time.Minute
+
+	strictChurnMetricsService = "kgateway-loadtest-metrics"
+	metricsPort               = 9092
+
+	defersMetric           = "kgateway_xds_snapshot_perclient_defers_total"
+	recoveriesMetric       = "kgateway_xds_snapshot_perclient_recoveries_total"
+	boundedPublishesMetric = "kgateway_xds_snapshot_perclient_bounded_publishes_total"
+
+	stableRouteHost    = "stable.strict-churn.example.com"
+	postChurnRouteHost = "postchurn.strict-churn.example.com"
+)
+
+var strictChurnGateways = []string{"churn-gw-1", "churn-gw-2"}
+
+// Fleet scale, overridable to push past the laptop-friendly defaults when
+// hunting load-dependent behavior (e.g. KGW_LOADTEST_BACKENDS=800).
+var (
+	strictChurnBackends = envScale("KGW_LOADTEST_BACKENDS", 200)
+	strictChurnRoutes   = envScale("KGW_LOADTEST_ROUTES", 200)
+)
+
+func envScale(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// controllerAppName returns the app.kubernetes.io/name of the controller under
+// test. Defaults to the OSS controller; override with
+// KGW_LOADTEST_CONTROLLER_APP (e.g. for a downstream distribution) to point
+// the deployment lookup and metrics scrape at a differently-labeled control
+// plane. The gateway class is not parameterized — create a GatewayClass named
+// "kgateway" bound to the distribution's controllerName instead.
+func controllerAppName() string {
+	if app := os.Getenv("KGW_LOADTEST_CONTROLLER_APP"); app != "" {
+		return app
+	}
+	return "kgateway"
+}
+
+func controllerSelector() string {
+	return fmt.Sprintf("%s=%s", testdefaults.WellKnownAppLabel, controllerAppName())
+}
+
+var _ e2e.NewSuiteFunc = NewStrictChurnSuite
+
+func NewStrictChurnSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &StrictChurnSuite{
+		LoadTestingSuite: LoadTestingSuite{
+			Suite:            suite.Suite{},
+			ctx:              ctx,
+			testInstallation: testInst,
+		},
+	}
+}
+
+type StrictChurnSuite struct {
+	LoadTestingSuite
+	loadTestManager      *LoadTestManager
+	installNamespace     string
+	controllerDeployment string
+}
+
+func (s *StrictChurnSuite) SetupSuite() {
+	// Hard opt-in gate, independent of -run regexes: this suite mutates the
+	// controller deployment (strict validation env, a mid-test restart), so a
+	// broad invocation like the nightly's unanchored `^TestKgateway` matcher
+	// must not pick it up implicitly. `make run-load-tests-strict-churn` sets
+	// the variable.
+	if os.Getenv("KGW_ENABLE_STRICT_CHURN") != "true" {
+		s.T().Skip("StrictChurn mutates the controller deployment; set KGW_ENABLE_STRICT_CHURN=true (or use `make run-load-tests-strict-churn`) to run it")
+	}
+	s.loadTestManager = NewLoadTestManager(s.ctx, s.testInstallation,
+		fmt.Sprintf("kgateway-strictchurn-%d", time.Now().UnixNano()))
+	s.installNamespace = s.testInstallation.Metadata.InstallNamespace
+
+	name, err := s.resolveControllerDeployment()
+	s.Require().NoError(err, "should find the kgateway controller deployment in %s", s.installNamespace)
+	s.controllerDeployment = name
+
+	// The curl pod issues both data-plane probes and metrics scrapes; nginx is
+	// the real backend behind the stable and post-churn routes (the simulated
+	// services have unroutable endpoints, so they can't answer traffic).
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, testdefaults.CurlPodManifest)
+	s.Require().NoError(err, "should apply curl pod")
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, testdefaults.NginxPodManifest)
+	s.Require().NoError(err, "should apply nginx backend")
+	s.testInstallation.AssertionsT(s.T()).EventuallyPodsRunning(s.ctx,
+		testdefaults.CurlPod.GetNamespace(), metav1.ListOptions{LabelSelector: testdefaults.CurlPodLabelSelector})
+	s.testInstallation.AssertionsT(s.T()).EventuallyPodsRunning(s.ctx,
+		testdefaults.NginxPod.GetNamespace(), metav1.ListOptions{
+			FieldSelector: "metadata.name=" + testdefaults.NginxPod.GetName(),
+		})
+
+	s.Require().NoError(s.createMetricsService(), "should expose controller metrics")
+
+	s.T().Logf("Enabling strict validation on deployment/%s in %s", s.controllerDeployment, s.installNamespace)
+	s.Require().NoError(s.setValidationMode("KGW_VALIDATION_MODE=STRICT"))
+}
+
+func (s *StrictChurnSuite) TearDownSuite() {
+	// SetupSuite skipped (opt-in gate) before creating anything: do not touch
+	// the cluster — the curl/nginx manifests may be in use by other suites.
+	if s.loadTestManager == nil {
+		return
+	}
+	// Restore the controller before anything else so a failed run doesn't
+	// leave the install in strict mode for whoever uses the cluster next.
+	if s.controllerDeployment != "" {
+		if err := s.setValidationMode("KGW_VALIDATION_MODE-"); err != nil {
+			s.T().Logf("WARNING: failed to restore validation mode: %v", err)
+		}
+	}
+	if s.loadTestManager != nil {
+		s.loadTestManager.CleanupAll()
+	}
+	_ = s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, testdefaults.NginxPodManifest)
+	_ = s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, testdefaults.CurlPodManifest)
+}
+
+func (s *StrictChurnSuite) resolveControllerDeployment() (string, error) {
+	out, _, err := s.testInstallation.ClusterContext.Cli.Execute(s.ctx,
+		"get", "deploy", "-n", s.installNamespace,
+		"-l", controllerSelector(),
+		"-o", "jsonpath={.items[0].metadata.name}")
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(out)
+	if name == "" {
+		return "", fmt.Errorf("no deployment matching %q in %s", controllerSelector(), s.installNamespace)
+	}
+	return name, nil
+}
+
+// setValidationMode applies a `kubectl set env` expression (KEY=VALUE or KEY-)
+// to the controller deployment and waits for the resulting rollout.
+func (s *StrictChurnSuite) setValidationMode(envExpr string) error {
+	if err := s.testInstallation.Actions.Kubectl().RunCommand(s.ctx,
+		"set", "env", "-n", s.installNamespace,
+		"deployment/"+s.controllerDeployment, envExpr); err != nil {
+		return err
+	}
+	return s.testInstallation.Actions.Kubectl().DeploymentRolloutStatus(s.ctx,
+		s.controllerDeployment, "-n", s.installNamespace, "--timeout=120s")
+}
+
+// createMetricsService exposes the controller's metrics port inside the
+// cluster so the curl pod can scrape it. The default install has no metrics
+// Service; the e2e metrics feature creates its own, so this one gets a
+// distinct name to avoid colliding if both ever share a cluster.
+func (s *StrictChurnSuite) createMetricsService() error {
+	return s.loadTestManager.createResource(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strictChurnMetricsService,
+			Namespace: s.installNamespace,
+			Labels:    map[string]string{"loadtest": "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{testdefaults.WellKnownAppLabel: controllerAppName()},
+			Ports: []corev1.ServicePort{{
+				Name:       "metrics",
+				Port:       metricsPort,
+				TargetPort: intstr.FromString("metrics"),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	})
+}
+
+func (s *StrictChurnSuite) TestStrictChurnConvergence() {
+	s.T().Log("=== StrictChurn: strict validation + route/Service churn + controller restart ===")
+
+	// Phase 1: scale fixture — fake Services/EndpointSlices and baseline routes.
+	s.Require().NoError(s.loadTestManager.SetupSimulation(strictChurnBackends, "strict-churn"),
+		"should setup cluster simulation")
+	s.Require().NoError(s.loadTestManager.SetupTestInfrastructure(), "should setup test infrastructure")
+	s.createReferenceGrants()
+
+	s.Require().NoError(s.loadTestManager.CreateGateways(strictChurnGateways), "should create gateways")
+	s.Require().NoError(s.loadTestManager.WaitForGatewayReadiness(gatewayReadinessTimeout), "gateways should be ready")
+
+	config := &AttachedRoutesConfig{
+		Gateways:    strictChurnGateways,
+		Routes:      strictChurnRoutes,
+		GracePeriod: GetConfig(strictChurnRoutes).GracePeriod,
+		BatchSize:   GetOptimalBatchSize(strictChurnRoutes),
+	}
+	s.Require().NoError(s.loadTestManager.CreateRoutesBatched(config), "should create baseline routes")
+	s.waitForAttachedRoutes(strictChurnGateways[0], strictChurnRoutes/len(strictChurnGateways), translationCompletionTimeout)
+
+	// Phase 2: a stable route to a real backend, verified working before any
+	// churn. This is the route that must never break.
+	s.createRouteToNginx("stable-route", strictChurnGateways[0], stableRouteHost)
+	s.assertRouteServes(strictChurnGateways[0], stableRouteHost, stableRouteBound)
+	s.T().Log("Stable route serving 200 — starting churn")
+
+	// Phase 3: two permanently-unhealthy references that persist through the
+	// run, attached to the stable route's gateway. The dangling route's
+	// Service never exists (unresolvable backend); the starved route's
+	// Service exists but its selector matches no pods, so the referenced EDS
+	// cluster never gets a ready endpoint — the "stable service with no
+	// ready CLA" shape that historically wedged the all-or-nothing
+	// consistency gate for the whole gateway. A correct control plane must
+	// keep publishing for the rest of the gateway's config regardless.
+	s.createDanglingRoute(strictChurnGateways[0])
+	s.createStarvedRoute(strictChurnGateways[0])
+
+	// Phase 4: churn — create/delete a Service+EndpointSlice and a route each
+	// cycle, restart the controller halfway through, and require the stable
+	// route back at 200 before the next cycle. A background churner also
+	// rewrites the simulated fleet's EndpointSlices continuously: real
+	// clusters never quiesce, and an all-or-nothing consistency gate that
+	// requires a globally-consistent instant will never find one while
+	// endpoints keep moving. (This is the load shape that separates a
+	// bounded-wait control plane from a wedged one; quiet-endpoint runs
+	// converge even on builds with the unbounded gate.)
+	defersBeforeChurn := s.scrapeCounterSum(defersMetric)
+	churnerCtx, stopChurner := context.WithCancel(s.ctx)
+	defer stopChurner()
+	s.startEndpointChurner(churnerCtx)
+	for cycle := range strictChurnCycles {
+		s.runChurnCycle(cycle)
+
+		// Client identity churn: roll each gateway's Envoy once mid-run. A
+		// rolled pod reconnects as a brand-new xDS client whose first
+		// snapshot must be built from scratch while the fleet churns —
+		// completion is asserted after the loop (gatewayRolloutBound).
+		switch cycle {
+		case 2:
+			s.rollGateway(strictChurnGateways[0])
+		case 5:
+			s.rollGateway(strictChurnGateways[1])
+		}
+
+		if cycle == strictChurnCycles/2 {
+			s.T().Logf("Cycle %d: restarting controller mid-churn", cycle)
+			s.Require().NoError(s.testInstallation.Actions.Kubectl().RestartDeploymentAndWait(s.ctx,
+				s.controllerDeployment, "-n", s.installNamespace), "controller should restart cleanly mid-churn")
+		}
+
+		s.assertRouteServes(strictChurnGateways[0], stableRouteHost, stableRouteBound)
+		time.Sleep(churnCycleInterval)
+	}
+
+	// Phase 4b: every rolled gateway must finish its rollout — the freshly
+	// started Envoy only reports Ready once it has received config, so a
+	// control plane that withholds a new client's first snapshot indefinitely
+	// fails here with a wedged rollout.
+	for _, gw := range strictChurnGateways {
+		s.Require().NoError(s.testInstallation.Actions.Kubectl().DeploymentRolloutStatus(s.ctx,
+			gw, "-n", s.loadTestManager.testNamespace, "--timeout="+gatewayRolloutBound),
+			"gateway %s rollout must complete: a fresh Envoy client must receive its first xDS snapshot", gw)
+	}
+	s.T().Log("Route churn + gateway rolls complete — asserting convergence under live endpoint churn")
+
+	// Phase 5: liveness — config created while the fleet's endpoints are
+	// still moving must flow to the data plane within the bound. This is the
+	// assertion that separates a bounded-wait publisher from an
+	// all-or-nothing gate: the latter waits for a globally-consistent
+	// instant that a busy fleet never provides.
+	s.createRouteToNginx("postchurn-route", strictChurnGateways[1], postChurnRouteHost)
+	s.assertRouteServes(strictChurnGateways[1], postChurnRouteHost, convergenceBound)
+	stopChurner()
+
+	// Phase 6: the defer counter must plateau — two samples plateauWindow
+	// apart with no increments. A sustained defer rate after inputs settle is
+	// exactly the wedge signature this scenario exists to catch.
+	var lastDefers float64 = -1
+	s.Require().Eventually(func() bool {
+		current := s.scrapeCounterSum(defersMetric)
+		plateaued := lastDefers >= 0 && current == lastDefers
+		if !plateaued {
+			s.T().Logf("defers_total=%v (waiting for plateau)", current)
+		}
+		lastDefers = current
+		return plateaued
+	}, plateauTimeout, plateauWindow, "per-client defers must stop increasing after churn ends")
+
+	// Phase 7: every defer episode must have healed. The counters reset on
+	// the mid-churn restart, so compare against the post-restart baseline.
+	finalDefers := s.scrapeCounterSum(defersMetric)
+	finalRecoveries := s.scrapeCounterSum(recoveriesMetric)
+	finalBoundedFirst := s.scrapeCounterSumMatching(boundedPublishesMetric, `mode="first_publish"`)
+	finalBoundedCarry := s.scrapeCounterSumMatching(boundedPublishesMetric, `mode="carry_forward"`)
+	s.T().Logf("Final counters: defers_total=%v (pre-churn %v), recoveries_total=%v, bounded_publishes_total{first_publish}=%v, bounded_publishes_total{carry_forward}=%v",
+		finalDefers, defersBeforeChurn, finalRecoveries, finalBoundedFirst, finalBoundedCarry)
+	if finalDefers > 0 {
+		s.Require().GreaterOrEqual(finalRecoveries, float64(1),
+			"clients were deferred (%v defers) but never recovered; per-client publication is wedged", finalDefers)
+	}
+
+	s.T().Log("=== StrictChurn PASSED: stable traffic held, post-churn config converged, defers plateaued ===")
+}
+
+// runChurnCycle creates this cycle's Service+EndpointSlice+route, then deletes
+// the previous cycle's, so the controller continuously sees backend and route
+// add/remove events without the resource count growing.
+func (s *StrictChurnSuite) runChurnCycle(cycle int) {
+	simNS := s.loadTestManager.simulator.config.Namespace
+	svcName := fmt.Sprintf("churn-svc-%d", cycle)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: simNS,
+			Labels:    map[string]string{"loadtest": "true", "churn": "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": svcName},
+			Ports: []corev1.ServicePort{{
+				Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
+	port := int32(8080)
+	portName := "http"
+	protocol := corev1.ProtocolTCP
+	eps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: simNS,
+			Labels: map[string]string{
+				"kubernetes.io/service-name": svcName,
+				"loadtest":                   "true",
+				"churn":                      "true",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses: []string{fmt.Sprintf("10.250.0.%d", (cycle%250)+1)},
+		}},
+		Ports: []discoveryv1.EndpointPort{{Name: &portName, Port: &port, Protocol: &protocol}},
+	}
+	route := s.buildChurnRoute(fmt.Sprintf("churn-route-%d", cycle), strictChurnGateways[cycle%len(strictChurnGateways)],
+		fmt.Sprintf("churn-%d.strict-churn.example.com", cycle), svcName, simNS)
+
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, svc), "churn service create")
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, eps), "churn endpointslice create")
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "churn route create")
+
+	// Delete the previous cycle's resources (kept alive one cycle so the
+	// controller always overlaps an add with a remove).
+	if cycle > 0 {
+		prev := cycle - 1
+		prevSvc := fmt.Sprintf("churn-svc-%d", prev)
+		_ = s.testInstallation.Actions.Kubectl().RunCommand(s.ctx,
+			"delete", "httproute", fmt.Sprintf("churn-route-%d", prev),
+			"-n", s.loadTestManager.testNamespace, "--ignore-not-found", "--wait=false")
+		_ = s.testInstallation.Actions.Kubectl().RunCommand(s.ctx,
+			"delete", "service", prevSvc, "-n", simNS, "--ignore-not-found", "--wait=false")
+		_ = s.testInstallation.Actions.Kubectl().RunCommand(s.ctx,
+			"delete", "endpointslice", prevSvc, "-n", simNS, "--ignore-not-found", "--wait=false")
+	}
+	// The last cycle's leftovers are deleted by namespace teardown.
+}
+
+func (s *StrictChurnSuite) createDanglingRoute(gateway string) {
+	route := s.buildChurnRoute("dangling-route", gateway,
+		"dangling.strict-churn.example.com", "no-such-service", s.loadTestManager.testNamespace)
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "dangling route create")
+	s.loadTestManager.createdRoutes = append(s.loadTestManager.createdRoutes, route)
+}
+
+// startEndpointChurner continuously rewrites simulated EndpointSlices, one
+// every endpointChurnInterval, rotating through the fleet. Each write is a
+// real input change (the endpoint IP moves), so every referenced backend's
+// per-client endpoint translation keeps re-running for every connected
+// client — the steady-state load shape of a production fleet where pods are
+// always rolling somewhere.
+func (s *StrictChurnSuite) startEndpointChurner(ctx context.Context) {
+	cfg := s.loadTestManager.simulator.config
+	simNS := cfg.Namespace
+	// The simulator sizes the fleet itself: the number of sim-service-*
+	// EndpointSlices is FakeNodeCount*ServicesPerNode, NOT strictChurnBackends.
+	// Rotate over what actually exists or the churner runs off the end of the
+	// fleet and stops producing churn.
+	totalSimServices := cfg.FakeNodeCount * cfg.ServicesPerNode
+	s.Require().Positive(totalSimServices, "simulation must have services to churn")
+	go func() {
+		ticker := time.NewTicker(endpointChurnInterval)
+		defer ticker.Stop()
+		attempts, writes := 0, 0
+		for {
+			select {
+			case <-ctx.Done():
+				s.T().Logf("Endpoint churner stopped after %d EndpointSlice rewrites (%d attempts)", writes, attempts)
+				return
+			case <-ticker.C:
+			}
+			idx := attempts % totalSimServices
+			ip := fmt.Sprintf("10.246.%d.%d", (attempts/250)%200, attempts%250+1)
+			// Advance every tick regardless of outcome so one unpatchable
+			// slice can never wedge the rotation.
+			attempts++
+			patch := fmt.Sprintf(`[{"op":"replace","path":"/endpoints/0/addresses/0","value":%q}]`, ip)
+			eps := &discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("sim-service-%d", idx), Namespace: simNS,
+			}}
+			if err := s.testInstallation.ClusterContext.Client.Patch(ctx, eps,
+				client.RawPatch(types.JSONPatchType, []byte(patch))); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				s.T().Logf("endpoint churn patch failed (continuing): %v", err)
+				continue
+			}
+			writes++
+		}
+	}()
+}
+
+// rollGateway triggers a rolling restart of a gateway's Envoy deployment
+// (named after the Gateway by the deployer) without waiting — completion is
+// asserted later against gatewayRolloutBound.
+func (s *StrictChurnSuite) rollGateway(gateway string) {
+	s.T().Logf("Rolling gateway %s (new xDS client identity)", gateway)
+	s.Require().NoError(s.testInstallation.Actions.Kubectl().RestartDeployment(s.ctx,
+		gateway, "-n", s.loadTestManager.testNamespace), "should roll gateway %s", gateway)
+}
+
+// createStarvedRoute creates a Service whose selector matches no pods plus a
+// route referencing it: the backendRef resolves (the Service exists), so the
+// gateway's referenced-cluster set permanently contains an EDS cluster that
+// will never have a ready endpoint.
+func (s *StrictChurnSuite) createStarvedRoute(gateway string) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "starved-svc",
+			Namespace: s.loadTestManager.testNamespace,
+			Labels:    map[string]string{"loadtest": "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "starved-no-such-pod"},
+			Ports: []corev1.ServicePort{{
+				Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
+	s.Require().NoError(s.loadTestManager.createResource(svc), "starved service create")
+	route := s.buildChurnRoute("starved-route", gateway,
+		"starved.strict-churn.example.com", "starved-svc", s.loadTestManager.testNamespace)
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "starved route create")
+	s.loadTestManager.createdRoutes = append(s.loadTestManager.createdRoutes, route)
+}
+
+func (s *StrictChurnSuite) createRouteToNginx(name, gateway, hostname string) {
+	route := s.buildChurnRoute(name, gateway, hostname,
+		testdefaults.NginxSvc.GetName(), testdefaults.NginxSvc.GetNamespace())
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "route %s create", name)
+	s.loadTestManager.createdRoutes = append(s.loadTestManager.createdRoutes, route)
+}
+
+func (s *StrictChurnSuite) buildChurnRoute(name, gateway, hostname, backendSvc, backendNS string) *gwv1.HTTPRoute {
+	pathType := gwv1.PathMatchPathPrefix
+	pathValue := "/"
+	ns := gwv1.Namespace(backendNS)
+	port := gwv1.PortNumber(80)
+	if backendNS == testdefaults.NginxSvc.GetNamespace() {
+		port = gwv1.PortNumber(8080)
+	}
+	return &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: s.loadTestManager.testNamespace,
+			Labels:    map[string]string{"loadtest": "true"},
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{{Name: gwv1.ObjectName(gateway)}},
+			},
+			Hostnames: []gwv1.Hostname{gwv1.Hostname(hostname)},
+			Rules: []gwv1.HTTPRouteRule{{
+				Matches: []gwv1.HTTPRouteMatch{{
+					Path: &gwv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				BackendRefs: []gwv1.HTTPBackendRef{{
+					BackendRef: gwv1.BackendRef{
+						BackendObjectReference: gwv1.BackendObjectReference{
+							Name:      gwv1.ObjectName(backendSvc),
+							Namespace: &ns,
+							Port:      &port,
+						},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+// createReferenceGrants permits the test namespace's routes to reference
+// Services in the simulation and nginx namespaces. Without these, every
+// cross-namespace backendRef is RefNotPermitted and no clusters are built —
+// which would silence the strict-validation load this scenario exists to apply.
+func (s *StrictChurnSuite) createReferenceGrants() {
+	for _, targetNS := range []string{
+		s.loadTestManager.simulator.config.Namespace,
+		testdefaults.NginxSvc.GetNamespace(),
+	} {
+		grant := &gwv1b1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "strict-churn-grant",
+				Namespace: targetNS,
+				Labels:    map[string]string{"loadtest": "true"},
+			},
+			Spec: gwv1b1.ReferenceGrantSpec{
+				From: []gwv1b1.ReferenceGrantFrom{{
+					Group:     gwv1b1.Group(gwv1.GroupName),
+					Kind:      "HTTPRoute",
+					Namespace: gwv1b1.Namespace(s.loadTestManager.testNamespace),
+				}},
+				To: []gwv1b1.ReferenceGrantTo{{
+					Group: "",
+					Kind:  "Service",
+				}},
+			},
+		}
+		s.Require().NoError(s.loadTestManager.createResource(grant),
+			"should create ReferenceGrant in %s", targetNS)
+	}
+}
+
+// assertRouteServes requires the given hostname to answer 200 with the nginx
+// body through the gateway's in-cluster Service within the bound.
+func (s *StrictChurnSuite) assertRouteServes(gateway, hostname string, bound time.Duration) {
+	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(metav1.ObjectMeta{
+				Name: gateway, Namespace: s.loadTestManager.testNamespace,
+			})),
+			curl.WithHostHeader(hostname),
+			curl.WithPath("/"),
+			curl.WithPort(80),
+		},
+		&testmatchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Body:       gomega.ContainSubstring(testdefaults.NginxResponse),
+		},
+		bound, 2*time.Second,
+	)
+}
+
+// waitForAttachedRoutes polls a gateway's listener status until at least
+// minRoutes report attached.
+func (s *StrictChurnSuite) waitForAttachedRoutes(gateway string, minRoutes int, timeout time.Duration) {
+	s.Require().Eventually(func() bool {
+		gw := &gwv1.Gateway{}
+		if err := s.testInstallation.ClusterContext.Client.Get(s.ctx,
+			types.NamespacedName{Namespace: s.loadTestManager.testNamespace, Name: gateway}, gw); err != nil {
+			return false
+		}
+		if len(gw.Status.Listeners) == 0 {
+			return false
+		}
+		attached := int(gw.Status.Listeners[0].AttachedRoutes)
+		s.T().Logf("Gateway %s: AttachedRoutes=%d (waiting for >=%d)", gateway, attached, minRoutes)
+		return attached >= minRoutes
+	}, timeout, translationPollingInterval, "baseline routes should attach to %s", gateway)
+}
+
+// scrapeCounterSum scrapes the controller's /metrics endpoint via the curl pod
+// and returns the sum of the named counter across all label sets. Returns 0
+// when the metric has not been emitted (a counter that never incremented is
+// absent from the exposition).
+func (s *StrictChurnSuite) scrapeCounterSum(metricName string) float64 {
+	var sum float64
+	s.Require().Eventually(func() bool {
+		resp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, testdefaults.CurlPodExecOpt,
+			curl.WithHost(kubeutils.ServiceFQDN(metav1.ObjectMeta{
+				Name: strictChurnMetricsService, Namespace: s.installNamespace,
+			})),
+			curl.WithPort(metricsPort),
+			curl.WithPath("/metrics"),
+		)
+		if err != nil {
+			s.T().Logf("metrics scrape failed (will retry): %v", err)
+			return false
+		}
+		sum = sumCounterText(resp.StdOut, metricName)
+		return true
+	}, 60*time.Second, 2*time.Second, "should scrape controller metrics")
+	return sum
+}
+
+// scrapeCounterSumMatching is scrapeCounterSum restricted to samples whose
+// label block contains labelSubstr (e.g. `mode="carry_forward"`).
+func (s *StrictChurnSuite) scrapeCounterSumMatching(metricName, labelSubstr string) float64 {
+	var sum float64
+	s.Require().Eventually(func() bool {
+		resp, err := s.testInstallation.ClusterContext.Cli.CurlFromPod(s.ctx, testdefaults.CurlPodExecOpt,
+			curl.WithHost(kubeutils.ServiceFQDN(metav1.ObjectMeta{
+				Name: strictChurnMetricsService, Namespace: s.installNamespace,
+			})),
+			curl.WithPort(metricsPort),
+			curl.WithPath("/metrics"),
+		)
+		if err != nil {
+			s.T().Logf("metrics scrape failed (will retry): %v", err)
+			return false
+		}
+		var filtered strings.Builder
+		for line := range strings.Lines(resp.StdOut) {
+			if strings.Contains(line, labelSubstr) {
+				filtered.WriteString(line)
+			}
+		}
+		sum = sumCounterText(filtered.String(), metricName)
+		return true
+	}, 60*time.Second, 2*time.Second, "should scrape controller metrics")
+	return sum
+}
+
+// sumCounterText sums every sample of the named counter in Prometheus text
+// exposition format, across all label sets.
+func sumCounterText(metricsText, metricName string) float64 {
+	var sum float64
+	for line := range strings.Lines(metricsText) {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, metricName) {
+			continue
+		}
+		rest := line[len(metricName):]
+		// Accept only "name{labels} value" or "name value" — not other
+		// metrics sharing the prefix.
+		if len(rest) == 0 || (rest[0] != '{' && rest[0] != ' ') {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if v, err := strconv.ParseFloat(fields[len(fields)-1], 64); err == nil {
+			sum += v
+		}
+	}
+	return sum
+}

--- a/test/e2e/tests/kgateway_tests.go
+++ b/test/e2e/tests/kgateway_tests.go
@@ -90,6 +90,9 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("CSRF", csrf.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("AutoHostRewrite", auto_host_rewrite.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("AttachedRoutes", loadtesting.NewAttachedRoutesSuite)
+	// StrictChurn mutates the controller deployment; hard-gated behind
+	// KGW_ENABLE_STRICT_CHURN and excluded from CI e2e clusters.
+	kubeGatewaySuiteRunner.Register("StrictChurn", loadtesting.NewStrictChurnSuite)
 	kubeGatewaySuiteRunner.Register("DirectResponse", directresponse.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("PathMatching", path_matching.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TimeoutRetry", timeoutretry.NewTestingSuite)

--- a/test/e2e/tests/kgateway_tests.go
+++ b/test/e2e/tests/kgateway_tests.go
@@ -91,7 +91,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("AutoHostRewrite", auto_host_rewrite.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("AttachedRoutes", loadtesting.NewAttachedRoutesSuite)
 	// StrictChurn mutates the controller deployment; hard-gated behind
-	// KGW_ENABLE_STRICT_CHURN and excluded from CI e2e clusters.
+	// KGW_ENABLE_STRICT_CHURN so CI shard coverage only exercises the skip path.
 	kubeGatewaySuiteRunner.Register("StrictChurn", loadtesting.NewStrictChurnSuite)
 	kubeGatewaySuiteRunner.Register("DirectResponse", directresponse.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("PathMatching", path_matching.NewTestingSuite)

--- a/test/helm/helm_version_test.go
+++ b/test/helm/helm_version_test.go
@@ -14,6 +14,12 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+func normalizeHelmTemplateGoldenOutput(in []byte) []byte {
+	// Helm v4 emits an extra blank line before some YAML document separators.
+	// Keep the goldens focused on rendered resources rather than that formatter detail.
+	return []byte(strings.ReplaceAll(string(in), "\n\n---\n# Source:", "\n---\n# Source:"))
+}
+
 func TestHelmChartVersionAndAppVersion(t *testing.T) {
 	goldenFile := filepath.Join("testdata", "helm-version-output.golden")
 	helmChartPath := filepath.Join("..", "..", "install", "helm", "kgateway")
@@ -683,7 +689,7 @@ controller:
 				err = helmCmd.Run()
 				require.NoError(t, err, "helm template failed: %s", stderr.String())
 
-				got := output.Bytes()
+				got := normalizeHelmTemplateGoldenOutput(output.Bytes())
 
 				// Golden file path: testdata/<chart>/<values-case>.golden
 				goldenDir := filepath.Join("testdata", chart)


### PR DESCRIPTION
# Description

Refs #14184. Builds on the strict-validation verdict cache (#14242 on `v2.3.x`, forward-ported to `main` as #14253, both merged) and is the comprehensive `main`-side counterpart to the minimal `v2.3.x` bound in #14266.

The per-client snapshot transform defers publication until its inputs are coherent: per-client endpoints derived, every referenced cluster present, every referenced EDS cluster backed by a usable ClusterLoadAssignment. Deferral is the right *short-term* call — inputs usually converge within a recompute or two, and a warm client keeps its last coherent config. But today the wait is **unbounded**, which produces two outage modes on busy fleets where gate evaluations keep overlapping in-flight recomputes.

## How this relates to the other #14184 PRs

- **#14242 / #14253 (merged)** removed the strict-validation fork-storm that let the per-client queue fall minutes behind — the cost that turned a brief deferral into a sustained freeze.
- **#14266 (`v2.3.x`, minimal)** adds the smallest safe first-publish bound so a never-published gateway pod stops crash-looping, plus telemetry. It deliberately omits carry-forward, the budget knob, the EDS-alignment work, and reclaim.
- **This PR (`main`, comprehensive)** is the superset of #14266's bound: it adds carry-forward merges, an operator-facing budget knob, and the EDS-vs-CDS alignment / usable-endpoint fixes (the work also proposed standalone in #14257). It targets `main` because these richer pieces are larger than the conservative `v2.3.x` patch line should carry.
- The xDS **client-identity** re-derivation (#14244) is **not** part of this PR — it fixes a different bug and lands on its own merits.

## Problem

- A client that has **never** been published anything binds no listeners and its pod never goes Ready. Rollouts wedge; under default probes the pod crash-loops, reconnects as a brand-new client, and re-triggers the full per-client fan-out — the failure feeds itself.
- A client that **is** published stays frozen on stale config indefinitely: new and changed routes never reach the data plane while anything in its input set is incoherent.
- A referenced EDS cluster that is present but **empty or stale** can pin a proxy to endpoints that no longer exist, because an empty ClusterLoadAssignment counted as "ready" and the EDS resource set was not kept in positive alignment with the CDS set.

## Fix

Split "is the snapshot coherent?" from "should it be published?", bound the wait for everyone, and keep EDS aligned with CDS.

1. **Annotate instead of withhold.** The transform's guards compute exactly as before, but a failed guard no longer drops the row. The snapshot is built, annotated `deferred` (with reasons), and explicit empty ClusterLoadAssignments are synthesized for missing EDS references so it is always self-consistent.
2. **Bounded publication policy in `syncXds`.** Coherent snapshots publish immediately. Deferred snapshots are withheld up to a budget (default 15s — the common case converges within it and the coherent snapshot wins, discarding the timer). At budget expiry the action depends on a four-way classification, because a controller-local cache miss does **not** prove a proxy is cold — after a reconnect or controller restart an Envoy is new to this process while still serving production traffic from config accepted on a prior stream:
   - **coherent** → publish immediately;
   - **warm, local cached snapshot** → merge with carry-forward: any referenced cluster or CLA the deferred snapshot is missing is retained from the currently-published snapshot (preference: new real CLA > previously-published real CLA > synthesized empty). An incomplete publish can never remove or empty a resource the client is actively using; staleness shrinks from "the whole gateway is frozen" to "only the still-incoherent references are stale," and new valid config keeps flowing under churn;
   - **warm via prior xDS version** (no local snapshot, but the client's initial ADS request reported a prior accepted version/nonce) → **withhold** — there is nothing to carry forward and publishing an incomplete SotW snapshot would replace the config the proxy is already serving, regressing #13868's make-before-break. The client keeps its last-good config until a coherent snapshot is built (which still publishes immediately). Tracked so the stale-risk is visible (see metrics);
   - **cold** (no local snapshot and no prior xDS version) → publish the latest deferred snapshot as-is: for a client with no config at all, a bounded degradation strictly beats an unbounded outage (the pod binds its listeners and goes Ready; routes to not-yet-ready clusters 503 instead of the pod crash-looping).

   Prior-xDS-version warmth is detected by recording, in the xDS callbacks, whether a client's first request carried a version/nonce, and is cleared when the UCC disconnects.
3. **EDS/CDS alignment + usable-endpoint readiness** (the #14257 work). EDS resources are positively filtered to the clusters actually in the client's CDS snapshot, with a content-derived version so the EDS version moves whenever the set changes (fixes go-control-plane suppressing named SotW EDS responses that pinned a proxy to stale endpoints). A present-but-empty CLA no longer counts as ready, and the budget+carry-forward path closes the residual gap #14257 noted in isolation.

Mechanics that make this safe: the budget timer and both publish paths share one lock, so an expiring timer can never overwrite a newer coherent snapshot; merged and synthesized resource sets always get distinct versions, so a client that received an empty or carried-forward CLA is guaranteed an update push when the real one arrives (tested); client departure cancels pending state.

## Configuration

`KGW_PER_CLIENT_PUBLISH_BUDGET` (`Settings.PerClientPublishBudget`, default `15s`) bounds the wait. `0` disables bounded publishing entirely, restoring the pre-bound withhold-forever semantics as a conservative opt-out.

## Observability

- `kgateway_xds_snapshot_perclient_defers_total{gateway,namespace,reason}` — withheld updates by guard (`endpoints_not_ready` | `missing_clusters` | `missing_endpoints`)
- `kgateway_xds_snapshot_perclient_recoveries_total{gateway,namespace}` — clients resuming coherent publication
- `kgateway_xds_snapshot_perclient_bounded_publishes_total{gateway,namespace,mode}` — budget-expiry publishes, `first_publish` vs `carry_forward`
- `kgateway_xds_snapshot_perclient_deferred_withheld_total{gateway,namespace,reason,warm_reason}` — deferred snapshots withheld from a warm client at budget expiry, distinguishing local-cache warmth from the prior-xDS-version reconnect case (the stale-risk that the safety-over-liveness choice for possibly-warm clients trades for)

A sustained defer rate with no recoveries now points at the misconfigured/incoherent reference directly, instead of requiring log archaeology.

## Testing

- Publication-policy unit tests: deferred-then-budget publish, latest-pending-wins, coherent supersedes pending (including the timer race), warm-client (local cache) withheld-then-merged, **prior-xDS-version clients do not receive a deferred snapshot after the budget but still receive coherent snapshots immediately, and their prior-version state is cleared on UCC disconnect**, cold clients still receive the bounded deferred first publish, carry-forward preserves in-use clusters and prefers real CLAs over synthesized empties, coherent-after-bounded overwrite (no dead-end empty endpoints), budget=0 disables bounded publishing, departure cancellation; transform tests for deferred annotation and CLA synthesis; EDS-alignment/usable-endpoint filter tests; withheld-deferred metric covers both warm reasons.
- `setup_test` scenarios that apply a backend with no usable endpoints are run with a shortened `PerClientPublishBudget` (and `test-service` is given a real EndpointSlice) so a deliberately-deferred first publish is still observed within the test's xDS-dump wait window — the production 15s default exceeds those ~7-10s windows.
- `make run-load-tests-strict-churn` (`test/e2e/features/loadtesting/strictchurn_suite.go`): strict validation, hundreds of simulated backends, continuous EndpointSlice churn (run *through* the convergence assertion, not stopped before it), route create/delete cycles, a dangling backendRef, a zero-endpoint Service, gateway-pod rolls (a rolled pod is a new client and must complete its rollout), and a controller restart mid-churn. Hard-gated behind `KGW_ENABLE_STRICT_CHURN=true` (it mutates the controller deployment) and wired into nightly only.
- Differential evidence: at 800 backends / 500m CPU the scenario fails on the unfixed build (gateway never starts) and passes here on top of the merged validator cache — stable routes held through churn and restart, rolled gateways became Ready, defers plateaued with recoveries. A run with the budget tightened to 2s exercised both bounded-publish modes (`first_publish` and `carry_forward`) with zero traffic loss. [Fresh numbers from a `main`-rebased run to be attached as a PR comment.]

# Change Type

/kind fix

# Changelog

```release-note
Per-client xDS publication deferrals are now bounded and EDS is kept aligned with CDS. When a client's inputs stay incoherent past the KGW_PER_CLIENT_PUBLISH_BUDGET (default 15s), a cold client (never published, no prior accepted xDS version) receives the latest snapshot as-is (with explicit empty ClusterLoadAssignments synthesized for not-yet-ready EDS references) so new gateway pods always become Ready; a warm client receives a carry-forward merge (local cache) or keeps its last-good config (a reconnect/restart that reports a prior xDS version), so an incomplete publish can never remove config a proxy is actively serving. Stale or empty EDS is no longer published. New metrics: kgateway_xds_snapshot_perclient_defers_total, ..._recoveries_total, ..._bounded_publishes_total{mode}, and ..._deferred_withheld_total{warm_reason}.
```

# Additional Notes

- Within the budget, behavior is byte-identical to today. The only change is that "withhold" now has a deadline — and only for clients proven cold (no local snapshot **and** no prior accepted xDS version). This is the safety-over-liveness choice the review of the earlier unbounded approach required: a controller-local cache miss does not prove an Envoy is cold, so a reconnect/restart that reports a prior version is treated as warm and never receives a partial snapshot, preserving #13868.
- The carry-forward design is the synthesis of two review constraints: publication must never remove a resource a warm client is using (no partial publishes), and no client may stay frozen forever waiting for global coherence. Carrying forward the previously-published resource for exactly the incoherent references satisfies both.
- Deferral no longer produces KRT Delete events, so a Delete on the per-client collection now reliably means client departure — a clean seam for a follow-up that reclaims SnapshotCache entries of departed clients (a known pre-existing leak, untouched here).
- Relationship to #14257: this PR incorporates that EDS-alignment / usable-endpoint work and closes the residual staleness gap its Additional Notes called out via carry-forward. If #14257 lands first, this rebases on top of it; otherwise it carries those fixes.
