### PR TITLE
perf(ci): scope buildx layer-cache tags by Envoy version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,8 +70,8 @@ dockers:
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
       - '--build-arg=BASE_IMAGE={{ envOrDefault "DISTROLESS_BASE_IMAGE" "cgr.dev/chainguard/glibc-dynamic:latest" }}'
       - "--build-arg=RUST_MODULE_DIR=_output/rust/arm64"
-      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64"
-      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64,mode=max,ignore-error=true"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64-{{ .Env.ENVOY_VERSION_TAG }}"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:arm64-{{ .Env.ENVOY_VERSION_TAG }},mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ else }}--progress=auto{{ end }}'
   - image_templates:
@@ -88,8 +88,8 @@ dockers:
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
       - '--build-arg=BASE_IMAGE={{ envOrDefault "DISTROLESS_BASE_IMAGE" "cgr.dev/chainguard/glibc-dynamic:latest" }}'
       - "--build-arg=RUST_MODULE_DIR=_output/rust/amd64"
-      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64"
-      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64,mode=max,ignore-error=true"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64-{{ .Env.ENVOY_VERSION_TAG }}"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/kgateway-cache:amd64-{{ .Env.ENVOY_VERSION_TAG }},mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ else }}--progress=auto{{ end }}'
   - image_templates:
@@ -102,8 +102,8 @@ dockers:
       - "--platform=linux/arm64"
       - "--build-arg=GOARCH=arm64"
       - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
-      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64"
-      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64,mode=max,ignore-error=true"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64-{{ .Env.ENVOY_VERSION_TAG }}"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64-{{ .Env.ENVOY_VERSION_TAG }},mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ else }}--progress=auto{{ end }}'
   - image_templates:
@@ -116,8 +116,8 @@ dockers:
       - "--platform=linux/amd64"
       - "--build-arg=GOARCH=amd64"
       - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
-      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64"
-      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64,mode=max,ignore-error=true"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64-{{ .Env.ENVOY_VERSION_TAG }}"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64-{{ .Env.ENVOY_VERSION_TAG }},mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ else }}--progress=auto{{ end }}'
   - image_templates:
@@ -135,8 +135,8 @@ dockers:
       - "--build-arg=ENTRYPOINT_SCRIPT=/cmd/envoyinit/docker-entrypoint.sh"
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
       - "--build-arg=RUST_MODULE_DIR=_output/rust/arm64"
-      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64"
-      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64,mode=max,ignore-error=true"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64-{{ .Env.ENVOY_VERSION_TAG }}"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:arm64-{{ .Env.ENVOY_VERSION_TAG }},mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ else }}--progress=auto{{ end }}'
   - image_templates:
@@ -154,8 +154,8 @@ dockers:
       - "--build-arg=ENTRYPOINT_SCRIPT=/cmd/envoyinit/docker-entrypoint.sh"
       - "--build-arg=ENVOY_IMAGE={{ .Env.ENVOY_IMAGE }}"
       - "--build-arg=RUST_MODULE_DIR=_output/rust/amd64"
-      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64"
-      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64,mode=max,ignore-error=true"
+      - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64-{{ .Env.ENVOY_VERSION_TAG }}"
+      - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/envoy-wrapper-cache:amd64-{{ .Env.ENVOY_VERSION_TAG }},mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--no-cache{{ else }}--progress=auto{{ end }}'
 docker_manifests:

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,14 @@ endif
 
 export ENVOY_IMAGE ?= envoyproxy/envoy:v1.38.1
 
+# Envoy version tag (e.g. v1.38.1) extracted from ENVOY_IMAGE. Exported so goreleaser.yaml and the
+# local *-docker cache-from targets can suffix the registry layer-cache tags with it. The Envoy base
+# is the layer that differs across release lines (main/v2.3.x/v2.2.x each pin a different Envoy), so
+# without this suffix every branch writes the same `*-cache:<arch>` tag and main's frequent pushes
+# constantly evict the release lines' cache -- turning release-branch PR builds into full QEMU rebuilds.
+# Scoping the cache tag per Envoy version gives each release line a cache that survives main churn.
+export ENVOY_VERSION_TAG ?= $(shell echo $(ENVOY_IMAGE) | cut -d':' -f2)
+
 # ENVOY_IMAGE is used by some of the *-docker targets which are used by CI e2e tests, so figure out the correct image
 # to use base on GOARCH. This doesn't affect goreleaser
 ifeq ($(GOARCH), arm64)
@@ -749,9 +757,9 @@ CONTROLLER_OUTPUT_DIR=$(OUTPUT_DIR)/pkg/kgateway
 export CONTROLLER_IMAGE_REPO ?= kgateway
 
 # Registry cache repo for controller Docker build (set to enable, e.g., ghcr.io/kgateway-dev/kgateway-cache).
-# The arch tag is appended automatically as :$(GOARCH) to match what goreleaser publishes.
+# The cache tag is suffixed automatically as :$(GOARCH)-$(ENVOY_VERSION_TAG) to match what goreleaser publishes.
 CONTROLLER_CACHE_REF ?=
-CONTROLLER_CACHE_FROM := $(if $(CONTROLLER_CACHE_REF),--cache-from type=registry$(comma)ref=$(CONTROLLER_CACHE_REF):$(GOARCH),)
+CONTROLLER_CACHE_FROM := $(if $(CONTROLLER_CACHE_REF),--cache-from type=registry$(comma)ref=$(CONTROLLER_CACHE_REF):$(GOARCH)-$(ENVOY_VERSION_TAG),)
 
 # We include the files in K8S_GATEWAY_SOURCES as dependencies to the kgateway build
 # so changes in those directories cause the make target to rebuild
@@ -788,9 +796,9 @@ SDS_OUTPUT_DIR=$(OUTPUT_DIR)/$(SDS_DIR)
 export SDS_IMAGE_REPO ?= sds
 
 # Registry cache repo for sds Docker build (set to enable, e.g., ghcr.io/kgateway-dev/sds-cache).
-# The arch tag is appended automatically as :$(GOARCH) to match what goreleaser publishes.
+# The cache tag is suffixed automatically as :$(GOARCH)-$(ENVOY_VERSION_TAG) to match what goreleaser publishes.
 SDS_CACHE_REF ?=
-SDS_CACHE_FROM := $(if $(SDS_CACHE_REF),--cache-from type=registry$(comma)ref=$(SDS_CACHE_REF):$(GOARCH),)
+SDS_CACHE_FROM := $(if $(SDS_CACHE_REF),--cache-from type=registry$(comma)ref=$(SDS_CACHE_REF):$(GOARCH)-$(ENVOY_VERSION_TAG),)
 
 $(SDS_OUTPUT_DIR)/sds-linux-$(GOARCH): $(SDS_SOURCES)
 	$(GO_BUILD_FLAGS) GOOS=linux go build -ldflags='$(LDFLAGS)' -gcflags='$(GCFLAGS)' -o $@ ./cmd/sds/...
@@ -825,9 +833,9 @@ export ENVOYINIT_IMAGE_REPO ?= envoy-wrapper
 # Registry cache for envoyinit Docker build (set to enable, e.g., ghcr.io/kgateway-dev/envoy-wrapper-cache)
 
 # Registry cache-from targets the image goreleaser publishes on main/release.
-# The arch tag is appended automatically as :$(GOARCH) to match what goreleaser publishes.
+# The cache tag is suffixed automatically as :$(GOARCH)-$(ENVOY_VERSION_TAG) to match what goreleaser publishes.
 ENVOYINIT_CACHE_REF ?=
-ENVOYINIT_CACHE_FROM := $(if $(ENVOYINIT_CACHE_REF),--cache-from type=registry$(comma)ref=$(ENVOYINIT_CACHE_REF):$(GOARCH),)
+ENVOYINIT_CACHE_FROM := $(if $(ENVOYINIT_CACHE_REF),--cache-from type=registry$(comma)ref=$(ENVOYINIT_CACHE_REF):$(GOARCH)-$(ENVOY_VERSION_TAG),)
 
 # Optional local BuildKit cache paths, typically wired to actions/cache in CI
 # so PR runs can read AND write layer cache without needing registry push auth.

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,18 @@ endif
 
 export ENVOY_IMAGE ?= envoyproxy/envoy:v1.38.1
 
-# Envoy version tag (e.g. v1.38.1) extracted from ENVOY_IMAGE. Exported so goreleaser.yaml and the
-# local *-docker cache-from targets can suffix the registry layer-cache tags with it. The Envoy base
-# is the layer that differs across release lines (main/v2.3.x/v2.2.x each pin a different Envoy), so
-# without this suffix every branch writes the same `*-cache:<arch>` tag and main's frequent pushes
-# constantly evict the release lines' cache -- turning release-branch PR builds into full QEMU rebuilds.
-# Scoping the cache tag per Envoy version gives each release line a cache that survives main churn.
+# Envoy version tag (e.g. v1.38.1) extracted from ENVOY_IMAGE, used to suffix the registry
+# layer-cache tags. The Envoy base is the layer that differs across release lines
+# (main/v2.3.x/v2.2.x each pin a different Envoy), so without this suffix every branch writes the
+# same `*-cache:<arch>` tag and main's frequent pushes constantly evict the release lines' cache
+# -- turning release-branch PR builds into full QEMU rebuilds. Scoping the cache tag per Envoy
+# version gives each release line a cache that survives main churn.
+#
+# The local *-docker cache-from targets read this as a make variable ($(ENVOY_VERSION_TAG)); the
+# `release` target additionally passes it into goreleaser's environment explicitly, because GNU
+# Make 4.3 (the ubuntu-22.04 CI runner) does not reliably export a $(shell)-derived variable to
+# child processes -- see the note on the `release` target. The `export` below still helps on
+# make 4.4+ and for any other subprocess.
 export ENVOY_VERSION_TAG ?= $(shell echo $(ENVOY_IMAGE) | cut -d':' -f2)
 
 # ENVOY_IMAGE is used by some of the *-docker targets which are used by CI e2e tests, so figure out the correct image
@@ -1013,9 +1019,15 @@ GORELEASER_ARGS ?= --snapshot --clean
 GORELEASER_TIMEOUT ?= 60m
 GORELEASER_CURRENT_TAG ?= $(VERSION)
 
+# ENVOY_VERSION_TAG is passed explicitly (not just via `export`) because GNU Make 4.3 -- the
+# version on the ubuntu-22.04 CI runner -- does not reliably export a shell-derived variable to
+# child processes, so goreleaser's `.Env.ENVOY_VERSION_TAG` (used to scope the buildx cache tags
+# in .goreleaser.yaml) ends up unset and the docker build-flag template fails with
+# `map has no entry for key "ENVOY_VERSION_TAG"`. An inline assignment on the command itself is
+# unaffected by that quirk (make 4.4+ exports it fine).
 .PHONY: release
 release: ## Create a release using goreleaser
-	GORELEASER_CURRENT_TAG=$(GORELEASER_CURRENT_TAG) go tool -modfile=tools/go.mod goreleaser release $(GORELEASER_ARGS) --timeout $(GORELEASER_TIMEOUT)
+	GORELEASER_CURRENT_TAG=$(GORELEASER_CURRENT_TAG) ENVOY_VERSION_TAG=$(ENVOY_VERSION_TAG) go tool -modfile=tools/go.mod goreleaser release $(GORELEASER_ARGS) --timeout $(GORELEASER_TIMEOUT)
 .PHONY: release-notes
 release-notes: ## Generate release notes (PREVIOUS_TAG required, CURRENT_TAG optional)
 	./hack/generate-release-notes.sh -p $(PREVIOUS_TAG) -c $(or $(CURRENT_TAG),HEAD)


### PR DESCRIPTION
# Description

The `Release` workflow's `goreleaser` job is bimodal: ~10–13m when the Docker layer cache hits, but ~27–31m when it misses. Profiling a slow run showed ~29m of the 30m37s is the single `Run goreleaser` step, and within it the docker image build phase is **21m34s on a miss vs ~30s on a hit** (goreleaser's own `took:` line) — i.e. on a hit, even the QEMU-emulated arm64 `apt-get upgrade` in the envoy-wrapper image restores instantly; the only thing that matters is cache hit vs miss.

Root cause: the buildx registry cache tag was `*-cache:{arch}` — arch only, no branch/version scope. Every non-PR push writes that shared tag, but each release line pins a different Envoy base (`main` v1.38.1, `v2.3.x` v1.37.5, `v2.2.x` v1.36.9), so the `FROM $ENVOY_IMAGE` layer — and everything below it — differs per line. Since `release.yaml` `push:` triggers only on `main`, main's frequent pushes constantly evict the release lines' cache, and release-branch PRs always miss → full emulated rebuild.

This is visible in a natural experiment — the same `bump-containerd` change on three bases:

| base   | goreleaser duration |
|--------|---------------------|
| main   | 15m54s              |
| v2.3.x | 27m37s              |
| v2.2.x | 28m03s              |

## What changed

- Scope every buildx cache ref by the Envoy version: `*-cache:{arch}` -> `*-cache:{arch}-{{ .Env.ENVOY_VERSION_TAG }}` (all 12 cache-from/cache-to refs in `.goreleaser.yaml`).
- Export `ENVOY_VERSION_TAG` (derived from `ENVOY_IMAGE`) from the `Makefile`, and apply the same `:{arch}-{ENVOY_VERSION_TAG}` suffix to the local opt-in `*_CACHE_FROM` docker targets so local builds stay consistent with what goreleaser publishes.

Each release line now owns a distinct cache tag, so main's pushes can no longer evict the release lines' cache.

## Note on rollout (seeding)

Scoping only pays off once a scoped tag is populated, and only logged-in builds push cache (`cache-to` is a silent no-op on PRs via `ignore-error=true`). So:

- main PRs self-heal on the next main push.
- A release line's PRs speed up after that line's next `workflow_dispatch` release seeds its scoped tag (releases export `cache-to` even with `--no-cache`), after which they hit permanently.

A follow-up cache-warm job (or release-branch push trigger) could seed release lines immediately rather than waiting on the next patch release; intentionally left out of this PR.

# Change Type
/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
