### PR TITLE
test: Use go.mod's helm (helm 3) when refreshing golden files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,17 +457,17 @@ test-with-coverage: test
 
 .PHONY: golden-deployer
 golden-deployer:  ## Refreshes golden files for ./test/deployer snapshot testing
-	REFRESH_GOLDEN=true go test ./test/deployer/... > /dev/null || true
+	HELM="$(HELM)" REFRESH_GOLDEN=true go test ./test/deployer/... > /dev/null || true
 	@echo ""
 	@echo "This must pass after refreshing:"
-	go test ./test/deployer/...
+	HELM="$(HELM)" go test ./test/deployer/...
 
 .PHONY: golden-helm
 golden-helm:  ## Refreshes golden files for ./test/helm snapshot testing
-	REFRESH_GOLDEN=true go test ./test/helm/... > /dev/null || true
+	HELM="$(HELM)" REFRESH_GOLDEN=true go test ./test/helm/... > /dev/null || true
 	@echo ""
 	@echo "This must pass after refreshing:"
-	go test ./test/helm/...
+	HELM="$(HELM)" go test ./test/helm/...
 
 ## Refreshes golden files for translation testing
 golden-translator-%:

--- a/test/helm/helm_command_test.go
+++ b/test/helm/helm_command_test.go
@@ -1,0 +1,20 @@
+package helm
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func helmCommand(args ...string) *exec.Cmd {
+	helm := os.Getenv("HELM")
+	if helm == "" {
+		helm = "go tool helm"
+	}
+
+	cmdParts := strings.Fields(helm)
+	if len(cmdParts) == 0 {
+		cmdParts = []string{"go", "tool", "helm"}
+	}
+	return exec.Command(cmdParts[0], append(cmdParts[1:], args...)...)
+}

--- a/test/helm/helm_command_test.go
+++ b/test/helm/helm_command_test.go
@@ -16,5 +16,6 @@ func helmCommand(args ...string) *exec.Cmd {
 	if len(cmdParts) == 0 {
 		cmdParts = []string{"go", "tool", "helm"}
 	}
+	//#nosec G204 - helm binary is sourced from the HELM env var (set by the developer/test harness), not untrusted input
 	return exec.Command(cmdParts[0], append(cmdParts[1:], args...)...)
 }

--- a/test/helm/helm_command_test.go
+++ b/test/helm/helm_command_test.go
@@ -16,6 +16,5 @@ func helmCommand(args ...string) *exec.Cmd {
 	if len(cmdParts) == 0 {
 		cmdParts = []string{"go", "tool", "helm"}
 	}
-	//#nosec G204 - helm binary is sourced from the HELM env var (set by the developer/test harness), not untrusted input
-	return exec.Command(cmdParts[0], append(cmdParts[1:], args...)...)
+	return exec.Command(cmdParts[0], append(cmdParts[1:], args...)...) //nolint:gosec // G204: helm binary is sourced from the HELM env var (set by the developer/test harness), not untrusted input
 }

--- a/test/helm/helm_version_test.go
+++ b/test/helm/helm_version_test.go
@@ -27,7 +27,7 @@ func TestHelmChartVersionAndAppVersion(t *testing.T) {
 	_, err = os.Stat(absHelmChartPath)
 	require.NoError(t, err, "helm chart not found at %s", absHelmChartPath)
 
-	helmCmd := exec.Command("helm", "template", "foobar", absHelmChartPath, "--namespace", "default")
+	helmCmd := helmCommand("template", "foobar", absHelmChartPath, "--namespace", "default")
 	grepCmd := exec.Command("grep", "-E", "-w", "-B", "1", "0\\.0\\.[12]")
 
 	helmOutput, err := helmCmd.StdoutPipe()
@@ -157,7 +157,7 @@ func TestImageTagVPrefix(t *testing.T) {
 					args = append(args, "--set", setValue)
 				}
 
-				helmCmd := exec.Command("helm", args...)
+				helmCmd := helmCommand(args...)
 				var output bytes.Buffer
 				var stderr bytes.Buffer
 				helmCmd.Stdout = &output
@@ -263,7 +263,7 @@ func renderHelmTemplate(t *testing.T, chart string, valuesYAML string, apiVersio
 		args = append(args, "-f", valuesFile.Name())
 	}
 
-	helmCmd := exec.Command("helm", args...)
+	helmCmd := helmCommand(args...)
 	var output bytes.Buffer
 	var stderr bytes.Buffer
 	helmCmd.Stdout = &output
@@ -678,7 +678,7 @@ func TestHelmChartTemplate(t *testing.T) {
 					args = append(args, "-f", valuesFile.Name())
 				}
 
-				helmCmd := exec.Command("helm", args...)
+				helmCmd := helmCommand(args...)
 				var output bytes.Buffer
 				var stderr bytes.Buffer
 				helmCmd.Stdout = &output

--- a/test/helm/packaged_chart_test.go
+++ b/test/helm/packaged_chart_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -142,7 +141,7 @@ func renderChartAtPath(t *testing.T, chartPath, valuesYAML string, apiVersions [
 		args = append(args, "-f", valuesFile.Name())
 	}
 
-	helmCmd := exec.Command("helm", args...)
+	helmCmd := helmCommand(args...)
 	var output, stderr bytes.Buffer
 	helmCmd.Stdout = &output
 	helmCmd.Stderr = &stderr


### PR DESCRIPTION
# Description

On systems with helm 4, use 'helm 3' for unittest golden file regeneration to avoid whitespace scuffles.

# Change Type
/kind cleanup

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
