### PR TITLE
[WIP] cleanup: translate backend clusters once per backend, overlay per client

### DIFF
--- a/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
@@ -41,9 +41,10 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 	return sdk.Plugin{
 		ContributesPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
 			gk: {
-				Name:                      "destrule",
-				PerClientProcessBackend:   d.processBackend,
-				PerClientProcessEndpoints: d.processEndpoints,
+				Name:                           "destrule",
+				PerClientProcessBackend:        d.processBackend,
+				PerClientProcessBackendApplies: d.appliesToBackend,
+				PerClientProcessEndpoints:      d.processEndpoints,
 			},
 		},
 	}
@@ -77,6 +78,19 @@ func (d *destrulePlugin) processEndpoints(
 	hasher.Write([]byte(destrule.UID))
 	hasher.Write(fmt.Appendf(nil, "%v", destrule.Generation))
 	return hasher.Sum64()
+}
+
+// appliesToBackend reports whether processBackend would mutate the cluster for this (backend,
+// client) pair: there must be a matching destination rule whose traffic policy carries outlier
+// detection. It mirrors processBackend's guard exactly so the per-client cluster copy is only taken
+// when the overlay actually changes the cluster.
+func (d *destrulePlugin) appliesToBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) bool {
+	destrule := d.destinationRulesIndex.FetchDestRulesFor(kctx, ucc.Namespace, in.CanonicalHostname, ucc.Labels)
+	if destrule == nil {
+		return false
+	}
+	trafficPolicy := getTrafficPolicy(destrule, uint32(in.GetPort())) //nolint:gosec // G115: BackendObjectIR port is int32 representing a port number, always in valid range
+	return trafficPolicy.GetOutlierDetection() != nil
 }
 
 func (d *destrulePlugin) processBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR, outCluster *envoyclusterv3.Cluster) {

--- a/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
@@ -68,7 +68,8 @@ func NewPlugin(
 			// Contributing a PerClientProcessEndpoints function can return an empty CLA but
 			// it is still redundant.
 			VirtualWaypointGK: {
-				PerClientProcessBackend: pcp.processBackend,
+				PerClientProcessBackend:        pcp.processBackend,
+				PerClientProcessBackendApplies: pcp.appliesToBackend,
 			},
 		}
 	}
@@ -80,6 +81,18 @@ type PerClientProcessor struct {
 	waypointQueries          waypointquery.WaypointQueries
 	commonCols               *collections.CommonCollections
 	waypointGatewayClassName string
+}
+
+// appliesToBackend reports whether processBackend might modify the cluster for this (backend,
+// client) pair. It applies the same cheap filters processBackend uses first -- the ambient
+// redirection annotation on the ucc and the ingress-use-waypoint label on the backend -- so the
+// dominant non-ambient case skips the per-client cluster copy. The deeper gateway/service checks in
+// processBackend may still no-op, which is acceptable since ambient-redirected clients are rare.
+func (t *PerClientProcessor) appliesToBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) bool {
+	if val, ok := ucc.Labels[istioannot.AmbientRedirection.Name]; !ok || val != "enabled" {
+		return false
+	}
+	return HasIngressUseWaypointLabel(kctx, t.commonCols, in)
 }
 
 func (t *PerClientProcessor) processBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) {

--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -29,6 +29,10 @@ type uccWithCluster struct {
 	BackendSource ir.ObjectSource
 	// BackendGeneration is the observed generation of the source Backend.
 	BackendGeneration int64
+	// SharesBase is true when this row reuses the client-independent base cluster proto verbatim
+	// (no per-client overlay changed it). Such rows were already validated once at the base, so the
+	// per-client residual validation pass skips them.
+	SharesBase bool
 }
 
 func (c uccWithCluster) ResourceName() string {
@@ -40,6 +44,7 @@ func (c uccWithCluster) Equals(in uccWithCluster) bool {
 		c.ClusterVersion == in.ClusterVersion &&
 		c.BackendSource == in.BackendSource &&
 		c.BackendGeneration == in.BackendGeneration &&
+		c.SharesBase == in.SharesBase &&
 		errString(c.Error) == errString(in.Error)
 }
 
@@ -66,14 +71,23 @@ func NewPerClientEnvoyClusters(
 	finalBackends krt.Collection[*ir.BackendObjectIR],
 	uccs krt.Collection[ir.UniquelyConnectedClient],
 ) PerClientEnvoyClusters {
-	// baseClusters holds the client-independent ("base") translation of each Backend, computed
-	// once per Backend rather than once per (backend, client). The per-client overlay (destination
-	// rules, locality priorities) is layered on cheaply below.
+	// baseClusters holds the client-independent ("base") translation of each Backend, computed once
+	// per Backend rather than once per (backend, client). The per-client overlay (destination rules,
+	// locality priorities) is layered on cheaply below. In strict mode the base is validated here,
+	// exactly once per Backend, so the many clients that share it never re-validate identical content.
 	baseClusters := krt.NewCollection(finalBackends, func(kctx krt.HandlerContext, backendObj *ir.BackendObjectIR) *irtranslator.BackendBaseCluster {
-		return translator.TranslateBackendBase(ctx, backendObj)
+		base := translator.TranslateBackendBase(ctx, backendObj)
+		if base != nil {
+			translator.ValidateBaseCluster(ctx, base)
+		}
+		return base
 	}, krtopts.ToOptions("BackendBaseClusters")...)
 
-	clusters := krt.NewManyCollection(finalBackends, func(kctx krt.HandlerContext, backendObj *ir.BackendObjectIR) []uccWithCluster {
+	// translatedClusters produces the per-(backend, client) rows by overlaying per-client concerns
+	// onto the shared base. It runs no Envoy validation. Rows whose overlay did not change the base
+	// proto are flagged SharesBase (and reuse the base version hash) so the validation pass below can
+	// skip them: they were already validated once when the base was translated.
+	translatedClusters := krt.NewManyCollection(finalBackends, func(kctx krt.HandlerContext, backendObj *ir.BackendObjectIR) []uccWithCluster {
 		base := krt.FetchOne(kctx, baseClusters, krt.FilterKey(backendObj.ResourceName()))
 		if base == nil || base.Cluster == nil {
 			// Unsupported backend (no translator/plugin); nothing to emit.
@@ -92,7 +106,7 @@ func NewPerClientEnvoyClusters(
 			var c *envoyclusterv3.Cluster
 			var err error
 			if base.Err != nil {
-				// Base translation failed; every client shares the blackhole cluster + error.
+				// Base translation/validation failed; every client shares the blackhole + error.
 				c, err = base.Cluster, base.Err
 			} else {
 				c, err = translator.ApplyPerClientOverlay(ctx, kctx, ucc, backendObj, base)
@@ -100,18 +114,39 @@ func NewPerClientEnvoyClusters(
 			if c == nil {
 				continue
 			}
+			// Reuse the base version hash (and skip re-validation) for clients that share the base
+			// cluster by identity. Only clients whose overlay produced a distinct proto need a fresh
+			// hash and a residual validation. This keeps hashing + validation at
+			// O(backends + overlays) instead of O(backends x clients).
+			sharesBase := c == base.Cluster
+			clusterVersion := base.Version
+			if !sharesBase {
+				clusterVersion = utils.HashProto(c)
+			}
 			uccWithClusterRet = append(uccWithClusterRet, uccWithCluster{
 				Name:    c.GetName(),
 				Client:  ucc,
 				Cluster: c,
 				// pass along the error(s) indicating to consumers that this cluster is not usable
 				Error:             err,
-				ClusterVersion:    utils.HashProto(c),
+				ClusterVersion:    clusterVersion,
 				BackendSource:     backendObj.GetObjectSource(),
 				BackendGeneration: backendGeneration,
+				SharesBase:        sharesBase,
 			})
 		}
 		return uccWithClusterRet
+	}, krtopts.ToOptions("TranslatedPerClientEnvoyClusters")...)
+	translatedIdx := krtpkg.UnnamedIndex(translatedClusters, func(ucc uccWithCluster) []string {
+		return []string{ucc.Client.ResourceName()}
+	})
+
+	// clusters validates each client's residual clusters (those whose per-client overlay changed the
+	// base) in a single Envoy invocation per client. A client's clusters have distinct names (one per
+	// backend), so they batch safely; base-shared clusters were already validated once above.
+	clusters := krt.NewManyCollection(uccs, func(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient) []uccWithCluster {
+		translated := krt.Fetch(kctx, translatedClusters, krt.FilterIndex(translatedIdx, ucc.ResourceName()))
+		return validateResidualClusters(ctx, translator, translated)
 	}, krtopts.ToOptions("PerClientEnvoyClusters")...)
 	idx := krtpkg.UnnamedIndex(clusters, func(ucc uccWithCluster) []string {
 		return []string{ucc.Client.ResourceName()}
@@ -121,4 +156,65 @@ func NewPerClientEnvoyClusters(
 		clusters: clusters,
 		index:    idx,
 	}
+}
+
+// validateResidualClusters validates, in strict mode, the per-client clusters whose overlay changed
+// the shared base (SharesBase == false). Base-shared clusters were already validated once when the
+// base was translated, so they are skipped. The residuals are validated in one Envoy call; only if
+// that batch fails are they validated one-by-one to isolate the offender(s), which are blackholed,
+// after which the survivors are re-checked together to catch any cross-cluster interaction.
+func validateResidualClusters(
+	ctx context.Context,
+	translator *irtranslator.BackendTranslator,
+	clusters []uccWithCluster,
+) []uccWithCluster {
+	if translator == nil || !translator.StrictValidationEnabled() {
+		return clusters
+	}
+
+	candidates := make([]int, 0, len(clusters))
+	candidateClusters := make([]*envoyclusterv3.Cluster, 0, len(clusters))
+	for i := range clusters {
+		if clusters[i].SharesBase || clusters[i].Error != nil || clusters[i].Cluster == nil {
+			continue
+		}
+		candidates = append(candidates, i)
+		candidateClusters = append(candidateClusters, clusters[i].Cluster)
+	}
+	if len(candidateClusters) == 0 {
+		return clusters
+	}
+
+	if err := translator.ValidateClusterConfigs(ctx, candidateClusters); err == nil {
+		return clusters
+	} else {
+		logger.Debug("strict backend batch validation failed; isolating invalid clusters", "clusters", len(candidateClusters), "error", err)
+	}
+
+	survivingClusters := make([]*envoyclusterv3.Cluster, 0, len(candidateClusters))
+	survivingIndexes := make([]int, 0, len(candidateClusters))
+	for _, idx := range candidates {
+		if err := translator.ValidateClusterConfig(ctx, clusters[idx].Cluster); err != nil {
+			markClusterValidationError(&clusters[idx], err)
+			continue
+		}
+		survivingClusters = append(survivingClusters, clusters[idx].Cluster)
+		survivingIndexes = append(survivingIndexes, idx)
+	}
+
+	if err := translator.ValidateClusterConfigs(ctx, survivingClusters); err != nil {
+		logger.Error("strict backend batch validation failed after invalid cluster isolation", "clusters", len(survivingClusters), "error", err)
+		for _, idx := range survivingIndexes {
+			markClusterValidationError(&clusters[idx], err)
+		}
+	}
+	return clusters
+}
+
+func markClusterValidationError(cluster *uccWithCluster, err error) {
+	logger.Error("cluster failed xDS validation in strict mode", "cluster", cluster.Name, "error", err)
+	cluster.Error = err
+	cluster.Cluster = irtranslator.BlackholeClusterForName(cluster.Name)
+	cluster.ClusterVersion = utils.HashProto(cluster.Cluster)
+	cluster.SharesBase = false
 }

--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -66,21 +66,39 @@ func NewPerClientEnvoyClusters(
 	finalBackends krt.Collection[*ir.BackendObjectIR],
 	uccs krt.Collection[ir.UniquelyConnectedClient],
 ) PerClientEnvoyClusters {
+	// baseClusters holds the client-independent ("base") translation of each Backend, computed
+	// once per Backend rather than once per (backend, client). The per-client overlay (destination
+	// rules, locality priorities) is layered on cheaply below.
+	baseClusters := krt.NewCollection(finalBackends, func(kctx krt.HandlerContext, backendObj *ir.BackendObjectIR) *irtranslator.BackendBaseCluster {
+		return translator.TranslateBackendBase(ctx, backendObj)
+	}, krtopts.ToOptions("BackendBaseClusters")...)
+
 	clusters := krt.NewManyCollection(finalBackends, func(kctx krt.HandlerContext, backendObj *ir.BackendObjectIR) []uccWithCluster {
-		backendLogger := logger.With("backend", backendObj)
+		base := krt.FetchOne(kctx, baseClusters, krt.FilterKey(backendObj.ResourceName()))
+		if base == nil || base.Cluster == nil {
+			// Unsupported backend (no translator/plugin); nothing to emit.
+			return nil
+		}
+
 		uccs := krt.Fetch(kctx, uccs)
 		uccWithClusterRet := make([]uccWithCluster, 0, len(uccs))
 
-		for _, ucc := range uccs {
-			backendLogger.Debug("applying destination rules for backend", "ucc", ucc.ResourceName())
+		var backendGeneration int64
+		if backendObj.Obj != nil {
+			backendGeneration = backendObj.Obj.GetGeneration()
+		}
 
-			c, err := translator.TranslateBackend(ctx, kctx, ucc, backendObj)
+		for _, ucc := range uccs {
+			var c *envoyclusterv3.Cluster
+			var err error
+			if base.Err != nil {
+				// Base translation failed; every client shares the blackhole cluster + error.
+				c, err = base.Cluster, base.Err
+			} else {
+				c, err = translator.ApplyPerClientOverlay(ctx, kctx, ucc, backendObj, base)
+			}
 			if c == nil {
 				continue
-			}
-			var backendGeneration int64
-			if backendObj.Obj != nil {
-				backendGeneration = backendObj.Obj.GetGeneration()
 			}
 			uccWithClusterRet = append(uccWithClusterRet, uccWithCluster{
 				Name:    c.GetName(),

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -46,11 +46,60 @@ type BackendTranslator struct {
 	Mode                apisettings.ValidationMode
 }
 
-// TranslateBackend translates a BackendObjectIR to an Envoy Cluster. If we encounter any
-// errors during translation, a blackhole cluster is returned along with the error. The error
-// return value is what matters as consumers (pkg/kgateway/proxy_syncer/perclient.go) will
-// drop errored clusters from the xDS snapshot and track them separately for status reporting.
-// The blackhole cluster itself is not sent to Envoy but provides a consistent return structure.
+// BackendBaseCluster is the client-independent ("base") translation of a Backend into an
+// Envoy Cluster. It is produced once per Backend and shared across all uniquely-connected
+// clients; the per-client overlay (destination rules, locality priorities) is applied later
+// by ApplyPerClientOverlay. Splitting translation this way avoids re-running the full backend
+// plugin chain once per (backend, client) pair.
+type BackendBaseCluster struct {
+	// Name is the source Backend's ResourceName; it keys this element in the KRT collection.
+	Name string
+	// Cluster is the base proto. When Err != nil this is a blackhole cluster and the overlay
+	// is skipped (all clients share the blackhole + error).
+	// +krtEqualsTodo include full cluster diff in equality
+	Cluster *envoyclusterv3.Cluster
+	// Version is HashProto(Cluster); it stands in for a deep proto diff in Equals.
+	Version uint64
+	// InlineEps are the inline endpoints captured from InitEnvoyBackend, needed by the
+	// per-client endpoint plugins / inline-CLA path. Nil for EDS clusters.
+	InlineEps *ir.EndpointsForBackend
+	// Err is the base translation error, if any. Compared by message in Equals because all
+	// errored clusters share one blackhole proto, so Version can't tell error states apart.
+	Err error
+}
+
+func (b BackendBaseCluster) ResourceName() string {
+	return b.Name
+}
+
+func (b BackendBaseCluster) Equals(in BackendBaseCluster) bool {
+	return b.Name == in.Name &&
+		b.Version == in.Version &&
+		errMsg(b.Err) == errMsg(in.Err) &&
+		inlineEpsEqual(b.InlineEps, in.InlineEps)
+}
+
+func errMsg(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func inlineEpsEqual(a, b *ir.EndpointsForBackend) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equals(*b)
+}
+
+// TranslateBackend translates a BackendObjectIR to an Envoy Cluster for a single client. It is a
+// thin wrapper over the base translation (TranslateBackendBase) followed by the per-client overlay
+// (ApplyPerClientOverlay). If we encounter any errors during translation, a blackhole cluster is
+// returned along with the error. The error return value is what matters as consumers
+// (pkg/kgateway/proxy_syncer/perclient.go) will drop errored clusters from the xDS snapshot and
+// track them separately for status reporting. The blackhole cluster itself is not sent to Envoy
+// but provides a consistent return structure.
 func (t *BackendTranslator) TranslateBackend(
 	ctx context.Context,
 	kctx krt.HandlerContext,
@@ -67,11 +116,41 @@ func (t *BackendTranslator) TranslateBackend(
 		return nil, errors.New("no backend plugin found for " + gk.String())
 	}
 
+	base := t.TranslateBackendBase(ctx, backend)
+	if base == nil {
+		// Unreachable given the checks above, but keep a defined return.
+		return nil, errors.New("no base cluster translated for " + gk.String())
+	}
+	if base.Err != nil {
+		return base.Cluster, base.Err
+	}
+	return t.ApplyPerClientOverlay(ctx, kctx, ucc, backend, base)
+}
+
+// TranslateBackendBase performs the client-independent ("base") translation of a Backend into an
+// Envoy Cluster: initialization, the backend plugin, DNS lookup family, client-independent backend
+// policies (ProcessBackend), default locality config, and the gateway backend client certificate.
+// Per-client concerns (destination rules, endpoint locality priorities, the inline CLA) are NOT
+// applied here; they are layered on by ApplyPerClientOverlay. Returns nil only when the Backend is
+// unsupported (no translator / no plugin), mirroring the old nil-cluster contract.
+func (t *BackendTranslator) TranslateBackendBase(
+	ctx context.Context,
+	backend *ir.BackendObjectIR,
+) *BackendBaseCluster {
+	gk := backend.GetGroupKind()
+	process, ok := t.ContributedBackends[gk]
+	if !ok {
+		return nil
+	}
+	if process.InitEnvoyBackend == nil {
+		return nil
+	}
+
 	// Check for pre-existing errors in the Backend IR before starting translation.
 	// Exit translation early if we have errors
 	if backend.Errors != nil {
 		logger.Error("backend has pre-existing errors", "backend", backend.GetName(), "errors", backend.Errors)
-		return buildBlackholeCluster(backend), errors.Join(backend.Errors...)
+		return newBlackholeBase(backend, errors.Join(backend.Errors...))
 	}
 
 	// Initialize the cluster with minimal configuration
@@ -79,18 +158,51 @@ func (t *BackendTranslator) TranslateBackend(
 	inlineEps := process.InitEnvoyBackend(ctx, *backend, out)
 	processDnsLookupFamily(out, t.CommonCols)
 
-	// Apply policies to the computed cluster
-	if err := t.runPolicies(kctx, ctx, ucc, backend, inlineEps, out); err != nil {
+	// Apply client-independent backend policies to the computed cluster.
+	if err := t.runBaseBackendPolicies(ctx, backend, out); err != nil {
 		logger.Error("failed to apply policies to cluster", "cluster", out.GetName(), "error", err)
-		return buildBlackholeCluster(backend), err
+		return newBlackholeBase(backend, err)
 	}
 	defaultLocalityConfig(out)
 	if err := applyGatewayBackendClientCertificate(out, backend); err != nil {
 		logger.Error("failed to apply gateway backend client certificate", "cluster", out.GetName(), "error", err)
-		return buildBlackholeCluster(backend), err
+		return newBlackholeBase(backend, err)
 	}
 
-	// In strict mode, validate the final cluster configuration using Envoy
+	return &BackendBaseCluster{
+		Name:      backend.ResourceName(),
+		Cluster:   out,
+		Version:   utils.HashProto(out),
+		InlineEps: inlineEps,
+	}
+}
+
+// ApplyPerClientOverlay layers the per-client concerns onto a copy of the base cluster: the
+// PerClientProcessBackend hooks (e.g. Istio destination rules, waypoint), endpoint plugins, and the
+// inline ClusterLoadAssignment built from the client's locality. The base proto is never mutated.
+// In strict mode the final per-client cluster is validated (the caching validator deduplicates
+// identical content across clients).
+func (t *BackendTranslator) ApplyPerClientOverlay(
+	ctx context.Context,
+	kctx krt.HandlerContext,
+	ucc ir.UniquelyConnectedClient,
+	backend *ir.BackendObjectIR,
+	base *BackendBaseCluster,
+) (*envoyclusterv3.Cluster, error) {
+	// Fast path: when nothing varies per client for this cluster and we are not validating,
+	// reuse the shared base proto directly (it is immutable downstream). This is the common
+	// case for EDS clusters when Istio integration is disabled.
+	if t.Mode != apisettings.ValidationStrict && base.InlineEps == nil && !t.hasPerClientBackendPlugins() {
+		return base.Cluster, nil
+	}
+
+	out, ok := proto.Clone(base.Cluster).(*envoyclusterv3.Cluster)
+	if !ok {
+		return buildBlackholeCluster(backend), errors.New("failed to clone base cluster")
+	}
+	t.runPerClientPolicies(kctx, ctx, ucc, backend, base.InlineEps, out)
+
+	// In strict mode, validate the final per-client cluster configuration using Envoy.
 	if t.Mode == apisettings.ValidationStrict && t.Validator != nil {
 		if err := t.validateClusterConfig(ctx, out); err != nil {
 			logger.Error("cluster failed xDS validation in strict mode", "cluster", out.GetName(), "error", err)
@@ -99,6 +211,28 @@ func (t *BackendTranslator) TranslateBackend(
 	}
 
 	return out, nil
+}
+
+func newBlackholeBase(backend *ir.BackendObjectIR, err error) *BackendBaseCluster {
+	bh := buildBlackholeCluster(backend)
+	return &BackendBaseCluster{
+		Name:    backend.ResourceName(),
+		Cluster: bh,
+		Version: utils.HashProto(bh),
+		Err:     err,
+	}
+}
+
+// hasPerClientBackendPlugins reports whether any contributed policy plugin performs per-client
+// backend processing. When none do (and there are no inline endpoints), the per-client overlay is
+// a no-op and the base cluster can be reused as-is.
+func (t *BackendTranslator) hasPerClientBackendPlugins() bool {
+	for _, p := range t.ContributedPolicies {
+		if p.PerClientProcessBackend != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // defaultLocalityConfig keeps traffic evenly distributed across zones for clusters
@@ -131,34 +265,15 @@ func defaultLocalityConfig(c *envoyclusterv3.Cluster) {
 	}
 }
 
-func (t *BackendTranslator) runPolicies(
-	kctx krt.HandlerContext,
+// runBaseBackendPolicies applies the client-independent backend policies (ProcessBackend) to the
+// cluster. It is run once per Backend as part of base translation.
+func (t *BackendTranslator) runBaseBackendPolicies(
 	ctx context.Context,
-	ucc ir.UniquelyConnectedClient,
 	backend *ir.BackendObjectIR,
-	inlineEps *ir.EndpointsForBackend,
 	out *envoyclusterv3.Cluster,
 ) error {
-	// if the backend was initialized with inlineEps then we
-	// need an EndpointsInputs to run plugins against
-	var endpointInputs *endpoints.EndpointsInputs
-	if inlineEps != nil {
-		endpointInputs = &endpoints.EndpointsInputs{
-			EndpointsForBackend: *inlineEps,
-		}
-		endpointInputs.EndpointsForBackend.AttachedPolicies = backend.AttachedPolicies
-	}
-
 	var errs []error
 	for gk, policyPlugin := range t.ContributedPolicies {
-		// TODO: in theory it would be nice to do `ProcessBackend` once, and only do
-		// the the per-client processing for each client.
-		// that would require refactoring and thinking about the proper IR, so we'll punt on that for
-		// now, until we have more backend plugin examples to properly understand what it should look
-		// like.
-		if policyPlugin.PerClientProcessBackend != nil {
-			policyPlugin.PerClientProcessBackend(kctx, ctx, ucc, *backend, out)
-		}
 		// if the policy plugin has no ProcessBackend function, skip it
 		if policyPlugin.ProcessBackend == nil {
 			continue
@@ -178,6 +293,35 @@ func (t *BackendTranslator) runPolicies(
 			policyPlugin.ProcessBackend(ctx, polAttachment.PolicyIr, *backend, out)
 		}
 	}
+	return errors.Join(errs...)
+}
+
+// runPerClientPolicies applies the client-specific overlay to a (cloned) cluster: the
+// PerClientProcessBackend hooks, endpoint plugins, and the inline ClusterLoadAssignment derived from
+// the client's locality. None of the per-client hooks return errors, so this does not.
+func (t *BackendTranslator) runPerClientPolicies(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniquelyConnectedClient,
+	backend *ir.BackendObjectIR,
+	inlineEps *ir.EndpointsForBackend,
+	out *envoyclusterv3.Cluster,
+) {
+	// if the backend was initialized with inlineEps then we
+	// need an EndpointsInputs to run plugins against
+	var endpointInputs *endpoints.EndpointsInputs
+	if inlineEps != nil {
+		endpointInputs = &endpoints.EndpointsInputs{
+			EndpointsForBackend: *inlineEps,
+		}
+		endpointInputs.EndpointsForBackend.AttachedPolicies = backend.AttachedPolicies
+	}
+
+	for _, policyPlugin := range t.ContributedPolicies {
+		if policyPlugin.PerClientProcessBackend != nil {
+			policyPlugin.PerClientProcessBackend(kctx, ctx, ucc, *backend, out)
+		}
+	}
 
 	if endpointInputs != nil {
 		for _, processEndpoints := range t.orderedEndpointPlugins() {
@@ -194,8 +338,6 @@ func (t *BackendTranslator) runPolicies(
 			*endpointInputs,
 		)
 	}
-
-	return errors.Join(errs...)
 }
 
 func (t *BackendTranslator) orderedEndpointPlugins() []sdk.EndpointPlugin {

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -190,9 +190,10 @@ func (t *BackendTranslator) ApplyPerClientOverlay(
 	base *BackendBaseCluster,
 ) (*envoyclusterv3.Cluster, error) {
 	// Fast path: when nothing varies per client for this cluster and we are not validating,
-	// reuse the shared base proto directly (it is immutable downstream). This is the common
-	// case for EDS clusters when Istio integration is disabled.
-	if t.Mode != apisettings.ValidationStrict && base.InlineEps == nil && !t.hasPerClientBackendPlugins() {
+	// reuse the shared base proto directly (it is immutable downstream). This is the common case
+	// for EDS clusters when no per-client plugin (destination rule, waypoint) matches this pair --
+	// including every cluster when Istio integration is disabled.
+	if t.Mode != apisettings.ValidationStrict && base.InlineEps == nil && !t.anyPerClientBackendApplies(kctx, ctx, ucc, backend) {
 		return base.Cluster, nil
 	}
 
@@ -223,12 +224,26 @@ func newBlackholeBase(backend *ir.BackendObjectIR, err error) *BackendBaseCluste
 	}
 }
 
-// hasPerClientBackendPlugins reports whether any contributed policy plugin performs per-client
-// backend processing. When none do (and there are no inline endpoints), the per-client overlay is
-// a no-op and the base cluster can be reused as-is.
-func (t *BackendTranslator) hasPerClientBackendPlugins() bool {
+// anyPerClientBackendApplies reports whether any contributed policy plugin would modify the cluster
+// for this (backend, client) pair. A plugin that performs per-client backend processing but does not
+// provide a PerClientProcessBackendApplies predicate is conservatively assumed to always apply. When
+// this returns false (and there are no inline endpoints), the per-client overlay is a no-op and the
+// base cluster can be reused as-is, avoiding a per-pair clone.
+func (t *BackendTranslator) anyPerClientBackendApplies(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniquelyConnectedClient,
+	backend *ir.BackendObjectIR,
+) bool {
 	for _, p := range t.ContributedPolicies {
-		if p.PerClientProcessBackend != nil {
+		if p.PerClientProcessBackend == nil {
+			continue
+		}
+		if p.PerClientProcessBackendApplies == nil {
+			// Plugin may modify the cluster; we cannot safely skip the overlay.
+			return true
+		}
+		if p.PerClientProcessBackendApplies(kctx, ctx, ucc, *backend) {
 			return true
 		}
 	}

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -121,10 +121,24 @@ func (t *BackendTranslator) TranslateBackend(
 		// Unreachable given the checks above, but keep a defined return.
 		return nil, errors.New("no base cluster translated for " + gk.String())
 	}
+	// Validate the client-independent base once; a failure here is shared by every client.
+	t.ValidateBaseCluster(ctx, base)
 	if base.Err != nil {
 		return base.Cluster, base.Err
 	}
-	return t.ApplyPerClientOverlay(ctx, kctx, ucc, backend, base)
+	out, err := t.ApplyPerClientOverlay(ctx, kctx, ucc, backend, base)
+	if err != nil {
+		return out, err
+	}
+	// Only the per-client residual (a cluster the overlay actually changed) still needs validating;
+	// clusters identical to the base were already covered by ValidateBaseCluster above.
+	if t.StrictValidationEnabled() && out != base.Cluster {
+		if err := t.ValidateClusterConfig(ctx, out); err != nil {
+			logger.Error("cluster failed xDS validation in strict mode", "cluster", out.GetName(), "error", err)
+			return buildBlackholeCluster(backend), err
+		}
+	}
+	return out, nil
 }
 
 // TranslateBackendBase performs the client-independent ("base") translation of a Backend into an
@@ -180,8 +194,9 @@ func (t *BackendTranslator) TranslateBackendBase(
 // ApplyPerClientOverlay layers the per-client concerns onto a copy of the base cluster: the
 // PerClientProcessBackend hooks (e.g. Istio destination rules, waypoint), endpoint plugins, and the
 // inline ClusterLoadAssignment built from the client's locality. The base proto is never mutated.
-// In strict mode the final per-client cluster is validated (the caching validator deduplicates
-// identical content across clients).
+// It performs no Envoy validation: the base is validated once by ValidateBaseCluster, and the
+// per-client residual is validated by the caller (TranslateBackend, or the proxy_syncer cluster
+// collection which batches a client's residuals into one Envoy invocation).
 func (t *BackendTranslator) ApplyPerClientOverlay(
 	ctx context.Context,
 	kctx krt.HandlerContext,
@@ -189,11 +204,12 @@ func (t *BackendTranslator) ApplyPerClientOverlay(
 	backend *ir.BackendObjectIR,
 	base *BackendBaseCluster,
 ) (*envoyclusterv3.Cluster, error) {
-	// Fast path: when nothing varies per client for this cluster and we are not validating,
-	// reuse the shared base proto directly (it is immutable downstream). This is the common case
-	// for EDS clusters when no per-client plugin (destination rule, waypoint) matches this pair --
-	// including every cluster when Istio integration is disabled.
-	if t.Mode != apisettings.ValidationStrict && base.InlineEps == nil && !t.anyPerClientBackendApplies(kctx, ctx, ucc, backend) {
+	// Fast path: when nothing varies per client for this cluster, reuse the shared base proto
+	// directly (it is immutable downstream, and already validated). This is the common case for EDS
+	// clusters when no per-client plugin (destination rule, waypoint) matches this pair -- including
+	// every cluster when Istio integration is disabled. Returning the base by identity lets the
+	// caller skip both re-hashing and re-validating this client's copy.
+	if base.InlineEps == nil && !t.anyPerClientBackendApplies(kctx, ctx, ucc, backend) {
 		return base.Cluster, nil
 	}
 
@@ -202,14 +218,6 @@ func (t *BackendTranslator) ApplyPerClientOverlay(
 		return buildBlackholeCluster(backend), errors.New("failed to clone base cluster")
 	}
 	t.runPerClientPolicies(kctx, ctx, ucc, backend, base.InlineEps, out)
-
-	// In strict mode, validate the final per-client cluster configuration using Envoy.
-	if t.Mode == apisettings.ValidationStrict && t.Validator != nil {
-		if err := t.validateClusterConfig(ctx, out); err != nil {
-			logger.Error("cluster failed xDS validation in strict mode", "cluster", out.GetName(), "error", err)
-			return buildBlackholeCluster(backend), err
-		}
-	}
 
 	return out, nil
 }
@@ -362,12 +370,48 @@ func (t *BackendTranslator) orderedEndpointPlugins() []sdk.EndpointPlugin {
 	return OrderedEndpointPlugins(t.ContributedPolicies)
 }
 
-// validateClusterConfig validates an individual cluster configuration using Envoy's
-// validation. This catches configuration errors that would cause Envoy data plane NACKs,
-// such as invalid cipher suites, invalid TLS parameters, etc.
-func (t *BackendTranslator) validateClusterConfig(ctx context.Context, cluster *envoyclusterv3.Cluster) error {
+// StrictValidationEnabled reports whether translated backend clusters must be validated by Envoy.
+func (t *BackendTranslator) StrictValidationEnabled() bool {
+	return t.Mode == apisettings.ValidationStrict && t.Validator != nil
+}
+
+// ValidateBaseCluster validates the client-independent base cluster once, in strict mode. On
+// failure it converts the base to a blackhole and records the error, so every client that shares
+// the base inherits the blackhole + error without re-validating identical content.
+func (t *BackendTranslator) ValidateBaseCluster(ctx context.Context, base *BackendBaseCluster) {
+	if base == nil || base.Cluster == nil || base.Err != nil || !t.StrictValidationEnabled() {
+		return
+	}
+	if err := t.ValidateClusterConfig(ctx, base.Cluster); err != nil {
+		logger.Error("base cluster failed xDS validation in strict mode", "cluster", base.Cluster.GetName(), "error", err)
+		base.Cluster = BlackholeClusterForName(base.Cluster.GetName())
+		base.Version = utils.HashProto(base.Cluster)
+		base.Err = err
+	}
+}
+
+// ValidateClusterConfig validates a single cluster configuration using Envoy's validation. This
+// catches configuration errors that would cause Envoy data plane NACKs, such as invalid cipher
+// suites, invalid TLS parameters, etc.
+func (t *BackendTranslator) ValidateClusterConfig(ctx context.Context, cluster *envoyclusterv3.Cluster) error {
+	return t.ValidateClusterConfigs(ctx, []*envoyclusterv3.Cluster{cluster})
+}
+
+// ValidateClusterConfigs validates multiple cluster configurations in a single Envoy invocation.
+// Callers must ensure the clusters have distinct names; Envoy rejects a bootstrap with duplicate
+// cluster names. (Per-client variants of one Backend share a name, so they cannot be batched
+// together -- batch across distinct backends instead, e.g. all of one client's clusters.)
+func (t *BackendTranslator) ValidateClusterConfigs(ctx context.Context, clusters []*envoyclusterv3.Cluster) error {
+	if len(clusters) == 0 {
+		return nil
+	}
+	if t.Validator == nil {
+		return errors.New("strict validation requested but no validator configured")
+	}
 	builder := bootstrap.New()
-	builder.AddCluster(cluster)
+	for _, cluster := range clusters {
+		builder.AddCluster(cluster)
+	}
 	bootstrap, err := builder.Build()
 	if err != nil {
 		return err
@@ -509,18 +553,24 @@ func initializeCluster(b *ir.BackendObjectIR) *envoyclusterv3.Cluster {
 }
 
 func buildBlackholeCluster(b *ir.BackendObjectIR) *envoyclusterv3.Cluster {
-	out := &envoyclusterv3.Cluster{
-		Name:     b.ClusterName(),
+	return BlackholeClusterForName(b.ClusterName())
+}
+
+// BlackholeClusterForName returns an inert STATIC cluster with no endpoints. It represents a
+// backend whose translation or validation failed, keeping the cluster name present in xDS without
+// routing traffic to it.
+func BlackholeClusterForName(name string) *envoyclusterv3.Cluster {
+	return &envoyclusterv3.Cluster{
+		Name:     name,
 		Metadata: new(envoycorev3.Metadata),
 		ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
 			Type: envoyclusterv3.Cluster_STATIC,
 		},
 		LoadAssignment: &envoyendpointv3.ClusterLoadAssignment{
-			ClusterName: b.ClusterName(),
+			ClusterName: name,
 			Endpoints:   []*envoyendpointv3.LocalityLbEndpoints{},
 		},
 	}
-	return out
 }
 
 func createCommonLbConfig(b *ir.BackendObjectIR) *envoyclusterv3.Cluster_CommonLbConfig {

--- a/pkg/kgateway/translator/irtranslator/backend_baseoverlay_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_baseoverlay_test.go
@@ -1,0 +1,126 @@
+package irtranslator_test
+
+import (
+	"context"
+	"testing"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/irtranslator"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+// perClientGK is the group/kind used by the synthetic per-client policy plugin below.
+var perClientGK = schema.GroupKind{Group: "group", Kind: "kind"}
+
+// newOverlayTestTranslator builds a translator with an EDS backend and a per-client policy plugin
+// that sets OutlierDetection only for clients labeled version=canary. This mirrors how the real
+// destination-rule plugin mutates a cluster per uniquely-connected-client.
+func newOverlayTestTranslator() *irtranslator.BackendTranslator {
+	return &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			perClientGK: {
+				InitEnvoyBackend: func(_ context.Context, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+					out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}
+					return nil
+				},
+			},
+		},
+		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
+			perClientGK: {
+				PerClientProcessBackend: func(_ krt.HandlerContext, _ context.Context, ucc ir.UniquelyConnectedClient, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
+					if ucc.Labels["version"] == "canary" {
+						out.OutlierDetection = &envoyclusterv3.OutlierDetection{}
+					}
+				},
+			},
+		},
+	}
+}
+
+func overlayTestBackend() *ir.BackendObjectIR {
+	b := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "group",
+		Kind:      "kind",
+		Namespace: "default",
+		Name:      "b1",
+	}, 8080, "", "")
+	return &b
+}
+
+// TestPerClientOverlayDoesNotMutateBase asserts the base cluster is never mutated by the per-client
+// overlay (copy-on-write), so concurrent clients cannot see each other's mutations.
+func TestPerClientOverlayDoesNotMutateBase(t *testing.T) {
+	tr := newOverlayTestTranslator()
+	backend := overlayTestBackend()
+	var kctx krt.TestingDummyContext
+
+	base := tr.TranslateBackendBase(context.Background(), backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Err)
+	require.Nil(t, base.Cluster.GetOutlierDetection(), "base must not carry per-client overlay state")
+
+	canary := ir.NewUniquelyConnectedClient("role", "default", map[string]string{"version": "canary"}, ir.PodLocality{})
+	stable := ir.NewUniquelyConnectedClient("role", "default", map[string]string{"version": "stable"}, ir.PodLocality{})
+
+	cCanary, err := tr.ApplyPerClientOverlay(context.Background(), kctx, canary, backend, base)
+	require.NoError(t, err)
+	cStable, err := tr.ApplyPerClientOverlay(context.Background(), kctx, stable, backend, base)
+	require.NoError(t, err)
+
+	assert.NotNil(t, cCanary.GetOutlierDetection(), "canary client should get the overlay")
+	assert.Nil(t, cStable.GetOutlierDetection(), "stable client should not get the overlay")
+	assert.Nil(t, base.Cluster.GetOutlierDetection(), "base must remain unmodified after overlays")
+	assert.NotSame(t, base.Cluster, cCanary, "overlay must return a distinct proto, not the shared base")
+}
+
+// TestPerClientOverlayFastPathSharesBase asserts that when no per-client work applies (no per-client
+// plugins, EDS cluster, non-strict mode) the overlay returns the shared base proto without cloning.
+func TestPerClientOverlayFastPathSharesBase(t *testing.T) {
+	tr := &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			perClientGK: {
+				InitEnvoyBackend: func(_ context.Context, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+					out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}
+					return nil
+				},
+			},
+		},
+		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{},
+	}
+	backend := overlayTestBackend()
+	var kctx krt.TestingDummyContext
+
+	base := tr.TranslateBackendBase(context.Background(), backend)
+	require.NotNil(t, base)
+
+	ucc := ir.NewUniquelyConnectedClient("role", "default", nil, ir.PodLocality{})
+	c, err := tr.ApplyPerClientOverlay(context.Background(), kctx, ucc, backend, base)
+	require.NoError(t, err)
+	assert.Same(t, base.Cluster, c, "fast path should reuse the shared base proto")
+}
+
+// TestTranslateBackendMatchesBaseThenOverlay asserts the TranslateBackend wrapper produces the same
+// result as base translation followed by the per-client overlay.
+func TestTranslateBackendMatchesBaseThenOverlay(t *testing.T) {
+	tr := newOverlayTestTranslator()
+	backend := overlayTestBackend()
+	var kctx krt.TestingDummyContext
+	canary := ir.NewUniquelyConnectedClient("role", "default", map[string]string{"version": "canary"}, ir.PodLocality{})
+
+	wrapped, err := tr.TranslateBackend(context.Background(), kctx, canary, backend)
+	require.NoError(t, err)
+
+	base := tr.TranslateBackendBase(context.Background(), backend)
+	require.NotNil(t, base)
+	overlay, err := tr.ApplyPerClientOverlay(context.Background(), kctx, canary, backend, base)
+	require.NoError(t, err)
+
+	assert.True(t, proto.Equal(wrapped, overlay), "wrapper output must equal base->overlay output")
+}

--- a/pkg/kgateway/translator/irtranslator/backend_bench_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_bench_test.go
@@ -1,0 +1,175 @@
+package irtranslator
+
+// White-box benchmark (internal package) comparing the per-client cluster fan-out before and after
+// the base+overlay refactor (Stage 1a).
+//
+//   Old: full translation per (backend, client) pair, in place — no base cache, no clone, no fast
+//        path. This faithfully reconstructs the pre-refactor TranslateBackend body.
+//   New: base translated once per backend, then a cheap per-client overlay applied per pair.
+//
+// Swept across Istio off/on (whether a per-client backend plugin is registered) and light/heavy
+// backends (how expensive the client-independent base translation is). The delta scales linearly
+// with the number of (backend, client) pairs.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+const (
+	benchNumBackends = 200
+	benchNumClients  = 20
+)
+
+var benchGK = schema.GroupKind{Group: "bench", Kind: "Backend"}
+
+// benchSink prevents the compiler from optimizing away the translated clusters.
+var benchSink *envoyclusterv3.Cluster
+
+func benchInit(heavy bool) func(context.Context, ir.BackendObjectIR, *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+	return func(_ context.Context, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+		out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}
+		out.EdsClusterConfig = &envoyclusterv3.Cluster_EdsClusterConfig{
+			EdsConfig: &envoycorev3.ConfigSource{
+				ConfigSourceSpecifier: &envoycorev3.ConfigSource_Ads{Ads: &envoycorev3.AggregatedConfigSource{}},
+			},
+		}
+		if heavy {
+			// Simulate a TLS backend: a proto marshal as part of base translation.
+			if tlsAny, err := utils.MessageToAny(&envoytlsv3.UpstreamTlsContext{Sni: out.GetName()}); err == nil {
+				out.TransportSocket = &envoycorev3.TransportSocket{
+					Name:       "envoy.transport_sockets.tls",
+					ConfigType: &envoycorev3.TransportSocket_TypedConfig{TypedConfig: tlsAny},
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func benchTranslator(istioOn, heavy bool) *BackendTranslator {
+	t := &BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			benchGK: {InitEnvoyBackend: benchInit(heavy)},
+		},
+		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{},
+		// Mode left as zero value (non-strict): validation is skipped, matching the default deployment.
+	}
+	if istioOn {
+		// A destination-rule-like per-client plugin: it only modifies clients whose label matches
+		// (a "destination rule" is present), and advertises that via the applies predicate so the
+		// translator can skip the per-client clone for non-matching pairs.
+		t.ContributedPolicies[benchGK] = sdk.PolicyPlugin{
+			PerClientProcessBackend: func(_ krt.HandlerContext, _ context.Context, ucc ir.UniquelyConnectedClient, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
+				if ucc.Labels["bench-mutate"] == "yes" {
+					out.OutlierDetection = &envoyclusterv3.OutlierDetection{}
+				}
+			},
+			PerClientProcessBackendApplies: func(_ krt.HandlerContext, _ context.Context, ucc ir.UniquelyConnectedClient, _ ir.BackendObjectIR) bool {
+				return ucc.Labels["bench-mutate"] == "yes"
+			},
+		}
+	}
+	return t
+}
+
+func benchBackends(n int) []*ir.BackendObjectIR {
+	out := make([]*ir.BackendObjectIR, n)
+	for i := range n {
+		b := ir.NewBackendObjectIR(ir.ObjectSource{
+			Group:     "bench",
+			Kind:      "Backend",
+			Namespace: "default",
+			Name:      fmt.Sprintf("b%d", i),
+		}, 8080, "", "")
+		out[i] = &b
+	}
+	return out
+}
+
+func benchUCCs(m int) []ir.UniquelyConnectedClient {
+	out := make([]ir.UniquelyConnectedClient, m)
+	for i := range m {
+		// Model sparse destination-rule matching: only ~1 in 10 clients is targeted by a DR.
+		mutate := "no"
+		if i%10 == 0 {
+			mutate = "yes"
+		}
+		out[i] = ir.NewUniquelyConnectedClient(
+			fmt.Sprintf("role%d", i),
+			"default",
+			map[string]string{"bench-mutate": mutate, "idx": fmt.Sprintf("%d", i)},
+			ir.PodLocality{Region: "r", Zone: fmt.Sprintf("z%d", i%3)},
+		)
+	}
+	return out
+}
+
+// legacyTranslate reconstructs the pre-refactor per-pair translation: a full, in-place translation
+// for every (backend, client), with no base caching, no clone, and no fast path.
+func (t *BackendTranslator) legacyTranslate(ctx context.Context, kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, backend *ir.BackendObjectIR) *envoyclusterv3.Cluster {
+	process := t.ContributedBackends[backend.GetGroupKind()]
+	out := initializeCluster(backend)
+	inlineEps := process.InitEnvoyBackend(ctx, *backend, out)
+	processDnsLookupFamily(out, t.CommonCols)
+	_ = t.runBaseBackendPolicies(ctx, backend, out)
+	t.runPerClientPolicies(kctx, ctx, ucc, backend, inlineEps, out)
+	defaultLocalityConfig(out)
+	_ = applyGatewayBackendClientCertificate(out, backend)
+	return out
+}
+
+func benchmarkPerClientClusters(b *testing.B, istioOn, heavy bool) {
+	t := benchTranslator(istioOn, heavy)
+	backends := benchBackends(benchNumBackends)
+	uccs := benchUCCs(benchNumClients)
+	ctx := context.Background()
+	var kctx krt.TestingDummyContext
+
+	b.Run("Old", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			for _, backend := range backends {
+				for _, ucc := range uccs {
+					benchSink = t.legacyTranslate(ctx, kctx, ucc, backend)
+				}
+			}
+		}
+	})
+
+	b.Run("New", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			bases := make([]*BackendBaseCluster, len(backends))
+			for j, backend := range backends {
+				bases[j] = t.TranslateBackendBase(ctx, backend)
+			}
+			for j, backend := range backends {
+				for _, ucc := range uccs {
+					benchSink, _ = t.ApplyPerClientOverlay(ctx, kctx, ucc, backend, bases[j])
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkPerClientClusters(b *testing.B) {
+	for _, istioOn := range []bool{false, true} {
+		for _, heavy := range []bool{false, true} {
+			b.Run(fmt.Sprintf("istio=%v/heavy=%v", istioOn, heavy), func(b *testing.B) {
+				benchmarkPerClientClusters(b, istioOn, heavy)
+			})
+		}
+	}
+}

--- a/pkg/pluginsdk/types.go
+++ b/pkg/pluginsdk/types.go
@@ -46,6 +46,18 @@ type PerClientProcessBackend func(
 	out *envoyclusterv3.Cluster,
 )
 
+// PerClientProcessBackendApplies reports whether PerClientProcessBackend would modify the cluster
+// for this (backend, client) pair. It must be cheap and free of side effects. When set, the
+// translator uses it to skip the per-client cluster copy entirely for pairs the plugin does not
+// touch, so the client reuses the shared base cluster. A plugin that sets PerClientProcessBackend
+// but leaves this nil is conservatively assumed to always apply (the cluster is always copied).
+type PerClientProcessBackendApplies func(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniquelyConnectedClient,
+	in ir.BackendObjectIR,
+) bool
+
 type (
 	// GetPolicyStatusFn is a type that plugins can implement to get the PolicyStatus for the given policy
 	GetPolicyStatusFn func(context.Context, types.NamespacedName) (gwv1.PolicyStatus, error)
@@ -60,9 +72,10 @@ type PolicyPlugin struct {
 	NewGatewayTranslationPass func(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass
 
 	// Backend processing for envoy proxy
-	ProcessBackend            ProcessBackend
-	PerClientProcessBackend   PerClientProcessBackend
-	PerClientProcessEndpoints EndpointPlugin
+	ProcessBackend                 ProcessBackend
+	PerClientProcessBackend        PerClientProcessBackend
+	PerClientProcessBackendApplies PerClientProcessBackendApplies
+	PerClientProcessEndpoints      EndpointPlugin
 
 	Policies krt.Collection[ir.PolicyWrapper]
 	// ProcessPolicyStaleStatusMarkers add empty reports for policies to clear stale status


### PR DESCRIPTION
# Description

When Istio integration is enabled, kgateway's Envoy xDS graph is per-uniquely-connected-client (per-UCC), not per-gateway. The per-client cluster collection translated each backend by calling the full `TranslateBackend` once per `(backend, client)` pair — `O(backends × clients)` *full* translations — even though the client only influences a thin slice of the work, and even when Istio integration is off. The in-code TODO in `runPolicies` called this out: *"do `ProcessBackend` once, and only do the per-client processing for each client."*

This PR translates each backend once (client-independent **base**) and applies a cheap per-client **overlay**, materializing a distinct per-client cluster only for the pairs a per-client plugin actually touches.

This PR is in three commits:

1. **Base / overlay split** (`pkg/kgateway/translator/irtranslator/backend.go`, `pkg/kgateway/proxy_syncer/backends.go`)
   - New `BackendBaseCluster` KRT element: base cluster proto + version hash + captured inline endpoints + any base error.
   - `TranslateBackendBase` runs the client-independent steps once per backend (init, `InitEnvoyBackend`, DNS lookup family, the `ProcessBackend` policy loop, `defaultLocalityConfig`, gateway client cert).
   - `ApplyPerClientOverlay` copy-on-writes the base, applies `PerClientProcessBackend` + endpoint plugins + the inline CLA, and strict-validates the final cluster.
   - `runPolicies` is split into `runBaseBackendPolicies` / `runPerClientPolicies`; `TranslateBackend` becomes a thin `base → overlay` wrapper with an unchanged signature. `NewPerClientEnvoyClusters` builds a backend-keyed base collection and applies the overlay per UCC; `uccWithCluster` output, index, and `Error` semantics are unchanged.

2. **Clone gating** (`pkg/pluginsdk/types.go`, `destrule`, `waypoint`)
   - New optional `PerClientProcessBackendApplies` predicate on `PolicyPlugin`. When set, the translator skips the per-client copy entirely for pairs the plugin does not touch — the client reuses the shared base proto. A plugin that sets `PerClientProcessBackend` but leaves the predicate nil is conservatively assumed to always apply.
   - `destrule` mirrors `processBackend`'s guard exactly (matching DR with outlier detection). `waypoint` reuses the cheap ambient/ingress-use-waypoint filters it already applies first.

The second commit is what makes this a net win with Istio enabled: without it, registering a per-client plugin copies every pair and regresses the per-client path (~2x slower); with the predicate, only the (usually sparse) DR/waypoint-matching pairs are copied.

## Performance

Measured with the microbenchmark, 200 backends × 20 clients on an Apple M4 Max, comparing the old per-pair translation against this change:

| Scenario                        | Before   | After  | Speedup | Allocs before → after |
| ------------------------------- | -------- | ------ | ------- | --------------------- |
| Istio off, light backends       | 845 µs   | 190 µs | 4.4x    | 40,000 → 2,601        |
| Istio off, heavy (TLS) backends | 1,434 µs | 267 µs | 5.4x    | 64,000 → 3,801        |
| Istio on, ~10% DR match, light  | 1,188 µs | 646 µs | 1.8x    | 40,400 → 7,001        |
| Istio on, ~10% DR match, heavy  | 1,761 µs | 813 µs | 2.2x    | 64,400 → 9,801        |

This is a constant-factor + allocation reduction, not an asymptotic one — the collection still has `O(backends × clients)` rows. The benefit scales with how sparsely destination rules match; if every client is targeted by a distinct DR, the per-pair copy cost remains (only the base translation is saved).

# Change Type

/kind cleanup

# Changelog

```release-note
Improved control plane performance by translating backend clusters once per backend and applying per-client overlays only where a destination rule or waypoint matches, instead of fully re-translating every backend for every connected proxy.
```

# Additional Notes

- Behavior-preserving: the gateway translator golden suite produces **zero diffs**.
- Copy-on-write is the key correctness guard — a test asserts the base proto is never mutated and that two clients sharing a backend get independent protos. Strict-validation caching tests and the `SnapshotPerClient*` consistency gates pass.
- New SDK field `PerClientProcessBackendApplies` is additive and optional; existing plugins are unaffected.
- krtequals analyzer + full lint pass on all changed packages.
