### PR TITLE
cleanup: apply TrafficPolicy retry per-route instead of per-vhost

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -398,13 +398,7 @@ func (p *trafficPolicyPluginGwPass) ApplyVhostPlugin(
 	// keeps that precedence explicit and consistent with the other per-route settings.
 	if policy.spec.retry != nil {
 		for _, route := range out.Routes {
-			action := route.GetRoute()
-			if action == nil {
-				continue
-			}
-			if action.GetRetryPolicy() == nil {
-				action.RetryPolicy = policy.spec.retry.policy
-			}
+			applyRetryPolicy(policy.spec.retry, route)
 		}
 	}
 
@@ -803,17 +797,30 @@ func (p *trafficPolicyPluginGwPass) handlePerRoutePolicies(
 		}
 	}
 
-	// Only set the retry policy if it is not already set, which implies that it was
-	// set by the builtin HTTPRouteRetry policy
-	if action.GetRetryPolicy() == nil && spec.retry != nil {
-		action.RetryPolicy = spec.retry.policy
-	}
+	applyRetryPolicy(spec.retry, out)
 
 	// Apply URL rewrite configuration
 	applyURLRewrite(spec.urlRewrite, out)
 
 	// Apply route-level tracing overrides
 	p.handleRouteTracing(spec, out)
+}
+
+func applyRetryPolicy(retry *retryIR, out *envoyroutev3.Route) {
+	if retry == nil || out == nil {
+		return
+	}
+
+	action := out.GetRoute()
+	if action == nil {
+		return
+	}
+
+	// Only set the retry policy if it is not already set, which implies that it was
+	// set by the builtin HTTPRouteRetry policy or a more specific TrafficPolicy.
+	if action.GetRetryPolicy() == nil {
+		action.RetryPolicy = retry.policy
+	}
 }
 
 func (p *trafficPolicyPluginGwPass) SupportsPolicyMerge() bool {

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -392,7 +392,22 @@ func (p *trafficPolicyPluginGwPass) ApplyVhostPlugin(
 		return
 	}
 
-	p.handlePerVHostPolicies(policy.spec, out)
+	// Apply the retry policy to each route rather than to the vhost. A route-level
+	// retry policy (set by a more specific TrafficPolicy or the builtin HTTPRouteRetry
+	// policy) fully overrides the vhost-level one in Envoy, so applying it per route
+	// keeps that precedence explicit and consistent with the other per-route settings.
+	if policy.spec.retry != nil {
+		for _, route := range out.Routes {
+			action := route.GetRoute()
+			if action == nil {
+				continue
+			}
+			if action.GetRetryPolicy() == nil {
+				action.RetryPolicy = policy.spec.retry.policy
+			}
+		}
+	}
+
 	p.handlePolicies(pCtx.FilterChainName, &pCtx.TypedFilterConfig, policy.spec)
 }
 
@@ -799,16 +814,6 @@ func (p *trafficPolicyPluginGwPass) handlePerRoutePolicies(
 
 	// Apply route-level tracing overrides
 	p.handleRouteTracing(spec, out)
-}
-
-// handlePerVHostPolicies handles policies that are meant to be processed at the vhost level
-func (p *trafficPolicyPluginGwPass) handlePerVHostPolicies(
-	spec trafficPolicySpecIr,
-	out *envoyroutev3.VirtualHost,
-) {
-	if spec.retry != nil {
-		out.RetryPolicy = spec.retry.policy
-	}
 }
 
 func (p *trafficPolicyPluginGwPass) SupportsPolicyMerge() bool {

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/timeout-retry.yaml
@@ -49,11 +49,6 @@ Routes:
           retry:
           - gateway.kgateway.dev/TrafficPolicy/default/example-gateway-retry-and-timeout
     name: listener~80~builtin_com
-    retryPolicy:
-      numRetries: 3
-      retryBackOff:
-        baseInterval: 0.025s
-      retryOn: gateway-error
     routes:
     - match:
         prefix: /
@@ -86,11 +81,6 @@ Routes:
           retry:
           - gateway.kgateway.dev/TrafficPolicy/default/example-gateway-retry-and-timeout
     name: listener~80~example-retry-and-timeouts_com
-    retryPolicy:
-      numRetries: 3
-      retryBackOff:
-        baseInterval: 0.025s
-      retryOn: gateway-error
     routes:
     - match:
         safeRegex:
@@ -146,11 +136,6 @@ Routes:
           retry:
           - gateway.kgateway.dev/TrafficPolicy/default/example-gateway-retry-and-timeout
     name: listener~80~example-retry_com
-    retryPolicy:
-      numRetries: 3
-      retryBackOff:
-        baseInterval: 0.025s
-      retryOn: gateway-error
     routes:
     - match:
         prefix: /
@@ -180,11 +165,6 @@ Routes:
           retry:
           - gateway.kgateway.dev/TrafficPolicy/default/example-gateway-retry-and-timeout
     name: listener~80~example_com
-    retryPolicy:
-      numRetries: 3
-      retryBackOff:
-        baseInterval: 0.025s
-      retryOn: gateway-error
     routes:
     - match:
         prefix: /
@@ -198,6 +178,11 @@ Routes:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
         idleTimeout: 5s
+        retryPolicy:
+          numRetries: 3
+          retryBackOff:
+            baseInterval: 0.025s
+          retryOn: gateway-error
         timeout: 9s
 Statuses:
   gateways:


### PR DESCRIPTION
# Description

Listener-attached `TrafficPolicy` retry was applied to the Envoy `VirtualHost`
(`VirtualHost.RetryPolicy`) via `handlePerVHostPolicies`. In Envoy, a route-level
`retry_policy` fully overrides the vhost-level one, so the vhost value was dead
config for any route that already had its own retry (from a more specific
`TrafficPolicy` or the builtin `HTTPRouteRetry` policy).

This change removes `handlePerVHostPolicies` and instead applies the retry to each
route under the vhost in `ApplyVhostPlugin`, skipping routes that already have a
retry policy. This matches how the other per-route settings (timeouts, retry at
gateway scope, etc.) are handled and keeps precedence explicit.

Behavior is unchanged:

- Routes that previously inherited the vhost-level retry now carry it directly.
- Routes that overrode it keep their own retry (the now-removed vhost-level value
  was already ignored by Envoy for those routes).

The `traffic-policy/timeout-retry` golden reflects this: redundant vhost-level
retry blocks are removed, and the one route that genuinely inherited the gateway
retry (`example.com`, which had only a timeout) now carries it at the route level.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Only the `timeout-retry` translator golden changed; the change was verified to be a
no-op for all other gateway-translator goldens (they pass unchanged in comparison
mode).