### PR TITLE
chore(ci): bumps qemu

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -217,7 +217,7 @@ jobs:
           # during cross-platform `docker build`, breaking the arm64 release image.
           # A versioned tag gives a version-specific cache key (sidestepping the
           # poisoned `latest` cache) and a QEMU build that contains the upstream fix.
-          image: tonistiigi/binfmt:qemu-v10.2.1
+          image: tonistiigi/binfmt:qemu-v10.2.3
       - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10.0
 
       - name: Download release notes


### PR DESCRIPTION
# Description
Bumps qemu, which is segfaulting on the old version during 'release.yaml' invocation on push to `main`. No idea if this bump will help, but trying it is the easiest way to find out.
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind bump

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
