### PR TITLE
fix: use rooted FQDN for xDS cluster address to avoid DNS search expansion

### DIFF
--- a/pkg/kgateway/controller/start.go
+++ b/pkg/kgateway/controller/start.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"strings"
 	"sync/atomic"
 
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -231,14 +232,17 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 
 	xdsHost := globalSettings.XdsServiceHost
 	if xdsHost == "" {
-		// Append a trailing dot to make this an absolute (rooted) DNS name. Without it,
-		// the in-cluster FQDN has 4 dots and is treated as relative under the default
-		// ndots:5 resolver config, so Envoy's strict_dns cluster expands every search
-		// domain on each re-resolution cycle, producing a burst of NXDOMAIN lookups.
-		xdsHost = kubeutils.ServiceFQDN(metav1.ObjectMeta{
+		// Ensure exactly one trailing dot so this is an absolute (rooted) DNS name.
+		// Without it, the in-cluster FQDN has 4 dots and is treated as relative under
+		// the default ndots:5 resolver config, so Envoy's strict_dns cluster expands
+		// every search domain on each re-resolution cycle, producing a burst of
+		// NXDOMAIN lookups. TrimSuffix keeps this idempotent in case the FQDN is
+		// already rooted (e.g. a CLUSTER_DOMAIN env var set with a trailing dot),
+		// avoiding a double dot that would itself break resolution.
+		xdsHost = strings.TrimSuffix(kubeutils.ServiceFQDN(metav1.ObjectMeta{
 			Name:      globalSettings.XdsServiceName,
 			Namespace: namespaces.GetPodNamespace(),
-		}) + "."
+		}), ".") + "."
 	}
 
 	xdsPort := globalSettings.XdsServicePort

--- a/pkg/kgateway/controller/start.go
+++ b/pkg/kgateway/controller/start.go
@@ -231,10 +231,14 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 
 	xdsHost := globalSettings.XdsServiceHost
 	if xdsHost == "" {
+		// Append a trailing dot to make this an absolute (rooted) DNS name. Without it,
+		// the in-cluster FQDN has 4 dots and is treated as relative under the default
+		// ndots:5 resolver config, so Envoy's strict_dns cluster expands every search
+		// domain on each re-resolution cycle, producing a burst of NXDOMAIN lookups.
 		xdsHost = kubeutils.ServiceFQDN(metav1.ObjectMeta{
 			Name:      globalSettings.XdsServiceName,
 			Namespace: namespaces.GetPodNamespace(),
-		})
+		}) + "."
 	}
 
 	xdsPort := globalSettings.XdsServicePort

--- a/test/e2e/features/deployer/suite.go
+++ b/test/e2e/features/deployer/suite.go
@@ -595,8 +595,8 @@ func xdsClusterAssertion(t *testing.T, testInstallation *e2e.TestInstallation) f
 			g.Expect(xdsSocketAddress).NotTo(gomega.BeNil())
 
 			g.Expect(xdsSocketAddress.GetAddress()).To(gomega.Equal(
-				fmt.Sprintf("%s.%s.svc.cluster.local", wellknown.DefaultXdsService, testInstallation.Metadata.InstallNamespace),
-			), "xds socket address points to kgateway service, in installation namespace")
+				fmt.Sprintf("%s.%s.svc.cluster.local.", wellknown.DefaultXdsService, testInstallation.Metadata.InstallNamespace),
+			), "xds socket address points to kgateway service, in installation namespace, as a rooted FQDN")
 
 			g.Expect(xdsSocketAddress.GetPortValue()).To(gomega.Equal(wellknown.DefaultXdsPort),
 				"xds socket port points to kgateway service, in installation namespace")


### PR DESCRIPTION
# Description

The Envoy bootstrap rendered by kgateway sets the `xds_cluster` socket address to the kgateway control-plane FQDN **without a trailing dot**, e.g. `kgateway.kgateway-system.svc.cluster.local`. Because this name has 4 dots and is not rooted, the default `ndots:5` resolver config treats it as a relative name. The `xds_cluster` uses `envoy.cluster.strict_dns` with `respect_dns_ttl: true`, so on every re-resolution cycle (every 5s, matching the kgateway Service TTL) Envoy's c-ares resolver walks **every** search domain before the bare-name attempt — 8 NXDOMAIN lookups followed by the successful one. At a 5s TTL this is ~96 wasted CoreDNS queries per minute per gateway pod, scaling with pods and replicas.

The address originates in `pkg/kgateway/controller/start.go`, where `kubeutils.ServiceFQDN(...)` returns the dotless FQDN. This change appends a trailing dot so the name is absolute (rooted), so the resolver skips search-domain expansion entirely (1–2 queries instead of 9–10).

Only the kgateway-generated FQDN is normalized. An explicitly configured `XdsServiceHost` (which may be an IP literal or a short name) is intentionally left untouched.

The e2e deployer assertion (`xdsClusterAssertion`) is updated to expect the rooted FQDN. The deployer golden tests set `XdsHost` explicitly (mirroring the user-supplied branch), so they are unaffected.

Fixes #14284

# Change Type

/kind fix

# Changelog

```release-note
Fix excessive DNS queries from gateway pods by rendering the xDS cluster address as a rooted FQDN (trailing dot), preventing DNS search-domain expansion under the default ndots:5 resolver config.
```
