### PR TITLE
fix: make route delegation matcher inheritance regex-aware

### DIFF
--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -3847,6 +3847,10 @@ func TestRouteDelegation(t *testing.T) {
 		test(t, "inherit_parentref.yaml")
 	})
 
+	t.Run("RegularExpression parent matcher inheritance", func(t *testing.T) {
+		test(t, "inherit_parent_matcher_regex.yaml")
+	})
+
 	t.Run("Parent delegates to multiple chidren", func(t *testing.T) {
 		test(t, "multiple_children.yaml")
 	})

--- a/pkg/kgateway/translator/gateway/testutils/inputs/delegation/inherit_parent_matcher_regex.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/delegation/inherit_parent_matcher_regex.yaml
@@ -1,0 +1,70 @@
+# This test contains a parent route with a RegularExpression path matcher and two
+# children that inherit the parent matcher via the inherit-parent-matcher annotation.
+# The merged child matcher must remain a regular expression so the parent regex is
+# not mangled (https://github.com/kgateway-dev/kgateway/issues/13792).
+#
+# Input:
+# - Parent infra/example-route:
+#   - Delegate ^/teams/[^/]+(?:/.*)?$ to routes in "a" namespace
+# - Child a/route-a (inherit-parent-matcher=true):
+#   - PathPrefix /members goes to a/svc-a
+# - Child a/route-b (inherit-parent-matcher=true):
+#   - Exact /owners goes to a/svc-a
+#
+# Expected output routes (child inherits parent regex, child path appended as regex):
+# - ^/teams/[^/]+(?:/.*)?/members(?:/.*)?$ -> a/svc-a
+# - ^/teams/[^/]+(?:/.*)?/owners$ -> a/svc-a
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: ^/teams/[^/]+(?:/.*)?$
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+  annotations:
+    delegation.kgateway.dev/inherit-parent-matcher: "true"
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /members
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-b
+  namespace: a
+  annotations:
+    delegation.kgateway.dev/inherit-parent-matcher: "true"
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /owners
+    backendRefs:
+    - name: svc-a
+      port: 8080

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parent_matcher_regex.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parent_matcher_regex.yaml
@@ -143,6 +143,11 @@ Statuses:
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
         controllerName: kgateway
         parentRef:
           group: gateway.networking.k8s.io
@@ -162,6 +167,11 @@ Statuses:
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
         controllerName: kgateway
         parentRef:
           group: gateway.networking.k8s.io
@@ -181,6 +191,11 @@ Statuses:
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
         controllerName: kgateway
         parentRef:
           group: ""

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parent_matcher_regex.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/inherit_parent_matcher_regex.yaml
@@ -1,0 +1,188 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_a_svc-a_8080
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_b_svc-b_8080
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_infra_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        safeRegex:
+          googleRe2: {}
+          regex: ^/teams/[^/]+(?:/.*)?/members(?:/.*)?$
+      name: listener~80~example_com-route-1-httproute-route-a-a-0-0-matcher-0
+      route:
+        cluster: kube_a_svc-a_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        safeRegex:
+          googleRe2: {}
+          regex: ^/teams/[^/]+(?:/.*)?/owners$
+      name: listener~80~example_com-route-2-httproute-route-b-a-0-0-matcher-0
+      route:
+        cluster: kube_a_svc-a_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    infra/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    a/route-a:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    a/route-b:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: example-route
+          namespace: infra
+    infra/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/pkg/kgateway/translator/httproute/delegation_helpers.go
+++ b/pkg/kgateway/translator/httproute/delegation_helpers.go
@@ -2,6 +2,7 @@ package httproute
 
 import (
 	"path"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -9,6 +10,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/query"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/routeutils"
 	delegationutils "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils/delegation"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
@@ -108,7 +110,10 @@ func filterDelegatedChildren(
 
 // mergeParentChildRouteMatch is called only when inherit-parent-matcher is set.
 // It merges the parent route match into the child as follows:
-//   - the resulting path consists of parent path + child path
+//   - the resulting path consists of parent path + child path. When the parent
+//     path matcher is a RegularExpression, the paths are merged into a regular
+//     expression (see mergeRegexParentPath) so the parent regex is preserved;
+//     otherwise the literal paths are joined.
 //   - the resulting headers consist of the combined headers from parent and child, with parent header taking
 //     precedence on any name conflicts
 //   - the resulting query parameters consist of the combined query parameters from parent and child, with parent
@@ -122,13 +127,26 @@ func mergeParentChildRouteMatch(
 		return
 	}
 
+	// Per the Gateway API spec a nil Path (or a nil Type/Value) defaults to a
+	// PathPrefix match on "/". routeutils.ParsePath applies those defaults so we
+	// never dereference a nil parent or child path below.
+	parentPathType, parentPathValue := routeutils.ParsePath(parent.Path)
+	childPathType, childPathValue := routeutils.ParsePath(child.Path)
+
 	if child.Path == nil {
 		child.Path = &gwv1.HTTPPathMatch{
-			Type:  new(gwv1.PathMatchPathPrefix),
-			Value: new(""),
+			Type:  new(childPathType),
+			Value: new(childPathValue),
 		}
 	}
-	child.Path.Value = new(path.Join(*parent.Path.Value, *child.Path.Value))
+	if parentPathType == gwv1.PathMatchRegularExpression {
+		// path.Join would mangle a regex (it normalizes slashes and strips
+		// anchors/groups), so build a regex that keeps the parent matcher intact.
+		child.Path.Value = new(mergeRegexParentPath(parentPathValue, childPathType, childPathValue))
+		child.Path.Type = new(gwv1.PathMatchRegularExpression)
+	} else {
+		child.Path.Value = new(path.Join(parentPathValue, childPathValue))
+	}
 
 	// Inherit parent and child headers and query parameters while augmenting the merge
 	// with additions specified on the child
@@ -139,6 +157,32 @@ func mergeParentChildRouteMatch(
 	if parent.Method != nil {
 		child.Method = new(*parent.Method)
 	}
+}
+
+// mergeRegexParentPath appends the child path onto a RegularExpression parent
+// path, producing a single regular expression. The parent's trailing "$" anchor
+// is dropped so the child can extend it, and re-added only when the parent regex
+// was already end-anchored so an unanchored parent (e.g. "/a/.*") keeps its
+// unanchored semantics. A non-regex child is matched literally via
+// regexp.QuoteMeta; a regex child is inlined without its own anchors. A
+// PathPrefix child stays open-ended so deeper paths still match.
+func mergeRegexParentPath(parentRegex string, childType gwv1.PathMatchType, childValue string) string {
+	parentEndAnchored := strings.HasSuffix(parentRegex, "$")
+	merged := strings.TrimSuffix(parentRegex, "$")
+	switch childType {
+	case gwv1.PathMatchRegularExpression:
+		merged += strings.TrimSuffix(strings.TrimPrefix(childValue, "^"), "$")
+	case gwv1.PathMatchExact:
+		merged += regexp.QuoteMeta(childValue)
+	default:
+		merged += regexp.QuoteMeta(childValue) + "(?:/.*)?"
+	}
+	// Preserve the parent's end-anchoring: only re-add "$" when the parent regex
+	// was already end-anchored, leaving unanchored parents unanchored.
+	if parentEndAnchored {
+		merged += "$"
+	}
+	return merged
 }
 
 // mergeHeaders merges parent and child header matches. If a header name is specified on both

--- a/pkg/kgateway/translator/httproute/delegation_helpers.go
+++ b/pkg/kgateway/translator/httproute/delegation_helpers.go
@@ -134,10 +134,7 @@ func mergeParentChildRouteMatch(
 	childPathType, childPathValue := routeutils.ParsePath(child.Path)
 
 	if child.Path == nil {
-		child.Path = &gwv1.HTTPPathMatch{
-			Type:  new(childPathType),
-			Value: new(childPathValue),
-		}
+		child.Path = &gwv1.HTTPPathMatch{}
 	}
 	if parentPathType == gwv1.PathMatchRegularExpression {
 		// path.Join would mangle a regex (it normalizes slashes and strips
@@ -146,6 +143,7 @@ func mergeParentChildRouteMatch(
 		child.Path.Type = new(gwv1.PathMatchRegularExpression)
 	} else {
 		child.Path.Value = new(path.Join(parentPathValue, childPathValue))
+		child.Path.Type = new(childPathType)
 	}
 
 	// Inherit parent and child headers and query parameters while augmenting the merge

--- a/pkg/kgateway/translator/httproute/delegation_helpers_test.go
+++ b/pkg/kgateway/translator/httproute/delegation_helpers_test.go
@@ -1,0 +1,125 @@
+package httproute
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func pathMatch(t gwv1.PathMatchType, v string) *gwv1.HTTPRouteMatch {
+	return &gwv1.HTTPRouteMatch{
+		Path: &gwv1.HTTPPathMatch{Type: new(t), Value: new(v)},
+	}
+}
+
+func TestMergeParentChildRouteMatchPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		parent       *gwv1.HTTPRouteMatch
+		child        *gwv1.HTTPRouteMatch
+		expectedPath string
+		expectedType gwv1.PathMatchType
+		// regexMatches are paths the resulting matcher must match; regexRejects must not match.
+		regexMatches []string
+		regexRejects []string
+		// unanchoredParent asserts the merged regex is not end-anchored, i.e. an
+		// unanchored parent regex stays unanchored after merging.
+		unanchoredParent bool
+	}{
+		{
+			name:         "PathPrefix parent and PathPrefix child are joined",
+			parent:       pathMatch(gwv1.PathMatchPathPrefix, "/api"),
+			child:        pathMatch(gwv1.PathMatchPathPrefix, "/v1"),
+			expectedPath: "/api/v1",
+			expectedType: gwv1.PathMatchPathPrefix,
+		},
+		{
+			name:         "PathPrefix parent and Exact child retain child type",
+			parent:       pathMatch(gwv1.PathMatchPathPrefix, "/api"),
+			child:        pathMatch(gwv1.PathMatchExact, "/users"),
+			expectedPath: "/api/users",
+			expectedType: gwv1.PathMatchExact,
+		},
+		{
+			name:         "RegularExpression parent and PathPrefix child stay open-ended",
+			parent:       pathMatch(gwv1.PathMatchRegularExpression, "^/teams/[^/]+(?:/.*)?$"),
+			child:        pathMatch(gwv1.PathMatchPathPrefix, "/members"),
+			expectedPath: "^/teams/[^/]+(?:/.*)?/members(?:/.*)?$",
+			expectedType: gwv1.PathMatchRegularExpression,
+			regexMatches: []string{"/teams/acme/members", "/teams/acme/members/123"},
+			regexRejects: []string{"/teams/acme/owners"},
+		},
+		{
+			name:         "RegularExpression parent and Exact child are anchored",
+			parent:       pathMatch(gwv1.PathMatchRegularExpression, "^/teams/[^/]+$"),
+			child:        pathMatch(gwv1.PathMatchExact, "/members"),
+			expectedPath: "^/teams/[^/]+/members$",
+			expectedType: gwv1.PathMatchRegularExpression,
+			regexMatches: []string{"/teams/acme/members"},
+			regexRejects: []string{"/teams/acme/members/extra"},
+		},
+		{
+			name:         "RegularExpression parent and RegularExpression child drop child anchors",
+			parent:       pathMatch(gwv1.PathMatchRegularExpression, "^/teams/[^/]+$"),
+			child:        pathMatch(gwv1.PathMatchRegularExpression, "^/v[0-9]+$"),
+			expectedPath: "^/teams/[^/]+/v[0-9]+$",
+			expectedType: gwv1.PathMatchRegularExpression,
+			regexMatches: []string{"/teams/acme/v2"},
+			regexRejects: []string{"/teams/acme/vX"},
+		},
+		{
+			name:         "special characters in child are escaped under regex parent",
+			parent:       pathMatch(gwv1.PathMatchRegularExpression, "^/teams/[^/]+$"),
+			child:        pathMatch(gwv1.PathMatchExact, "/a.b"),
+			expectedPath: `^/teams/[^/]+/a\.b$`,
+			expectedType: gwv1.PathMatchRegularExpression,
+			regexMatches: []string{"/teams/acme/a.b"},
+			regexRejects: []string{"/teams/acme/axb"},
+		},
+		{
+			name:             "unanchored RegularExpression parent and PathPrefix child stay unanchored",
+			parent:           pathMatch(gwv1.PathMatchRegularExpression, "/a/.*"),
+			child:            pathMatch(gwv1.PathMatchPathPrefix, "/b"),
+			expectedPath:     "/a/.*/b(?:/.*)?",
+			expectedType:     gwv1.PathMatchRegularExpression,
+			regexMatches:     []string{"/a/x/b", "/a/x/b/deeper"},
+			regexRejects:     []string{"/a/x"},
+			unanchoredParent: true,
+		},
+		{
+			name:             "unanchored RegularExpression parent and Exact child stay unanchored",
+			parent:           pathMatch(gwv1.PathMatchRegularExpression, "/a/.*"),
+			child:            pathMatch(gwv1.PathMatchExact, "/b"),
+			expectedPath:     "/a/.*/b",
+			expectedType:     gwv1.PathMatchRegularExpression,
+			regexMatches:     []string{"/a/x/b"},
+			regexRejects:     []string{"/a/x"},
+			unanchoredParent: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mergeParentChildRouteMatch(tc.parent, tc.child)
+			assert.Equal(t, tc.expectedPath, *tc.child.Path.Value)
+			assert.Equal(t, tc.expectedType, *tc.child.Path.Type)
+			if tc.unanchoredParent {
+				assert.False(t, strings.HasSuffix(*tc.child.Path.Value, "$"),
+					"unanchored parent regex must stay unanchored after merge")
+			}
+			if tc.expectedType == gwv1.PathMatchRegularExpression {
+				re, err := regexp.Compile(*tc.child.Path.Value)
+				assert.NoError(t, err)
+				for _, p := range tc.regexMatches {
+					assert.True(t, re.MatchString(p), "expected %q to match", p)
+				}
+				for _, p := range tc.regexRejects {
+					assert.False(t, re.MatchString(p), "expected %q not to match", p)
+				}
+			}
+		})
+	}
+}

--- a/pkg/kgateway/translator/httproute/delegation_helpers_test.go
+++ b/pkg/kgateway/translator/httproute/delegation_helpers_test.go
@@ -44,6 +44,38 @@ func TestMergeParentChildRouteMatchPath(t *testing.T) {
 			expectedType: gwv1.PathMatchExact,
 		},
 		{
+			name:         "nil parent path defaults to root PathPrefix",
+			parent:       &gwv1.HTTPRouteMatch{},
+			child:        pathMatch(gwv1.PathMatchPathPrefix, "/api"),
+			expectedPath: "/api",
+			expectedType: gwv1.PathMatchPathPrefix,
+		},
+		{
+			name: "nil parent path fields default to root PathPrefix",
+			parent: &gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{},
+			},
+			child:        pathMatch(gwv1.PathMatchExact, "/api"),
+			expectedPath: "/api",
+			expectedType: gwv1.PathMatchExact,
+		},
+		{
+			name:         "nil child path defaults to root PathPrefix",
+			parent:       pathMatch(gwv1.PathMatchPathPrefix, "/api"),
+			child:        &gwv1.HTTPRouteMatch{},
+			expectedPath: "/api",
+			expectedType: gwv1.PathMatchPathPrefix,
+		},
+		{
+			name:   "nil child path fields default to root PathPrefix",
+			parent: pathMatch(gwv1.PathMatchPathPrefix, "/api"),
+			child: &gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{},
+			},
+			expectedPath: "/api",
+			expectedType: gwv1.PathMatchPathPrefix,
+		},
+		{
 			name:         "RegularExpression parent and PathPrefix child stay open-ended",
 			parent:       pathMatch(gwv1.PathMatchRegularExpression, "^/teams/[^/]+(?:/.*)?$"),
 			child:        pathMatch(gwv1.PathMatchPathPrefix, "/members"),


### PR DESCRIPTION
# Description

When `inherit-parent-matcher` is set, `mergeParentChildRouteMatch` combines the
parent and child path matches with `path.Join`. That works for literal paths but
corrupts a `RegularExpression` parent by normalizing the expression as a file
path, so the delegated child route no longer matches as intended.

This change merges regular-expression parents without passing them through
`path.Join`. It preserves whether the parent expression was end-anchored,
escapes literal child paths, and keeps PathPrefix children open-ended. Literal
parent paths retain the existing behavior. Missing path fields are also resolved
through the Gateway API path defaults instead of being dereferenced directly.

Fixes #13792

# Change Type

/kind fix

# Changelog

```release-note
Route delegation with `delegation.kgateway.dev/inherit-parent-matcher` now preserves a parent's RegularExpression path matcher when merging it into a child, instead of corrupting the regex with path.Join.
```

# Additional Notes

Added table-driven unit coverage for literal, regex, unanchored, and defaulted
path combinations, plus a translator golden case for inherited regex matchers.
