### PR TITLE
[WIP] feat(xds): locality-agnostic xDS path for DISABLE_POD_LOCALITY_XDS

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -88,7 +88,7 @@ jobs:
           # May 29, 2026: ~10 minutes
           - cluster-name: 'cluster-three'
             go-test-args: '-timeout=25m'
-            go-test-run-regex: '^TestKgateway$$/^DynamicForwardProxy$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^EC2$$|^TestKgateway$$/^AccessLog$$|^TestKgateway$$/^LocalRateLimit$$|^TestKgateway$$/^Cors$$|^TestKgateway$$/^BackendConfigPolicy$$|^TestKgateway$$/^ListenerPolicy$$|^TestKgateway$$/^Tracing$$|^TestKgateway$$/^DirectResponse$$|^TestKgateway$$/^AdminServer$$|^TestKgateway$$/^FaultInjection$$'
+            go-test-run-regex: '^TestKgateway$$/^DynamicForwardProxy$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^EC2$$|^TestKgateway$$/^AccessLog$$|^TestKgateway$$/^LocalRateLimit$$|^TestKgateway$$/^Cors$$|^TestKgateway$$/^BackendConfigPolicy$$|^TestKgateway$$/^ListenerPolicy$$|^TestKgateway$$/^Tracing$$|^TestKgateway$$/^DirectResponse$$|^TestKgateway$$/^AdminServer$$|^TestKgateway$$/^FaultInjection$$|^TestKgateway$$/^PodLocalityXDS$$'
             localstack: 'true'
           # May 29, 2026: ~8 minutes
           - cluster-name: 'cluster-four'

--- a/pkg/kgateway/controller/start.go
+++ b/pkg/kgateway/controller/start.go
@@ -91,6 +91,13 @@ type StartConfig struct {
 
 	// StatusSyncerOptions is the list of options to be passed when creating the StatusSyncer
 	StatusSyncerOptions []proxy_syncer.StatusSyncerOption
+
+	// DisablePodLocalityXDS selects the locality-agnostic xDS graph in the proxy
+	// syncer (set from the DISABLE_POD_LOCALITY_XDS env var in setup). When true,
+	// every replica of a gateway shares one locality-agnostic identity, so each
+	// backend is translated once and snapshots are assembled per gateway role
+	// rather than per connected client.
+	DisablePodLocalityXDS bool
 }
 
 // Start runs the controllers responsible for processing the K8s Gateway API objects
@@ -158,6 +165,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 			cfg.CommonCollections,
 			cfg.SetupOpts.Cache,
 			cfg.Validator,
+			cfg.DisablePodLocalityXDS,
 		)
 		proxySyncer.Init(ctx, cfg.KrtOptions)
 		if err := cfg.Manager.Add(proxySyncer); err != nil {

--- a/pkg/kgateway/proxy_syncer/backends_agnostic.go
+++ b/pkg/kgateway/proxy_syncer/backends_agnostic.go
@@ -1,0 +1,57 @@
+package proxy_syncer
+
+import (
+	"context"
+
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/irtranslator"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	krtutil "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// agnosticUCC is the sentinel client used to translate backends once when pod
+// locality is disabled (DISABLE_POD_LOCALITY_XDS). Its empty Namespace/Labels/
+// Locality make every per-client translation hook (destrule DR matching,
+// endpoint locality prioritization) produce output identical to every connected
+// client, so a single translation is valid for all replicas of all gateways.
+var agnosticUCC = ir.UniquelyConnectedClient{}
+
+// NewAgnosticEnvoyClusters translates each backend's cluster exactly once, with
+// no dependency on the connected-client set. This is the CDS half of the
+// locality-agnostic xDS graph: because cluster output does not vary by client
+// when locality is disabled, there is no need to fan out over every
+// UniquelyConnectedClient as NewPerClientEnvoyClusters does. A client connecting
+// or disconnecting therefore triggers zero cluster re-translation.
+//
+// The result reuses uccWithCluster (with agnosticUCC as Client) so the same row
+// type feeds GenerateBackendStatusReport, which keys only on Error/BackendSource/
+// BackendGeneration.
+func NewAgnosticEnvoyClusters(
+	ctx context.Context,
+	krtopts krtutil.KrtOptions,
+	translator *irtranslator.BackendTranslator,
+	finalBackends krt.Collection[*ir.BackendObjectIR],
+) krt.Collection[uccWithCluster] {
+	return krt.NewCollection(finalBackends, func(kctx krt.HandlerContext, backendObj *ir.BackendObjectIR) *uccWithCluster {
+		c, err := translator.TranslateBackend(ctx, kctx, agnosticUCC, backendObj)
+		if c == nil {
+			return nil
+		}
+		var backendGeneration int64
+		if backendObj.Obj != nil {
+			backendGeneration = backendObj.Obj.GetGeneration()
+		}
+		return &uccWithCluster{
+			Name:    c.GetName(),
+			Client:  agnosticUCC,
+			Cluster: c,
+			// pass along the error(s) indicating to consumers that this cluster is not usable
+			Error:             err,
+			ClusterVersion:    utils.HashProto(c),
+			BackendSource:     backendObj.GetObjectSource(),
+			BackendGeneration: backendGeneration,
+		}
+	}, krtopts.ToOptions("AgnosticEnvoyClusters")...)
+}

--- a/pkg/kgateway/proxy_syncer/cla_agnostic.go
+++ b/pkg/kgateway/proxy_syncer/cla_agnostic.go
@@ -1,0 +1,32 @@
+package proxy_syncer
+
+import (
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	krtutil "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// NewAgnosticEnvoyEndpoints builds each backend's ClusterLoadAssignment exactly
+// once, with no dependency on the connected-client set. This is the EDS half of
+// the locality-agnostic xDS graph: with pod locality disabled, endpoint
+// prioritization yields uniform priorities for every client, so the CLA is
+// identical across replicas and a single translation per backend is valid for
+// all gateways. A client connecting or disconnecting triggers zero CLA
+// re-translation.
+func NewAgnosticEnvoyEndpoints(
+	krtopts krtutil.KrtOptions,
+	kgatewayEndpoints krt.Collection[ir.EndpointsForBackend],
+	translateEndpoints func(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) (*envoyendpointv3.ClusterLoadAssignment, uint64),
+) krt.Collection[UccWithEndpoints] {
+	return krt.NewCollection(kgatewayEndpoints, func(kctx krt.HandlerContext, ep ir.EndpointsForBackend) *UccWithEndpoints {
+		cla, additionalHash := translateEndpoints(kctx, agnosticUCC, ep)
+		return &UccWithEndpoints{
+			Client:        agnosticUCC,
+			Endpoints:     cla,
+			EndpointsHash: ep.LbEpsEqualityHash ^ additionalHash,
+			endpointsName: ep.ResourceName(),
+		}
+	}, krtopts.ToOptions("AgnosticEnvoyEndpoints")...)
+}

--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -257,7 +257,16 @@ func snapshotPerClient(
 		return &snap
 	}, krtopts.ToOptions("PerClientXdsSnapshots")...)
 
-	metrics.RegisterEvents(xdsSnapshotsForUcc, func(o krt.Event[XdsSnapWrapper]) {
+	registerSnapshotResourceMetrics(xdsSnapshotsForUcc)
+
+	return xdsSnapshotsForUcc
+}
+
+// registerSnapshotResourceMetrics publishes per-resource-type counts for each
+// published snapshot (and zeroes them on Delete). Shared by both the per-client
+// (snapshotPerClient) and per-role (snapshotPerRole) xDS graphs.
+func registerSnapshotResourceMetrics(snapshots krt.Collection[XdsSnapWrapper]) {
+	metrics.RegisterEvents(snapshots, func(o krt.Event[XdsSnapWrapper]) {
 		cd := getDetailsFromXDSClientResourceName(o.Latest().ResourceName())
 
 		switch o.Event {
@@ -329,8 +338,125 @@ func snapshotPerClient(
 				}.toMetricsLabels()...)
 		}
 	})
+}
 
-	return xdsSnapshotsForUcc
+// snapshotPerRole builds one xDS snapshot per gateway role for the
+// locality-agnostic path (DISABLE_POD_LOCALITY_XDS). Unlike snapshotPerClient it
+// is keyed off the per-gateway listener/route snapshots (mostXdsSnapshots), not
+// off the connected-client set, and it draws clusters/endpoints from
+// client-agnostic collections that are translated once per backend. Because no
+// collection here depends on the UniquelyConnectedClient set, a client
+// connecting or disconnecting triggers no recomputation, and there are no
+// per-(client,backend) rows that can go missing — the O(backends x clients)
+// fan-out that #14184 traces to is structurally absent on this path.
+//
+// The #13868 coherence guards are preserved, just applied per role: if a
+// referenced cluster or its EDS ClusterLoadAssignment is not yet present, the
+// transform returns nil, which surfaces as a Delete and is a no-op in the xDS
+// subscriber (retain last-good). A warm Envoy keeps serving its previous
+// snapshot until a coherent one replaces it.
+func snapshotPerRole(
+	krtopts krtutil.KrtOptions,
+	mostXdsSnapshots krt.Collection[GatewayXdsResources],
+	endpoints krt.Collection[UccWithEndpoints],
+	clusters krt.Collection[uccWithCluster],
+) krt.Collection[XdsSnapWrapper] {
+	snapshots := krt.NewCollection(mostXdsSnapshots, func(kctx krt.HandlerContext, gw GatewayXdsResources) *XdsSnapWrapper {
+		proxyKey := gw.ResourceName()
+		defer (collectXDSTransformMetrics(proxyKey))(nil)
+
+		// Client-agnostic clusters/endpoints are global (one row per backend), so
+		// every role draws from the same set; fetch them all.
+		allClusters := krt.Fetch(kctx, clusters)
+		allEndpoints := krt.Fetch(kctx, endpoints)
+
+		// Build backend cluster resources, separating errored clusters (they share a
+		// blackhole proto and are never sent to Envoy), mirroring snapshotPerClient.
+		clustersProto := make(map[string]envoycachetypes.ResourceWithTTL, len(allClusters)+len(gw.Clusters))
+		var (
+			clustersHash    uint64
+			erroredClusters []string
+		)
+		for _, c := range allClusters {
+			if c.Error != nil {
+				erroredClusters = append(erroredClusters, c.Name)
+				continue
+			}
+			clustersProto[c.Name] = envoycachetypes.ResourceWithTTL{Resource: c.Cluster}
+			clustersHash ^= c.ClusterVersion
+		}
+		// Merge the per-gateway extra clusters (ext_authz, ratelimit, etc.) carried in
+		// the role's listener/route snapshot.
+		for _, item := range gw.Clusters {
+			clustersProto[envoycache.GetResourceName(item.Resource)] = item
+		}
+		clusterResources := envoycache.Resources{
+			Version: fmt.Sprintf("%d", clustersHash^gw.ClustersHash),
+			Items:   clustersProto,
+		}
+
+		if missingClusters := findMissingReferencedClusters(
+			gw.ReferencedClusters,
+			clusterResources.Items,
+			erroredClusters,
+		); len(missingClusters) > 0 {
+			logger.Info(
+				"defer building snapshot until all referenced clusters are ready",
+				"proxy_key", proxyKey,
+				"missing_clusters", missingClusters,
+			)
+			return nil
+		}
+
+		endpointsProto := make([]envoycachetypes.ResourceWithTTL, 0, len(allEndpoints))
+		var endpointsHash uint64
+		for _, ep := range allEndpoints {
+			endpointsProto = append(endpointsProto, envoycachetypes.ResourceWithTTL{Resource: ep.Endpoints})
+			endpointsHash ^= ep.EndpointsHash
+		}
+		endpointResources := envoycache.NewResourcesWithTTL(fmt.Sprintf("%d", endpointsHash), endpointsProto)
+
+		// Exclude CLAs for STATIC clusters so the ADS snapshot only contains resources Envoy will request.
+		endpointRes := filterEndpointResourcesForStaticClusters(clusterResources, endpointResources)
+		if missingEndpointClusters := findMissingReferencedEndpointResources(
+			gw.ReferencedClusters,
+			clusterResources.Items,
+			endpointRes.Items,
+			erroredClusters,
+		); len(missingEndpointClusters) > 0 {
+			logger.Info(
+				"defer building snapshot until all referenced EDS resources are ready",
+				"proxy_key", proxyKey,
+				"missing_endpoint_clusters", missingEndpointClusters,
+			)
+			return nil
+		}
+
+		snap := XdsSnapWrapper{
+			erroredClusters: erroredClusters,
+			proxyKey:        proxyKey,
+		}
+		snapshot := &envoycache.Snapshot{}
+		snapshot.Resources[envoycachetypes.Cluster] = clusterResources
+		snapshot.Resources[envoycachetypes.Endpoint] = endpointRes
+		snapshot.Resources[envoycachetypes.Route] = gw.Routes
+		snapshot.Resources[envoycachetypes.Listener] = gw.Listeners
+		snapshot.Resources[envoycachetypes.Secret] = gw.Secrets
+		snap.snap = snapshot
+		logger.Debug("snapshots", "proxy_key", proxyKey,
+			"listeners", resourcesStringer(gw.Listeners).String(),
+			"clusters", resourcesStringer(clusterResources).String(),
+			"routes", resourcesStringer(gw.Routes).String(),
+			"endpoints", resourcesStringer(endpointRes).String(),
+			"secrets", resourcesStringer(gw.Secrets).String(),
+		)
+
+		return &snap
+	}, krtopts.ToOptions("PerRoleXdsSnapshots")...)
+
+	registerSnapshotResourceMetrics(snapshots)
+
+	return snapshots
 }
 
 // collectReferencedClusters returns the set of cluster names referenced as

--- a/pkg/kgateway/proxy_syncer/perrole_test.go
+++ b/pkg/kgateway/proxy_syncer/perrole_test.go
@@ -1,0 +1,174 @@
+package proxy_syncer
+
+import (
+	"testing"
+	"time"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/xds"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// roleSnapshot builds a single-vhost RouteConfiguration referencing the given
+// clusters plus a minimal Listener, and returns a GatewayXdsResources keyed by
+// the (ns, name) role. Mirrors the helpers in perclient_test.go.
+func roleSnapshot(ns, name string, weightedClusters ...string) GatewayXdsResources {
+	clusterWeights := make([]*envoyroutev3.WeightedCluster_ClusterWeight, 0, len(weightedClusters))
+	for _, c := range weightedClusters {
+		clusterWeights = append(clusterWeights, &envoyroutev3.WeightedCluster_ClusterWeight{Name: c, Weight: wrapperspb.UInt32(1)})
+	}
+	routes := sliceToResources([]*envoyroutev3.RouteConfiguration{
+		{
+			Name: "route-config-" + name,
+			VirtualHosts: []*envoyroutev3.VirtualHost{
+				{
+					Name:    "vhost",
+					Domains: []string{"*"},
+					Routes: []*envoyroutev3.Route{
+						{
+							Name: "weighted-route",
+							Action: &envoyroutev3.Route_Route{
+								Route: &envoyroutev3.RouteAction{
+									ClusterSpecifier: &envoyroutev3.RouteAction_WeightedClusters{
+										WeightedClusters: &envoyroutev3.WeightedCluster{Clusters: clusterWeights},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener-" + name}})
+	return GatewayXdsResources{
+		NamespacedName:     types.NamespacedName{Namespace: ns, Name: name},
+		Routes:             routes,
+		Listeners:          listeners,
+		ReferencedClusters: collectReferencedClusters(routes, listeners),
+	}
+}
+
+// TestSnapshotPerRoleDefersUntilReferencedClustersAreReady proves the #13868
+// coherence guard is preserved on the locality-agnostic path: a role whose route
+// references a cluster that has not yet been translated publishes nothing, and
+// begins publishing once the missing cluster appears.
+func TestSnapshotPerRoleDefersUntilReferencedClustersAreReady(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{
+		roleSnapshot("ns", "gw", "cluster-a", "cluster-b"),
+	})
+	// Backend-keyed (client-agnostic) clusters: only cluster-a is present at first.
+	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
+		{Client: agnosticUCC, Name: "cluster-a", Cluster: &envoyclusterv3.Cluster{Name: "cluster-a"}, ClusterVersion: 1},
+	})
+	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, nil)
+
+	snapshots := snapshotPerRole(krtutil.KrtOptions{}, mostXdsSnapshots, endpointCol, clusterCol)
+
+	g.Consistently(func() int {
+		return len(snapshots.List())
+	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0), "must defer while cluster-b is missing")
+
+	clusterCol.UpdateObject(uccWithCluster{Client: agnosticUCC, Name: "cluster-b", Cluster: &envoyclusterv3.Cluster{Name: "cluster-b"}, ClusterVersion: 2})
+
+	g.Eventually(func() int {
+		return len(snapshots.List())
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+
+	snap := snapshots.List()[0].snap
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-b"))
+}
+
+// TestSnapshotPerRoleDefersUntilReferencedEDSClustersHaveEndpoints proves the
+// EDS coherence guard is preserved per role: an EDS cluster without its CLA
+// defers publication until the CLA arrives.
+func TestSnapshotPerRoleDefersUntilReferencedEDSClustersHaveEndpoints(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{
+		roleSnapshot("ns", "gw", "cluster-a"),
+	})
+	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
+		{
+			Client: agnosticUCC,
+			Name:   "cluster-a",
+			Cluster: &envoyclusterv3.Cluster{
+				Name:                 "cluster-a",
+				ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS},
+			},
+			ClusterVersion: 1,
+		},
+	})
+	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, nil)
+
+	snapshots := snapshotPerRole(krtutil.KrtOptions{}, mostXdsSnapshots, endpointCol, clusterCol)
+
+	g.Consistently(func() int {
+		return len(snapshots.List())
+	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0), "must defer while EDS CLA is missing")
+
+	endpointCol.UpdateObject(UccWithEndpoints{
+		Client:        agnosticUCC,
+		Endpoints:     &envoyendpointv3.ClusterLoadAssignment{ClusterName: "cluster-a"},
+		EndpointsHash: 3,
+		endpointsName: "cluster-a",
+	})
+
+	g.Eventually(func() int {
+		return len(snapshots.List())
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+
+	snap := snapshots.List()[0].snap
+	g.Expect(snap.Resources[envoycachetypes.Endpoint].Items).To(gomega.HaveKey("cluster-a"))
+}
+
+// TestSnapshotPerRoleBuildsOneSnapshotPerRole proves the locality-agnostic graph
+// produces exactly one snapshot per gateway role (keyed by role, not by
+// connected client) and that the single client-agnostic backend cluster is
+// shared across both roles' snapshots.
+func TestSnapshotPerRoleBuildsOneSnapshotPerRole(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{
+		roleSnapshot("ns", "gw1", "cluster-a"),
+		roleSnapshot("ns", "gw2", "cluster-a"),
+	})
+	// A single backend-keyed cluster row, shared by every role (no per-client fan-out).
+	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
+		{Client: agnosticUCC, Name: "cluster-a", Cluster: &envoyclusterv3.Cluster{Name: "cluster-a"}, ClusterVersion: 1},
+	})
+	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, nil)
+
+	snapshots := snapshotPerRole(krtutil.KrtOptions{}, mostXdsSnapshots, endpointCol, clusterCol)
+
+	g.Eventually(func() int {
+		return len(snapshots.List())
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(2), "one snapshot per gateway role")
+
+	wantKeys := map[string]bool{
+		xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw1"): false,
+		xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw2"): false,
+	}
+	for _, w := range snapshots.List() {
+		_, ok := wantKeys[w.proxyKey]
+		g.Expect(ok).To(gomega.BeTrue(), "unexpected proxyKey %q", w.proxyKey)
+		wantKeys[w.proxyKey] = true
+		g.Expect(w.snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
+	}
+	for key, seen := range wantKeys {
+		g.Expect(seen).To(gomega.BeTrue(), "missing snapshot for role %q", key)
+	}
+}

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -57,6 +57,12 @@ type ProxySyncer struct {
 
 	uniqueClients krt.Collection[ir.UniquelyConnectedClient]
 
+	// disablePodLocalityXDS selects the locality-agnostic xDS graph (see
+	// snapshotPerRole). When true, backends are translated once (client-agnostic)
+	// and snapshots are assembled per gateway role rather than per connected
+	// client, because every replica of a gateway shares one identity.
+	disablePodLocalityXDS bool
+
 	statusReport            krt.Singleton[report]
 	backendPolicyReport     krt.Singleton[report]
 	backendStatusReport     krt.Singleton[report]
@@ -160,6 +166,7 @@ func NewProxySyncer(
 	commonCols *collections.CommonCollections,
 	xdsCache envoycache.SnapshotCache,
 	validator validator.Validator,
+	disablePodLocalityXDS bool,
 ) *ProxySyncer {
 	return &ProxySyncer{
 		controllerName:           controllerName,
@@ -170,6 +177,7 @@ func NewProxySyncer(
 		uniqueClients:            uniqueClients,
 		translator:               translator.NewCombinedTranslator(ctx, mergedPlugins, commonCols, validator),
 		plugins:                  mergedPlugins,
+		disablePodLocalityXDS:    disablePodLocalityXDS,
 		reportQueue:              utils.NewAsyncQueue[reports.ReportMap](),
 		backendPolicyReportQueue: utils.NewAsyncQueue[reports.ReportMap](),
 		backendStatusReportQueue: utils.NewAsyncQueue[reports.ReportMap](),
@@ -304,27 +312,61 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 		return toResources(gw, *xdsSnap, rm)
 	}, krtopts.ToOptions("MostXdsSnapshots")...)
 
-	epPerClient := NewPerClientEnvoyEndpoints(
-		krtopts,
-		s.uniqueClients,
-		newFinalBackendEndpoints(krtopts, finalBackends, allEndpoints),
-		s.translator.TranslateEndpoints,
-	)
-	clustersPerClient := NewPerClientEnvoyClusters(
-		ctx,
-		krtopts,
-		s.translator.GetBackendTranslator(),
-		finalBackends,
-		s.uniqueClients,
-	)
+	// statusClusters is the cluster collection consumed by backendStatusReport for
+	// per-backend translation-error attribution. Both xDS paths populate it; the
+	// locality-agnostic path produces one row per backend, the per-client path one
+	// row per (backend, client).
+	var statusClusters krt.Collection[uccWithCluster]
+	if s.disablePodLocalityXDS {
+		// Locality-agnostic graph: translate each backend once (no per-client
+		// fan-out) and assemble one snapshot per gateway role. See snapshotPerRole.
+		if s.commonCols.Settings.EnableIstioIntegration {
+			logger.Info("DISABLE_POD_LOCALITY_XDS is set: DestinationRule per-client " +
+				"workload selection is inert (clients have no locality/labels); " +
+				"host-scoped DestinationRule effects still apply identically to all clients")
+		}
+		agnosticClusters := NewAgnosticEnvoyClusters(
+			ctx,
+			krtopts,
+			s.translator.GetBackendTranslator(),
+			finalBackends,
+		)
+		agnosticEndpoints := NewAgnosticEnvoyEndpoints(
+			krtopts,
+			newFinalBackendEndpoints(krtopts, finalBackends, allEndpoints),
+			s.translator.TranslateEndpoints,
+		)
+		s.perclientSnapCollection = snapshotPerRole(
+			krtopts,
+			s.mostXdsSnapshots,
+			agnosticEndpoints,
+			agnosticClusters,
+		)
+		statusClusters = agnosticClusters
+	} else {
+		epPerClient := NewPerClientEnvoyEndpoints(
+			krtopts,
+			s.uniqueClients,
+			newFinalBackendEndpoints(krtopts, finalBackends, allEndpoints),
+			s.translator.TranslateEndpoints,
+		)
+		clustersPerClient := NewPerClientEnvoyClusters(
+			ctx,
+			krtopts,
+			s.translator.GetBackendTranslator(),
+			finalBackends,
+			s.uniqueClients,
+		)
 
-	s.perclientSnapCollection = snapshotPerClient(
-		krtopts,
-		s.uniqueClients,
-		s.mostXdsSnapshots,
-		epPerClient,
-		clustersPerClient,
-	)
+		s.perclientSnapCollection = snapshotPerClient(
+			krtopts,
+			s.uniqueClients,
+			s.mostXdsSnapshots,
+			epPerClient,
+			clustersPerClient,
+		)
+		statusClusters = clustersPerClient.clusters
+	}
 
 	excludedPolicyKinds := make(map[schema.GroupKind]struct{})
 	for gk, plugin := range s.plugins.ContributesPolicies {
@@ -354,7 +396,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 		if kgwBackendCol != nil {
 			kgwBackends = krt.Fetch(kctx, kgwBackendCol)
 		}
-		clusters := krt.Fetch(kctx, clustersPerClient.clusters)
+		clusters := krt.Fetch(kctx, statusClusters)
 		merged := GenerateBackendStatusReport(kgwBackends, clusters)
 		return &report{merged}
 	}, krtopts.ToOptions("BackendStatusReport")...)

--- a/pkg/kgateway/setup/setup.go
+++ b/pkg/kgateway/setup/setup.go
@@ -400,7 +400,12 @@ func (s *setup) buildKgatewayWithConfig(
 
 	augmentedPods, _ := krtcollections.NewPodsCollection(s.apiClient, krtOpts)
 	augmentedPodsForUcc := augmentedPods
-	if envutils.IsEnvTruthy("DISABLE_POD_LOCALITY_XDS") {
+	// DISABLE_POD_LOCALITY_XDS collapses every replica of a gateway to a single
+	// locality-agnostic client identity (see uniqueclients.go). The same decision
+	// selects the locality-agnostic xDS graph in the proxy syncer, so capture it
+	// once here and thread it through StartConfig to keep the two consistent.
+	disablePodLocalityXDS := envutils.IsEnvTruthy("DISABLE_POD_LOCALITY_XDS")
+	if disablePodLocalityXDS {
 		augmentedPodsForUcc = nil
 	}
 
@@ -435,6 +440,7 @@ func (s *setup) buildKgatewayWithConfig(
 		Validator:                   s.validator,
 		GatewayControllerExtension:  s.gatewayControllerExtension,
 		StatusSyncerOptions:         s.statusSyncerOptions,
+		DisablePodLocalityXDS:       disablePodLocalityXDS,
 	})
 	if err != nil {
 		slog.Error("failed initializing controller: ", "error", err)

--- a/test/e2e/features/podlocalityxds/suite.go
+++ b/test/e2e/features/podlocalityxds/suite.go
@@ -1,0 +1,141 @@
+//go:build e2e
+
+package podlocalityxds
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
+	"github.com/kgateway-dev/kgateway/v2/test/helpers"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
+)
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+// disablePodLocalityEnv is the raw (non KGW_-prefixed) env var that selects the
+// locality-agnostic xDS code path in the controller.
+const disablePodLocalityEnv = "DISABLE_POD_LOCALITY_XDS"
+
+// testingSuite verifies the locality-agnostic xDS code path selected by
+// DISABLE_POD_LOCALITY_XDS=true. On that path kgateway translates each backend
+// once (client-agnostic) and assembles one snapshot per gateway role
+// (snapshotPerRole) instead of fanning out per connected client. These tests
+// assert the resulting snapshot is valid and servable end-to-end, and that
+// config changes converge while the flag is set.
+type testingSuite struct {
+	*base.BaseTestingSuite
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+	}
+}
+
+// SetupSuite switches the controller to the locality-agnostic xDS path before the
+// base suite applies the routing manifests, so they are translated under that
+// path. The env var (and the controller rollout) is reverted on teardown.
+func (s *testingSuite) SetupSuite() {
+	s.setControllerEnvVar(disablePodLocalityEnv, "true")
+	s.BaseTestingSuite.SetupSuite()
+}
+
+// TestRoutingWithLocalityDisabled asserts that, with locality disabled, the base
+// gateway serves a route to the shared backend — i.e. snapshotPerRole produced a
+// coherent, Envoy-accepted snapshot.
+func (s *testingSuite) TestRoutingWithLocalityDisabled() {
+	common.BaseGateway.Send(
+		s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK},
+		curl.WithPath("/"),
+		curl.WithHostHeader("locality.example.com"),
+		curl.WithPort(80),
+	)
+}
+
+// TestRouteUpdateConvergesWithLocalityDisabled asserts that a route added at
+// runtime converges on the locality-agnostic path while the original route keeps
+// serving — i.e. the per-role snapshot recomputes on listener/route changes.
+func (s *testingSuite) TestRouteUpdateConvergesWithLocalityDisabled() {
+	// The setup route still serves.
+	common.BaseGateway.Send(
+		s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK},
+		curl.WithPath("/"),
+		curl.WithHostHeader("locality.example.com"),
+		curl.WithPort(80),
+	)
+	// The route added by this test case's manifest converges.
+	common.BaseGateway.Send(
+		s.T(),
+		&testmatchers.HttpResponse{StatusCode: http.StatusOK},
+		curl.WithPath("/extra"),
+		curl.WithHostHeader("locality-extra.example.com"),
+		curl.WithPort(80),
+	)
+}
+
+// setControllerEnvVar appends an env var to the kgateway controller Deployment,
+// waits for the rollout, and registers a cleanup that reverts it. Mirrors the
+// pattern used by the waypoint suite.
+func (s *testingSuite) setControllerEnvVar(name, value string) {
+	controllerNamespace, ok := os.LookupEnv(testutils.InstallNamespace)
+	if !ok {
+		s.FailNow(testutils.InstallNamespace + " environment variable not set")
+	}
+
+	original := &appsv1.Deployment{}
+	err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx, client.ObjectKey{
+		Namespace: controllerNamespace,
+		Name:      helpers.DefaultKgatewayDeploymentName,
+	}, original)
+	s.Require().NoError(err, "get controller deployment")
+
+	envVar := corev1.EnvVar{Name: name, Value: value}
+	modified := original.DeepCopy()
+	modified.Spec.Template.Spec.Containers[0].Env = append(
+		modified.Spec.Template.Spec.Containers[0].Env,
+		envVar,
+	)
+	modified.ResourceVersion = ""
+	err = s.TestInstallation.ClusterContext.Client.Patch(s.Ctx, modified, client.MergeFrom(original))
+	s.Require().NoError(err, "patch controller deployment with %s=%s", name, value)
+
+	labelSelector := metav1.ListOptions{LabelSelector: defaults.WellKnownAppLabel + "=kgateway"}
+	s.TestInstallation.AssertionsT(s.T()).EventuallyPodContainerContainsEnvVar(
+		s.Ctx,
+		controllerNamespace,
+		labelSelector,
+		helpers.KgatewayContainerName,
+		envVar,
+	)
+
+	testutils.Cleanup(s.T(), func() {
+		original.ResourceVersion = ""
+		err := s.TestInstallation.ClusterContext.Client.Patch(s.Ctx, original, client.MergeFrom(modified))
+		s.Require().NoError(err, "revert controller deployment")
+		s.TestInstallation.AssertionsT(s.T()).EventuallyPodContainerDoesNotContainEnvVar(
+			s.Ctx,
+			controllerNamespace,
+			labelSelector,
+			helpers.KgatewayContainerName,
+			envVar.Name,
+		)
+	})
+
+	// Wait for the controller pods to be running again after the patch.
+	s.TestInstallation.AssertionsT(s.T()).EventuallyPodsRunning(s.Ctx, controllerNamespace, labelSelector)
+}

--- a/test/e2e/features/podlocalityxds/testdata/route-extra.yaml
+++ b/test/e2e/features/podlocalityxds/testdata/route-extra.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: locality-route-extra
+  namespace: kgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: kgateway-base
+  hostnames:
+    - "locality-extra.example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /extra
+      backendRefs:
+        - name: backend
+          port: 80

--- a/test/e2e/features/podlocalityxds/testdata/route.yaml
+++ b/test/e2e/features/podlocalityxds/testdata/route.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: locality-route
+  namespace: kgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: kgateway-base
+  hostnames:
+    - "locality.example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: backend
+          port: 80

--- a/test/e2e/features/podlocalityxds/types.go
+++ b/test/e2e/features/podlocalityxds/types.go
@@ -1,0 +1,30 @@
+//go:build e2e
+
+package podlocalityxds
+
+import (
+	"path/filepath"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+)
+
+var (
+	// manifests
+	routeManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "route.yaml")
+	extraRouteManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "route-extra.yaml")
+
+	// setup routes the shared kgateway-base/backend echo service through the base
+	// gateway. It is applied after the controller is switched to the
+	// locality-agnostic xDS path, so the snapshot is built by snapshotPerRole.
+	setup = base.TestCase{
+		Manifests: []string{routeManifest},
+	}
+
+	testCases = map[string]*base.TestCase{
+		"TestRoutingWithLocalityDisabled": {},
+		"TestRouteUpdateConvergesWithLocalityDisabled": {
+			Manifests: []string{extraRouteManifest},
+		},
+	}
+)

--- a/test/e2e/tests/kgateway_tests.go
+++ b/test/e2e/tests/kgateway_tests.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/loadtesting"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/oauth"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/path_matching"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/podlocalityxds"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/policyselector"
 	global_rate_limit "github.com/kgateway-dev/kgateway/v2/test/e2e/features/rate_limit/global"
 	local_rate_limit "github.com/kgateway-dev/kgateway/v2/test/e2e/features/rate_limit/local"
@@ -103,6 +104,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("BasicAuth", basicauth.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("OAuth", oauth.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("WebSocket", websocket.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("PodLocalityXDS", podlocalityxds.NewTestingSuite)
 
 	return kubeGatewaySuiteRunner
 }


### PR DESCRIPTION
# Description

kgateway translates backends into Envoy clusters and endpoints **per connected proxy**: the per-client pipeline runs the full backend translation for every `(backend, connected client)` pair. On large fleets this fan-out is `O(backends × clients)`, and it is the work that the readiness gate added in #13868 can amplify into a stalled per-client snapshot (see #14184).

The `DISABLE_POD_LOCALITY_XDS` environment variable already existed to drop pod locality from a proxy's client identity, collapsing all replicas of a gateway to a single identity. But it only shrank the *inputs* to the existing per-client graph — the same fan-out machinery and per-client snapshot path still ran.

This PR makes `DISABLE_POD_LOCALITY_XDS=true` select a genuinely separate, simpler xDS code path. When pod locality is disabled, per-client translation cannot diverge between clients (DestinationRule selection has no labels/namespace to match on, and endpoint prioritization is uniform), so each backend's cluster and endpoints are translated **once** (client-agnostic) and a snapshot is assembled **per gateway role** instead of per connected client. A proxy connecting or disconnecting no longer triggers any backend re-translation, and there are no per-`(client, backend)` snapshot rows. The locality-aware path (the default) is unchanged.

The coherence guarantee from #13868 is preserved on the new path, simply applied per gateway role: a snapshot is withheld (the proxy keeps its last-good config) until every referenced cluster and its EDS resources are present.

Refs #14184.

# Change Type

/kind feature

# Changelog

```release-note
When `DISABLE_POD_LOCALITY_XDS=true`, kgateway now uses a locality-agnostic xDS code path that translates each backend once and builds a single xDS snapshot per gateway role, rather than once per connected proxy. This removes the per-proxy translation fan-out for deployments that do not need locality-aware routing (e.g. single-zone clusters with no DestinationRules or locality-based traffic distribution), reducing control-plane work and convergence time. The locality-aware path remains the default and is unchanged.
```

# Additional Notes

## When can I set `DISABLE_POD_LOCALITY_XDS=true`?

This flag is **controller-wide** — it changes the xDS path for *every* gateway the controller manages — so it is only safe when **no proxy needs to route differently based on its own location**. Pod locality affects the generated config in these places:

1. **Endpoint prioritization** (EDS, or the inline load assignment of DNS/STATIC clusters), when a Service requests locality-based traffic distribution — `spec.trafficDistribution: PreferClose`, or the `networking.istio.io/traffic-distribution` annotation set to `PreferClose` / `PreferSameZone` / `PreferSameNode` / `PreferNetwork`.
2. **DestinationRule matching and `localityLbSetting`** (CDS + EDS), only when Istio integration is enabled (`KGW_ENABLE_ISTIO_INTEGRATION=true`; off by default).
3. **ServiceEntry / WorkloadEntry endpoint locality** (Istio integration only), which is declared in the resource spec rather than derived from cluster nodes.

If none of these is in effect, every proxy already receives identical config, and the locality-agnostic path is behaviorally equivalent — just cheaper.

**Safe to enable when all of the following hold:**

- The cluster is effectively single-zone for routing — a backend's ready endpoints do not span more than one of the locality dimensions (`region` / `zone` / `subzone`) that any locality config keys on. The simplest sufficient condition for Kubernetes-Service backends: **all nodes are in one region and zone**.
- **No DestinationRule** sets `localityLbSetting` (or Istio integration is disabled, in which case DestinationRules are not consumed at all).
- **No Service** uses locality-based traffic distribution that would actually split endpoints into priority tiers.
- If Istio integration is enabled, **no ServiceEntry or WorkloadEntry declares endpoints with explicit `locality`** that you route across with `PreferClose` or a DestinationRule `localityLbSetting`. ServiceEntry/WorkloadEntry endpoints take their locality from the resource spec, not from cluster nodes — including DNS-resolution ServiceEntries, whose endpoints are inline in the cluster rather than served via EDS — so the "all nodes in one zone" shortcut does not cover them.

**Quick rules of thumb:**

- **Istio integration off** → only Kubernetes Services matter, so the node-topology check is sufficient: a single-zone cluster with no `trafficDistribution`/`PreferClose` is always safe.
- **Istio integration on** → you must also account for spec-declared endpoint locality (ServiceEntry/WorkloadEntry) and DestinationRule `localityLbSetting`, not just node topology.

> Note on the single-zone subtlety: even with `PreferClose`/`PreferSameZone` set, if all endpoints share one zone the prioritizer produces a single tier and all traffic flows there regardless — so disabling locality changes nothing observable. It only matters once endpoints actually span the keyed dimension.

**Do not set it when:**

- Backends have endpoints across **multiple zones (or regions)** and you use any locality-based traffic distribution or DestinationRule `localityLbSetting` — disabling locality would drop zone preference and send cross-zone traffic that would otherwise stay local.
- You use **`PreferSameNode`** (keys on node/subzone) on a multi-node cluster.
- You use **ServiceEntry/WorkloadEntry with explicit endpoint `locality`** (any resolution, including `DNS`) together with locality-aware routing — those endpoints span localities by declaration regardless of your Kubernetes node topology.
- You plan to **expand to multiple zones** — remove the flag *before* doing so to restore locality-aware routing.

When any of those apply, leave the flag unset; those deployments stay on the default per-client path.

## Implementation notes

- Both paths feed the same xDS publish path, snapshot metrics, and Backend status reporting.
- **Correctness** rests on there being no per-client translation divergence when locality is disabled. The in-tree per-client hooks (DestinationRule matching and endpoint locality prioritization, including the inline load assignments of DNS/STATIC ServiceEntry clusters) all key on labels/namespace/locality, which are empty on this path; a controller log notes when Istio integration is enabled alongside the flag.
- **Testing:** unit tests for the per-role assembler (per-role coherence-gate deferral preserved; one snapshot per role with shared backend clusters) and a new e2e suite (`PodLocalityXDS`) that sets the flag on the controller and asserts routing plus runtime route convergence.
