### PR TITLE
fix: compare pointer-bearing IR fields by value in Equals (HttpListenerPolicyIr, directResponse)

### DIFF
--- a/pkg/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -40,7 +41,13 @@ func (d *directResponse) Equals(in any) bool {
 	if !ok {
 		return false
 	}
-	return d.spec == d2.spec
+	// DirectResponseSpec contains pointer fields (Body, BodyFormat), so a struct
+	// `==` would compare those by pointer identity. Because the IR is rebuilt from
+	// a freshly decoded object on every recompute, equal specs get distinct
+	// pointers and `==` would spuriously report inequality, triggering needless
+	// re-translation. DirectResponseSpec is a plain (non-proto) API type, so a
+	// value-based DeepEqual is correct here.
+	return reflect.DeepEqual(d.spec, d2.spec)
 }
 
 type directResponsePluginGwPass struct {

--- a/pkg/kgateway/extensions2/plugins/directresponse/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/directresponse/equality_harness_test.go
@@ -10,8 +10,6 @@ package directresponse
 import (
 	"testing"
 
-	"k8s.io/utils/ptr"
-
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
@@ -21,10 +19,10 @@ func baseHarnessDirectResponse() *directResponse {
 	return &directResponse{
 		spec: kgateway.DirectResponseSpec{
 			StatusCode: 503,
-			Body:       ptr.To("service unavailable"),
+			Body:       new("service unavailable"),
 			BodyFormat: &shared.BodyFormat{
-				ContentType: ptr.To("text/plain"),
-				Text:        ptr.To("oops"),
+				ContentType: new("text/plain"),
+				Text:        new("oops"),
 			},
 		},
 	}
@@ -38,7 +36,7 @@ func TestHarnessDirectResponseEquals(t *testing.T) {
 		},
 		{
 			Field:  "spec",
-			Mutate: func(d **directResponse) { (*d).spec.Body = ptr.To("different body") },
+			Mutate: func(d **directResponse) { (*d).spec.Body = new("different body") },
 		},
 		{
 			Field:  "spec",
@@ -46,7 +44,7 @@ func TestHarnessDirectResponseEquals(t *testing.T) {
 		},
 		{
 			Field:  "spec",
-			Mutate: func(d **directResponse) { (*d).spec.BodyFormat.ContentType = ptr.To("application/json") },
+			Mutate: func(d **directResponse) { (*d).spec.BodyFormat.ContentType = new("application/json") },
 		},
 		{
 			Field:  "spec",

--- a/pkg/kgateway/extensions2/plugins/directresponse/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/directresponse/equality_harness_test.go
@@ -1,0 +1,65 @@
+package directresponse
+
+// equality_harness_test.go verifies that directResponse.Equals detects a change
+// in every field and treats specs with equal content but distinct pointers as
+// equal. The reflexivity subtest guards against comparing DirectResponseSpec's
+// pointer fields (Body, BodyFormat) by identity instead of value.
+//
+// See test/testutils/equalstest for the harness API.
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+func baseHarnessDirectResponse() *directResponse {
+	return &directResponse{
+		spec: kgateway.DirectResponseSpec{
+			StatusCode: 503,
+			Body:       ptr.To("service unavailable"),
+			BodyFormat: &shared.BodyFormat{
+				ContentType: ptr.To("text/plain"),
+				Text:        ptr.To("oops"),
+			},
+		},
+	}
+}
+
+func TestHarnessDirectResponseEquals(t *testing.T) {
+	cases := []equalstest.Case[*directResponse]{
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.StatusCode = 500 },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.Body = ptr.To("different body") },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.Body = nil },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.BodyFormat.ContentType = ptr.To("application/json") },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.BodyFormat = nil },
+		},
+	}
+
+	equalstest.Run(
+		t,
+		baseHarnessDirectResponse,
+		func(a, b *directResponse) bool { return a.Equals(b) },
+		cases,
+		[]string{"ct"}, // +noKrtEquals, direct_response_plugin.go
+		equalstest.IncludeUnexported(),
+	)
+}

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
@@ -1,0 +1,226 @@
+package listenerpolicy
+
+// equality_harness_test.go verifies that HttpListenerPolicyIr.Equals detects a
+// change in every field. Because all fields of HttpListenerPolicyIr are
+// unexported, the harness is run with equalstest.IncludeUnexported so the
+// completeness check still fails when a field is added without a matching
+// Equals comparison — instead of silently dropping Envoy config updates.
+//
+// See test/testutils/equalstest for the harness API.
+
+import (
+	"testing"
+	"time"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoytracev3 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
+	healthcheckv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoyxffv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/original_ip_detection/xff/v3"
+	envoyuuidv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/request_id/uuid/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/utils/ptr"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+// baseHarnessHttpListenerPolicyIr returns a fully-populated HttpListenerPolicyIr
+// so that every field can be mutated to a distinguishable value by a Case below.
+func baseHarnessHttpListenerPolicyIr() *HttpListenerPolicyIr {
+	return &HttpListenerPolicyIr{
+		upgradeConfigs: []*envoy_hcm.HttpConnectionManager_UpgradeConfig{
+			{UpgradeType: "websocket"},
+		},
+		useRemoteAddress:           ptr.To(true),
+		xffNumTrustedHops:          ptr.To(uint32(2)),
+		xffConfig:                  &envoyxffv3.XffConfig{XffNumTrustedHops: 1},
+		skipXffAppend:              ptr.To(true),
+		serverHeaderTransformation: ptr.To(envoy_hcm.HttpConnectionManager_OVERWRITE),
+		streamIdleTimeout:          ptr.To(5 * time.Second),
+		idleTimeout:                ptr.To(30 * time.Second),
+		http2ProtocolOptions: &envoycorev3.Http2ProtocolOptions{
+			MaxConcurrentStreams: wrapperspb.UInt32(100),
+		},
+		healthCheckPolicy:         &healthcheckv3.HealthCheck{PassThroughMode: wrapperspb.Bool(false)},
+		preserveHttp1HeaderCase:   ptr.To(true),
+		preserveExternalRequestId: ptr.To(true),
+		generateRequestId:         ptr.To(true),
+		accessLogConfig:           []proto.Message{wrapperspb.String("access-log")},
+		accessLogPolicies: []kgateway.AccessLog{
+			{FileSink: &kgateway.FileSink{Path: "/dev/stdout"}},
+		},
+		tracingProvider:      &envoytracev3.OpenTelemetryConfig{ServiceName: "svc"},
+		tracingConfig:        &envoy_hcm.HttpConnectionManager_Tracing{MaxPathTagLength: wrapperspb.UInt32(256)},
+		localReplyConfig:     &envoy_hcm.LocalReplyConfig{},
+		acceptHttp10:         ptr.To(true),
+		defaultHostForHttp10: ptr.To("example.com"),
+		earlyHeaderMutationExtensions: []*envoycorev3.TypedExtensionConfig{
+			{Name: "ext"},
+		},
+		maxRequestHeadersKb:      ptr.To(uint32(96)),
+		maxRequestsPerConnection: ptr.To(uint32(100)),
+		maxHeadersCount:          ptr.To(uint32(100)),
+		uuidRequestIdConfig:      &envoyuuidv3.UuidRequestIdConfig{PackTraceReason: wrapperspb.Bool(true)},
+		forwardClientCertMode:    ptr.To(envoy_hcm.HttpConnectionManager_SANITIZE_SET),
+		setCurrentClientCertDetails: &envoy_hcm.HttpConnectionManager_SetCurrentClientCertDetails{
+			Subject: wrapperspb.Bool(true),
+		},
+		stripHostPortMode: ptr.To(kgateway.StripMatchingHostPortMode),
+	}
+}
+
+// TestHarnessHttpListenerPolicyIrEquals exercises every field of
+// HttpListenerPolicyIr. The reflexivity check (base().Equals(base()), with two
+// independent sets of pointers) also guards the serverHeaderTransformation
+// regression: it compares enum values, not pointer identity.
+func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
+	cases := []equalstest.Case[*HttpListenerPolicyIr]{
+		{
+			Field: "upgradeConfigs",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).upgradeConfigs = []*envoy_hcm.HttpConnectionManager_UpgradeConfig{{UpgradeType: "h2c"}}
+			},
+		},
+		{
+			Field:  "useRemoteAddress",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).useRemoteAddress = ptr.To(false) },
+		},
+		{
+			Field:  "xffNumTrustedHops",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).xffNumTrustedHops = ptr.To(uint32(5)) },
+		},
+		{
+			Field:  "xffConfig",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).xffConfig = &envoyxffv3.XffConfig{XffNumTrustedHops: 9} },
+		},
+		{
+			Field:  "skipXffAppend",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).skipXffAppend = ptr.To(false) },
+		},
+		{
+			Field: "serverHeaderTransformation",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).serverHeaderTransformation = ptr.To(envoy_hcm.HttpConnectionManager_APPEND_IF_ABSENT)
+			},
+		},
+		{
+			Field:  "streamIdleTimeout",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).streamIdleTimeout = ptr.To(10 * time.Second) },
+		},
+		{
+			Field:  "idleTimeout",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).idleTimeout = ptr.To(60 * time.Second) },
+		},
+		{
+			Field: "http2ProtocolOptions",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).http2ProtocolOptions = &envoycorev3.Http2ProtocolOptions{MaxConcurrentStreams: wrapperspb.UInt32(200)}
+			},
+		},
+		{
+			Field: "healthCheckPolicy",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).healthCheckPolicy = &healthcheckv3.HealthCheck{PassThroughMode: wrapperspb.Bool(true)}
+			},
+		},
+		{
+			Field:  "preserveHttp1HeaderCase",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveHttp1HeaderCase = ptr.To(false) },
+		},
+		{
+			Field:  "preserveExternalRequestId",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveExternalRequestId = ptr.To(false) },
+		},
+		{
+			Field:  "generateRequestId",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).generateRequestId = ptr.To(false) },
+		},
+		{
+			Field: "accessLogConfig",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).accessLogConfig = []proto.Message{wrapperspb.String("access-log-2")}
+			},
+		},
+		{
+			Field: "accessLogPolicies",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).accessLogPolicies = []kgateway.AccessLog{{FileSink: &kgateway.FileSink{Path: "/dev/stderr"}}}
+			},
+		},
+		{
+			Field: "tracingProvider",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).tracingProvider = &envoytracev3.OpenTelemetryConfig{ServiceName: "svc-2"}
+			},
+		},
+		{
+			Field: "tracingConfig",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).tracingConfig = &envoy_hcm.HttpConnectionManager_Tracing{MaxPathTagLength: wrapperspb.UInt32(512)}
+			},
+		},
+		{
+			Field:  "localReplyConfig",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).localReplyConfig = nil },
+		},
+		{
+			Field:  "acceptHttp10",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).acceptHttp10 = ptr.To(false) },
+		},
+		{
+			Field:  "defaultHostForHttp10",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).defaultHostForHttp10 = ptr.To("other.com") },
+		},
+		{
+			Field: "earlyHeaderMutationExtensions",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).earlyHeaderMutationExtensions = []*envoycorev3.TypedExtensionConfig{{Name: "ext-2"}}
+			},
+		},
+		{
+			Field:  "maxRequestHeadersKb",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxRequestHeadersKb = ptr.To(uint32(128)) },
+		},
+		{
+			Field:  "maxRequestsPerConnection",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxRequestsPerConnection = ptr.To(uint32(200)) },
+		},
+		{
+			Field:  "maxHeadersCount",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxHeadersCount = ptr.To(uint32(200)) },
+		},
+		{
+			Field: "uuidRequestIdConfig",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).uuidRequestIdConfig = &envoyuuidv3.UuidRequestIdConfig{PackTraceReason: wrapperspb.Bool(false)}
+			},
+		},
+		{
+			Field: "forwardClientCertMode",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).forwardClientCertMode = ptr.To(envoy_hcm.HttpConnectionManager_FORWARD_ONLY)
+			},
+		},
+		{
+			Field: "setCurrentClientCertDetails",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).setCurrentClientCertDetails = &envoy_hcm.HttpConnectionManager_SetCurrentClientCertDetails{Cert: true}
+			},
+		},
+		{
+			Field:  "stripHostPortMode",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).stripHostPortMode = ptr.To(kgateway.StripAnyHostPortMode) },
+		},
+	}
+
+	equalstest.Run(
+		t,
+		baseHarnessHttpListenerPolicyIr,
+		func(a, b *HttpListenerPolicyIr) bool { return a.Equals(b) },
+		cases,
+		nil,
+		equalstest.IncludeUnexported(),
+	)
+}

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
@@ -20,7 +20,6 @@ import (
 	envoyuuidv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/request_id/uuid/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	"k8s.io/utils/ptr"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
@@ -33,20 +32,20 @@ func baseHarnessHttpListenerPolicyIr() *HttpListenerPolicyIr {
 		upgradeConfigs: []*envoy_hcm.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
 		},
-		useRemoteAddress:           ptr.To(true),
-		xffNumTrustedHops:          ptr.To(uint32(2)),
+		useRemoteAddress:           new(true),
+		xffNumTrustedHops:          new(uint32(2)),
 		xffConfig:                  &envoyxffv3.XffConfig{XffNumTrustedHops: 1},
-		skipXffAppend:              ptr.To(true),
-		serverHeaderTransformation: ptr.To(envoy_hcm.HttpConnectionManager_OVERWRITE),
-		streamIdleTimeout:          ptr.To(5 * time.Second),
-		idleTimeout:                ptr.To(30 * time.Second),
+		skipXffAppend:              new(true),
+		serverHeaderTransformation: new(envoy_hcm.HttpConnectionManager_OVERWRITE),
+		streamIdleTimeout:          new(5 * time.Second),
+		idleTimeout:                new(30 * time.Second),
 		http2ProtocolOptions: &envoycorev3.Http2ProtocolOptions{
 			MaxConcurrentStreams: wrapperspb.UInt32(100),
 		},
 		healthCheckPolicy:         &healthcheckv3.HealthCheck{PassThroughMode: wrapperspb.Bool(false)},
-		preserveHttp1HeaderCase:   ptr.To(true),
-		preserveExternalRequestId: ptr.To(true),
-		generateRequestId:         ptr.To(true),
+		preserveHttp1HeaderCase:   new(true),
+		preserveExternalRequestId: new(true),
+		generateRequestId:         new(true),
 		accessLogConfig:           []proto.Message{wrapperspb.String("access-log")},
 		accessLogPolicies: []kgateway.AccessLog{
 			{FileSink: &kgateway.FileSink{Path: "/dev/stdout"}},
@@ -54,20 +53,20 @@ func baseHarnessHttpListenerPolicyIr() *HttpListenerPolicyIr {
 		tracingProvider:      &envoytracev3.OpenTelemetryConfig{ServiceName: "svc"},
 		tracingConfig:        &envoy_hcm.HttpConnectionManager_Tracing{MaxPathTagLength: wrapperspb.UInt32(256)},
 		localReplyConfig:     &envoy_hcm.LocalReplyConfig{},
-		acceptHttp10:         ptr.To(true),
-		defaultHostForHttp10: ptr.To("example.com"),
+		acceptHttp10:         new(true),
+		defaultHostForHttp10: new("example.com"),
 		earlyHeaderMutationExtensions: []*envoycorev3.TypedExtensionConfig{
 			{Name: "ext"},
 		},
-		maxRequestHeadersKb:      ptr.To(uint32(96)),
-		maxRequestsPerConnection: ptr.To(uint32(100)),
-		maxHeadersCount:          ptr.To(uint32(100)),
+		maxRequestHeadersKb:      new(uint32(96)),
+		maxRequestsPerConnection: new(uint32(100)),
+		maxHeadersCount:          new(uint32(100)),
 		uuidRequestIdConfig:      &envoyuuidv3.UuidRequestIdConfig{PackTraceReason: wrapperspb.Bool(true)},
-		forwardClientCertMode:    ptr.To(envoy_hcm.HttpConnectionManager_SANITIZE_SET),
+		forwardClientCertMode:    new(envoy_hcm.HttpConnectionManager_SANITIZE_SET),
 		setCurrentClientCertDetails: &envoy_hcm.HttpConnectionManager_SetCurrentClientCertDetails{
 			Subject: wrapperspb.Bool(true),
 		},
-		stripHostPortMode: ptr.To(kgateway.StripMatchingHostPortMode),
+		stripHostPortMode: new(kgateway.StripMatchingHostPortMode),
 	}
 }
 
@@ -85,11 +84,11 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		},
 		{
 			Field:  "useRemoteAddress",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).useRemoteAddress = ptr.To(false) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).useRemoteAddress = new(false) },
 		},
 		{
 			Field:  "xffNumTrustedHops",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).xffNumTrustedHops = ptr.To(uint32(5)) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).xffNumTrustedHops = new(uint32(5)) },
 		},
 		{
 			Field:  "xffConfig",
@@ -97,21 +96,21 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		},
 		{
 			Field:  "skipXffAppend",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).skipXffAppend = ptr.To(false) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).skipXffAppend = new(false) },
 		},
 		{
 			Field: "serverHeaderTransformation",
 			Mutate: func(d **HttpListenerPolicyIr) {
-				(*d).serverHeaderTransformation = ptr.To(envoy_hcm.HttpConnectionManager_APPEND_IF_ABSENT)
+				(*d).serverHeaderTransformation = new(envoy_hcm.HttpConnectionManager_APPEND_IF_ABSENT)
 			},
 		},
 		{
 			Field:  "streamIdleTimeout",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).streamIdleTimeout = ptr.To(10 * time.Second) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).streamIdleTimeout = new(10 * time.Second) },
 		},
 		{
 			Field:  "idleTimeout",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).idleTimeout = ptr.To(60 * time.Second) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).idleTimeout = new(60 * time.Second) },
 		},
 		{
 			Field: "http2ProtocolOptions",
@@ -127,15 +126,15 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		},
 		{
 			Field:  "preserveHttp1HeaderCase",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveHttp1HeaderCase = ptr.To(false) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveHttp1HeaderCase = new(false) },
 		},
 		{
 			Field:  "preserveExternalRequestId",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveExternalRequestId = ptr.To(false) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveExternalRequestId = new(false) },
 		},
 		{
 			Field:  "generateRequestId",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).generateRequestId = ptr.To(false) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).generateRequestId = new(false) },
 		},
 		{
 			Field: "accessLogConfig",
@@ -167,11 +166,11 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		},
 		{
 			Field:  "acceptHttp10",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).acceptHttp10 = ptr.To(false) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).acceptHttp10 = new(false) },
 		},
 		{
 			Field:  "defaultHostForHttp10",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).defaultHostForHttp10 = ptr.To("other.com") },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).defaultHostForHttp10 = new("other.com") },
 		},
 		{
 			Field: "earlyHeaderMutationExtensions",
@@ -181,15 +180,15 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		},
 		{
 			Field:  "maxRequestHeadersKb",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxRequestHeadersKb = ptr.To(uint32(128)) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxRequestHeadersKb = new(uint32(128)) },
 		},
 		{
 			Field:  "maxRequestsPerConnection",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxRequestsPerConnection = ptr.To(uint32(200)) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxRequestsPerConnection = new(uint32(200)) },
 		},
 		{
 			Field:  "maxHeadersCount",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxHeadersCount = ptr.To(uint32(200)) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxHeadersCount = new(uint32(200)) },
 		},
 		{
 			Field: "uuidRequestIdConfig",
@@ -200,7 +199,7 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		{
 			Field: "forwardClientCertMode",
 			Mutate: func(d **HttpListenerPolicyIr) {
-				(*d).forwardClientCertMode = ptr.To(envoy_hcm.HttpConnectionManager_FORWARD_ONLY)
+				(*d).forwardClientCertMode = new(envoy_hcm.HttpConnectionManager_FORWARD_ONLY)
 			},
 		},
 		{
@@ -211,7 +210,7 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		},
 		{
 			Field:  "stripHostPortMode",
-			Mutate: func(d **HttpListenerPolicyIr) { (*d).stripHostPortMode = ptr.To(kgateway.StripAnyHostPortMode) },
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).stripHostPortMode = new(kgateway.StripAnyHostPortMode) },
 		},
 	}
 

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
@@ -141,7 +141,7 @@ func (d *HttpListenerPolicyIr) Equals(in any) bool {
 	}
 
 	// Check serverHeaderTransformation
-	if d.serverHeaderTransformation != d2.serverHeaderTransformation {
+	if !cmputils.PointerValsEqual(d.serverHeaderTransformation, d2.serverHeaderTransformation) {
 		return false
 	}
 

--- a/test/testutils/equalstest/equalstest.go
+++ b/test/testutils/equalstest/equalstest.go
@@ -8,6 +8,22 @@ import (
 	"testing"
 )
 
+// Option configures the behavior of Run.
+type Option func(*config)
+
+type config struct {
+	includeUnexported bool
+}
+
+// IncludeUnexported makes the completeness check consider unexported fields in
+// addition to exported ones. Use it for IR types whose fields are all
+// unexported (e.g. plugin-internal PolicyIRs), where the default
+// exported-only check would enforce nothing. The test must live in the same
+// package as T so its Mutate closures can reach those fields.
+func IncludeUnexported() Option {
+	return func(c *config) { c.includeUnexported = true }
+}
+
 // Case mutates one logical field of T and states whether Equals must
 // report inequality afterwards.
 type Case[T any] struct {
@@ -29,8 +45,13 @@ type Case[T any] struct {
 //
 // T must be a struct or a pointer to a struct; pointers are dereferenced one
 // level before field reflection.
-func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []Case[T], exempt []string) {
+func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []Case[T], exempt []string, opts ...Option) {
 	t.Helper()
+
+	cfg := config{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
 	// 1. Reflexivity check: two identical base instances must be equal.
 	t.Run("reflexivity", func(t *testing.T) {
@@ -78,7 +99,7 @@ func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []C
 		t.Fatalf("equalstest.Run: type %s is not a struct or pointer to struct", typ)
 	}
 
-	missing := uncoveredFields(typ, covered, exemptSet)
+	missing := uncoveredFields(typ, covered, exemptSet, cfg.includeUnexported)
 	if len(missing) > 0 {
 		t.Errorf(
 			"completeness check failed for %s: exported field(s) %v are neither covered by a mutation Case nor listed as exempt — add a Case or add the field name to exempt",
@@ -91,9 +112,9 @@ func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []C
 // uncoveredFields returns the exported field names of typ that are not present
 // in covered or exempt. It flattens anonymous (embedded) struct fields one
 // level deep, matching the same logic used by Run's completeness check.
-func uncoveredFields(typ reflect.Type, covered map[string]bool, exempt map[string]bool) []string {
+func uncoveredFields(typ reflect.Type, covered map[string]bool, exempt map[string]bool, includeUnexported bool) []string {
 	var missing []string
-	for _, field := range exportedFields(typ) {
+	for _, field := range candidateFields(typ, includeUnexported) {
 		if !covered[field] && !exempt[field] {
 			missing = append(missing, field)
 		}
@@ -101,19 +122,21 @@ func uncoveredFields(typ reflect.Type, covered map[string]bool, exempt map[strin
 	return missing
 }
 
-// exportedFields returns all exported field names of a struct type, flattening
-// anonymous (embedded) struct fields one level deep.
-func exportedFields(t reflect.Type) []string {
+// candidateFields returns the field names of a struct type that the
+// completeness check should cover, flattening anonymous (embedded) struct
+// fields one level deep. Unexported fields are included only when
+// includeUnexported is set.
+func candidateFields(t reflect.Type, includeUnexported bool) []string {
 	var names []string
 	for f := range t.Fields() {
-		if !f.IsExported() {
+		if !f.IsExported() && !includeUnexported {
 			continue
 		}
 		if f.Anonymous && f.Type.Kind() == reflect.Struct {
 			// Flatten embedded struct fields one level.
 			embedded := f.Type
 			for ef := range embedded.Fields() {
-				if ef.IsExported() {
+				if ef.IsExported() || includeUnexported {
 					names = append(names, ef.Name)
 				}
 			}

--- a/test/testutils/equalstest/equalstest_internal_test.go
+++ b/test/testutils/equalstest/equalstest_internal_test.go
@@ -26,7 +26,7 @@ func TestUncoveredFields_UncoveredFieldIsFlagged(t *testing.T) {
 	exempt := map[string]bool{}
 
 	// "Embedded" comes from flattening EmbeddedBase; it is not in covered or exempt.
-	missing := uncoveredFields(typ, covered, exempt)
+	missing := uncoveredFields(typ, covered, exempt, false)
 	if len(missing) != 1 || missing[0] != "Embedded" {
 		t.Errorf("expected [Embedded] to be uncovered, got %v", missing)
 	}
@@ -37,7 +37,7 @@ func TestUncoveredFields_ExemptFieldIsNotFlagged(t *testing.T) {
 	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
 	exempt := map[string]bool{"Embedded": true}
 
-	missing := uncoveredFields(typ, covered, exempt)
+	missing := uncoveredFields(typ, covered, exempt, false)
 	if len(missing) != 0 {
 		t.Errorf("expected no uncovered fields when Embedded is exempt, got %v", missing)
 	}
@@ -52,7 +52,7 @@ func TestUncoveredFields_EmbeddedStructNameAlsoReturned(t *testing.T) {
 	// exportedFields emits both "Embedded" (flattened) and "EmbeddedBase" (the
 	// embedding name itself). With covered containing only "Embedded",
 	// "EmbeddedBase" must appear as uncovered.
-	missing := uncoveredFields(typ, covered, exempt)
+	missing := uncoveredFields(typ, covered, exempt, false)
 	if len(missing) != 1 || missing[0] != "EmbeddedBase" {
 		t.Errorf("expected [EmbeddedBase] to be uncovered, got %v", missing)
 	}
@@ -64,8 +64,48 @@ func TestUncoveredFields_AllCoveredReturnsEmpty(t *testing.T) {
 	covered := map[string]bool{"Plain": true, "Embedded": true, "EmbeddedBase": true}
 	exempt := map[string]bool{}
 
-	missing := uncoveredFields(typ, covered, exempt)
+	missing := uncoveredFields(typ, covered, exempt, false)
 	if len(missing) != 0 {
 		t.Errorf("expected no uncovered fields, got %v", missing)
+	}
+}
+
+// unexportedFixture has only unexported fields, modelling a plugin-internal
+// PolicyIR.
+type unexportedFixture struct {
+	exported   string //nolint:unused // referenced only via reflection
+	hidden     int    //nolint:unused // referenced only via reflection
+	alsoHidden bool   //nolint:unused // referenced only via reflection
+}
+
+func TestUncoveredFields_UnexportedSkippedByDefault(t *testing.T) {
+	typ := reflect.TypeFor[unexportedFixture]()
+	covered := map[string]bool{}
+	exempt := map[string]bool{}
+
+	// Without includeUnexported, unexported fields are not candidates, so
+	// nothing is flagged even with an empty cover set.
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields when unexported are skipped, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_UnexportedIncludedWhenRequested(t *testing.T) {
+	typ := reflect.TypeFor[unexportedFixture]()
+	covered := map[string]bool{"hidden": true}
+	exempt := map[string]bool{}
+
+	// With includeUnexported, all unexported fields are candidates; the two not
+	// covered must be flagged.
+	missing := uncoveredFields(typ, covered, exempt, true)
+	want := map[string]bool{"exported": true, "alsoHidden": true}
+	if len(missing) != len(want) {
+		t.Fatalf("expected %d uncovered fields, got %v", len(want), missing)
+	}
+	for _, m := range missing {
+		if !want[m] {
+			t.Errorf("unexpected uncovered field %q (got %v)", m, missing)
+		}
 	}
 }


### PR DESCRIPTION
# Description

Fixes two `Equals` implementations that compared pointer-bearing fields by **pointer identity** instead of by value. Because these IRs are rebuilt from freshly-decoded objects on every recompute, equal content gets distinct pointers, so `Equals` spuriously reports inequality and triggers needless re-translation.

### 1. `HttpListenerPolicyIr.Equals` (`listenerpolicy/http.go`)

`serverHeaderTransformation` was compared with `!=` (pointer identity) rather than by value. Switched to `cmputils.PointerValsEqual`, matching the other pointer fields in the method.

Also added an `Equals` harness test covering **every** field of `HttpListenerPolicyIr`, modeled on `pkg/pluginsdk/ir/equality_harness_test.go`. The harness's `reflexivity` subtest (`base().Equals(base())` over two independent sets of pointers) directly guards the fixed bug.

Because all fields of `HttpListenerPolicyIr` are unexported, the harness's completeness check (which fails when a field is added without updating `Equals`) would otherwise enforce nothing. So this extends the shared `equalstest` harness with a non-breaking variadic `IncludeUnexported()` option; existing callers are unaffected.

### 2. `directResponse.Equals` (`directresponse/direct_response_plugin.go`)

Found while auditing every `Equals` method across the plugin packages for the same bug class. `directResponse.Equals` did `d.spec == d2.spec`, but `DirectResponseSpec` has pointer fields (`Body *string`, `BodyFormat *shared.BodyFormat`), so struct `==` compared those by pointer identity. Switched to value comparison with `reflect.DeepEqual` — `DirectResponseSpec` is a plain (non-proto) API type, consistent with how the core IR package compares such structs (`pkg/pluginsdk/ir/gatewayextension.go`, `backend.go`). Added a harness test whose reflexivity check guards the regression.

### Changes

- `pkg/kgateway/extensions2/plugins/listenerpolicy/http.go`: use `cmputils.PointerValsEqual` for `serverHeaderTransformation`.
- `pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go`: new harness test, one mutation case per field (28 fields) plus reflexivity/symmetry/completeness.
- `pkg/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go`: compare spec by value.
- `pkg/kgateway/extensions2/plugins/directresponse/equality_harness_test.go`: new harness test.
- `test/testutils/equalstest/equalstest.go`: add `IncludeUnexported()` option (variadic, backwards compatible).
- `test/testutils/equalstest/equalstest_internal_test.go`: tests for the new option.

# Change Type

/kind fix

# Changelog

```release-note
Fixed two HTTPListenerPolicy/DirectResponse cases where an IR field could be compared by pointer identity instead of value, causing spurious re-translations.
```

## Additional Notes

Verified each harness catches its regression: temporarily reverting either fix makes the corresponding `reflexivity` subtest fail ("Equals(base(), base()) returned false"), then pass once restored.

Audit also surfaced (reviewed, intentionally not changed): a deliberate `+krtEqualsTodo` on `TrafficPolicyGatewayExtensionIR.Name`, an existing `reflect.DeepEqual` on `FilterStage` (behaviorally correct), and a latent (currently unreachable) nil-deref in `oauthIR.Equals`. The other ~38 `Equals` methods are clean.
