### PR TITLE
fix(listenerpolicy): apply gateway-level listener policies to listeners

### DIFF
--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -486,14 +486,17 @@ func GatewaysForEnvoyTransformationFunc(config *GatewayIndexConfig) func(kctx kr
 
 		// TODO: http polic
 		//		panic("TODO: implement http policies not just listener")
-		gwIR.AttachedListenerPolicies = ToAttachedPolicies(
-			config.PolicyIndex.GetTargetingPolicies(kctx, gwIR.ObjectSource, "", gw.GetLabels()))
+		gatewayPolicies := config.PolicyIndex.GetTargetingPolicies(kctx, gwIR.ObjectSource, "", gw.GetLabels())
+		gwIR.AttachedListenerPolicies = ToAttachedPolicies(gatewayPolicies)
 		gwIR.AttachedHttpPolicies = gwIR.AttachedListenerPolicies // see if i can find a better way to segment the listener level and http level policies
 		for _, l := range gw.Spec.Listeners {
+			listenerSpecificPolicies := config.PolicyIndex.GetTargetingPolicies(kctx, gwIR.ObjectSource, string(l.Name), gw.GetLabels())
+			listenerPolicies := append([]ir.PolicyAtt{}, listenerSpecificPolicies...)
+			listenerPolicies = append(listenerPolicies, gatewayPolicies...)
 			gwIR.Listeners = append(gwIR.Listeners, ir.Listener{
 				Listener:         l,
 				Parent:           gw,
-				AttachedPolicies: ToAttachedPolicies(config.PolicyIndex.GetTargetingPolicies(kctx, gwIR.ObjectSource, string(l.Name), gw.GetLabels())),
+				AttachedPolicies: ToAttachedPolicies(listenerPolicies),
 				PolicyAncestorRef: gwv1.ParentReference{
 					Group:     new(gwv1.Group(wellknown.GatewayGVK.Group)),
 					Kind:      new(gwv1.Kind(wellknown.GatewayGVK.Kind)),


### PR DESCRIPTION
# Description

When a ListenerPolicy targets a whole Gateway without a sectionName, the clientCertificateValidation settings were being silently ignored the policy showed as Accepted and Attached but Envoy never got the validation_context in its TLS config.

The fix is straightforward - gateway-level policies now get merged into each listener's AttachedPolicies, the same way ListenerSets already handle this in the same file.

Fixes #14280 

# Change Type

/kind fix

# Changelog

```release-note
None 
```

# Additional Notes

