### PR TITLE
feat: expose Prometheus metrics for EC2 endpoint discovery

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backend/ec2.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2.go
@@ -693,7 +693,7 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 					// reason (not the Degraded override) so the counter always
 					// attributes a concrete failure cause.
 					recordEc2PollError(cfg.namespace, cfg.name, reason)
-					recordEc2PollDuration(cfg.namespace, cfg.name, pollSeconds)
+					recordEc2PollDuration(cfg.namespace, cfg.name, ec2PollResultError, pollSeconds)
 				}
 				nextStateMu.Unlock()
 				return
@@ -711,7 +711,7 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 				backendState := selectResolvedEc2Backend(cfg, instances)
 				resolved[cfg.resourceName] = backendState
 				recordEc2PollSuccess(cfg.namespace, cfg.name, len(backendState.endpoints))
-				recordEc2PollDuration(cfg.namespace, cfg.name, pollSeconds)
+				recordEc2PollDuration(cfg.namespace, cfg.name, ec2PollResultSuccess, pollSeconds)
 				logger.Debug(
 					"resolved EC2 backend endpoints",
 					"backend", cfg.resourceName,

--- a/pkg/kgateway/extensions2/plugins/backend/ec2.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2.go
@@ -22,6 +22,7 @@ import (
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"golang.org/x/sync/singleflight"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -130,6 +131,8 @@ type ec2TagFilter struct {
 
 type ec2BackendConfig struct {
 	resourceName string
+	namespace    string
+	name         string
 	region       string
 	roleArn      string
 	port         uint32
@@ -458,6 +461,25 @@ func newEc2EndpointsCollection(
 		return c.discoveryStatusForBackend(kctx, backend)
 	}, commoncol.KrtOpts.ToOptions("AwsEc2DiscoveryStatus")...)
 
+	// Drop per-Backend discovery metric series when a Backend is deleted so stale
+	// gauges don't remain visible indefinitely. Registered unconditionally (not via
+	// metrics.RegisterEvents, which skips registration when metrics are inactive at
+	// setup): the per-poll recording in the discovery loop is guarded dynamically by
+	// metrics.Active(), so cleanup must stay symmetric with it rather than gated once
+	// at startup. deleteEc2DiscoveryMetrics is a harmless no-op when no series exist.
+	backends.Register(func(o krt.Event[ir.BackendObjectIR]) {
+		if o.Event != controllers.EventDelete {
+			return
+		}
+		deleted := o.Latest()
+		obj, ok := deleted.Obj.(*kgateway.Backend)
+		if !ok || obj.Spec.Aws == nil || obj.Spec.Aws.Ec2 == nil {
+			return
+		}
+		src := deleted.GetObjectSource()
+		deleteEc2DiscoveryMetrics(src.Namespace, src.Name)
+	})
+
 	go c.run(ctx)
 
 	return c
@@ -665,6 +687,10 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 						message: ec2DiscoveryFailureMessage(message, carried),
 					}
 					nextState[cfg.resourceName] = backendState
+					// Record the poll outcome with the underlying classification
+					// reason (not the Degraded override) so the counter always
+					// attributes a concrete failure cause.
+					recordEc2PollError(cfg.namespace, cfg.name, reason)
 				}
 				nextStateMu.Unlock()
 				return
@@ -679,14 +705,16 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 			)
 			resolved := make(map[string]ec2ResolvedBackend, len(groupedBackends))
 			for _, cfg := range groupedBackends {
-				resolved[cfg.resourceName] = selectResolvedEc2Backend(cfg, instances)
+				backendState := selectResolvedEc2Backend(cfg, instances)
+				resolved[cfg.resourceName] = backendState
+				recordEc2PollSuccess(cfg.namespace, cfg.name, len(backendState.endpoints))
 				logger.Debug(
 					"resolved EC2 backend endpoints",
 					"backend", cfg.resourceName,
 					"region", cfg.region,
 					"address_type", cfg.addressType,
 					"filters", len(cfg.filters),
-					"resolved_endpoints", len(resolved[cfg.resourceName].endpoints),
+					"resolved_endpoints", len(backendState.endpoints),
 				)
 			}
 			nextStateMu.Lock()
@@ -840,8 +868,11 @@ func ec2ConfigFromBackend(backend ir.BackendObjectIR) *ec2BackendConfig {
 		return nil
 	}
 
+	src := backend.GetObjectSource()
 	cfg := &ec2BackendConfig{
 		resourceName: backend.ResourceName(),
+		namespace:    src.Namespace,
+		name:         src.Name,
 		region:       ec2Ir.region,
 		roleArn:      ec2Ir.roleArn,
 		port:         ec2Ir.port,

--- a/pkg/kgateway/extensions2/plugins/backend/ec2.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2.go
@@ -794,6 +794,11 @@ func (c *ec2EndpointsCollection) discoveryStatusForBackend(kctx krt.HandlerConte
 	// filtered out before the discovery loop builds a pollable config. Surface a
 	// CredentialError here so the failure is never silent (FR-8, NFR-2).
 	if message, unresolved := ec2UnresolvedSecretCredential(backend, obj); unresolved {
+		// This backend never enters the poll loop, so reflect its error state in the
+		// metrics here; otherwise an unresolvable secret (the most common
+		// misconfiguration) would be invisible to error_state alerting.
+		src := backend.GetObjectSource()
+		recordEc2CredentialErrorState(src.Namespace, src.Name)
 		return ec2DiscoveryStatusUpdate(backend, ec2DiscoveryStatus{
 			status:  metav1.ConditionFalse,
 			reason:  string(kgateway.BackendReasonCredentialError),

--- a/pkg/kgateway/extensions2/plugins/backend/ec2.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2.go
@@ -866,11 +866,11 @@ func ec2ConfigFromBackend(backend ir.BackendObjectIR) *ec2BackendConfig {
 	if !ok || backendIR.awsIr == nil || backendIR.awsIr.ec2Ir == nil {
 		return nil
 	}
+	// An EC2 backend with a secret-auth credential that could not be resolved never
+	// builds an ec2Ir (translation records the error and leaves awsIr nil), so a
+	// non-nil ec2Ir here implies the secret resolved; no missing-secret guard is
+	// needed. Such backends are surfaced as CredentialError via discoveryStatusForBackend.
 	ec2Ir := backendIR.awsIr.ec2Ir
-	if obj.Spec.Aws.Auth != nil && obj.Spec.Aws.Auth.Type == kgateway.AwsAuthTypeSecret && ec2Ir.secret == nil {
-		logger.Debug("skipping EC2 backend discovery due to missing secret credentials", "backend", backend.ResourceName())
-		return nil
-	}
 
 	src := backend.GetObjectSource()
 	cfg := &ec2BackendConfig{

--- a/pkg/kgateway/extensions2/plugins/backend/ec2.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2.go
@@ -471,12 +471,12 @@ func newEc2EndpointsCollection(
 		if o.Event != controllers.EventDelete {
 			return
 		}
-		deleted := o.Latest()
-		obj, ok := deleted.Obj.(*kgateway.Backend)
-		if !ok || obj.Spec.Aws == nil || obj.Spec.Aws.Ec2 == nil {
-			return
-		}
-		src := deleted.GetObjectSource()
+		// Delete by object-source identity rather than inspecting the deleted Obj:
+		// the identity is always populated, and deleteEc2DiscoveryMetrics is a no-op
+		// for non-EC2 backends (which never recorded any series). Every backend is
+		// uniquely keyed by namespace/name, so this only ever clears the series of
+		// the backend being removed.
+		src := o.Latest().GetObjectSource()
 		deleteEc2DiscoveryMetrics(src.Namespace, src.Name)
 	})
 
@@ -662,7 +662,9 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 			if len(groupedBackends) > 0 {
 				source.secret = groupedBackends[0].secret
 			}
+			start := time.Now()
 			instances, err := c.lister.ListInstances(ctx, source)
+			pollSeconds := time.Since(start).Seconds()
 			if err != nil {
 				reason, message := classifyEc2DiscoveryError(err)
 				nextStateMu.Lock()
@@ -691,6 +693,7 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 					// reason (not the Degraded override) so the counter always
 					// attributes a concrete failure cause.
 					recordEc2PollError(cfg.namespace, cfg.name, reason)
+					recordEc2PollDuration(cfg.namespace, cfg.name, pollSeconds)
 				}
 				nextStateMu.Unlock()
 				return
@@ -708,6 +711,7 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 				backendState := selectResolvedEc2Backend(cfg, instances)
 				resolved[cfg.resourceName] = backendState
 				recordEc2PollSuccess(cfg.namespace, cfg.name, len(backendState.endpoints))
+				recordEc2PollDuration(cfg.namespace, cfg.name, pollSeconds)
 				logger.Debug(
 					"resolved EC2 backend endpoints",
 					"backend", cfg.resourceName,

--- a/pkg/kgateway/extensions2/plugins/backend/metrics.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"time"
+
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
 )
@@ -61,6 +63,27 @@ var (
 		},
 		[]string{ec2MetricNamespaceLabel, ec2MetricNameLabel},
 	)
+
+	// ec2DiscoveryPollDuration measures the wall-clock time of the AWS
+	// DescribeInstances round trip for a poll, attributed to each Backend in the
+	// credential scope. Both successful and failed polls are observed, so the
+	// distribution includes slow timeouts. Buckets span from a fast in-region
+	// listing up to ec2RefreshTimeout (30s).
+	ec2DiscoveryPollDuration = metrics.NewHistogram(
+		metrics.HistogramOpts{
+			Subsystem: ec2DiscoverySubsystem,
+			Name:      "poll_duration_seconds",
+			Help:      "Duration of EC2 endpoint discovery polls per Backend",
+			// Classic buckets are kept as a fallback for scrapers that do not
+			// support native histograms; they span a fast in-region listing up to
+			// the 30s refresh timeout.
+			Buckets:                         []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30},
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		},
+		[]string{ec2MetricNamespaceLabel, ec2MetricNameLabel},
+	)
 )
 
 func ec2MetricIdentity(namespace, name string) []metrics.Label {
@@ -109,6 +132,16 @@ func recordEc2PollError(namespace, name, reason string) {
 	ec2DiscoveryErrorState.Set(1, identity...)
 }
 
+// recordEc2PollDuration observes how long a discovery poll took for a Backend. The
+// same duration is recorded for every Backend sharing a credential scope, since they
+// are resolved from a single AWS DescribeInstances call.
+func recordEc2PollDuration(namespace, name string, seconds float64) {
+	if !metrics.Active() {
+		return
+	}
+	ec2DiscoveryPollDuration.Observe(seconds, ec2MetricIdentity(namespace, name)...)
+}
+
 // deleteEc2DiscoveryMetrics removes every metric series for a Backend, called when the
 // Backend is deleted so stale per-Backend gauges do not remain visible indefinitely.
 func deleteEc2DiscoveryMetrics(namespace, name string) {
@@ -116,6 +149,7 @@ func deleteEc2DiscoveryMetrics(namespace, name string) {
 	ec2DiscoveryPollTotal.DeletePartialMatch(identity...)
 	ec2DiscoveryEndpointsActive.DeletePartialMatch(identity...)
 	ec2DiscoveryErrorState.DeletePartialMatch(identity...)
+	ec2DiscoveryPollDuration.DeletePartialMatch(identity...)
 }
 
 // ResetEc2DiscoveryMetrics resets the EC2 discovery metrics.
@@ -124,4 +158,5 @@ func ResetEc2DiscoveryMetrics() {
 	ec2DiscoveryPollTotal.Reset()
 	ec2DiscoveryEndpointsActive.Reset()
 	ec2DiscoveryErrorState.Reset()
+	ec2DiscoveryPollDuration.Reset()
 }

--- a/pkg/kgateway/extensions2/plugins/backend/metrics.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics.go
@@ -21,10 +21,6 @@ const (
 
 	ec2PollResultSuccess = "success"
 	ec2PollResultError   = "error"
-	// ec2PollReasonNone is the reason recorded on a successful poll that resolved
-	// endpoints. It mirrors the convention of a non-empty reason on every series so
-	// the label is never absent.
-	ec2PollReasonNone = "none"
 )
 
 var (
@@ -100,13 +96,14 @@ func ec2MetricIdentity(namespace, name string) []metrics.Label {
 
 // recordEc2PollSuccess records the outcome of a successful discovery poll for a
 // Backend: it increments the poll counter, updates the active endpoint gauge to the
-// freshly resolved count, and clears the error-state gauge. A successful poll that
-// matched no instances is still a success, recorded with reason=NoMatchingInstances.
+// freshly resolved count, and clears the error-state gauge. The reason label mirrors
+// the Backend's EndpointsDiscovered status condition: reason=Discovered when endpoints
+// resolved, and reason=NoMatchingInstances when the poll succeeded but matched none.
 func recordEc2PollSuccess(namespace, name string, endpointCount int) {
 	if !metrics.Active() {
 		return
 	}
-	reason := ec2PollReasonNone
+	reason := string(kgateway.BackendReasonDiscovered)
 	if endpointCount == 0 {
 		reason = string(kgateway.BackendReasonNoMatchingInstances)
 	}

--- a/pkg/kgateway/extensions2/plugins/backend/metrics.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics.go
@@ -142,6 +142,22 @@ func recordEc2PollDuration(namespace, name string, seconds float64) {
 	ec2DiscoveryPollDuration.Observe(seconds, ec2MetricIdentity(namespace, name)...)
 }
 
+// recordEc2CredentialErrorState marks a Backend as being in an error state because its
+// secret-auth credential could not be resolved. Such a Backend never enters the poll
+// loop, so this is the only place its error_state is set; endpoints_active is set to 0
+// because no endpoints are served while credentials are unresolved (and so a Backend
+// that was previously healthy doesn't leave a stale non-zero gauge after its secret is
+// removed). poll_total and poll_duration_seconds are intentionally left untouched: no
+// poll occurs, and incrementing a counter from a KRT recompute would double-count.
+func recordEc2CredentialErrorState(namespace, name string) {
+	if !metrics.Active() {
+		return
+	}
+	identity := ec2MetricIdentity(namespace, name)
+	ec2DiscoveryErrorState.Set(1, identity...)
+	ec2DiscoveryEndpointsActive.Set(0, identity...)
+}
+
 // deleteEc2DiscoveryMetrics removes every metric series for a Backend, called when the
 // Backend is deleted so stale per-Backend gauges do not remain visible indefinitely.
 func deleteEc2DiscoveryMetrics(namespace, name string) {

--- a/pkg/kgateway/extensions2/plugins/backend/metrics.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics.go
@@ -67,8 +67,13 @@ var (
 	// ec2DiscoveryPollDuration measures the wall-clock time of the AWS
 	// DescribeInstances round trip for a poll, attributed to each Backend in the
 	// credential scope. Both successful and failed polls are observed, so the
-	// distribution includes slow timeouts. Buckets span from a fast in-region
-	// listing up to ec2RefreshTimeout (30s).
+	// distribution includes slow timeouts; it is partitioned by result so operators
+	// can isolate successful-poll latency from failures, whose latency is bimodal
+	// (fast credential/authorization rejections vs. slow timeouts). Only result is
+	// added, not reason: reason belongs on the counter, and native histograms
+	// allocate per label-set, so each extra label value multiplies retained
+	// histograms per Backend. Buckets span from a fast in-region listing up to
+	// ec2RefreshTimeout (30s).
 	ec2DiscoveryPollDuration = metrics.NewHistogram(
 		metrics.HistogramOpts{
 			Subsystem: ec2DiscoverySubsystem,
@@ -82,7 +87,7 @@ var (
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		},
-		[]string{ec2MetricNamespaceLabel, ec2MetricNameLabel},
+		[]string{ec2MetricNamespaceLabel, ec2MetricNameLabel, ec2MetricResultLabel},
 	)
 )
 
@@ -132,14 +137,17 @@ func recordEc2PollError(namespace, name, reason string) {
 	ec2DiscoveryErrorState.Set(1, identity...)
 }
 
-// recordEc2PollDuration observes how long a discovery poll took for a Backend. The
-// same duration is recorded for every Backend sharing a credential scope, since they
-// are resolved from a single AWS DescribeInstances call.
-func recordEc2PollDuration(namespace, name string, seconds float64) {
+// recordEc2PollDuration observes how long a discovery poll took for a Backend,
+// partitioned by result (success/error). The same duration is recorded for every
+// Backend sharing a credential scope, since they are resolved from a single AWS
+// DescribeInstances call.
+func recordEc2PollDuration(namespace, name, result string, seconds float64) {
 	if !metrics.Active() {
 		return
 	}
-	ec2DiscoveryPollDuration.Observe(seconds, ec2MetricIdentity(namespace, name)...)
+	ec2DiscoveryPollDuration.Observe(seconds, append(ec2MetricIdentity(namespace, name),
+		metrics.Label{Name: ec2MetricResultLabel, Value: result},
+	)...)
 }
 
 // recordEc2CredentialErrorState marks a Backend as being in an error state because its

--- a/pkg/kgateway/extensions2/plugins/backend/metrics.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics.go
@@ -1,0 +1,127 @@
+package backend
+
+import (
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
+)
+
+// EC2 endpoint discovery metrics. The exposed names are
+// kgateway_ec2_discovery_poll_total, kgateway_ec2_discovery_endpoints_active, and
+// kgateway_ec2_discovery_error_state, following the kgateway_<subsystem>_<name>
+// convention used elsewhere in the codebase.
+const (
+	ec2DiscoverySubsystem = "ec2_discovery"
+
+	ec2MetricNamespaceLabel = "namespace"
+	ec2MetricNameLabel      = "name"
+	ec2MetricResultLabel    = "result"
+	ec2MetricReasonLabel    = "reason"
+
+	ec2PollResultSuccess = "success"
+	ec2PollResultError   = "error"
+	// ec2PollReasonNone is the reason recorded on a successful poll that resolved
+	// endpoints. It mirrors the convention of a non-empty reason on every series so
+	// the label is never absent.
+	ec2PollReasonNone = "none"
+)
+
+var (
+	// ec2DiscoveryPollTotal counts EC2 discovery refresh attempts per Backend,
+	// partitioned by result (success/error) and reason. The reason values match the
+	// Reason values used in the Backend's EndpointsDiscovered status condition.
+	ec2DiscoveryPollTotal = metrics.NewCounter(
+		metrics.CounterOpts{
+			Subsystem: ec2DiscoverySubsystem,
+			Name:      "poll_total",
+			Help:      "Total number of EC2 endpoint discovery refresh attempts per Backend",
+		},
+		[]string{ec2MetricNamespaceLabel, ec2MetricNameLabel, ec2MetricResultLabel, ec2MetricReasonLabel},
+	)
+
+	// ec2DiscoveryEndpointsActive reports the number of active Envoy endpoints for a
+	// Backend after the most recent successful poll. It is not updated on a failed
+	// poll, so it retains the last successful value (NFR-3 graceful degradation).
+	ec2DiscoveryEndpointsActive = metrics.NewGauge(
+		metrics.GaugeOpts{
+			Subsystem: ec2DiscoverySubsystem,
+			Name:      "endpoints_active",
+			Help:      "Current number of active Envoy endpoints discovered for an EC2 Backend",
+		},
+		[]string{ec2MetricNamespaceLabel, ec2MetricNameLabel},
+	)
+
+	// ec2DiscoveryErrorState is 1 when the most recent poll for a Backend failed and 0
+	// when it succeeded. It intentionally carries no reason label: reason-specific
+	// diagnosis is provided by ec2DiscoveryPollTotal and the Backend status condition.
+	ec2DiscoveryErrorState = metrics.NewGauge(
+		metrics.GaugeOpts{
+			Subsystem: ec2DiscoverySubsystem,
+			Name:      "error_state",
+			Help:      "Whether the most recent EC2 discovery poll for a Backend failed (1) or succeeded (0)",
+		},
+		[]string{ec2MetricNamespaceLabel, ec2MetricNameLabel},
+	)
+)
+
+func ec2MetricIdentity(namespace, name string) []metrics.Label {
+	return []metrics.Label{
+		{Name: ec2MetricNamespaceLabel, Value: namespace},
+		{Name: ec2MetricNameLabel, Value: name},
+	}
+}
+
+// recordEc2PollSuccess records the outcome of a successful discovery poll for a
+// Backend: it increments the poll counter, updates the active endpoint gauge to the
+// freshly resolved count, and clears the error-state gauge. A successful poll that
+// matched no instances is still a success, recorded with reason=NoMatchingInstances.
+func recordEc2PollSuccess(namespace, name string, endpointCount int) {
+	if !metrics.Active() {
+		return
+	}
+	reason := ec2PollReasonNone
+	if endpointCount == 0 {
+		reason = string(kgateway.BackendReasonNoMatchingInstances)
+	}
+	identity := ec2MetricIdentity(namespace, name)
+	ec2DiscoveryPollTotal.Inc(append(identity,
+		metrics.Label{Name: ec2MetricResultLabel, Value: ec2PollResultSuccess},
+		metrics.Label{Name: ec2MetricReasonLabel, Value: reason},
+	)...)
+	ec2DiscoveryEndpointsActive.Set(float64(endpointCount), identity...)
+	ec2DiscoveryErrorState.Set(0, identity...)
+}
+
+// recordEc2PollError records the outcome of a failed discovery poll for a Backend:
+// it increments the poll counter with the classified failure reason and sets the
+// error-state gauge to 1. The active endpoint gauge is intentionally left unchanged
+// so it retains the last successful value (graceful degradation). The reason
+// is the underlying classification (CredentialError/AuthorizationError/DiscoveryError),
+// not the Degraded status reason, so the counter always attributes a concrete cause.
+func recordEc2PollError(namespace, name, reason string) {
+	if !metrics.Active() {
+		return
+	}
+	identity := ec2MetricIdentity(namespace, name)
+	ec2DiscoveryPollTotal.Inc(append(identity,
+		metrics.Label{Name: ec2MetricResultLabel, Value: ec2PollResultError},
+		metrics.Label{Name: ec2MetricReasonLabel, Value: reason},
+	)...)
+	ec2DiscoveryErrorState.Set(1, identity...)
+}
+
+// deleteEc2DiscoveryMetrics removes every metric series for a Backend, called when the
+// Backend is deleted so stale per-Backend gauges do not remain visible indefinitely.
+func deleteEc2DiscoveryMetrics(namespace, name string) {
+	identity := ec2MetricIdentity(namespace, name)
+	ec2DiscoveryPollTotal.DeletePartialMatch(identity...)
+	ec2DiscoveryEndpointsActive.DeletePartialMatch(identity...)
+	ec2DiscoveryErrorState.DeletePartialMatch(identity...)
+}
+
+// ResetEc2DiscoveryMetrics resets the EC2 discovery metrics.
+// This is provided for testing purposes only.
+func ResetEc2DiscoveryMetrics() {
+	ec2DiscoveryPollTotal.Reset()
+	ec2DiscoveryEndpointsActive.Reset()
+	ec2DiscoveryErrorState.Reset()
+}

--- a/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
@@ -1,0 +1,184 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
+	"github.com/kgateway-dev/kgateway/v2/pkg/metrics/metricstest"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+const (
+	pollTotalMetric       = "kgateway_ec2_discovery_poll_total"
+	endpointsActiveMetric = "kgateway_ec2_discovery_endpoints_active"
+	errorStateMetric      = "kgateway_ec2_discovery_error_state"
+)
+
+func backendIdentityLabels(namespace, name string) []metrics.Label {
+	return []metrics.Label{
+		{Name: "name", Value: name},
+		{Name: "namespace", Value: namespace},
+	}
+}
+
+func TestComputeStateRecordsSuccessfulPollMetrics(t *testing.T) {
+	ResetEc2DiscoveryMetrics()
+
+	backend := newEc2Backend("backend-a", "arn:aws:iam::123456789012:role/shared", nil)
+	c := &ec2EndpointsCollection{
+		backends: krt.NewStaticCollection(nil, []ir.BackendObjectIR{
+			backendObjectIR(backend, newTestAWSSecret("aws-creds", "default", "1")),
+		}),
+		lister: &fakeEc2InstanceLister{
+			instances: []ec2DiscoveredInstance{
+				{instanceID: "i-1", privateIP: "10.0.0.10"},
+				{instanceID: "i-2", privateIP: "10.0.0.11"},
+			},
+		},
+	}
+
+	if _, err := c.computeState(context.Background()); err != nil {
+		t.Fatalf("computeState() error = %v", err)
+	}
+
+	gathered := metricstest.MustGatherMetrics(t)
+	gathered.AssertMetricsInclude(pollTotalMetric, []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetric{
+			Labels: []metrics.Label{
+				{Name: "name", Value: "backend-a"},
+				{Name: "namespace", Value: "default"},
+				{Name: "reason", Value: "none"},
+				{Name: "result", Value: "success"},
+			},
+			Value: 1,
+		},
+	})
+	gathered.AssertMetric(endpointsActiveMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  2,
+	})
+	gathered.AssertMetric(errorStateMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  0,
+	})
+}
+
+func TestComputeStateRecordsNoMatchingInstancesMetrics(t *testing.T) {
+	ResetEc2DiscoveryMetrics()
+
+	backend := newEc2Backend("backend-a", "arn:aws:iam::123456789012:role/shared", []kgateway.AwsTagFilter{tagKeyValue("app", "nope")})
+	c := &ec2EndpointsCollection{
+		backends: krt.NewStaticCollection(nil, []ir.BackendObjectIR{
+			backendObjectIR(backend, newTestAWSSecret("aws-creds", "default", "1")),
+		}),
+		lister: &fakeEc2InstanceLister{
+			instances: []ec2DiscoveredInstance{
+				{instanceID: "i-1", privateIP: "10.0.0.10", tags: map[string]string{"app": "payments"}},
+			},
+		},
+	}
+
+	if _, err := c.computeState(context.Background()); err != nil {
+		t.Fatalf("computeState() error = %v", err)
+	}
+
+	gathered := metricstest.MustGatherMetrics(t)
+	// A successful poll that matched nothing is still result=success, with
+	// reason=NoMatchingInstances rather than an error.
+	gathered.AssertMetricsInclude(pollTotalMetric, []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetric{
+			Labels: []metrics.Label{
+				{Name: "name", Value: "backend-a"},
+				{Name: "namespace", Value: "default"},
+				{Name: "reason", Value: "NoMatchingInstances"},
+				{Name: "result", Value: "success"},
+			},
+			Value: 1,
+		},
+	})
+	gathered.AssertMetric(endpointsActiveMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  0,
+	})
+	gathered.AssertMetric(errorStateMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  0,
+	})
+}
+
+func TestComputeStateRecordsErrorPollMetricsAndRetainsEndpointGauge(t *testing.T) {
+	ResetEc2DiscoveryMetrics()
+
+	backend := newEc2Backend("backend-a", "arn:aws:iam::123456789012:role/shared", nil)
+	backendIR := backendObjectIR(backend, newTestAWSSecret("aws-creds", "default", "1"))
+	c := &ec2EndpointsCollection{
+		backends: krt.NewStaticCollection(nil, []ir.BackendObjectIR{backendIR}),
+		lister: &fakeEc2InstanceLister{
+			instances: []ec2DiscoveredInstance{{instanceID: "i-1", privateIP: "10.0.0.10"}},
+		},
+	}
+
+	// First poll succeeds and resolves one endpoint.
+	state, err := c.computeState(context.Background())
+	if err != nil {
+		t.Fatalf("computeState() error = %v", err)
+	}
+	c.state = state
+
+	// Second poll fails: endpoints carry forward (degraded), but the counter must
+	// record the underlying classification reason, not the Degraded status reason.
+	c.lister = &fakeEc2InstanceLister{
+		err: fmt.Errorf("describe instances: %w", &smithy.GenericAPIError{Code: "AuthFailure", Message: "auth failed"}),
+	}
+	if _, err := c.computeState(context.Background()); err == nil {
+		t.Fatal("computeState() error = nil, want error")
+	}
+
+	gathered := metricstest.MustGatherMetrics(t)
+	gathered.AssertMetricsInclude(pollTotalMetric, []metricstest.ExpectMetric{
+		&metricstest.ExpectedMetric{
+			Labels: []metrics.Label{
+				{Name: "name", Value: "backend-a"},
+				{Name: "namespace", Value: "default"},
+				{Name: "reason", Value: "AuthorizationError"},
+				{Name: "result", Value: "error"},
+			},
+			Value: 1,
+		},
+	})
+	gathered.AssertMetric(errorStateMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  1,
+	})
+	// The active-endpoint gauge is not updated on a failed poll, so it retains the
+	// value from the last successful poll (NFR-3 graceful degradation).
+	gathered.AssertMetric(endpointsActiveMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  1,
+	})
+}
+
+func TestDeleteEc2DiscoveryMetricsRemovesBackendSeries(t *testing.T) {
+	ResetEc2DiscoveryMetrics()
+
+	recordEc2PollSuccess("default", "backend-a", 3)
+	recordEc2PollSuccess("default", "backend-b", 5)
+
+	deleteEc2DiscoveryMetrics("default", "backend-a")
+
+	gathered := metricstest.MustGatherMetrics(t)
+	// Only the surviving Backend's gauge series remain; the deleted Backend leaves
+	// no stale per-Backend gauge behind.
+	gathered.AssertMetricsLabels(endpointsActiveMetric, [][]metrics.Label{
+		backendIdentityLabels("default", "backend-b"),
+	})
+	gathered.AssertMetricsLabels(errorStateMetric, [][]metrics.Label{
+		backendIdentityLabels("default", "backend-b"),
+	})
+}

--- a/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/smithy-go"
 	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
@@ -168,6 +169,39 @@ func TestComputeStateRecordsErrorPollMetricsAndRetainsEndpointGauge(t *testing.T
 	// A failed poll still has a duration (it can be a slow timeout), so it is observed.
 	gathered.AssertMetricLabels(pollDurationMetric, backendIdentityLabels("default", "backend-a"))
 	gathered.AssertHistogramPopulated(pollDurationMetric)
+}
+
+func TestDiscoveryStatusForBackendRecordsErrorStateForUnresolvedSecret(t *testing.T) {
+	ResetEc2DiscoveryMetrics()
+
+	// A secret-auth backend whose secret cannot be resolved never enters the poll
+	// loop, but must still flip error_state so missing-secret misconfigurations are
+	// visible to alerting.
+	be := newEc2Backend("backend-a", "", nil)
+	be.Spec.Aws.Auth = &kgateway.AwsAuth{
+		Type:      kgateway.AwsAuthTypeSecret,
+		SecretRef: &corev1.LocalObjectReference{Name: "missing-secret"},
+	}
+	backend := backendObjectIR(be, nil)
+
+	c := &ec2EndpointsCollection{enabled: true}
+	if got := c.discoveryStatusForBackend(krt.TestingDummyContext{}, backend); got == nil {
+		t.Fatal("discoveryStatusForBackend() = nil, want a CredentialError status")
+	}
+
+	gathered := metricstest.MustGatherMetrics(t)
+	gathered.AssertMetric(errorStateMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  1,
+	})
+	// No endpoints are served while credentials are unresolved.
+	gathered.AssertMetric(endpointsActiveMetric, &metricstest.ExpectedMetric{
+		Labels: backendIdentityLabels("default", "backend-a"),
+		Value:  0,
+	})
+	// poll_total / poll_duration_seconds stay poll-scoped: no poll occurred, so no
+	// per-backend series is recorded for this backend.
+	gathered.AssertMetricNotExists(pollDurationMetric)
 }
 
 func TestDeleteEc2DiscoveryMetricsRemovesBackendSeries(t *testing.T) {

--- a/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
@@ -64,7 +64,7 @@ func TestComputeStateRecordsSuccessfulPollMetrics(t *testing.T) {
 			Labels: []metrics.Label{
 				{Name: "name", Value: "backend-a"},
 				{Name: "namespace", Value: "default"},
-				{Name: "reason", Value: "none"},
+				{Name: "reason", Value: "Discovered"},
 				{Name: "result", Value: "success"},
 			},
 			Value: 1,

--- a/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
@@ -18,6 +18,7 @@ const (
 	pollTotalMetric       = "kgateway_ec2_discovery_poll_total"
 	endpointsActiveMetric = "kgateway_ec2_discovery_endpoints_active"
 	errorStateMetric      = "kgateway_ec2_discovery_error_state"
+	pollDurationMetric    = "kgateway_ec2_discovery_poll_duration_seconds"
 )
 
 func backendIdentityLabels(namespace, name string) []metrics.Label {
@@ -67,6 +68,8 @@ func TestComputeStateRecordsSuccessfulPollMetrics(t *testing.T) {
 		Labels: backendIdentityLabels("default", "backend-a"),
 		Value:  0,
 	})
+	gathered.AssertMetricLabels(pollDurationMetric, backendIdentityLabels("default", "backend-a"))
+	gathered.AssertHistogramPopulated(pollDurationMetric)
 }
 
 func TestComputeStateRecordsNoMatchingInstancesMetrics(t *testing.T) {
@@ -162,23 +165,31 @@ func TestComputeStateRecordsErrorPollMetricsAndRetainsEndpointGauge(t *testing.T
 		Labels: backendIdentityLabels("default", "backend-a"),
 		Value:  1,
 	})
+	// A failed poll still has a duration (it can be a slow timeout), so it is observed.
+	gathered.AssertMetricLabels(pollDurationMetric, backendIdentityLabels("default", "backend-a"))
+	gathered.AssertHistogramPopulated(pollDurationMetric)
 }
 
 func TestDeleteEc2DiscoveryMetricsRemovesBackendSeries(t *testing.T) {
 	ResetEc2DiscoveryMetrics()
 
 	recordEc2PollSuccess("default", "backend-a", 3)
+	recordEc2PollDuration("default", "backend-a", 0.2)
 	recordEc2PollSuccess("default", "backend-b", 5)
+	recordEc2PollDuration("default", "backend-b", 0.3)
 
 	deleteEc2DiscoveryMetrics("default", "backend-a")
 
 	gathered := metricstest.MustGatherMetrics(t)
-	// Only the surviving Backend's gauge series remain; the deleted Backend leaves
-	// no stale per-Backend gauge behind.
+	// Only the surviving Backend's series remain; the deleted Backend leaves no
+	// stale per-Backend gauge or histogram behind.
 	gathered.AssertMetricsLabels(endpointsActiveMetric, [][]metrics.Label{
 		backendIdentityLabels("default", "backend-b"),
 	})
 	gathered.AssertMetricsLabels(errorStateMetric, [][]metrics.Label{
+		backendIdentityLabels("default", "backend-b"),
+	})
+	gathered.AssertMetricsLabels(pollDurationMetric, [][]metrics.Label{
 		backendIdentityLabels("default", "backend-b"),
 	})
 }

--- a/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/metrics_test.go
@@ -29,6 +29,15 @@ func backendIdentityLabels(namespace, name string) []metrics.Label {
 	}
 }
 
+// pollDurationLabels returns the label set for a poll_duration_seconds series,
+// which is partitioned by result in addition to the Backend identity. Labels are
+// kept in sorted order (name < namespace < result) to match the gathered output.
+func pollDurationLabels(namespace, name, result string) []metrics.Label {
+	return append(backendIdentityLabels(namespace, name),
+		metrics.Label{Name: "result", Value: result},
+	)
+}
+
 func TestComputeStateRecordsSuccessfulPollMetrics(t *testing.T) {
 	ResetEc2DiscoveryMetrics()
 
@@ -69,7 +78,7 @@ func TestComputeStateRecordsSuccessfulPollMetrics(t *testing.T) {
 		Labels: backendIdentityLabels("default", "backend-a"),
 		Value:  0,
 	})
-	gathered.AssertMetricLabels(pollDurationMetric, backendIdentityLabels("default", "backend-a"))
+	gathered.AssertMetricLabels(pollDurationMetric, pollDurationLabels("default", "backend-a", "success"))
 	gathered.AssertHistogramPopulated(pollDurationMetric)
 }
 
@@ -166,8 +175,13 @@ func TestComputeStateRecordsErrorPollMetricsAndRetainsEndpointGauge(t *testing.T
 		Labels: backendIdentityLabels("default", "backend-a"),
 		Value:  1,
 	})
-	// A failed poll still has a duration (it can be a slow timeout), so it is observed.
-	gathered.AssertMetricLabels(pollDurationMetric, backendIdentityLabels("default", "backend-a"))
+	// A failed poll still has a duration (it can be a slow timeout), so it is observed
+	// under result=error. The first (successful) poll is recorded separately under
+	// result=success, demonstrating the result partition.
+	gathered.AssertMetricsLabels(pollDurationMetric, [][]metrics.Label{
+		pollDurationLabels("default", "backend-a", "error"),
+		pollDurationLabels("default", "backend-a", "success"),
+	})
 	gathered.AssertHistogramPopulated(pollDurationMetric)
 }
 
@@ -208,9 +222,9 @@ func TestDeleteEc2DiscoveryMetricsRemovesBackendSeries(t *testing.T) {
 	ResetEc2DiscoveryMetrics()
 
 	recordEc2PollSuccess("default", "backend-a", 3)
-	recordEc2PollDuration("default", "backend-a", 0.2)
+	recordEc2PollDuration("default", "backend-a", ec2PollResultSuccess, 0.2)
 	recordEc2PollSuccess("default", "backend-b", 5)
-	recordEc2PollDuration("default", "backend-b", 0.3)
+	recordEc2PollDuration("default", "backend-b", ec2PollResultSuccess, 0.3)
 
 	deleteEc2DiscoveryMetrics("default", "backend-a")
 
@@ -224,6 +238,6 @@ func TestDeleteEc2DiscoveryMetricsRemovesBackendSeries(t *testing.T) {
 		backendIdentityLabels("default", "backend-b"),
 	})
 	gathered.AssertMetricsLabels(pollDurationMetric, [][]metrics.Label{
-		backendIdentityLabels("default", "backend-b"),
+		pollDurationLabels("default", "backend-b", "success"),
 	})
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -156,6 +156,9 @@ func (c *prometheusCounter) Reset() {
 type Histogram interface {
 	Metric
 	Observe(float64, ...Label)
+	// DeletePartialMatch deletes all series whose labels contain all of the
+	// provided label name-value pairs, returning the number of series removed.
+	DeletePartialMatch(...Label) int
 	Reset()
 }
 
@@ -201,6 +204,12 @@ func (c *prometheusHistogram) Labels() []string {
 // validateLabels validates a slice of Label values for the histogram metric.
 func (h *prometheusHistogram) validateLabels(labels []Label) []string {
 	return validateLabels(h, labels)
+}
+
+// DeletePartialMatch deletes all series whose labels contain all of the provided
+// label name-value pairs.
+func (h *prometheusHistogram) DeletePartialMatch(labels ...Label) int {
+	return h.m.DeletePartialMatch(toPrometheusLabels(labels))
 }
 
 // Observe records a value in the histogram.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,6 +47,9 @@ type Counter interface {
 	Metric
 	Inc(...Label)
 	Add(float64, ...Label)
+	// DeletePartialMatch deletes all series whose labels contain all of the
+	// provided label name-value pairs, returning the number of series removed.
+	DeletePartialMatch(...Label) int
 	Reset()
 }
 
@@ -108,9 +111,25 @@ func validateLabels(metric Metric, labels []Label) []string {
 	return values
 }
 
+// toPrometheusLabels converts a slice of Label values to a prometheus.Labels map,
+// used for partial-match deletion where label order is irrelevant.
+func toPrometheusLabels(labels []Label) prometheus.Labels {
+	out := make(prometheus.Labels, len(labels))
+	for _, label := range labels {
+		out[label.Name] = label.Value
+	}
+	return out
+}
+
 // validateLabels validates a slice of Label values for the counter metric.
 func (c *prometheusCounter) validateLabels(labels []Label) []string {
 	return validateLabels(c, labels)
+}
+
+// DeletePartialMatch deletes all series whose labels contain all of the provided
+// label name-value pairs.
+func (c *prometheusCounter) DeletePartialMatch(labels ...Label) int {
+	return c.m.DeletePartialMatch(toPrometheusLabels(labels))
 }
 
 // Inc increments the counter by 1.
@@ -200,6 +219,9 @@ type Gauge interface {
 	Set(float64, ...Label)
 	Add(float64, ...Label)
 	Sub(float64, ...Label)
+	// DeletePartialMatch deletes all series whose labels contain all of the
+	// provided label name-value pairs, returning the number of series removed.
+	DeletePartialMatch(...Label) int
 	Reset()
 }
 
@@ -241,6 +263,12 @@ func (c *prometheusGauge) Labels() []string {
 // validateLabels validates a slice of Label values for the gauge metric.
 func (g *prometheusGauge) validateLabels(labels []Label) []string {
 	return validateLabels(g, labels)
+}
+
+// DeletePartialMatch deletes all series whose labels contain all of the provided
+// label name-value pairs.
+func (g *prometheusGauge) DeletePartialMatch(labels ...Label) int {
+	return g.m.DeletePartialMatch(toPrometheusLabels(labels))
 }
 
 // Set sets the gauge to a specific value.


### PR DESCRIPTION
# Description

Implements the remaining open requirement (FR-10) from [GG-1509](https://github.com/solo-io/gloo-gateway/issues/1509): expose Prometheus metrics for the EC2 backend endpoint-discovery loop added in #13961. Operators previously had only structured logs and no quantitative signal for EC2 discovery health.

Four per-Backend metrics are recorded by the EC2 EDS polling loop, following the codebase's `kgateway_<subsystem>_<name>` convention:

- **`kgateway_ec2_discovery_poll_total`** (counter) — total discovery refresh attempts per Backend, labeled `namespace`, `name`, `result` (`success`/`error`), and `reason`. The `reason` values match the `EndpointsDiscovered` status-condition reasons (`none`, `NoMatchingInstances`, `CredentialError`, `AuthorizationError`, `DiscoveryError`). A successful poll that matches zero instances is recorded as `result=success, reason=NoMatchingInstances` (not an error). A failed poll that still serves carried-forward endpoints (Degraded) records the underlying classification reason, not `Degraded`, so the counter always attributes a concrete cause.
- **`kgateway_ec2_discovery_endpoints_active`** (gauge) — active endpoint count, set after each successful poll. Left unchanged on a failed poll so it retains the last successful value (NFR-3 graceful degradation). Labels: `namespace`, `name`.
- **`kgateway_ec2_discovery_error_state`** (gauge) — `1` when the Backend's most recent discovery outcome was a failure, `0` on success. No `reason` label by design; reason-specific diagnosis is via the counter and the Backend status condition. Labels: `namespace`, `name`. This also covers the case where a secret-auth Backend's secret cannot be resolved (it never enters the poll loop but is set to `1` from the status path), so missing/typo'd `secretRef` misconfigurations are visible to alerting.
- **`kgateway_ec2_discovery_poll_duration_seconds`** (native histogram) — wall-clock duration of the AWS `DescribeInstances` round trip per poll, attributed to every Backend in the credential scope. Both successful and failed polls are observed so slow timeouts are visible; configured as a native histogram (bucket factor 1.1) with classic buckets retained as a fallback, spanning a fast in-region listing up to the 30s refresh timeout. Labels: `namespace`, `name`.

Metrics are recorded per Backend even though discovery batches AWS `DescribeInstances` calls by credential scope. Series for deleted Backends are removed via a delete handler on the backends collection so stale series don't linger indefinitely. This required adding a `DeletePartialMatch` method to the metrics `Counter`/`Gauge`/`Histogram` interfaces (no prior per-series deletion capability existed). The delete handler is registered unconditionally (not via `metrics.RegisterEvents`) so cleanup stays symmetric with the per-poll recording, which is guarded dynamically by `metrics.Active()`; it cleans up by object-source identity, which is always populated and is a no-op for non-EC2 backends.

# Change Type

/kind feature

# Changelog

```release-note
EC2 backends now expose Prometheus metrics for endpoint discovery: `kgateway_ec2_discovery_poll_total`, `kgateway_ec2_discovery_endpoints_active`, `kgateway_ec2_discovery_error_state`, and `kgateway_ec2_discovery_poll_duration_seconds`.
```

# Additional Notes

- New unit tests cover successful polls, no-matching-instances, error-with-carry-forward (degraded), poll-duration recording, unresolved-secret error state, and deletion cleanup. Metric names pass `promlint`.
- Includes a small cleanup removing an unreachable missing-secret guard in `ec2ConfigFromBackend` (translation already fails closed for unresolved secrets).
- No central metric registry/doc enumerates metrics, so no doc update was needed; `devel/architecture/metrics.md` documents only patterns.