### PR TITLE
test: unittest go build cache perf fixes

### DIFF
--- a/.github/actions/prep-go-runner/action.yaml
+++ b/.github/actions/prep-go-runner/action.yaml
@@ -15,6 +15,9 @@ outputs:
   go-build-cache-key:
     description: 'primary key for the Go build cache'
     value: ${{ steps.go-cache-keys.outputs.go-build }}
+  go-build-cache-key-race:
+    description: 'primary key for the race-instrumented (CGO + -race) Go build cache used by the unit tests'
+    value: ${{ steps.go-cache-keys.outputs.go-build-race }}
   go-build-cache-path:
     description: 'path to the Go build cache directory'
     value: ${{ steps.go-cache-paths.outputs.go-build }}
@@ -87,6 +90,7 @@ runs:
       shell: bash
       run: |
         echo "go-build=${{ runner.os }}-go-build-v3-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
+        echo "go-build-race=${{ runner.os }}-go-build-race-v3-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
     - name: Restore Go Build Cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: go-build-cache

--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -32,3 +32,31 @@ jobs:
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key }}
+      # The unit tests compile with `CGO_ENABLED=1 -race`, which produces a
+      # distinct set of GOCACHE entries from the CGO-disabled build primed
+      # above. Seed a second cache so PR unit jobs start with a warm
+      # race-instrumented build cache instead of recompiling the world.
+      - name: Restore Race Go Build Cache
+        id: race-build-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
+          key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}
+      - name: Prime Race Go Build Cache
+        if: steps.race-build-cache.outputs.cache-hit != 'true'
+        env:
+          CGO_ENABLED: '1'
+        run: |
+          # Start from an empty build cache so the race cache we save below
+          # contains only race-instrumented entries, not a superset that also
+          # duplicates the CGO-disabled entries saved above. The -race build
+          # can't reuse the non-race artifacts anyway (instrumentation changes
+          # every action ID), so nothing is lost by clearing them first.
+          go clean -cache
+          go test -run '^$' -race ./...
+      - name: Save Race Go Build Cache
+        if: success() && steps.race-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
+          key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -28,7 +28,17 @@ jobs:
         with:
           fetch-depth: 0
       - name: Prep Go Runner
+        id: prep-go-runner
         uses: ./.github/actions/prep-go-runner
+      - name: Restore Race Go Build Cache
+        # The tests below run with `CGO_ENABLED=1 -race`, which compiles a
+        # distinct set of GOCACHE entries from the CGO-disabled cache that
+        # prep-go-runner restores. This race-instrumented cache is seeded by
+        # the Cache Setup workflow on main; restore it so unit runs start warm.
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
+          key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}
       - name: Detect validator image rebuild
         id: validator-image
         shell: bash

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -27,12 +27,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version-file: go.mod
-      - name: Install dependencies
-        run: make mod-download
+      - name: Prep Go Runner
+        uses: ./.github/actions/prep-go-runner
       - name: Detect validator image rebuild
         id: validator-image
         shell: bash


### PR DESCRIPTION
# Description

Reduces duplication in the Unit Tests workflow and improves Go build-cache reuse for the unit job.

The `go` (Go Unit Tests) job in `unit.yaml` hand-rolled its own `Setup Go` + `make mod-download` steps, duplicating what the shared `./.github/actions/prep-go-runner` composite action already does (and which `verify.yaml`/`lint.yaml` use). This swaps those inline steps for the shared action, which also brings the job the centrally-seeded Go module and build caches it previously lacked.

The unit suite compiles and runs with `CGO_ENABLED=1 -race`, which produces a distinct set of `GOCACHE` entries from the `CGO_ENABLED=0` build that `cache-setup.yaml` primes on `main`. As a result the heaviest part of the unit job — the race-instrumented compile — got near-zero reuse from the existing cache and recompiled cold on every PR. This adds a second, race-instrumented build cache:

- `prep-go-runner` exposes a new `go-build-cache-key-race` output (key only; the shared action does not restore it, so `verify`/`lint` are unaffected).
- `cache-setup.yaml` primes (`CGO_ENABLED=1 go test -run '^$' -race ./...`) and saves that cache on pushes to `main`/`v1.**.x`. It runs `go clean -cache` first so the race blob contains only race-instrumented entries and does not duplicate the `CGO_ENABLED=0` cache.
- The `go` job in `unit.yaml` restores the race cache so PR unit runs start warm.

Net effect: less workflow duplication and a meaningfully warmer build cache for the unit job's race compile, with the extra priming cost confined to `cache-setup` on `main` (off the PR critical path).

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

- `package-kgateway-charts` is pure `helm package` and compiles no Go, so the workflow-level `CGO_ENABLED=0` has no effect on it.
- The race cache only populates after the next `cache-setup` run on `main`; until then the unit restore simply misses and behaves as before (no regression).
- GitHub Actions caps repo cache at 10 GB with LRU eviction. Keeping
  the -race blob pure (rather than a superset) was a deliberate choice
  to limit added footprint. I will look at the blob sizes on the
  first `cache-setup` run and make sure a subsequent PR unit.yaml run
  is a cache it.
