### PR TITLE
[2.3] bump envoy to 1.37.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ else
 	OSV_SCANNER_PLATFORM := --platform=linux/amd64
 endif
 
-export ENVOY_IMAGE ?= envoyproxy/envoy:v1.37.4
+export ENVOY_IMAGE ?= envoyproxy/envoy:v1.37.5
 
 # ENVOY_IMAGE is used by some of the *-docker targets which are used by CI e2e tests, so figure out the correct image
 # to use base on GOARCH. This doesn't affect goreleaser

--- a/internal/envoy_modules/Cargo.lock
+++ b/internal/envoy_modules/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "envoy-proxy-dynamic-modules-rust-sdk"
 version = "0.1.0"
-source = "git+https://github.com/envoyproxy/envoy?tag=v1.37.4#4de9a4b40f653bc2701f09dec7633ae118982ec4"
+source = "git+https://github.com/envoyproxy/envoy?tag=v1.37.5#f97695a50e11f5ff6719e129a466bf9204b64a7f"
 dependencies = [
  "bindgen",
  "mockall",

--- a/internal/envoy_modules/Cargo.toml
+++ b/internal/envoy_modules/Cargo.toml
@@ -13,4 +13,4 @@ default-members = ["module-init"]
 [workspace.dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
 # Update this single entry when upgrading Envoy.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.37.4" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.37.5" }

--- a/tilt-settings.yaml
+++ b/tilt-settings.yaml
@@ -38,7 +38,7 @@ providers:
     # NOTE: Do NOT include ENTRYPOINT here - the Tiltfile will append the correct
     # entrypoint (standard or debug) based on whether debug_port is set.
     dockerfile_contents: |
-      FROM envoyproxy/envoy:v1.37.4 as envoy-bin
+      FROM envoyproxy/envoy:v1.37.5 as envoy-bin
 
       FROM golang:latest as tilt
       WORKDIR /app


### PR DESCRIPTION
# Description

upgraded envoy to [1.37.5](https://github.com/envoyproxy/envoy/releases/tag/v1.37.5)
See envoy release note for a list of CVE fixes

# Change Type

/kind bump

# Changelog

```release-note
upgraded envoy to 1.37.5
```
