### PR TITLE
[WIP] fix: publish per-client xDS without indefinite readiness gates

### DIFF
--- a/pkg/kgateway/proxy_syncer/metrics.go
+++ b/pkg/kgateway/proxy_syncer/metrics.go
@@ -14,6 +14,7 @@ const (
 	gatewayLabel      = "gateway"
 	nameLabel         = "name"
 	namespaceLabel    = "namespace"
+	reasonLabel       = "reason"
 	resultLabel       = "result"
 	resourceLabel     = "resource"
 )
@@ -69,6 +70,14 @@ var (
 			Help:      "Current number of resources in XDS snapshot",
 		},
 		[]string{gatewayLabel, namespaceLabel, resourceLabel},
+	)
+	snapshotIncompletePublishesTotal = metrics.NewCounter(
+		metrics.CounterOpts{
+			Subsystem: snapshotSubsystem,
+			Name:      "incomplete_publishes_total",
+			Help:      "Total number of per-client XDS snapshots published while referenced inputs were incomplete",
+		},
+		[]string{gatewayLabel, namespaceLabel, reasonLabel},
 	)
 )
 
@@ -160,6 +169,18 @@ func collectXDSTransformMetrics(clientKey string) func(error) {
 	}
 }
 
+func recordIncompleteXDSPublish(clientKey, reason string) {
+	if !metrics.Active() {
+		return
+	}
+	cd := getDetailsFromXDSClientResourceName(clientKey)
+	snapshotIncompletePublishesTotal.Inc(
+		metrics.Label{Name: gatewayLabel, Value: cd.Gateway},
+		metrics.Label{Name: namespaceLabel, Value: cd.Namespace},
+		metrics.Label{Name: reasonLabel, Value: reason},
+	)
+}
+
 type resourceNameDetails struct {
 	Role      string
 	Namespace string
@@ -199,4 +220,5 @@ func ResetMetrics() {
 	snapshotTransformsTotal.Reset()
 	snapshotTransformDuration.Reset()
 	snapshotResources.Reset()
+	snapshotIncompletePublishesTotal.Reset()
 }

--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -69,7 +69,7 @@ func snapshotPerClient(
 	clusterSnapshot := krt.NewCollection(uccCol, func(kctx krt.HandlerContext, ucc ir.UniqlyConnectedClient) *clustersWithErrors {
 		clustersForUcc := clusters.FetchClustersForClient(kctx, ucc)
 		if len(clustersForUcc) == 0 {
-			logger.Info("no perclient clusters; defer building snapshot", "client", ucc.ResourceName())
+			logger.Info("no perclient clusters; publishing snapshot with empty per-client cluster set", "client", ucc.ResourceName())
 			return nil
 		}
 		logger.Debug("found perclient clusters", "client", ucc.ResourceName(), "clusters", len(clustersForUcc))
@@ -133,56 +133,18 @@ func snapshotPerClient(
 		clustersForUcc := krt.FetchOne(kctx, clusterSnapshot, krt.FilterKey(ucc.ResourceName()))
 		clientEndpointResources := krt.FetchOne(kctx, endpointResources, krt.FilterKey(ucc.ResourceName()))
 
-		// Defer publishing a per-client snapshot until its per-client inputs
-		// are coherent. Three guards:
+		// Publish best-effort per-client snapshots even while the per-client
+		// collections are catching up. Returning nil for these readiness gaps
+		// withdraws the KRT output row, and the xDS subscriber intentionally
+		// treats that Delete as a no-op so Envoy retains its previous snapshot.
+		// That "wait for completeness" behavior can strand a client on stale
+		// endpoints forever if a recompute edge is missed or an input remains
+		// temporarily incomplete. We keep the reference scans below for logs and
+		// metrics, but they are diagnostics only; publication continues.
 		//
-		//  1. If per-client endpoints haven't been derived yet for this UCC,
-		//     return nil. This handler can fire before the per-client
-		//     collections — driven by the same upstream events — have
-		//     re-run, so FetchOne may briefly return nil even though results
-		//     are imminent. clustersForUcc is treated differently as a
-		//     defensive measure: a nil clusterSnapshot entry can in principle
-		//     mean either "not yet processed" or "this UCC legitimately has
-		//     zero backend clusters". In practice the latter is hard to hit
-		//     because finalBackends pulls in a BackendObjectIR for every
-		//     Service port in the cluster (kube-apiserver, kube-dns, the
-		//     gateway's own Service, etc.), so clustersForUcc is virtually
-		//     never nil in an operational cluster — even for a gateway whose
-		//     HTTPRoutes only emit RequestRedirect or direct responses.
-		//     Substituting an empty resource set keeps the function honest
-		//     against narrow edge cases (a freshly started controller before
-		//     Service informers have synced, or a configuration whose only
-		//     backends are non-K8s and all fail translation) without
-		//     weakening guards 2 and 3, which still defer if any specific
-		//     cluster reference is missing.
-		//
-		//  2. If any cluster referenced as a dataplane routing target
-		//     (RouteAction / TcpProxy) is not yet present or explicitly
-		//     errored, return nil (see findMissingReferencedClusters below).
-		//     Publishing before then would emit a partial CDS referenced by
-		//     listeners/routes and cause Envoy to return 500/NC on routes
-		//     whose clusters just happen to be in the same CDS response.
-		//
-		//  3. If any referenced EDS cluster has no matching ClusterLoadAssignment
-		//     in the EDS resources that would be sent, return nil. Publishing
-		//     CDS/RDS/LDS before EDS catches up can make Envoy drop all hosts for
-		//     a route that was healthy before a controller restart.
-		//
-		// Returning nil removes this UCC's entry from the output collection,
-		// which surfaces as a Delete event in proxy_syncer.go's xDS
-		// subscriber. That Delete branch is intentionally a no-op so the
-		// xDS snapshot cache retains the last-published Snapshot for this
-		// client. Envoy therefore keeps serving its previous, coherent
-		// config until a new coherent snapshot overwrites it. This is what
-		// prevents an unresolvable reference — a user BackendRef typo, a
-		// plugin bug — from stranding Envoy: there is no error response on
-		// valid traffic during the defer window, only continuity.
-		//
-		// BackendRef typos never reach this gate as real cluster names:
-		// IR-time resolution substitutes wellknown.BlackholeClusterName,
-		// which findMissingReferencedClusters explicitly skips.
-		//
-		// Historical context: https://github.com/solo-io/gloo/pull/10611.
+		// BackendRef typos never reach these diagnostics as real cluster names:
+		// IR-time resolution substitutes wellknown.BlackholeClusterName, which
+		// findMissingReferencedClusters explicitly skips.
 		if clustersForUcc == nil {
 			clustersForUcc = &clustersWithErrors{
 				clusters: envoycache.Resources{
@@ -191,8 +153,12 @@ func snapshotPerClient(
 			}
 		}
 		if clientEndpointResources == nil {
-			logger.Info("per-client endpoints not ready; deferring snapshot", "client", ucc.ResourceName())
-			return nil
+			logger.Info("per-client endpoints not ready; publishing snapshot with empty endpoint resources", "client", ucc.ResourceName())
+			recordIncompleteXDSPublish(ucc.ResourceName(), "endpoints_not_ready")
+			clientEndpointResources = &endpointsWithUccName{
+				endpoints:    envoycache.NewResourcesWithTTL("0", nil),
+				resourceName: ucc.ResourceName(),
+			}
 		}
 
 		logger.Debug("found perclient clusters", "client", ucc.ResourceName(), "clusters", len(clustersForUcc.clusters.Items))
@@ -213,27 +179,28 @@ func snapshotPerClient(
 			clusterResources.Items,
 			clustersForUcc.erroredClusters,
 		); len(missingClusters) > 0 {
-			logger.Info(
-				"defer building snapshot until all referenced clusters are ready",
+			logger.Warn(
+				"publishing snapshot before all referenced clusters are ready",
 				"client", ucc.ResourceName(),
 				"missing_clusters", missingClusters,
 			)
-			return nil
+			recordIncompleteXDSPublish(ucc.ResourceName(), "missing_clusters")
 		}
-		// Exclude CLAs for STATIC clusters so ADS snapshot only contains resources Envoy will request.
-		endpointRes := filterEndpointResourcesForStaticClusters(clusterResources, clientEndpointResources.endpoints)
+		// Publish only CLAs required by EDS clusters in this CDS snapshot so ADS
+		// does not retain stale endpoint resources Envoy will no longer request.
+		endpointRes := filterEndpointResourcesForClusters(clusterResources, clientEndpointResources.endpoints)
 		if missingEndpointClusters := findMissingReferencedEndpointResources(
 			listenerRouteSnapshot.ReferencedClusters,
 			clusterResources.Items,
 			endpointRes.Items,
 			clustersForUcc.erroredClusters,
 		); len(missingEndpointClusters) > 0 {
-			logger.Info(
-				"defer building snapshot until all referenced EDS resources are ready",
+			logger.Warn(
+				"publishing snapshot before all referenced EDS resources are ready",
 				"client", ucc.ResourceName(),
 				"missing_endpoint_clusters", missingEndpointClusters,
 			)
-			return nil
+			recordIncompleteXDSPublish(ucc.ResourceName(), "missing_endpoints")
 		}
 
 		snap.erroredClusters = clustersForUcc.erroredClusters
@@ -547,32 +514,55 @@ func collectProtoClusterReferencesFromValue(v protoreflect.Value, referencedClus
 	collectProtoClusterReferences(msg.Interface(), referencedClusters)
 }
 
-// filterEndpointResourcesForStaticClusters returns endpoint resources excluding CLAs for clusters
-// that are STATIC (inline endpoints). Envoy does not request EDS for those; including them in the
-// snapshot triggers the ADS cache "not listed" warning when responding to EDS requests.
-func filterEndpointResourcesForStaticClusters(clusters envoycache.Resources, endpoints envoycache.Resources) envoycache.Resources {
-	staticClusterNames := make(map[string]struct{})
+// filterEndpointResourcesForClusters returns endpoint resources for EDS clusters present in
+// the same CDS snapshot. Envoy will not request CLAs for STATIC clusters or clusters no longer
+// present in CDS; leaving those stale CLAs in the ADS snapshot can make the cache refuse named
+// EDS responses.
+func filterEndpointResourcesForClusters(clusters envoycache.Resources, endpoints envoycache.Resources) envoycache.Resources {
+	requiredEndpointNames := make(map[string]struct{})
 	for _, item := range clusters.Items {
-		if c, ok := item.Resource.(*envoyclusterv3.Cluster); ok && c.GetType() == envoyclusterv3.Cluster_STATIC {
-			staticClusterNames[c.GetName()] = struct{}{}
+		endpointName, requiresEndpoint := endpointResourceNameForCluster(item)
+		if requiresEndpoint {
+			requiredEndpointNames[endpointName] = struct{}{}
 		}
 	}
-	if len(staticClusterNames) == 0 {
-		return endpoints
-	}
+
 	filteredEndpoints := make([]envoycachetypes.ResourceWithTTL, 0, len(endpoints.Items))
+	changed := false
 	for _, item := range endpoints.Items {
 		cla, ok := item.Resource.(*envoyendpointv3.ClusterLoadAssignment)
 		if !ok {
+			changed = true
 			continue
 		}
-		if _, isStatic := staticClusterNames[cla.GetClusterName()]; isStatic {
+		if _, required := requiredEndpointNames[cla.GetClusterName()]; !required {
+			changed = true
 			continue
 		}
 		filteredEndpoints = append(filteredEndpoints, item)
 	}
-	if len(filteredEndpoints) == len(endpoints.Items) {
+	if !changed && len(filteredEndpoints) == len(endpoints.Items) {
 		return endpoints
 	}
-	return envoycache.NewResourcesWithTTL(endpoints.Version, filteredEndpoints)
+	return envoycache.NewResourcesWithTTL(filteredEndpointResourcesVersion(endpoints.Version, filteredEndpoints), filteredEndpoints)
+}
+
+func filteredEndpointResourcesVersion(baseVersion string, endpoints []envoycachetypes.ResourceWithTTL) string {
+	var namesHash uint64
+	for _, name := range sortedResourceNames(endpoints) {
+		namesHash ^= utils.HashString(name)
+	}
+	return fmt.Sprintf("%s/%d", baseVersion, namesHash)
+}
+
+func sortedResourceNames(resources []envoycachetypes.ResourceWithTTL) []string {
+	names := make([]string, 0, len(resources))
+	for _, item := range resources {
+		name := envoycache.GetResourceName(item.Resource)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
 }

--- a/pkg/kgateway/proxy_syncer/perclient_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_test.go
@@ -34,7 +34,7 @@ import (
 	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
 )
 
-func TestFilterEndpointResourcesForStaticClusters_FiltersStaticClusterCLAs(t *testing.T) {
+func TestFilterEndpointResourcesForClusters_FiltersStaticClusterCLAs(t *testing.T) {
 	// Clusters: one STATIC ("static-cluster"), one EDS ("eds-cluster").
 	// Endpoints: CLAs for both. Expect only CLA for "eds-cluster" in result.
 	clusters := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
@@ -46,7 +46,7 @@ func TestFilterEndpointResourcesForStaticClusters_FiltersStaticClusterCLAs(t *te
 		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "eds-cluster"}},
 	})
 
-	out := filterEndpointResourcesForStaticClusters(clusters, endpoints)
+	out := filterEndpointResourcesForClusters(clusters, endpoints)
 
 	if len(out.Items) != 1 {
 		t.Fatalf("expected 1 endpoint resource, got %d", len(out.Items))
@@ -59,7 +59,7 @@ func TestFilterEndpointResourcesForStaticClusters_FiltersStaticClusterCLAs(t *te
 	}
 }
 
-func TestFilterEndpointResourcesForStaticClusters_ReturnsOriginalWhenNoFiltering(t *testing.T) {
+func TestFilterEndpointResourcesForClusters_ReturnsOriginalWhenNoFiltering(t *testing.T) {
 	// Only EDS clusters; no STATIC. Endpoints should be returned unchanged (same reference when possible).
 	clusters := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
 		{Resource: &envoyclusterv3.Cluster{Name: "eds-only", ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}}},
@@ -68,7 +68,7 @@ func TestFilterEndpointResourcesForStaticClusters_ReturnsOriginalWhenNoFiltering
 		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "eds-only"}},
 	})
 
-	out := filterEndpointResourcesForStaticClusters(clusters, endpoints)
+	out := filterEndpointResourcesForClusters(clusters, endpoints)
 
 	if len(out.Items) != 1 {
 		t.Fatalf("expected 1 endpoint resource, got %d", len(out.Items))
@@ -85,44 +85,44 @@ func TestFilterEndpointResourcesForStaticClusters_ReturnsOriginalWhenNoFiltering
 	}
 }
 
-func TestFilterEndpointResourcesForStaticClusters_EmptyClustersAndEndpoints(t *testing.T) {
+func TestFilterEndpointResourcesForClusters_EmptyClustersAndEndpoints(t *testing.T) {
 	emptyClusters := envoycache.NewResourcesWithTTL("v1", nil)
 	emptyEndpoints := envoycache.NewResourcesWithTTL("v1", nil)
 
-	out := filterEndpointResourcesForStaticClusters(emptyClusters, emptyEndpoints)
+	out := filterEndpointResourcesForClusters(emptyClusters, emptyEndpoints)
 
 	if len(out.Items) != 0 {
 		t.Errorf("expected 0 items, got %d", len(out.Items))
 	}
 }
 
-func TestFilterEndpointResourcesForStaticClusters_EmptyClustersNonEmptyEndpoints(t *testing.T) {
+func TestFilterEndpointResourcesForClusters_EmptyClustersNonEmptyEndpoints(t *testing.T) {
 	emptyClusters := envoycache.NewResourcesWithTTL("v1", nil)
 	endpoints := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
 		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "any"}},
 	})
 
-	out := filterEndpointResourcesForStaticClusters(emptyClusters, endpoints)
+	out := filterEndpointResourcesForClusters(emptyClusters, endpoints)
 
-	if len(out.Items) != 1 {
-		t.Fatalf("expected 1 endpoint when no static clusters, got %d", len(out.Items))
+	if len(out.Items) != 0 {
+		t.Fatalf("expected no endpoints when no EDS clusters are present, got %d", len(out.Items))
 	}
 }
 
-func TestFilterEndpointResourcesForStaticClusters_EmptyEndpoints(t *testing.T) {
+func TestFilterEndpointResourcesForClusters_EmptyEndpoints(t *testing.T) {
 	clusters := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
 		{Resource: &envoyclusterv3.Cluster{Name: "static-cluster", ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_STATIC}}},
 	})
 	emptyEndpoints := envoycache.NewResourcesWithTTL("v1", nil)
 
-	out := filterEndpointResourcesForStaticClusters(clusters, emptyEndpoints)
+	out := filterEndpointResourcesForClusters(clusters, emptyEndpoints)
 
 	if len(out.Items) != 0 {
 		t.Errorf("expected 0 items, got %d", len(out.Items))
 	}
 }
 
-func TestFilterEndpointResourcesForStaticClusters_MixedStaticAndNonStatic(t *testing.T) {
+func TestFilterEndpointResourcesForClusters_MixedStaticAndNonStatic(t *testing.T) {
 	// Two STATIC, two EDS. CLAs for all four. Result should have only the two EDS CLAs.
 	clusters := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
 		{Resource: &envoyclusterv3.Cluster{Name: "static-a", ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_STATIC}}},
@@ -137,7 +137,7 @@ func TestFilterEndpointResourcesForStaticClusters_MixedStaticAndNonStatic(t *tes
 		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "eds-b"}},
 	})
 
-	out := filterEndpointResourcesForStaticClusters(clusters, endpoints)
+	out := filterEndpointResourcesForClusters(clusters, endpoints)
 
 	if len(out.Items) != 2 {
 		t.Fatalf("expected 2 endpoint resources (eds-a, eds-b), got %d: %v", len(out.Items), mapKeys(out.Items))
@@ -156,7 +156,62 @@ func TestFilterEndpointResourcesForStaticClusters_MixedStaticAndNonStatic(t *tes
 	}
 }
 
-func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T) {
+func TestFilterEndpointResourcesForClusters_FiltersStaleCLAs(t *testing.T) {
+	clusters := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
+		{Resource: &envoyclusterv3.Cluster{Name: "cluster-a", ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}}},
+	})
+	endpoints := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
+		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "cluster-a"}},
+		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "stale-cluster"}},
+	})
+
+	out := filterEndpointResourcesForClusters(clusters, endpoints)
+
+	if len(out.Items) != 1 {
+		t.Fatalf("expected only current CDS endpoint resource, got %d: %v", len(out.Items), mapKeys(out.Items))
+	}
+	if _, ok := out.Items["cluster-a"]; !ok {
+		t.Errorf("expected CLA for cluster-a, got keys: %v", mapKeys(out.Items))
+	}
+	if _, ok := out.Items["stale-cluster"]; ok {
+		t.Error("expected stale-cluster CLA to be filtered out")
+	}
+	if out.Version == endpoints.Version {
+		t.Error("expected filtered endpoint resources to get a distinct version")
+	}
+}
+
+func TestFilterEndpointResourcesForClusters_UsesEdsServiceName(t *testing.T) {
+	clusters := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
+		{Resource: &envoyclusterv3.Cluster{
+			Name: "cluster-a",
+			ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
+				Type: envoyclusterv3.Cluster_EDS,
+			},
+			EdsClusterConfig: &envoyclusterv3.Cluster_EdsClusterConfig{
+				ServiceName: "eds-service-a",
+			},
+		}},
+	})
+	endpoints := envoycache.NewResourcesWithTTL("v1", []envoycachetypes.ResourceWithTTL{
+		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "cluster-a"}},
+		{Resource: &envoyendpointv3.ClusterLoadAssignment{ClusterName: "eds-service-a"}},
+	})
+
+	out := filterEndpointResourcesForClusters(clusters, endpoints)
+
+	if len(out.Items) != 1 {
+		t.Fatalf("expected only service-name CLA, got %d: %v", len(out.Items), mapKeys(out.Items))
+	}
+	if _, ok := out.Items["eds-service-a"]; !ok {
+		t.Errorf("expected CLA for eds-service-a, got keys: %v", mapKeys(out.Items))
+	}
+	if _, ok := out.Items["cluster-a"]; ok {
+		t.Error("expected cluster-name CLA to be filtered out when service_name is set")
+	}
+}
+
+func TestSnapshotPerClientPublishesWhenReferencedClustersAreMissing(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
@@ -226,9 +281,13 @@ func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T)
 		},
 	)
 
-	g.Consistently(func() int {
+	g.Eventually(func() int {
 		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+
+	snap := snapshots.List()[0].snap
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).ToNot(gomega.HaveKey("cluster-b"))
 
 	clusterCol.UpdateObject(uccWithCluster{
 		Client:         ucc,
@@ -237,16 +296,17 @@ func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T)
 		ClusterVersion: 2,
 	})
 
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+	g.Eventually(func() bool {
+		return len(snapshots.List()) == 1 &&
+			snapshots.List()[0].snap.Resources[envoycachetypes.Cluster].Items["cluster-b"].Resource != nil
+	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue())
 
-	snap := snapshots.List()[0].snap
+	snap = snapshots.List()[0].snap
 	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
 	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-b"))
 }
 
-func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testing.T) {
+func TestSnapshotPerClientPublishesWhenReferencedEDSClustersHaveNoEndpoints(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
@@ -314,9 +374,13 @@ func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testi
 		},
 	)
 
-	g.Consistently(func() int {
+	g.Eventually(func() int {
 		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+
+	snap := snapshots.List()[0].snap
+	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
+	g.Expect(snap.Resources[envoycachetypes.Endpoint].Items).ToNot(gomega.HaveKey("cluster-a"))
 
 	endpointCol.UpdateObject(UccWithEndpoints{
 		Client: ucc,
@@ -327,11 +391,12 @@ func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testi
 		endpointsName: "cluster-a",
 	})
 
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
+	g.Eventually(func() bool {
+		return len(snapshots.List()) == 1 &&
+			snapshots.List()[0].snap.Resources[envoycachetypes.Endpoint].Items["cluster-a"].Resource != nil
+	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue())
 
-	snap := snapshots.List()[0].snap
+	snap = snapshots.List()[0].snap
 	g.Expect(snap.Resources[envoycachetypes.Endpoint].Items).To(gomega.HaveKey("cluster-a"))
 }
 

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"sync/atomic"
+	"time"
 
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -36,6 +38,12 @@ import (
 )
 
 var _ manager.LeaderElectionRunnable = &ProxySyncer{}
+
+const (
+	xdsReadyGraceEnv      = "KGW_XDS_READY_GRACE"
+	defaultXDSReadyGrace  = 5 * time.Second
+	disabledXDSReadyGrace = 0 * time.Second
+)
 
 // ProxySyncer orchestrates the translation of K8s Gateway CRs to xDS
 // and setting the output xDS snapshot in the envoy snapshot cache,
@@ -465,25 +473,11 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 				snapWrap := e.Latest()
 				s.proxyTranslator.syncXds(ctx, snapWrap)
 			} else {
-				// Intentional no-op. When snapshotPerClient returns nil (its
-				// readiness guards deferred publishing), KRT surfaces a Delete
-				// for this UCC. Clearing the xDS cache here would withdraw
-				// Envoy's last coherent Snapshot for the duration of the defer,
-				// causing 500/NC on valid routes. Leaving the cache alone means
-				// Envoy keeps serving its previously-published config until a
-				// new coherent snapshot overwrites it — the "retain last good"
-				// behavior that prevents unresolvable cluster references from
-				// stranding live traffic.
-				//
-				// Known leak: this branch also fires when a UCC truly goes
-				// away (Envoy pod replaced on rollout, scaled down, etc.),
-				// and we cannot distinguish that from the "defer" case here.
-				// The SnapshotCache entry for that UCC is therefore never
-				// cleared and accumulates over the controller's lifetime.
-				// Pre-existing behavior (the prior ClearSnapshot call was
-				// already commented out); reclaiming these entries requires
-				// a separate signal — e.g. cross-referencing uccCol
-				// membership — and is left to a follow-up.
+				// Intentional no-op. A Delete can mean the UCC went away, or
+				// the gateway snapshot for this role is currently absent. In
+				// both cases, retain the last xDS cache snapshot until a future
+				// Add/Update overwrites it or a separate UCC-membership-based
+				// reclaimer proves the client has truly departed.
 			}
 
 			kmetrics.EndResourceXDSSync(kmetrics.ResourceSyncDetails{
@@ -494,9 +488,45 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 		}
 	}, true)
 
+	if err := waitForXDSReadyGrace(ctx, xdsReadyGrace()); err != nil {
+		return err
+	}
+
 	s.ready.Store(true)
 	<-ctx.Done()
 	return nil
+}
+
+func xdsReadyGrace() time.Duration {
+	raw := os.Getenv(xdsReadyGraceEnv)
+	if raw == "" {
+		return defaultXDSReadyGrace
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		logger.Warn("invalid XDS ready grace duration; using default", "env", xdsReadyGraceEnv, "value", raw, "default", defaultXDSReadyGrace, "error", err)
+		return defaultXDSReadyGrace
+	}
+	if parsed < disabledXDSReadyGrace {
+		logger.Warn("negative XDS ready grace duration; using default", "env", xdsReadyGraceEnv, "value", raw, "default", defaultXDSReadyGrace)
+		return defaultXDSReadyGrace
+	}
+	return parsed
+}
+
+func waitForXDSReadyGrace(ctx context.Context, grace time.Duration) error {
+	if grace <= disabledXDSReadyGrace {
+		return nil
+	}
+	logger.Info("waiting before declaring xDS ready", "duration", grace)
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (s *ProxySyncer) HasSynced() bool {

--- a/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer_test.go
@@ -2,6 +2,7 @@ package proxy_syncer
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,6 +59,47 @@ func TestIsGatewayStatusEqual(t *testing.T) {
 			if got := isGatewayStatusEqual(tt.objA, tt.objB); got != tt.want {
 				t.Errorf("isGatewayStatusEqual() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestXDSReadyGrace(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{
+			name: "default when unset",
+			env:  "",
+			want: defaultXDSReadyGrace,
+		},
+		{
+			name: "disabled",
+			env:  "0s",
+			want: 0,
+		},
+		{
+			name: "custom duration",
+			env:  "250ms",
+			want: 250 * time.Millisecond,
+		},
+		{
+			name: "invalid falls back to default",
+			env:  "nope",
+			want: defaultXDSReadyGrace,
+		},
+		{
+			name: "negative falls back to default",
+			env:  "-1s",
+			want: defaultXDSReadyGrace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(xdsReadyGraceEnv, tt.env)
+			assert.Equal(t, tt.want, xdsReadyGrace())
 		})
 	}
 }


### PR DESCRIPTION
# Description

PR #13868 added per-client xDS readiness gates to avoid reconnect-time snapshots where RDS/LDS referenced clusters that had not reached CDS/EDS yet. In production, those gates can become effectively permanent: `snapshotPerClient` returns `nil`, KRT surfaces a Delete, and the xDS syncer intentionally keeps the old cache snapshot. That strands proxies on stale config or prevents newly-started proxies from receiving config at all.

This changes the behavior from stop-and-wait to best-effort publication:

- Missing per-client endpoint rows publish with empty EDS resources instead of returning `nil`.
- Missing referenced CDS clusters and missing referenced EDS CLAs are logged and counted, but no longer block the snapshot.
- Published EDS is filtered to the CLAs required by the current CDS snapshot, avoiding stale/unrequested CLAs in ADS.
- A new `kgateway_xds_snapshot_incomplete_publishes_total{gateway,namespace,reason}` counter exposes incomplete best-effort publishes.
- Controller readiness now waits a small configurable grace period before advertising xDS readiness: `KGW_XDS_READY_GRACE`, default `5s`, `0s` disables.

Refs #14184.
Refs #13868.

# Change Type

/kind fix

# Changelog

```release-note
Per-client xDS snapshots are no longer withheld indefinitely while cluster or endpoint inputs catch up. The control plane now publishes best-effort snapshots, filters EDS resources to the current CDS set, records incomplete-publish metrics, and delays xDS readiness by a configurable short grace period.
```

# Additional Notes

The tradeoff is intentional: this removes the production deadness/stale-config failure mode, while the short readiness grace reduces the reconnect-time race #13868 was trying to avoid.
