### PR TITLE
fix: include retry and timeouts in TrafficPolicy.Validate()

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -206,6 +206,8 @@ func (p *TrafficPolicy) Validate() error {
 	validators = append(validators, p.spec.cors.Validate)
 	validators = append(validators, p.spec.headerModifiers.Validate)
 	validators = append(validators, p.spec.buffer.Validate)
+	validators = append(validators, p.spec.retry.Validate)
+	validators = append(validators, p.spec.timeouts.Validate)
 	validators = append(validators, p.spec.autoHostRewrite.Validate)
 	validators = append(validators, p.spec.rbac.Validate)
 	validators = append(validators, p.spec.jwt.Validate)


### PR DESCRIPTION
# Description

`TrafficPolicy.Validate()` delegates PGV validation to each policy sub-IR's `Validate()` method. However, the `retry` and `timeouts` sub-IRs were missing from the validator list, even though both are compared in `Equals()`.

This meant `retryIR.Validate()` — which runs PGV validation on the Envoy `RetryPolicy` proto — was being silently skipped, so a malformed retry policy IR would not be caught here. `timeoutsIR.Validate()` is currently a no-op, but is added for parity with `Equals()` and to future-proof against real validation being added there.

Both `Validate()` methods handle nil receivers safely, so this is safe when the sub-IR is unset.

# Change Type

/kind fix

# Changelog

```release-note
NONE
```
