### PR TITLE
fix: make report status rendering read-only

### DIFF
--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"sync/atomic"
 
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -12,7 +11,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -197,56 +195,7 @@ func (r report) ResourceName() string {
 
 // do we really need this for a singleton?
 func (r report) Equals(in report) bool {
-	if !maps.Equal(r.reportMap.Gateways, in.reportMap.Gateways) {
-		return false
-	}
-	if !maps.EqualFunc(r.reportMap.ListenerSets, in.reportMap.ListenerSets,
-		func(a, b map[types.NamespacedName]*reports.ListenerSetReport) bool {
-			return maps.Equal(a, b)
-		}) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.HTTPRoutes, in.reportMap.HTTPRoutes) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.TCPRoutes, in.reportMap.TCPRoutes) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.TLSRoutes, in.reportMap.TLSRoutes) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.Policies, in.reportMap.Policies) {
-		return false
-	}
-	if !maps.EqualFunc(r.reportMap.Backends, in.reportMap.Backends, backendReportEqual) {
-		return false
-	}
-	return true
-}
-
-// backendReportEqual reports whether two BackendReports hold the same conditions and observed generation.
-func backendReportEqual(a, b *reports.BackendReport) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	if a.GetObservedGeneration() != b.GetObservedGeneration() {
-		return false
-	}
-	ac, bc := a.GetConditions(), b.GetConditions()
-	if len(ac) != len(bc) {
-		return false
-	}
-	for i := range ac {
-		other := meta.FindStatusCondition(bc, ac[i].Type)
-		if other == nil ||
-			ac[i].Status != other.Status ||
-			ac[i].Reason != other.Reason ||
-			ac[i].Message != other.Message ||
-			ac[i].ObservedGeneration != other.ObservedGeneration {
-			return false
-		}
-	}
-	return true
+	return reports.EqualReportMaps(r.reportMap, in.reportMap)
 }
 
 var logger = logging.New("proxy_syncer")
@@ -398,78 +347,11 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 func mergeProxyReports(
 	proxies []GatewayXdsResources,
 ) reports.ReportMap {
-	merged := reports.NewReportMap()
-	for _, p := range proxies {
-		// 1. merge GW Reports for all Proxies' status reports
-		maps.Copy(merged.Gateways, p.reports.Gateways)
-
-		// 2. merge LS Reports for all Proxies' status reports
-		maps.Copy(merged.ListenerSets, p.reports.ListenerSets)
-
-		// 3. merge httproute parentRefs into RouteReports
-		for rnn, rr := range p.reports.HTTPRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.HTTPRoutes[rnn]
-			if old == nil {
-				merged.HTTPRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.HTTPRoutes[rnn].Parents, rr.Parents)
-		}
-
-		// 4. merge tcproute parentRefs into RouteReports
-		for rnn, rr := range p.reports.TCPRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.TCPRoutes[rnn]
-			if old == nil {
-				merged.TCPRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.TCPRoutes[rnn].Parents, rr.Parents)
-		}
-
-		for rnn, rr := range p.reports.TLSRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.TLSRoutes[rnn]
-			if old == nil {
-				merged.TLSRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.TLSRoutes[rnn].Parents, rr.Parents)
-		}
-
-		for rnn, rr := range p.reports.GRPCRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.GRPCRoutes[rnn]
-			if old == nil {
-				merged.GRPCRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.GRPCRoutes[rnn].Parents, rr.Parents)
-		}
-
-		for key, report := range p.reports.Policies {
-			// if we haven't encountered this policy, just copy it over completely
-			old := merged.Policies[key]
-			if old == nil {
-				merged.Policies[key] = report
-				continue
-			}
-			// else, let's merge our parentRefs into the existing map
-			// obsGen will stay as-is...
-			maps.Copy(merged.Policies[key].Ancestors, report.Ancestors)
-		}
+	inputs := make([]reports.ReportMap, 0, len(proxies))
+	for _, proxy := range proxies {
+		inputs = append(inputs, proxy.reports)
 	}
-
-	return merged
+	return reports.MergeReportMaps(inputs...)
 }
 
 func (s *ProxySyncer) Start(ctx context.Context) error {

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -205,13 +205,6 @@ func (r *PolicyReport) getAncestorRefOrNil(parentRef *gwv1.ParentReference) *Anc
 	return r.Ancestors[key]
 }
 
-// addMissingAncestorRefConditions initializes the AncestorRefReport with a default Pending
-// condition reason for the Accepted and Attached conditions.
-// Positive conditions will be added when the policy is processed and attached to targeted resources.
-func addMissingAncestorRefConditions(report *AncestorRefReport) {
-	report.Conditions = ancestorRefConditionsWithDefaults(report.Conditions)
-}
-
 func ancestorRefConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
 	out := slices.Clone(conditions)
 	if cond := meta.FindStatusCondition(out, string(shared.PolicyConditionAccepted)); cond == nil {

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -126,7 +126,7 @@ func (r *ReportMap) BuildPolicyStatus(
 			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)
 			continue
 		}
-		addMissingAncestorRefConditions(parentStatusReport)
+		ancestorConditions := ancestorRefConditionsWithDefaults(parentStatusReport.Conditions)
 
 		// Get the status of the current parentRef conditions if they exist
 		var currentParentRefConditions []metav1.Condition
@@ -138,7 +138,7 @@ func (r *ReportMap) BuildPolicyStatus(
 		}
 
 		// Build and append the Attached Condition.Type
-		existingConditions := addAttachmentCondition(parentStatusReport)
+		existingConditions := addAttachmentCondition(ancestorConditions, parentStatusReport.AttachmentState)
 
 		finalConditions := make([]metav1.Condition, 0, len(existingConditions))
 		for _, pCondition := range existingConditions {
@@ -202,9 +202,6 @@ func (r *ReportMap) BuildPolicyStatus(
 // If no report is found, nil is returned, signaling this parentRef is unknown to the report
 func (r *PolicyReport) getAncestorRefOrNil(parentRef *gwv1.ParentReference) *AncestorRefReport {
 	key := getParentRefKey(parentRef)
-	if r.Ancestors == nil {
-		r.Ancestors = make(map[ParentRefKey]*AncestorRefReport)
-	}
 	return r.Ancestors[key]
 }
 
@@ -212,33 +209,39 @@ func (r *PolicyReport) getAncestorRefOrNil(parentRef *gwv1.ParentReference) *Anc
 // condition reason for the Accepted and Attached conditions.
 // Positive conditions will be added when the policy is processed and attached to targeted resources.
 func addMissingAncestorRefConditions(report *AncestorRefReport) {
-	if cond := meta.FindStatusCondition(report.Conditions, string(shared.PolicyConditionAccepted)); cond == nil {
-		meta.SetStatusCondition(&report.Conditions, metav1.Condition{
+	report.Conditions = ancestorRefConditionsWithDefaults(report.Conditions)
+}
+
+func ancestorRefConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
+	if cond := meta.FindStatusCondition(out, string(shared.PolicyConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
 			Type:   string(shared.PolicyConditionAccepted),
 			Status: metav1.ConditionFalse,
 			Reason: string(shared.PolicyReasonPending),
 		})
 	}
-	if cond := meta.FindStatusCondition(report.Conditions, string(shared.PolicyConditionAttached)); cond == nil {
-		meta.SetStatusCondition(&report.Conditions, metav1.Condition{
+	if cond := meta.FindStatusCondition(out, string(shared.PolicyConditionAttached)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
 			Type:   string(shared.PolicyConditionAttached),
 			Status: metav1.ConditionFalse,
 			Reason: string(shared.PolicyReasonPending),
 		})
 	}
+	return out
 }
 
-func addAttachmentCondition(report *AncestorRefReport) []metav1.Condition {
-	if report.AttachmentState == reporter.PolicyAttachmentStatePending {
+func addAttachmentCondition(conditions []metav1.Condition, attachmentState reporter.PolicyAttachmentState) []metav1.Condition {
+	if attachmentState == reporter.PolicyAttachmentStatePending {
 		// no attachment state set, return the conditions as is
-		return report.Conditions
+		return conditions
 	}
 
 	// avoid modifying the existing Conditions on the report
-	existing := slices.Clone(report.Conditions)
+	existing := slices.Clone(conditions)
 
 	switch {
-	case report.AttachmentState.Has(reporter.PolicyAttachmentStateOverridden):
+	case attachmentState.Has(reporter.PolicyAttachmentStateOverridden):
 		meta.SetStatusCondition(&existing, metav1.Condition{
 			Type:    string(shared.PolicyConditionAttached),
 			Status:  metav1.ConditionFalse,
@@ -246,7 +249,7 @@ func addAttachmentCondition(report *AncestorRefReport) []metav1.Condition {
 			Message: reporter.PolicyOverriddenMsg,
 		})
 
-	case report.AttachmentState.Has(reporter.PolicyAttachmentStateMerged):
+	case attachmentState.Has(reporter.PolicyAttachmentStateMerged):
 		meta.SetStatusCondition(&existing, metav1.Condition{
 			Type:    string(shared.PolicyConditionAttached),
 			Status:  metav1.ConditionTrue,
@@ -254,7 +257,7 @@ func addAttachmentCondition(report *AncestorRefReport) []metav1.Condition {
 			Message: reporter.PolicyMergedMsg,
 		})
 
-	case report.AttachmentState.Has(reporter.PolicyAttachmentStateAttached):
+	case attachmentState.Has(reporter.PolicyAttachmentStateAttached):
 		meta.SetStatusCondition(&existing, metav1.Condition{
 			Type:    string(shared.PolicyConditionAttached),
 			Status:  metav1.ConditionTrue,

--- a/pkg/reports/report_map.go
+++ b/pkg/reports/report_map.go
@@ -1,0 +1,316 @@
+package reports
+
+import (
+	"maps"
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// MergeReportMaps returns a report map owned by the caller. The returned reports
+// do not alias the input report objects, so later status rendering and status
+// marker processing can safely mutate the merged map without writing into
+// per-translation reports.
+func MergeReportMaps(inputs ...ReportMap) ReportMap {
+	merged := NewReportMap()
+	for _, input := range inputs {
+		for key, report := range input.Gateways {
+			merged.Gateways[key] = cloneGatewayReport(report)
+		}
+		for gvk, reportsByName := range input.ListenerSets {
+			if merged.ListenerSets[gvk] == nil {
+				merged.ListenerSets[gvk] = make(map[types.NamespacedName]*ListenerSetReport, len(reportsByName))
+			}
+			for key, report := range reportsByName {
+				merged.ListenerSets[gvk][key] = cloneListenerSetReport(report)
+			}
+		}
+		mergeRouteReportMap(merged.HTTPRoutes, input.HTTPRoutes)
+		mergeRouteReportMap(merged.GRPCRoutes, input.GRPCRoutes)
+		mergeRouteReportMap(merged.TCPRoutes, input.TCPRoutes)
+		mergeRouteReportMap(merged.TLSRoutes, input.TLSRoutes)
+		for key, report := range input.Policies {
+			existing := merged.Policies[key]
+			if existing == nil {
+				merged.Policies[key] = clonePolicyReport(report)
+				continue
+			}
+			mergeAncestorReports(existing, report)
+		}
+		for key, report := range input.Backends {
+			merged.Backends[key] = cloneBackendReport(report)
+		}
+	}
+	return merged
+}
+
+func mergeRouteReportMap(dst, src map[types.NamespacedName]*RouteReport) {
+	for key, report := range src {
+		existing := dst[key]
+		if existing == nil {
+			dst[key] = cloneRouteReport(report)
+			continue
+		}
+		mergeParentReports(existing, report)
+	}
+}
+
+func mergeParentReports(dst, src *RouteReport) {
+	if dst == nil || src == nil {
+		return
+	}
+	if len(src.Parents) == 0 {
+		return
+	}
+	if dst.Parents == nil {
+		dst.Parents = make(map[ParentRefKey]*ParentRefReport, len(src.Parents))
+	}
+	for key, report := range src.Parents {
+		dst.Parents[key] = cloneParentRefReport(report)
+	}
+}
+
+func mergeAncestorReports(dst, src *PolicyReport) {
+	if dst == nil || src == nil {
+		return
+	}
+	if len(src.Ancestors) == 0 {
+		return
+	}
+	if dst.Ancestors == nil {
+		dst.Ancestors = make(map[ParentRefKey]*AncestorRefReport, len(src.Ancestors))
+	}
+	for key, report := range src.Ancestors {
+		dst.Ancestors[key] = cloneAncestorRefReport(report)
+	}
+}
+
+func cloneGatewayReport(in *GatewayReport) *GatewayReport {
+	if in == nil {
+		return nil
+	}
+	return &GatewayReport{
+		conditions:           slices.Clone(in.conditions),
+		listeners:            cloneListenerReports(in.listeners),
+		observedGeneration:   in.observedGeneration,
+		attachedListenerSets: in.attachedListenerSets,
+	}
+}
+
+func cloneListenerSetReport(in *ListenerSetReport) *ListenerSetReport {
+	if in == nil {
+		return nil
+	}
+	return &ListenerSetReport{
+		conditions:         slices.Clone(in.conditions),
+		listeners:          cloneListenerReports(in.listeners),
+		observedGeneration: in.observedGeneration,
+	}
+}
+
+func cloneListenerReports(in map[string]*ListenerReport) map[string]*ListenerReport {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]*ListenerReport, len(in))
+	for key, report := range in {
+		if report == nil {
+			out[key] = nil
+			continue
+		}
+		status := report.Status
+		status.Conditions = slices.Clone(status.Conditions)
+		status.SupportedKinds = slices.Clone(status.SupportedKinds)
+		out[key] = &ListenerReport{Status: status}
+	}
+	return out
+}
+
+func cloneRouteReport(in *RouteReport) *RouteReport {
+	if in == nil {
+		return nil
+	}
+	out := &RouteReport{observedGeneration: in.observedGeneration}
+	if in.Parents != nil {
+		out.Parents = make(map[ParentRefKey]*ParentRefReport, len(in.Parents))
+		for key, report := range in.Parents {
+			out.Parents[key] = cloneParentRefReport(report)
+		}
+	}
+	return out
+}
+
+func cloneParentRefReport(in *ParentRefReport) *ParentRefReport {
+	if in == nil {
+		return nil
+	}
+	return &ParentRefReport{Conditions: slices.Clone(in.Conditions)}
+}
+
+func clonePolicyReport(in *PolicyReport) *PolicyReport {
+	if in == nil {
+		return nil
+	}
+	out := &PolicyReport{observedGeneration: in.observedGeneration}
+	if in.Ancestors != nil {
+		out.Ancestors = make(map[ParentRefKey]*AncestorRefReport, len(in.Ancestors))
+		for key, report := range in.Ancestors {
+			out.Ancestors[key] = cloneAncestorRefReport(report)
+		}
+	}
+	return out
+}
+
+func cloneAncestorRefReport(in *AncestorRefReport) *AncestorRefReport {
+	if in == nil {
+		return nil
+	}
+	return &AncestorRefReport{
+		Conditions:      slices.Clone(in.Conditions),
+		AttachmentState: in.AttachmentState,
+	}
+}
+
+func cloneBackendReport(in *BackendReport) *BackendReport {
+	if in == nil {
+		return nil
+	}
+	return &BackendReport{
+		Conditions:         slices.Clone(in.Conditions),
+		observedGeneration: in.observedGeneration,
+	}
+}
+
+// EqualReportMaps compares report maps by semantic report contents rather than
+// report pointer identity. LastTransitionTime is intentionally ignored so
+// timestamp-only status changes do not cause KRT churn.
+func EqualReportMaps(a, b ReportMap) bool {
+	return maps.EqualFunc(a.Gateways, b.Gateways, gatewayReportEqual) &&
+		listenerSetMapsEqual(a.ListenerSets, b.ListenerSets) &&
+		maps.EqualFunc(a.HTTPRoutes, b.HTTPRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.GRPCRoutes, b.GRPCRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.TCPRoutes, b.TCPRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.TLSRoutes, b.TLSRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.Policies, b.Policies, policyReportEqual) &&
+		maps.EqualFunc(a.Backends, b.Backends, backendReportEqual)
+}
+
+func listenerSetMapsEqual(
+	a, b map[schema.GroupVersionKind]map[types.NamespacedName]*ListenerSetReport,
+) bool {
+	return maps.EqualFunc(a, b, func(a, b map[types.NamespacedName]*ListenerSetReport) bool {
+		return maps.EqualFunc(a, b, listenerSetReportEqual)
+	})
+}
+
+func gatewayReportEqual(a, b *GatewayReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		a.attachedListenerSets == b.attachedListenerSets &&
+		conditionsEqual(a.conditions, b.conditions) &&
+		maps.EqualFunc(a.listeners, b.listeners, listenerReportEqual)
+}
+
+func listenerSetReportEqual(a, b *ListenerSetReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		conditionsEqual(a.conditions, b.conditions) &&
+		maps.EqualFunc(a.listeners, b.listeners, listenerReportEqual)
+}
+
+func listenerReportEqual(a, b *ListenerReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return listenerStatusEqual(a.Status, b.Status)
+}
+
+func listenerStatusEqual(a, b gwv1.ListenerStatus) bool {
+	return a.Name == b.Name &&
+		a.AttachedRoutes == b.AttachedRoutes &&
+		slices.EqualFunc(a.SupportedKinds, b.SupportedKinds, routeGroupKindEqual) &&
+		conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func routeGroupKindEqual(a, b gwv1.RouteGroupKind) bool {
+	return ptrValueEqual(a.Group, b.Group) && a.Kind == b.Kind
+}
+
+func ptrValueEqual[T comparable](a, b *T) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func routeReportEqual(a, b *RouteReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		maps.EqualFunc(a.Parents, b.Parents, parentRefReportEqual)
+}
+
+func parentRefReportEqual(a, b *ParentRefReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func policyReportEqual(a, b *PolicyReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		maps.EqualFunc(a.Ancestors, b.Ancestors, ancestorRefReportEqual)
+}
+
+func ancestorRefReportEqual(a, b *AncestorRefReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.AttachmentState == b.AttachmentState &&
+		conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func backendReportEqual(a, b *BackendReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func conditionsEqual(a, b []metav1.Condition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, condition := range a {
+		other := findCondition(b, condition.Type)
+		if other == nil ||
+			condition.Status != other.Status ||
+			condition.Reason != other.Reason ||
+			condition.Message != other.Message ||
+			condition.ObservedGeneration != other.ObservedGeneration {
+			return false
+		}
+	}
+	return true
+}
+
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/reports/report_map.go
+++ b/pkg/reports/report_map.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"slices"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -294,7 +295,7 @@ func conditionsEqual(a, b []metav1.Condition) bool {
 		return false
 	}
 	for _, condition := range a {
-		other := findCondition(b, condition.Type)
+		other := meta.FindStatusCondition(b, condition.Type)
 		if other == nil ||
 			condition.Status != other.Status ||
 			condition.Reason != other.Reason ||
@@ -304,13 +305,4 @@ func conditionsEqual(a, b []metav1.Condition) bool {
 		}
 	}
 	return true
-}
-
-func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type == conditionType {
-			return &conditions[i]
-		}
-	}
-	return nil
 }

--- a/pkg/reports/report_map_test.go
+++ b/pkg/reports/report_map_test.go
@@ -1,0 +1,309 @@
+package reports
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+)
+
+// testCondition builds a condition with all the fields EqualReportMaps cares about,
+// plus a LastTransitionTime which it must ignore.
+func testCondition(condType string, status metav1.ConditionStatus, reason, message string, observedGen int64, transition time.Time) metav1.Condition {
+	return metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: observedGen,
+		LastTransitionTime: metav1.NewTime(transition),
+	}
+}
+
+var (
+	testGatewayKey = types.NamespacedName{Namespace: "default", Name: "gw"}
+	testRouteKey   = types.NamespacedName{Namespace: "default", Name: "route"}
+	testBackendKey = types.NamespacedName{Namespace: "default", Name: "backend"}
+	testLSKey      = types.NamespacedName{Namespace: "default", Name: "ls"}
+	testPolicyKey  = reporter.PolicyKey{Group: "example.com", Kind: "Policy", Namespace: "default", Name: "policy"}
+	testParentKey  = ParentRefKey{
+		Group:          gwv1.GroupVersion.Group,
+		Kind:           "Gateway",
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "gw"},
+	}
+)
+
+// fullReportMap builds a ReportMap that exercises every report kind (gateways,
+// nested listener sets, all four route kinds, policies and backends) with the
+// given LastTransitionTime stamped on every condition. Callers vary only the
+// transition time to assert it is ignored by EqualReportMaps.
+func fullReportMap(transition time.Time) ReportMap {
+	rm := NewReportMap()
+
+	rm.Gateways[testGatewayKey] = &GatewayReport{
+		observedGeneration:   5,
+		attachedListenerSets: 2,
+		conditions: []metav1.Condition{
+			testCondition(string(gwv1.GatewayConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", 5, transition),
+		},
+		listeners: map[string]*ListenerReport{
+			"http": {Status: gwv1.ListenerStatus{
+				Name:           "http",
+				AttachedRoutes: 3,
+				SupportedKinds: []gwv1.RouteGroupKind{{Kind: "HTTPRoute"}},
+				Conditions: []metav1.Condition{
+					testCondition(string(gwv1.ListenerConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", 5, transition),
+				},
+			}},
+		},
+	}
+
+	rm.ListenerSets[wellknown.ListenerSetGVK] = map[types.NamespacedName]*ListenerSetReport{
+		testLSKey: {
+			observedGeneration: 4,
+			conditions: []metav1.Condition{
+				testCondition(string(gwv1.GatewayConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", 4, transition),
+			},
+			listeners: map[string]*ListenerReport{
+				"http": {Status: gwv1.ListenerStatus{
+					Name: "http",
+					Conditions: []metav1.Condition{
+						testCondition(string(gwv1.ListenerConditionProgrammed), metav1.ConditionTrue, "Programmed", "programmed", 4, transition),
+					},
+				}},
+			},
+		},
+	}
+
+	routeReport := func(gen int64) *RouteReport {
+		return &RouteReport{
+			observedGeneration: gen,
+			Parents: map[ParentRefKey]*ParentRefReport{
+				testParentKey: {Conditions: []metav1.Condition{
+					testCondition(string(gwv1.RouteConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", gen, transition),
+				}},
+			},
+		}
+	}
+	rm.HTTPRoutes[testRouteKey] = routeReport(1)
+	rm.GRPCRoutes[testRouteKey] = routeReport(2)
+	rm.TCPRoutes[testRouteKey] = routeReport(3)
+	rm.TLSRoutes[testRouteKey] = routeReport(4)
+
+	rm.Policies[testPolicyKey] = &PolicyReport{
+		observedGeneration: 2,
+		Ancestors: map[ParentRefKey]*AncestorRefReport{
+			testParentKey: {
+				AttachmentState: reporter.PolicyAttachmentStateAttached,
+				Conditions: []metav1.Condition{
+					testCondition("Accepted", metav1.ConditionTrue, "Valid", "valid", 2, transition),
+				},
+			},
+		},
+	}
+
+	rm.Backends[testBackendKey] = &BackendReport{
+		observedGeneration: 9,
+		Conditions: []metav1.Condition{
+			testCondition("Accepted", metav1.ConditionTrue, "Accepted", "accepted", 9, transition),
+		},
+	}
+
+	return rm
+}
+
+func TestEqualReportMaps_EmptyMapsAreEqual(t *testing.T) {
+	assert.True(t, EqualReportMaps(NewReportMap(), NewReportMap()))
+}
+
+func TestEqualReportMaps_IdenticalMapsAreEqual(t *testing.T) {
+	now := time.Now()
+	assert.True(t, EqualReportMaps(fullReportMap(now), fullReportMap(now)))
+}
+
+// TestEqualReportMaps_IgnoresLastTransitionTime is the central promise: a status
+// rebuild that changes only condition timestamps must not be treated as a change,
+// otherwise KRT would churn on every reconcile.
+func TestEqualReportMaps_IgnoresLastTransitionTime(t *testing.T) {
+	a := fullReportMap(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	b := fullReportMap(time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC))
+	assert.True(t, EqualReportMaps(a, b), "maps differing only in LastTransitionTime must be equal")
+}
+
+// TestEqualReportMaps_DetectsConditionFieldChanges asserts the fields that DO
+// matter (Status/Reason/Message/ObservedGeneration) each break equality, even
+// though LastTransitionTime does not.
+func TestEqualReportMaps_DetectsConditionFieldChanges(t *testing.T) {
+	now := time.Now()
+	cases := map[string]func(*metav1.Condition){
+		"status":             func(c *metav1.Condition) { c.Status = metav1.ConditionFalse },
+		"reason":             func(c *metav1.Condition) { c.Reason = "Different" },
+		"message":            func(c *metav1.Condition) { c.Message = "different" },
+		"observedGeneration": func(c *metav1.Condition) { c.ObservedGeneration = 999 },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := fullReportMap(now)
+			b := fullReportMap(now)
+			mutate(&b.Gateways[testGatewayKey].conditions[0])
+			assert.False(t, EqualReportMaps(a, b), "change to condition %s must break equality", name)
+		})
+	}
+}
+
+func TestEqualReportMaps_DetectsConditionAddedOrRemoved(t *testing.T) {
+	now := time.Now()
+
+	a := fullReportMap(now)
+	b := fullReportMap(now)
+	b.Gateways[testGatewayKey].conditions = append(b.Gateways[testGatewayKey].conditions,
+		testCondition(string(gwv1.GatewayConditionProgrammed), metav1.ConditionTrue, "Programmed", "programmed", 5, now))
+	assert.False(t, EqualReportMaps(a, b), "an extra condition must break equality")
+
+	// A condition of the same type but absent on one side must also break equality.
+	c := fullReportMap(now)
+	c.Gateways[testGatewayKey].conditions = nil
+	assert.False(t, EqualReportMaps(a, c))
+}
+
+func TestEqualReportMaps_DetectsGatewayScalarChanges(t *testing.T) {
+	now := time.Now()
+
+	og := fullReportMap(now)
+	og.Gateways[testGatewayKey].observedGeneration = 6
+	assert.False(t, EqualReportMaps(fullReportMap(now), og), "observedGeneration change must break equality")
+
+	als := fullReportMap(now)
+	als.Gateways[testGatewayKey].attachedListenerSets = 99
+	assert.False(t, EqualReportMaps(fullReportMap(now), als), "attachedListenerSets change must break equality")
+}
+
+func TestEqualReportMaps_DetectsListenerStatusChanges(t *testing.T) {
+	now := time.Now()
+
+	routes := fullReportMap(now)
+	routes.Gateways[testGatewayKey].listeners["http"].Status.AttachedRoutes = 100
+	assert.False(t, EqualReportMaps(fullReportMap(now), routes), "AttachedRoutes change must break equality")
+
+	kinds := fullReportMap(now)
+	kinds.Gateways[testGatewayKey].listeners["http"].Status.SupportedKinds = []gwv1.RouteGroupKind{{Kind: "GRPCRoute"}}
+	assert.False(t, EqualReportMaps(fullReportMap(now), kinds), "SupportedKinds change must break equality")
+
+	added := fullReportMap(now)
+	added.Gateways[testGatewayKey].listeners["https"] = &ListenerReport{Status: gwv1.ListenerStatus{Name: "https"}}
+	assert.False(t, EqualReportMaps(fullReportMap(now), added), "extra listener must break equality")
+}
+
+// TestEqualReportMaps_ListenerSetGVKMaps covers the nested
+// GVK -> NamespacedName -> report map comparison for ListenerSets.
+func TestEqualReportMaps_ListenerSetGVKMaps(t *testing.T) {
+	now := time.Now()
+
+	t.Run("equal when content matches", func(t *testing.T) {
+		assert.True(t, EqualReportMaps(fullReportMap(now), fullReportMap(now)))
+	})
+
+	t.Run("different GVK key", func(t *testing.T) {
+		b := fullReportMap(now)
+		report := b.ListenerSets[wellknown.ListenerSetGVK][testLSKey]
+		delete(b.ListenerSets, wellknown.ListenerSetGVK)
+		otherGVK := schema.GroupVersionKind{Group: "other.io", Version: "v1", Kind: "OtherListenerSet"}
+		b.ListenerSets[otherGVK] = map[types.NamespacedName]*ListenerSetReport{testLSKey: report}
+		assert.False(t, EqualReportMaps(fullReportMap(now), b), "moving a report under a different GVK must break equality")
+	})
+
+	t.Run("different NamespacedName within GVK", func(t *testing.T) {
+		b := fullReportMap(now)
+		report := b.ListenerSets[wellknown.ListenerSetGVK][testLSKey]
+		delete(b.ListenerSets[wellknown.ListenerSetGVK], testLSKey)
+		b.ListenerSets[wellknown.ListenerSetGVK][types.NamespacedName{Namespace: "default", Name: "other-ls"}] = report
+		assert.False(t, EqualReportMaps(fullReportMap(now), b), "different listener set name must break equality")
+	})
+
+	t.Run("condition change within listener set", func(t *testing.T) {
+		b := fullReportMap(now)
+		b.ListenerSets[wellknown.ListenerSetGVK][testLSKey].conditions[0].Status = metav1.ConditionFalse
+		assert.False(t, EqualReportMaps(fullReportMap(now), b))
+	})
+
+	t.Run("ignores LastTransitionTime within listener set", func(t *testing.T) {
+		a := fullReportMap(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		b := fullReportMap(now)
+		// Wipe every difference except the listener-set timestamps, which differ via fullReportMap.
+		assert.True(t, EqualReportMaps(a, b))
+	})
+
+	t.Run("extra GVK entry", func(t *testing.T) {
+		b := fullReportMap(now)
+		b.ListenerSets[wellknown.XListenerSetGVK] = map[types.NamespacedName]*ListenerSetReport{
+			testLSKey: {observedGeneration: 1},
+		}
+		assert.False(t, EqualReportMaps(fullReportMap(now), b))
+	})
+}
+
+func TestEqualReportMaps_DetectsRouteChanges(t *testing.T) {
+	now := time.Now()
+
+	gen := fullReportMap(now)
+	gen.HTTPRoutes[testRouteKey].observedGeneration = 100
+	assert.False(t, EqualReportMaps(fullReportMap(now), gen), "route observedGeneration change must break equality")
+
+	cond := fullReportMap(now)
+	cond.TCPRoutes[testRouteKey].Parents[testParentKey].Conditions[0].Reason = "Different"
+	assert.False(t, EqualReportMaps(fullReportMap(now), cond), "parent condition change must break equality")
+
+	parent := fullReportMap(now)
+	parent.GRPCRoutes[testRouteKey].Parents[ParentRefKey{Kind: "Gateway", NamespacedName: types.NamespacedName{Name: "extra"}}] = &ParentRefReport{}
+	assert.False(t, EqualReportMaps(fullReportMap(now), parent), "extra parent must break equality")
+}
+
+func TestEqualReportMaps_DetectsPolicyChanges(t *testing.T) {
+	now := time.Now()
+
+	gen := fullReportMap(now)
+	gen.Policies[testPolicyKey].observedGeneration = 100
+	assert.False(t, EqualReportMaps(fullReportMap(now), gen), "policy observedGeneration change must break equality")
+
+	state := fullReportMap(now)
+	state.Policies[testPolicyKey].Ancestors[testParentKey].AttachmentState = reporter.PolicyAttachmentStateMerged
+	assert.False(t, EqualReportMaps(fullReportMap(now), state), "ancestor AttachmentState change must break equality")
+
+	cond := fullReportMap(now)
+	cond.Policies[testPolicyKey].Ancestors[testParentKey].Conditions[0].Message = "different"
+	assert.False(t, EqualReportMaps(fullReportMap(now), cond), "ancestor condition change must break equality")
+}
+
+func TestEqualReportMaps_DetectsBackendChanges(t *testing.T) {
+	now := time.Now()
+
+	gen := fullReportMap(now)
+	gen.Backends[testBackendKey].observedGeneration = 100
+	assert.False(t, EqualReportMaps(fullReportMap(now), gen), "backend observedGeneration change must break equality")
+
+	cond := fullReportMap(now)
+	cond.Backends[testBackendKey].Conditions[0].Status = metav1.ConditionFalse
+	assert.False(t, EqualReportMaps(fullReportMap(now), cond), "backend condition change must break equality")
+}
+
+// TestEqualReportMaps_NilReportPointers verifies that a nil report value compares
+// distinct from a populated one but equal to another nil under the same key.
+func TestEqualReportMaps_NilReportPointers(t *testing.T) {
+	a := NewReportMap()
+	a.Gateways[testGatewayKey] = nil
+	b := NewReportMap()
+	b.Gateways[testGatewayKey] = nil
+	assert.True(t, EqualReportMaps(a, b), "two nil reports under the same key must be equal")
+
+	c := fullReportMap(time.Now())
+	d := NewReportMap()
+	d.Gateways[testGatewayKey] = nil
+	assert.False(t, EqualReportMaps(c, d), "nil vs populated report must not be equal")
+}

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -99,11 +99,7 @@ func key(obj metav1.Object) types.NamespacedName {
 // NOTE: Exported for unit testing, validation_test.go should be refactored to reduce this visibility
 func (r *ReportMap) Gateway(gateway *gwv1.Gateway) *GatewayReport {
 	key := key(gateway)
-	report := r.Gateways[key]
-	if report != nil {
-		report.observedGeneration = gateway.Generation
-	}
-	return report
+	return r.Gateways[key]
 }
 
 func (r *ReportMap) GatewayNamespaceName(key types.NamespacedName) *GatewayReport {
@@ -143,11 +139,7 @@ func (r *ReportMap) ListenerSet(listenerSet client.Object) *ListenerSetReport {
 		r.ListenerSets[gvk] = make(map[types.NamespacedName]*ListenerSetReport)
 	}
 	key := key(listenerSet)
-	report := r.ListenerSets[gvk][key]
-	if report != nil {
-		report.observedGeneration = listenerSet.GetGeneration()
-	}
-	return report
+	return r.ListenerSets[gvk][key]
 }
 
 func (r *ReportMap) newListenerSetReport(listenerSet client.Object) *ListenerSetReport {
@@ -167,7 +159,10 @@ func (r *ReportMap) newListenerSetReport(listenerSet client.Object) *ListenerSet
 	return lsr
 }
 
-// route returns a RouteReport for the provided route object, nil if a report is not present.
+// route is a pure lookup that returns a RouteReport for the provided route object,
+// or nil if a report is not present. The observedGeneration is set at report
+// creation time (newRouteReport) and when the route is translated
+// (statusReporter.Route).
 // This is different than the Reporter.Route() method, as we need to understand when
 // reports are not generated for a route that has been translated. Supported object types are:
 //
@@ -180,35 +175,15 @@ func (r *ReportMap) route(obj metav1.Object) *RouteReport {
 
 	switch obj.(type) {
 	case *gwv1.HTTPRoute:
-		report := r.HTTPRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.HTTPRoutes[key]
 	case *gwv1a2.TCPRoute:
-		report := r.TCPRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.TCPRoutes[key]
 	case *gwv1.TLSRoute:
-		report := r.TLSRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.TLSRoutes[key]
 	case *gwv1a2.TLSRoute:
-		report := r.TLSRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.TLSRoutes[key]
 	case *gwv1.GRPCRoute:
-		report := r.GRPCRoutes[key]
-		if report != nil {
-			report.observedGeneration = obj.GetGeneration()
-		}
-		return report
+		return r.GRPCRoutes[key]
 	default:
 		slog.Warn("unsupported route type", "route_type", fmt.Sprintf("%T", obj))
 		return nil
@@ -405,6 +380,8 @@ func (r *statusReporter) Gateway(gateway *gwv1.Gateway) reporter.GatewayReporter
 	gr := r.report.Gateway(gateway)
 	if gr == nil {
 		gr = r.report.newGatewayReport(gateway)
+	} else {
+		gr.observedGeneration = gateway.Generation
 	}
 	return gr
 }
@@ -413,6 +390,8 @@ func (r *statusReporter) ListenerSet(listenerSet client.Object) reporter.Listene
 	lsr := r.report.ListenerSet(listenerSet)
 	if lsr == nil {
 		lsr = r.report.newListenerSetReport(listenerSet)
+	} else {
+		lsr.observedGeneration = listenerSet.GetGeneration()
 	}
 	return lsr
 }
@@ -421,6 +400,8 @@ func (r *statusReporter) Route(obj metav1.Object) reporter.RouteReporter {
 	rr := r.report.route(obj)
 	if rr == nil {
 		rr = r.report.newRouteReport(obj)
+	} else {
+		rr.observedGeneration = obj.GetGeneration()
 	}
 	return rr
 }
@@ -467,9 +448,6 @@ func getParentRefKey(parentRef *gwv1.ParentReference) ParentRefKey {
 // If no report is found, nil is returned, signaling this parentRef is unknown to the report
 func (r *RouteReport) getParentRefOrNil(parentRef *gwv1.ParentReference) *ParentRefReport {
 	key := getParentRefKey(parentRef)
-	if r.Parents == nil {
-		r.Parents = make(map[ParentRefKey]*ParentRefReport)
-	}
 	return r.Parents[key]
 }
 

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -125,7 +125,9 @@ func (r *ReportMap) newGatewayReport(gateway *gwv1.Gateway) *GatewayReport {
 	return gr
 }
 
-// Returns a ListenerSetReport for the provided ListenerSet, nil if there is not a report present.
+// ListenerSet is a pure lookup that returns the ListenerSetReport for the provided
+// ListenerSet, or nil if a report is not present. It must not mutate the ReportMap:
+// lazily creating the per-GVK map here would change ReportMap equality on a read.
 // This is different than the Reporter.ListenerSet() method, as we need to understand when
 // reports are not generated for a ListenerSet that has been translated.
 //
@@ -135,11 +137,11 @@ func (r *ReportMap) ListenerSet(listenerSet client.Object) *ListenerSetReport {
 	if gvk.Empty() {
 		gvk = wellknown.ListenerSetGVK
 	}
-	if r.ListenerSets[gvk] == nil {
-		r.ListenerSets[gvk] = make(map[types.NamespacedName]*ListenerSetReport)
+	lsByGVK := r.ListenerSets[gvk]
+	if lsByGVK == nil {
+		return nil
 	}
-	key := key(listenerSet)
-	return r.ListenerSets[gvk][key]
+	return lsByGVK[key(listenerSet)]
 }
 
 func (r *ReportMap) newListenerSetReport(listenerSet client.Object) *ListenerSetReport {

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
 
 // Status message constants
@@ -41,7 +40,7 @@ const (
 // TODO: refactor this struct + methods to better reflect the usage now in proxy_syncer
 
 func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attachedRoutes map[string]uint) *gwv1.GatewayStatus {
-	gwReport := r.Gateway(&gw)
+	gwReport := r.GatewayNamespaceName(key(&gw))
 	if gwReport == nil {
 		return nil
 	}
@@ -51,21 +50,20 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 	var invalidMessages []string
 
 	for _, lis := range gw.Spec.Listeners {
-		lisReport := gwReport.listener(string(lis.Name))
-		AddMissingListenerConditions(lisReport)
+		listenerStatus := listenerStatusFromGatewayReport(gwReport, lis)
 		// Get attached routes for this listener
 		if attachedRoutes != nil {
 			if count, exists := attachedRoutes[string(lis.Name)]; exists {
-				lisReport.Status.AttachedRoutes = int32(count) //nolint:gosec // G115: route count is always non-negative
+				listenerStatus.AttachedRoutes = int32(count) //nolint:gosec // G115: route count is always non-negative
 			}
 		}
 
-		finalConditions := make([]metav1.Condition, 0, len(lisReport.Status.Conditions))
+		finalConditions := make([]metav1.Condition, 0, len(listenerStatus.Conditions))
 		oldLisStatusIndex := slices.IndexFunc(gw.Status.Listeners, func(l gwv1.ListenerStatus) bool {
 			return l.Name == lis.Name
 		})
-		for _, lisCondition := range lisReport.Status.Conditions {
-			lisCondition.ObservedGeneration = gwReport.observedGeneration
+		for _, lisCondition := range listenerStatus.Conditions {
+			lisCondition.ObservedGeneration = gw.Generation
 
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 			if oldLisStatusIndex != -1 {
@@ -83,10 +81,12 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 				}
 			}
 		}
-		lisReport.Status.Conditions = finalConditions
+		listenerStatus.Conditions = finalConditions
 
-		finalListeners = append(finalListeners, lisReport.Status)
+		finalListeners = append(finalListeners, listenerStatus)
 	}
+
+	gwConditions := slices.Clone(gwReport.GetConditions())
 
 	// If any listeners have Programmed=False, set Gateway Accepted=True with ListenersNotValid reason
 	if len(invalidListeners) > 0 {
@@ -95,22 +95,21 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 			message = fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidListeners, ", "))
 		}
 
-		gwReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+		meta.SetStatusCondition(&gwConditions, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonListenersNotValid,
+			Reason:  string(gwv1.GatewayReasonListenersNotValid),
 			Message: message,
 		})
 	}
 
-	handleInvalidAddresses(gwReport, &gw)
-	handleInsecureFrontendValidationMode(gwReport, &gw)
-
-	addMissingGatewayConditions(r.Gateway(&gw), &gw)
+	gwConditions = handleInvalidAddresses(gwConditions, &gw)
+	gwConditions = handleInsecureFrontendValidationMode(gwConditions, &gw)
+	gwConditions = gatewayConditionsWithDefaults(gwConditions, &gw, finalListeners)
 
 	finalConditions := make([]metav1.Condition, 0)
-	for _, gwCondition := range gwReport.GetConditions() {
-		gwCondition.ObservedGeneration = gwReport.observedGeneration
+	for _, gwCondition := range gwConditions {
+		gwCondition.ObservedGeneration = gw.Generation
 
 		// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(gw.Status.Conditions, gwCondition.Type); cond != nil {
@@ -136,7 +135,40 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 	return &finalGwStatus
 }
 
-func handleInvalidAddresses(report *GatewayReport, g *gwv1.Gateway) {
+func listenerStatusFromGatewayReport(report *GatewayReport, listener gwv1.Listener) gwv1.ListenerStatus {
+	status := newListenerStatus(string(listener.Name))
+	if report != nil && report.listeners != nil {
+		if listenerReport := report.listeners[string(listener.Name)]; listenerReport != nil {
+			status = listenerReport.Status
+			status.Conditions = slices.Clone(listenerReport.Status.Conditions)
+			status.SupportedKinds = slices.Clone(listenerReport.Status.SupportedKinds)
+		}
+	}
+	status.Conditions = listenerConditionsWithDefaults(status.Conditions)
+	return status
+}
+
+func listenerStatusFromListenerSetReport(report *ListenerSetReport, listener gwv1.Listener) gwv1.ListenerStatus {
+	status := newListenerStatus(string(listener.Name))
+	if report != nil && report.listeners != nil {
+		if listenerReport := report.listeners[string(listener.Name)]; listenerReport != nil {
+			status = listenerReport.Status
+			status.Conditions = slices.Clone(listenerReport.Status.Conditions)
+			status.SupportedKinds = slices.Clone(listenerReport.Status.SupportedKinds)
+		}
+	}
+	status.Conditions = listenerConditionsWithDefaults(status.Conditions)
+	return status
+}
+
+func newListenerStatus(name string) gwv1.ListenerStatus {
+	return gwv1.ListenerStatus{
+		Name:           gwv1.SectionName(name),
+		SupportedKinds: []gwv1.RouteGroupKind{},
+	}
+}
+
+func handleInvalidAddresses(conditions []metav1.Condition, g *gwv1.Gateway) []metav1.Condition {
 	for _, addr := range g.Spec.Addresses {
 		if addr.Type == nil {
 			continue
@@ -144,34 +176,36 @@ func handleInvalidAddresses(report *GatewayReport, g *gwv1.Gateway) {
 		switch *addr.Type {
 		case gwv1.IPAddressType:
 		case gwv1.HostnameAddressType:
-			report.SetCondition(reporter.GatewayCondition{
-				Type:    gwv1.GatewayConditionProgrammed,
+			meta.SetStatusCondition(&conditions, metav1.Condition{
+				Type:    string(gwv1.GatewayConditionProgrammed),
 				Status:  metav1.ConditionFalse,
-				Reason:  gwv1.GatewayReasonAddressNotUsable,
+				Reason:  string(gwv1.GatewayReasonAddressNotUsable),
 				Message: "Hostname addresses may not be used",
 			})
 		default:
-			report.SetCondition(reporter.GatewayCondition{
-				Type:    gwv1.GatewayConditionAccepted,
+			meta.SetStatusCondition(&conditions, metav1.Condition{
+				Type:    string(gwv1.GatewayConditionAccepted),
 				Status:  metav1.ConditionFalse,
-				Reason:  gwv1.GatewayReasonUnsupportedAddress,
+				Reason:  string(gwv1.GatewayReasonUnsupportedAddress),
 				Message: "Unknown address kind",
 			})
 		}
 	}
+	return conditions
 }
 
-func handleInsecureFrontendValidationMode(report *GatewayReport, g *gwv1.Gateway) {
+func handleInsecureFrontendValidationMode(conditions []metav1.Condition, g *gwv1.Gateway) []metav1.Condition {
 	if !gatewayUsesInsecureFrontendValidationMode(g) {
-		return
+		return conditions
 	}
 
-	report.SetCondition(reporter.GatewayCondition{
-		Type:    gwv1.GatewayConditionInsecureFrontendValidationMode,
+	meta.SetStatusCondition(&conditions, metav1.Condition{
+		Type:    string(gwv1.GatewayConditionInsecureFrontendValidationMode),
 		Status:  metav1.ConditionTrue,
-		Reason:  gwv1.GatewayReasonConfigurationChanged,
+		Reason:  string(gwv1.GatewayReasonConfigurationChanged),
 		Message: GatewayInsecureFallbackMessage,
 	})
+	return conditions
 }
 
 func gatewayUsesInsecureFrontendValidationMode(g *gwv1.Gateway) bool {
@@ -223,7 +257,7 @@ func shouldPreserveGatewayCondition(condition metav1.Condition, finalConditions 
 }
 
 func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.ListenerSet) *gwv1.ListenerSetStatus {
-	lsReport := r.ListenerSet(&ls)
+	lsReport := r.listenerSetReportForStatus(&ls)
 	if lsReport == nil {
 		return nil
 	}
@@ -243,15 +277,14 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 	if !listenerSetRejected(lsReport) {
 		for _, l := range ls.Spec.Listeners {
 			lis := utils.ToListener(l)
-			lisReport := lsReport.listener(string(lis.Name))
-			AddMissingListenerConditions(lisReport)
+			listenerStatus := listenerStatusFromListenerSetReport(lsReport, lis)
 
-			finalConditions := make([]metav1.Condition, 0, len(lisReport.Status.Conditions))
+			finalConditions := make([]metav1.Condition, 0, len(listenerStatus.Conditions))
 			oldLisStatusIndex := slices.IndexFunc(ls.Status.Listeners, func(l gwv1.ListenerEntryStatus) bool {
 				return l.Name == lis.Name
 			})
-			for _, lisCondition := range lisReport.Status.Conditions {
-				lisCondition.ObservedGeneration = lsReport.observedGeneration
+			for _, lisCondition := range listenerStatus.Conditions {
+				lisCondition.ObservedGeneration = ls.Generation
 
 				// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
 				if oldLisStatusIndex != -1 {
@@ -269,10 +302,12 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 					}
 				}
 			}
-			lisReport.Status.Conditions = finalConditions
-			finalListeners = append(finalListeners, lisReport.Status)
+			listenerStatus.Conditions = finalConditions
+			finalListeners = append(finalListeners, listenerStatus)
 		}
 	}
+
+	lsConditions := slices.Clone(lsReport.GetConditions())
 
 	// If any listeners have Programmed=False, set ListenerSet Accepted=True with ListenersNotValid reason
 	if len(invalidListeners) > 0 {
@@ -281,10 +316,10 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 			message = fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidListeners, ", "))
 		}
 
-		lsReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+		meta.SetStatusCondition(&lsConditions, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonListenersNotValid,
+			Reason:  string(gwv1.GatewayReasonListenersNotValid),
 			Message: message,
 		})
 	}
@@ -292,26 +327,26 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 	// If there are no valid listeners, reject the listenerSet
 	if len(finalListeners) != 0 {
 		if len(invalidListeners) == len(finalListeners) {
-			lsReport.SetCondition(reporter.GatewayCondition{
-				Type:    gwv1.GatewayConditionAccepted,
+			meta.SetStatusCondition(&lsConditions, metav1.Condition{
+				Type:    string(gwv1.GatewayConditionAccepted),
 				Status:  metav1.ConditionFalse,
-				Reason:  gwv1.GatewayReasonListenersNotValid,
+				Reason:  string(gwv1.GatewayReasonListenersNotValid),
 				Message: "No valid listeners",
 			})
-			lsReport.SetCondition(reporter.GatewayCondition{
-				Type:    gwv1.GatewayConditionProgrammed,
+			meta.SetStatusCondition(&lsConditions, metav1.Condition{
+				Type:    string(gwv1.GatewayConditionProgrammed),
 				Status:  metav1.ConditionFalse,
-				Reason:  gwv1.GatewayReasonListenersNotValid,
+				Reason:  string(gwv1.GatewayReasonListenersNotValid),
 				Message: "No valid listeners",
 			})
 		}
 	}
 
-	AddMissingListenerSetConditions(r.ListenerSet(&ls))
+	lsConditions = listenerSetConditionsWithDefaults(lsConditions)
 
 	finalConditions := make([]metav1.Condition, 0)
-	for _, lsCondition := range lsReport.GetConditions() {
-		lsCondition.ObservedGeneration = lsReport.observedGeneration
+	for _, lsCondition := range lsConditions {
+		lsCondition.ObservedGeneration = ls.Generation
 
 		// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(ls.Status.Conditions, lsCondition.Type); cond != nil {
@@ -340,6 +375,18 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 	}
 	finalLsStatus.Listeners = fl
 	return &finalLsStatus
+}
+
+func (r *ReportMap) listenerSetReportForStatus(listenerSet client.Object) *ListenerSetReport {
+	gvk := listenerSet.GetObjectKind().GroupVersionKind()
+	if gvk.Empty() {
+		gvk = wellknown.ListenerSetGVK
+	}
+	lsByGVK := r.ListenerSets[gvk]
+	if lsByGVK == nil {
+		return nil
+	}
+	return lsByGVK[key(listenerSet)]
 }
 
 // BuildBackendStatus builds the Backend's status from its report, preserving the
@@ -402,6 +449,8 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 		return nil
 	}
 
+	observedGeneration := obj.GetGeneration()
+
 	slog.Debug("building status", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
 
 	var existingStatus gwv1.RouteStatus
@@ -458,7 +507,7 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)
 			continue
 		}
-		addMissingParentRefConditions(parentStatusReport)
+		parentConditions := parentRefConditionsWithDefaults(parentStatusReport.Conditions)
 
 		// Get the status of the current parentRef conditions if they exist
 		var currentParentRefConditions []metav1.Condition
@@ -469,9 +518,9 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 			currentParentRefConditions = existingStatus.Parents[currentParentRefIdx].Conditions
 		}
 
-		finalConditions := make([]metav1.Condition, 0, len(parentStatusReport.Conditions))
-		for _, pCondition := range parentStatusReport.Conditions {
-			pCondition.ObservedGeneration = routeReport.observedGeneration
+		finalConditions := make([]metav1.Condition, 0, len(parentConditions))
+		for _, pCondition := range parentConditions {
+			pCondition.ObservedGeneration = observedGeneration
 
 			// Copy old condition to preserve LastTransitionTime, if it exists
 			if cond := meta.FindStatusCondition(currentParentRefConditions, pCondition.Type); cond != nil {
@@ -550,34 +599,39 @@ func ParentString(ref gwv1.ParentReference) string {
 // so all missing conditions are assumed to be positive. Here we will add all missing conditions
 // to a given report, i.e. set healthy conditions
 func addMissingGatewayConditions(gwReport *GatewayReport, gw *gwv1.Gateway) {
+	gwReport.conditions = gatewayConditionsWithDefaults(gwReport.conditions, gw, listenerStatusesFromGatewayReport(gwReport))
+}
+
+func gatewayConditionsWithDefaults(conditions []metav1.Condition, gw *gwv1.Gateway, listeners []gwv1.ListenerStatus) []metav1.Condition {
+	out := slices.Clone(conditions)
 	// If the existing Gateway status contains an Accepted=False with Reason=InvalidParameters,
 	// we don't want to override it with a true Accepted status. The controller will set Accepted=True
 	// when the GatewayParameters are valid again. Otherwise there is a race condition between the controller and reporter.
 	// HACK: This is because both the controller and reporter set Accepted status.
 	existingAccepted := meta.FindStatusCondition(gw.Status.Conditions, string(gwv1.GatewayConditionAccepted))
 	hasInvalidParams := existingAccepted != nil && existingAccepted.Status == metav1.ConditionFalse && existingAccepted.Reason == string(gwv1.GatewayReasonInvalidParameters)
-	if !hasInvalidParams && meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionAccepted)) == nil {
-		gwReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+	if !hasInvalidParams && meta.FindStatusCondition(out, string(gwv1.GatewayConditionAccepted)) == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonAccepted,
+			Reason:  string(gwv1.GatewayReasonAccepted),
 			Message: GatewayAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionProgrammed)); cond == nil {
-		gwReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionProgrammed,
+	if cond := meta.FindStatusCondition(out, string(gwv1.GatewayConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionProgrammed),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonProgrammed,
+			Reason:  string(gwv1.GatewayReasonProgrammed),
 			Message: GatewayProgrammedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionResolvedRefs)); cond == nil {
+	if cond := meta.FindStatusCondition(out, string(gwv1.GatewayConditionResolvedRefs)); cond == nil {
 		reason := gwv1.GatewayReasonResolvedRefs
 		status := metav1.ConditionTrue
 		message := GatewayResolvedRefsMessage
-		for _, lisReport := range gwReport.listeners {
-			lisResolvedRefs := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionResolvedRefs))
+		for _, lisStatus := range listeners {
+			lisResolvedRefs := meta.FindStatusCondition(lisStatus.Conditions, string(gwv1.ListenerConditionResolvedRefs))
 			if lisResolvedRefs != nil && lisResolvedRefs.Status == metav1.ConditionFalse {
 				reason = gwv1.GatewayReasonListenersNotResolved
 				status = metav1.ConditionFalse
@@ -585,94 +639,124 @@ func addMissingGatewayConditions(gwReport *GatewayReport, gw *gwv1.Gateway) {
 				break
 			}
 		}
-		gwReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionResolvedRefs,
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionResolvedRefs),
 			Status:  status,
-			Reason:  reason,
+			Reason:  string(reason),
 			Message: message,
 		})
 	}
+	return out
+}
+
+func listenerStatusesFromGatewayReport(gwReport *GatewayReport) []gwv1.ListenerStatus {
+	if gwReport == nil || len(gwReport.listeners) == 0 {
+		return nil
+	}
+	out := make([]gwv1.ListenerStatus, 0, len(gwReport.listeners))
+	for name := range gwReport.listeners {
+		out = append(out, listenerStatusFromGatewayReport(gwReport, gwv1.Listener{Name: gwv1.SectionName(name)}))
+	}
+	return out
 }
 
 // Reports will initially only contain negative conditions found during translation,
 // so all missing conditions are assumed to be positive. Here we will add all missing conditions
 // to a given report, i.e. set healthy conditions
 func AddMissingListenerSetConditions(lsReport *ListenerSetReport) {
-	if cond := meta.FindStatusCondition(lsReport.GetConditions(), string(gwv1.GatewayConditionAccepted)); cond == nil {
-		lsReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+	lsReport.conditions = listenerSetConditionsWithDefaults(lsReport.conditions)
+}
+
+func listenerSetConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
+	if cond := meta.FindStatusCondition(out, string(gwv1.GatewayConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonAccepted,
+			Reason:  string(gwv1.GatewayReasonAccepted),
 			Message: ListenerSetAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lsReport.GetConditions(), string(gwv1.GatewayConditionProgrammed)); cond == nil {
-		lsReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionProgrammed,
+	if cond := meta.FindStatusCondition(out, string(gwv1.GatewayConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionProgrammed),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonProgrammed,
+			Reason:  string(gwv1.GatewayReasonProgrammed),
 			Message: ListenerSetProgrammedMessage,
 		})
 	}
+	return out
 }
 
 // Reports will initially only contain negative conditions found during translation,
 // so all missing conditions are assumed to be positive. Here we will add all missing conditions
 // to a given report, i.e. set healthy conditions
 func AddMissingListenerConditions(lisReport *ListenerReport) {
+	lisReport.Status.Conditions = listenerConditionsWithDefaults(lisReport.Status.Conditions)
+}
+
+func listenerConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
 	// set healthy conditions for Condition Types not set yet (i.e. no negative status yet, we can assume positive)
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionAccepted)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionAccepted,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.ListenerReasonAccepted,
+			Reason:  string(gwv1.ListenerReasonAccepted),
 			Message: ListenerAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionConflicted)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionConflicted,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionConflicted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionConflicted),
 			Status:  metav1.ConditionFalse,
-			Reason:  gwv1.ListenerReasonNoConflicts,
+			Reason:  string(gwv1.ListenerReasonNoConflicts),
 			Message: ListenerNoConflictsMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionResolvedRefs)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionResolvedRefs,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionResolvedRefs)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionResolvedRefs),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.ListenerReasonResolvedRefs,
+			Reason:  string(gwv1.ListenerReasonResolvedRefs),
 			Message: ValidRefsMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionProgrammed)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionProgrammed,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionProgrammed),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.ListenerReasonProgrammed,
+			Reason:  string(gwv1.ListenerReasonProgrammed),
 			Message: ListenerProgrammedMessage,
 		})
 	}
+	return out
 }
 
 // Reports will initially only contain negative conditions found during translation,
 // so all missing conditions are assumed to be positive. Here we will add all missing conditions
 // to a given report, i.e. set healthy conditions
 func addMissingParentRefConditions(report *ParentRefReport) {
-	if cond := meta.FindStatusCondition(report.Conditions, string(gwv1.RouteConditionAccepted)); cond == nil {
-		report.SetCondition(reporter.RouteCondition{
-			Type:    gwv1.RouteConditionAccepted,
+	report.Conditions = parentRefConditionsWithDefaults(report.Conditions)
+}
+
+func parentRefConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
+	if cond := meta.FindStatusCondition(out, string(gwv1.RouteConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.RouteConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.RouteReasonAccepted,
+			Reason:  string(gwv1.RouteReasonAccepted),
 			Message: RouteAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(report.Conditions, string(gwv1.RouteConditionResolvedRefs)); cond == nil {
-		report.SetCondition(reporter.RouteCondition{
-			Type:    gwv1.RouteConditionResolvedRefs,
+	if cond := meta.FindStatusCondition(out, string(gwv1.RouteConditionResolvedRefs)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.RouteConditionResolvedRefs),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.RouteReasonResolvedRefs,
+			Reason:  string(gwv1.RouteReasonResolvedRefs),
 			Message: ValidRefsMessage,
 		})
 	}
+	return out
 }

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -136,22 +136,25 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 }
 
 func listenerStatusFromGatewayReport(report *GatewayReport, listener gwv1.Listener) gwv1.ListenerStatus {
-	status := newListenerStatus(string(listener.Name))
-	if report != nil && report.listeners != nil {
-		if listenerReport := report.listeners[string(listener.Name)]; listenerReport != nil {
-			status = listenerReport.Status
-			status.Conditions = slices.Clone(listenerReport.Status.Conditions)
-			status.SupportedKinds = slices.Clone(listenerReport.Status.SupportedKinds)
-		}
+	var listeners map[string]*ListenerReport
+	if report != nil {
+		listeners = report.listeners
 	}
-	status.Conditions = listenerConditionsWithDefaults(status.Conditions)
-	return status
+	return listenerStatusFromReports(listeners, listener)
 }
 
 func listenerStatusFromListenerSetReport(report *ListenerSetReport, listener gwv1.Listener) gwv1.ListenerStatus {
+	var listeners map[string]*ListenerReport
+	if report != nil {
+		listeners = report.listeners
+	}
+	return listenerStatusFromReports(listeners, listener)
+}
+
+func listenerStatusFromReports(listeners map[string]*ListenerReport, listener gwv1.Listener) gwv1.ListenerStatus {
 	status := newListenerStatus(string(listener.Name))
-	if report != nil && report.listeners != nil {
-		if listenerReport := report.listeners[string(listener.Name)]; listenerReport != nil {
+	if listeners != nil {
+		if listenerReport := listeners[string(listener.Name)]; listenerReport != nil {
 			status = listenerReport.Status
 			status.Conditions = slices.Clone(listenerReport.Status.Conditions)
 			status.SupportedKinds = slices.Clone(listenerReport.Status.SupportedKinds)
@@ -257,7 +260,7 @@ func shouldPreserveGatewayCondition(condition metav1.Condition, finalConditions 
 }
 
 func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.ListenerSet) *gwv1.ListenerSetStatus {
-	lsReport := r.listenerSetReportForStatus(&ls)
+	lsReport := r.ListenerSet(&ls)
 	if lsReport == nil {
 		return nil
 	}
@@ -375,18 +378,6 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 	}
 	finalLsStatus.Listeners = fl
 	return &finalLsStatus
-}
-
-func (r *ReportMap) listenerSetReportForStatus(listenerSet client.Object) *ListenerSetReport {
-	gvk := listenerSet.GetObjectKind().GroupVersionKind()
-	if gvk.Empty() {
-		gvk = wellknown.ListenerSetGVK
-	}
-	lsByGVK := r.ListenerSets[gvk]
-	if lsByGVK == nil {
-		return nil
-	}
-	return lsByGVK[key(listenerSet)]
 }
 
 // BuildBackendStatus builds the Backend's status from its report, preserving the
@@ -595,13 +586,6 @@ func ParentString(ref gwv1.ParentReference) string {
 		ptr.OrEmpty(ref.Namespace))
 }
 
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingGatewayConditions(gwReport *GatewayReport, gw *gwv1.Gateway) {
-	gwReport.conditions = gatewayConditionsWithDefaults(gwReport.conditions, gw, listenerStatusesFromGatewayReport(gwReport))
-}
-
 func gatewayConditionsWithDefaults(conditions []metav1.Condition, gw *gwv1.Gateway, listeners []gwv1.ListenerStatus) []metav1.Condition {
 	out := slices.Clone(conditions)
 	// If the existing Gateway status contains an Accepted=False with Reason=InvalidParameters,
@@ -645,17 +629,6 @@ func gatewayConditionsWithDefaults(conditions []metav1.Condition, gw *gwv1.Gatew
 			Reason:  string(reason),
 			Message: message,
 		})
-	}
-	return out
-}
-
-func listenerStatusesFromGatewayReport(gwReport *GatewayReport) []gwv1.ListenerStatus {
-	if gwReport == nil || len(gwReport.listeners) == 0 {
-		return nil
-	}
-	out := make([]gwv1.ListenerStatus, 0, len(gwReport.listeners))
-	for name := range gwReport.listeners {
-		out = append(out, listenerStatusFromGatewayReport(gwReport, gwv1.Listener{Name: gwv1.SectionName(name)}))
 	}
 	return out
 }
@@ -731,13 +704,6 @@ func listenerConditionsWithDefaults(conditions []metav1.Condition) []metav1.Cond
 		})
 	}
 	return out
-}
-
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingParentRefConditions(report *ParentRefReport) {
-	report.Conditions = parentRefConditionsWithDefaults(report.Conditions)
 }
 
 func parentRefConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {

--- a/pkg/reports/status_purity_test.go
+++ b/pkg/reports/status_purity_test.go
@@ -1,0 +1,204 @@
+package reports
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+	pluginreporter "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+)
+
+func TestBuildGWStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "gw",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gwv1.GatewaySpec{
+			Listeners: []gwv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+	}
+
+	rep.Gateway(gw).Listener(&gw.Spec.Listeners[0])
+	gr := rm.GatewayNamespaceName(key(gw))
+	require.NotNil(t, gr)
+	beforeCond := slicesCloneConditions(gr.conditions)
+	beforeListenerCond := slicesCloneConditions(gr.listeners["http"].Status.Conditions)
+
+	status := rm.BuildGWStatus(context.Background(), *gw, nil)
+	require.NotNil(t, status)
+
+	require.Equal(t, beforeCond, gr.conditions, "BuildGWStatus must not mutate GatewayReport conditions")
+	require.Equal(t, beforeListenerCond, gr.listeners["http"].Status.Conditions, "BuildGWStatus must not mutate ListenerReport conditions")
+}
+
+func TestBuildRouteStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	parentRef := gwv1.ParentReference{
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      "gw",
+		Namespace: new(gwv1.Namespace("default")),
+	}
+	route := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "route",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{parentRef}},
+		},
+	}
+
+	rep.Route(route).ParentRef(&parentRef).SetCondition(pluginreporter.RouteCondition{
+		Type:   gwv1.RouteConditionAccepted,
+		Status: metav1.ConditionFalse,
+		Reason: gwv1.RouteReasonNoMatchingParent,
+	})
+	rr := rm.HTTPRoutes[types.NamespacedName{Namespace: route.Namespace, Name: route.Name}]
+	before := cloneParentConditionsForTest(rr)
+
+	status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
+	require.NotNil(t, status)
+
+	require.Equal(t, before, cloneParentConditionsForTest(rr), "BuildRouteStatus must not mutate RouteReport condition slices")
+}
+
+func TestBuildPolicyStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	policyKey := pluginreporter.PolicyKey{Group: "example.com", Kind: "Policy", Namespace: "default", Name: "policy"}
+	ancestorRef := gwv1.ParentReference{
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      "gw",
+		Namespace: new(gwv1.Namespace("default")),
+	}
+	rep.Policy(policyKey, 1).AncestorRef(ancestorRef)
+	pr := rm.Policies[policyKey]
+	before := cloneAncestorConditionsForTest(pr)
+
+	status := rm.BuildPolicyStatus(context.Background(), policyKey, "kgateway.dev/kgateway", gwv1.PolicyStatus{})
+	require.NotNil(t, status)
+	requireConditionForTest(t, status.Ancestors[0].Conditions, string(shared.PolicyConditionAttached))
+
+	require.Equal(t, before, cloneAncestorConditionsForTest(pr), "BuildPolicyStatus must not mutate PolicyReport condition slices")
+}
+
+func TestMergeReportMapsOwnsRouteAndPolicyReports(t *testing.T) {
+	routeKey := types.NamespacedName{Namespace: "default", Name: "route"}
+	policyKey := pluginreporter.PolicyKey{Group: "example.com", Kind: "Policy", Namespace: "default", Name: "policy"}
+
+	first := NewReportMap()
+	firstReporter := NewReporter(&first)
+	firstRoute := &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: routeKey.Namespace, Name: routeKey.Name}}
+	firstParent := gwv1.ParentReference{Name: "gw-a"}
+	firstReporter.Route(firstRoute).ParentRef(&firstParent).SetCondition(pluginreporter.RouteCondition{
+		Type:   gwv1.RouteConditionAccepted,
+		Status: metav1.ConditionTrue,
+		Reason: gwv1.RouteReasonAccepted,
+	})
+	firstAncestor := gwv1.ParentReference{Name: "policy-gw-a"}
+	firstReporter.Policy(policyKey, 1).AncestorRef(firstAncestor).SetCondition(pluginreporter.PolicyCondition{
+		Type:   string(shared.PolicyConditionAccepted),
+		Status: metav1.ConditionTrue,
+		Reason: string(shared.PolicyReasonValid),
+	})
+
+	second := NewReportMap()
+	secondReporter := NewReporter(&second)
+	secondRoute := &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: routeKey.Namespace, Name: routeKey.Name}}
+	secondParent := gwv1.ParentReference{Name: "gw-b"}
+	secondReporter.Route(secondRoute).ParentRef(&secondParent).SetCondition(pluginreporter.RouteCondition{
+		Type:   gwv1.RouteConditionResolvedRefs,
+		Status: metav1.ConditionTrue,
+		Reason: gwv1.RouteReasonResolvedRefs,
+	})
+	secondAncestor := gwv1.ParentReference{Name: "policy-gw-b"}
+	secondReporter.Policy(policyKey, 1).AncestorRef(secondAncestor).SetAttachmentState(pluginreporter.PolicyAttachmentStateAttached)
+
+	merged := MergeReportMaps(first, second)
+	require.Len(t, merged.HTTPRoutes[routeKey].Parents, 2)
+	require.Len(t, merged.Policies[policyKey].Ancestors, 2)
+
+	for _, parent := range merged.HTTPRoutes[routeKey].Parents {
+		parent.Conditions = append(parent.Conditions, metav1.Condition{Type: "mutated"})
+		break
+	}
+	for _, ancestor := range merged.Policies[policyKey].Ancestors {
+		ancestor.Conditions = append(ancestor.Conditions, metav1.Condition{Type: "mutated"})
+		break
+	}
+
+	require.NotContains(t, conditionTypesFromParents(first.HTTPRoutes[routeKey]), "mutated")
+	require.NotContains(t, conditionTypesFromParents(second.HTTPRoutes[routeKey]), "mutated")
+	require.NotContains(t, conditionTypesFromAncestors(first.Policies[policyKey]), "mutated")
+	require.NotContains(t, conditionTypesFromAncestors(second.Policies[policyKey]), "mutated")
+}
+
+func slicesCloneConditions(in []metav1.Condition) []metav1.Condition {
+	return append([]metav1.Condition(nil), in...)
+}
+
+func cloneParentConditionsForTest(rr *RouteReport) map[string][]metav1.Condition {
+	out := map[string][]metav1.Condition{}
+	for key, parent := range rr.Parents {
+		out[key.String()] = slicesCloneConditions(parent.Conditions)
+	}
+	return out
+}
+
+func cloneAncestorConditionsForTest(pr *PolicyReport) map[string][]metav1.Condition {
+	out := map[string][]metav1.Condition{}
+	for key, ancestor := range pr.Ancestors {
+		out[key.String()] = slicesCloneConditions(ancestor.Conditions)
+	}
+	return out
+}
+
+func requireConditionForTest(t *testing.T, conditions []metav1.Condition, conditionType string) {
+	t.Helper()
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return
+		}
+	}
+	t.Fatalf("expected condition %q", conditionType)
+}
+
+func conditionTypesFromParents(rr *RouteReport) []string {
+	var out []string
+	for _, parent := range rr.Parents {
+		for _, condition := range parent.Conditions {
+			out = append(out, condition.Type)
+		}
+	}
+	return out
+}
+
+func conditionTypesFromAncestors(pr *PolicyReport) []string {
+	var out []string
+	for _, ancestor := range pr.Ancestors {
+		for _, condition := range ancestor.Conditions {
+			out = append(out, condition.Type)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
# Description
Make report status rendering read-only so translation reports are only mutated while translation is writing to them. This moves owned report-map merging and semantic equality into `pkg/reports`, removes hidden lookup mutations, and updates status builders to construct fresh status/condition values instead of mutating shared report entries.

This is a follow-up direction for avoiding status-write feedback and report sharing races like those discussed in #14265.

# Change Type
/kind fix
/kind cleanup

# Changelog
```release-note
NONE
```
