### PR TITLE
fix: stamp Gateway observedGeneration from the report, not the live object

### DIFF
--- a/pkg/reports/observed_generation_test.go
+++ b/pkg/reports/observed_generation_test.go
@@ -154,40 +154,70 @@ func requireAllObservedGenerations(t *testing.T, status *gwv1.GatewayStatus, wan
 	}
 }
 
-func TestRouteStatusRefreshesObservedGenerationFromCurrentObject(t *testing.T) {
-	rm := reports.NewReportMap()
-	statusReporter := reports.NewReporter(&rm)
-
-	route := &gwv1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "example-route",
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: gwv1.HTTPRouteSpec{
-			CommonRouteSpec: gwv1.CommonRouteSpec{
-				ParentRefs: []gwv1.ParentReference{
-					{
-						Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
-						Kind:      new(gwv1.Kind("Gateway")),
-						Name:      "example-gateway",
-						Namespace: new(gwv1.Namespace("default")),
+// BuildRouteStatus must stamp the generation the report was built for, not the
+// live object's generation, for the same cross-cache reason as Gateway status:
+// the route is re-read by the syncer from a separate cache than translation
+// used, and stamping the live read can freeze observedGeneration on a skew.
+func TestRouteStatusStampsObservedGenerationFromReport(t *testing.T) {
+	newRoute := func(generation int64) *gwv1.HTTPRoute {
+		return &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "example-route",
+				Namespace:  "default",
+				Generation: generation,
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{
+						{
+							Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+							Kind:      new(gwv1.Kind("Gateway")),
+							Name:      "example-gateway",
+							Namespace: new(gwv1.Namespace("default")),
+						},
 					},
 				},
 			},
-		},
+		}
 	}
 
-	statusReporter.Route(route).ParentRef(&route.Spec.ParentRefs[0])
-
-	route.Generation = 2
-	status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
-	require.NotNil(t, status)
-	require.Len(t, status.Parents, 1)
-
-	for _, condition := range status.Parents[0].Conditions {
-		require.Equal(t, int64(2), condition.ObservedGeneration)
+	requireParentObservedGeneration := func(t *testing.T, status *gwv1.RouteStatus, want int64) {
+		t.Helper()
+		require.NotNil(t, status)
+		require.Len(t, status.Parents, 1)
+		for _, condition := range status.Parents[0].Conditions {
+			require.Equal(t, want, condition.ObservedGeneration)
+		}
 	}
+
+	// Report ahead of a stale live read: translation observed generation 2 but
+	// the syncer's cache still returns generation 1. The published status must
+	// reflect the report's generation (2).
+	t.Run("report ahead of stale live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		route := newRoute(2)
+		statusReporter.Route(route).ParentRef(&route.Spec.ParentRefs[0])
+
+		route.Generation = 1
+		status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
+		requireParentObservedGeneration(t, status, 2)
+	})
+
+	// Report behind the live read: observedGeneration must stay at the generation
+	// actually translated (1) rather than prematurely claiming generation 2.
+	t.Run("report behind live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		route := newRoute(1)
+		statusReporter.Route(route).ParentRef(&route.Spec.ParentRefs[0])
+
+		route.Generation = 2
+		status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
+		requireParentObservedGeneration(t, status, 1)
+	})
 }
 
 func TestPolicyStatusRefreshesObservedGenerationOnReporterReuse(t *testing.T) {

--- a/pkg/reports/observed_generation_test.go
+++ b/pkg/reports/observed_generation_test.go
@@ -275,3 +275,124 @@ func metaFindStatusCondition(conditions []metav1.Condition, conditionType string
 	}
 	return nil
 }
+
+// BuildBackendStatus must stamp the generation the report was built for, not
+// the live object's, for the same cross-cache reason as Gateway and Route
+// status.
+func TestBackendStatusStampsObservedGenerationFromReport(t *testing.T) {
+	newBackend := func(generation int64) *kgateway.Backend {
+		return &kgateway.Backend{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "example-backend",
+				Namespace:  "default",
+				Generation: generation,
+			},
+		}
+	}
+
+	reportBackend := func(statusReporter pluginreporter.Reporter, backend *kgateway.Backend) {
+		statusReporter.Backend(backend).SetCondition(pluginreporter.BackendCondition{
+			Type:    string(kgateway.BackendConditionAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(kgateway.BackendReasonInvalid),
+			Message: "translation failed",
+		})
+	}
+
+	requireObservedGeneration := func(t *testing.T, status *kgateway.BackendStatus, want int64) {
+		t.Helper()
+		require.NotNil(t, status)
+		require.NotEmpty(t, status.Conditions)
+		for _, condition := range status.Conditions {
+			require.Equal(t, want, condition.ObservedGeneration)
+		}
+	}
+
+	// Report ahead of a stale live read: the published status must reflect the
+	// report's generation (2), not the stale live read (1).
+	t.Run("report ahead of stale live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		backend := newBackend(2)
+		reportBackend(statusReporter, backend)
+
+		backend.Generation = 1
+		status := rm.BuildBackendStatus(context.Background(), backend, kgateway.BackendStatus{})
+		requireObservedGeneration(t, status, 2)
+	})
+
+	// Report behind the live read: observedGeneration must stay at the generation
+	// actually translated (1).
+	t.Run("report behind live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		backend := newBackend(1)
+		reportBackend(statusReporter, backend)
+
+		backend.Generation = 2
+		status := rm.BuildBackendStatus(context.Background(), backend, kgateway.BackendStatus{})
+		requireObservedGeneration(t, status, 1)
+	})
+}
+
+// BuildListenerSetStatus must stamp the generation the report was built for, not
+// the live object's, for the same cross-cache reason as Gateway and Route
+// status.
+func TestListenerSetStatusStampsObservedGenerationFromReport(t *testing.T) {
+	newListenerSet := func(generation int64) *gwv1.ListenerSet {
+		ls := &gwv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test",
+				Namespace:  "default",
+				Generation: generation,
+			},
+		}
+		ls.Spec.Listeners = []gwv1.ListenerEntry{
+			{Name: "http"},
+		}
+		return ls
+	}
+
+	requireAllObservedGenerations := func(t *testing.T, status *gwv1.ListenerSetStatus, want int64) {
+		t.Helper()
+		require.NotNil(t, status)
+		for _, condition := range status.Conditions {
+			require.Equal(t, want, condition.ObservedGeneration)
+		}
+		for _, listenerStatus := range status.Listeners {
+			for _, condition := range listenerStatus.Conditions {
+				require.Equal(t, want, condition.ObservedGeneration)
+			}
+		}
+	}
+
+	// Report ahead of a stale live read: the published status must reflect the
+	// report's generation (2), not the stale live read (1).
+	t.Run("report ahead of stale live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		ls := newListenerSet(2)
+		statusReporter.ListenerSet(ls)
+
+		ls.Generation = 1
+		status := rm.BuildListenerSetStatus(context.Background(), *ls)
+		requireAllObservedGenerations(t, status, 2)
+	})
+
+	// Report behind the live read: observedGeneration must stay at the generation
+	// actually translated (1).
+	t.Run("report behind live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		ls := newListenerSet(1)
+		statusReporter.ListenerSet(ls)
+
+		ls.Generation = 2
+		status := rm.BuildListenerSetStatus(context.Background(), *ls)
+		requireAllObservedGenerations(t, status, 1)
+	})
+}

--- a/pkg/reports/observed_generation_test.go
+++ b/pkg/reports/observed_generation_test.go
@@ -79,35 +79,77 @@ func requireConditionExists(t *testing.T, conditions []metav1.Condition, condTyp
 	return metav1.Condition{}
 }
 
-func TestGatewayStatusRefreshesObservedGenerationFromCurrentObject(t *testing.T) {
-	rm := reports.NewReportMap()
-	statusReporter := reports.NewReporter(&rm)
-
-	gw := &gwv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "example-gateway",
-			Namespace:  "default",
-			Generation: 1,
-		},
-		Spec: gwv1.GatewaySpec{
-			Listeners: []gwv1.Listener{
-				{Name: "http"},
+// BuildGWStatus must stamp the generation the report was built for, not the
+// live object's generation. The status syncer is triggered only by report
+// changes and reads the live Gateway from a separate (controller-runtime)
+// cache than the one translation uses (the istio KRT cache). If it stamped the
+// live generation, a skew between those two caches could freeze
+// observedGeneration: the report-change trigger fires once, the stale live read
+// stamps the wrong generation, and nothing re-triggers the sync. Sourcing the
+// generation from the report keeps the trigger and the stamp consistent.
+func TestGatewayStatusStampsObservedGenerationFromReport(t *testing.T) {
+	newGateway := func(generation int64) *gwv1.Gateway {
+		return &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "example-gateway",
+				Namespace:  "default",
+				Generation: generation,
 			},
-		},
+			Spec: gwv1.GatewaySpec{
+				Listeners: []gwv1.Listener{
+					{Name: "http"},
+				},
+			},
+		}
 	}
 
-	statusReporter.Gateway(gw)
+	// Report ahead of the live object: translation observed generation 2 but the
+	// syncer's cache still sees generation 1. This is the freeze case that
+	// regressed in #14295 - the published status must reflect the report's
+	// generation (2), not the stale live read (1).
+	t.Run("report ahead of stale live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
 
-	gw.Generation = 2
-	status := rm.BuildGWStatus(context.Background(), *gw, nil)
-	require.NotNil(t, status)
+		gw := newGateway(2)
+		statusReporter.Gateway(gw)
+
+		// Simulate the syncer's cache lagging behind translation's.
+		gw.Generation = 1
+		status := rm.BuildGWStatus(context.Background(), *gw, nil)
+		require.NotNil(t, status)
+
+		requireAllObservedGenerations(t, status, 2)
+	})
+
+	// Report behind the live object: the syncer's cache already sees generation
+	// 2, but translation has only processed generation 1. observedGeneration must
+	// stay at the generation actually translated (1) rather than prematurely
+	// claiming a generation whose status has not been computed yet.
+	t.Run("report behind live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		gw := newGateway(1)
+		statusReporter.Gateway(gw)
+
+		gw.Generation = 2
+		status := rm.BuildGWStatus(context.Background(), *gw, nil)
+		require.NotNil(t, status)
+
+		requireAllObservedGenerations(t, status, 1)
+	})
+}
+
+func requireAllObservedGenerations(t *testing.T, status *gwv1.GatewayStatus, want int64) {
+	t.Helper()
 
 	for _, condition := range status.Conditions {
-		require.Equal(t, int64(2), condition.ObservedGeneration)
+		require.Equal(t, want, condition.ObservedGeneration)
 	}
 	for _, listenerStatus := range status.Listeners {
 		for _, condition := range listenerStatus.Conditions {
-			require.Equal(t, int64(2), condition.ObservedGeneration)
+			require.Equal(t, want, condition.ObservedGeneration)
 		}
 	}
 }

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -296,7 +296,9 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 				return l.Name == lis.Name
 			})
 			for _, lisCondition := range listenerStatus.Conditions {
-				lisCondition.ObservedGeneration = ls.Generation
+				// Stamp the report's generation, not the live object's, for the same
+				// cross-cache reason as Gateway and Route status.
+				lisCondition.ObservedGeneration = lsReport.observedGeneration
 
 				// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
 				if oldLisStatusIndex != -1 {
@@ -358,7 +360,8 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 
 	finalConditions := make([]metav1.Condition, 0)
 	for _, lsCondition := range lsConditions {
-		lsCondition.ObservedGeneration = ls.Generation
+		// See note above: stamp the report's generation, not the live object's.
+		lsCondition.ObservedGeneration = lsReport.observedGeneration
 
 		// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(ls.Status.Conditions, lsCondition.Type); cond != nil {
@@ -402,7 +405,9 @@ func (r *ReportMap) BuildBackendStatus(
 		return nil
 	}
 
-	observedGeneration := obj.GetGeneration()
+	// Stamp the generation the report was built for, not the live object's, for
+	// the same cross-cache reason as Gateway and Route status.
+	observedGeneration := report.observedGeneration
 	finalConditions := make([]metav1.Condition, 0, len(report.Conditions))
 	for _, condition := range report.Conditions {
 		condition.ObservedGeneration = observedGeneration

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -449,7 +449,12 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 		return nil
 	}
 
-	observedGeneration := obj.GetGeneration()
+	// Stamp the generation the report was built for, not the live object's. As
+	// with Gateway status, the route is re-read by the syncer from a separate
+	// cache than the one translation used; sourcing the generation from the
+	// report keeps the sync trigger and the published value consistent and
+	// avoids freezing observedGeneration on a cache skew.
+	observedGeneration := routeReport.observedGeneration
 
 	slog.Debug("building status", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
 

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -63,7 +63,13 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 			return l.Name == lis.Name
 		})
 		for _, lisCondition := range listenerStatus.Conditions {
-			lisCondition.ObservedGeneration = gw.Generation
+			// Stamp the generation the report was built for, not the live object's
+			// generation. The report is produced by translation (istio cache) while
+			// the syncer reads the Gateway from a separate controller-runtime cache;
+			// using the live generation here lets the two caches disagree and freeze
+			// observedGeneration when they skew. The report's generation is internally
+			// consistent with the conditions it carries.
+			lisCondition.ObservedGeneration = gwReport.observedGeneration
 
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 			if oldLisStatusIndex != -1 {
@@ -109,7 +115,10 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 
 	finalConditions := make([]metav1.Condition, 0)
 	for _, gwCondition := range gwConditions {
-		gwCondition.ObservedGeneration = gw.Generation
+		// See note above: stamp the report's generation, not the live object's, so a
+		// skew between the translation cache and the syncer's cache cannot freeze
+		// observedGeneration.
+		gwCondition.ObservedGeneration = gwReport.observedGeneration
 
 		// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(gw.Status.Conditions, gwCondition.Type); cond != nil {


### PR DESCRIPTION
# Description

`BuildGWStatus` (and the other report builders) stamped each condition's `ObservedGeneration` from the **live** object re-read by the status syncer (`s.mgr.GetClient()`, the controller-runtime cache), while the report that *triggers* the sync is produced by translation from a **separate** cache (the istio KRT cache backing `GatewayIndex.Gateways`).

The status syncer is driven only by report changes. When those two caches skew — translation observes a new generation and enqueues a report, but the syncer's live read still returns the old generation — the sync fires once, stamps the stale generation, and nothing re-triggers it. `observedGeneration` then freezes at the old value.

This was masked before #14295: report-map equality was pointer-identity (always unequal), so status re-synced on every translation tick and a later tick eventually stamped the current generation. #14295 made report equality a deep value comparison, so status now only re-syncs on a real report diff — exposing the freeze.

It surfaced as the `GatewayObservedGenerationBump` conformance test hanging for its full 300s budget (and pushing the suite past the Go test timeout, producing a `panic: test timed out`) instead of passing in ~3s. The failure is intermittent because it depends on which informer wins the cache race at sync time.

### What changed

Source the `ObservedGeneration` stamp from the report's generation instead of the live object, across all report builders, so the value that triggers the sync and the value that is published always agree:

- `BuildGWStatus` — gateway and listener conditions (`gwReport.observedGeneration`).
- `BuildRouteStatus` — parentRef conditions (`routeReport.observedGeneration`).
- `BuildBackendStatus` — `report.observedGeneration`.
- `BuildListenerSetStatus` — listener and listener-set conditions (`lsReport.observedGeneration`).
- `BuildPolicyStatus` — already report-driven; no change.

This is also more correct: `observedGeneration` should reflect the generation that was actually translated, not whatever the live cache happens to show.

`pkg/reports/observed_generation_test.go` replaces the prior "FromCurrentObject" tests with skew regression tests covering both directions (report ahead of a stale live read, and report behind the live read) for Gateway, Route, Backend, and ListenerSet.

### Notes for reviewers

- This reverses the intent of the `*RefreshesObservedGenerationFromCurrentObject` tests (added in #13801). Report-driven stamping is the correct semantics: because the syncer is triggered only by report changes, stamping from the live read is exactly what enables the freeze.
- agentgateway's equivalent control plane already stamps from the report and builds status inside its translation collection (no separate cross-cache syncer read), which is why it doesn't exhibit this bug — this change brings kgateway's stamping in line.

# Change Type

/kind fix

# Changelog
```release-note
Fixed a bug where a Gateway, Route, Backend, or ListenerSet status observedGeneration could intermittently freeze at a stale value after a spec change, due to a skew between the translation cache and the status syncer's cache.
```
