### PR TITLE
[2.3] fix: use rooted FQDN for xDS cluster address

### DIFF
--- a/pkg/kgateway/controller/start.go
+++ b/pkg/kgateway/controller/start.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"strings"
 	"sync/atomic"
 
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -231,10 +232,17 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 
 	xdsHost := globalSettings.XdsServiceHost
 	if xdsHost == "" {
-		xdsHost = kubeutils.ServiceFQDN(metav1.ObjectMeta{
+		// Ensure exactly one trailing dot so this is an absolute (rooted) DNS name.
+		// Without it, the in-cluster FQDN has 4 dots and is treated as relative under
+		// the default ndots:5 resolver config, so Envoy's strict_dns cluster expands
+		// every search domain on each re-resolution cycle, producing a burst of
+		// NXDOMAIN lookups. TrimSuffix keeps this idempotent in case the FQDN is
+		// already rooted (e.g. a CLUSTER_DOMAIN env var set with a trailing dot),
+		// avoiding a double dot that would itself break resolution.
+		xdsHost = strings.TrimSuffix(kubeutils.ServiceFQDN(metav1.ObjectMeta{
 			Name:      globalSettings.XdsServiceName,
 			Namespace: namespaces.GetPodNamespace(),
-		})
+		}), ".") + "."
 	}
 
 	xdsPort := globalSettings.XdsServicePort

--- a/test/e2e/features/deployer/suite.go
+++ b/test/e2e/features/deployer/suite.go
@@ -584,8 +584,8 @@ func xdsClusterAssertion(t *testing.T, testInstallation *e2e.TestInstallation) f
 			g.Expect(xdsSocketAddress).NotTo(gomega.BeNil())
 
 			g.Expect(xdsSocketAddress.GetAddress()).To(gomega.Equal(
-				fmt.Sprintf("%s.%s.svc.cluster.local", wellknown.DefaultXdsService, testInstallation.Metadata.InstallNamespace),
-			), "xds socket address points to kgateway service, in installation namespace")
+				fmt.Sprintf("%s.%s.svc.cluster.local.", wellknown.DefaultXdsService, testInstallation.Metadata.InstallNamespace),
+			), "xds socket address points to kgateway service, in installation namespace, as a rooted FQDN")
 
 			g.Expect(xdsSocketAddress.GetPortValue()).To(gomega.Equal(wellknown.DefaultXdsPort),
 				"xds socket port points to kgateway service, in installation namespace")


### PR DESCRIPTION
# Description

Backports 73b6acdf5a0c789ad34454db23e39fff6e2841eb / #14291 to v2.3.x.

This uses a rooted FQDN for the default xDS service address so Envoy strict_dns resolution does not expand Kubernetes search domains on each re-resolution cycle.

# Change Type

/kind fix

# Changelog

```release-note
Use a rooted FQDN for the default xDS service address to avoid DNS search-domain expansion during Envoy DNS resolution.
```
