### PR TITLE
serviceentry: drain Terminating pods from ServiceEntry-derived endpoints

### DIFF
--- a/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
@@ -329,10 +329,9 @@ func selectedWorkloadFromEntry(
 			Addresses:       []string{weSpec.GetAddress()},
 			// WorkloadEntry / inline endpoints have no pod readiness or termination
 			// concept; their health is managed by the remote cluster (e.g. cross-network
-			// endpoints), so treat them as ready, never terminating, and never filter
-			// them on local pod readiness/termination.
-			Ready:       true,
-			Terminating: false,
+			// endpoints), so treat them as ready and never filter them on local pod
+			// readiness/termination. Terminating is left at its false zero value.
+			Ready: true,
 		},
 
 		weight:      weSpec.GetWeight(),

--- a/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
@@ -327,10 +327,12 @@ func selectedWorkloadFromEntry(
 			Locality:        locality,
 			AugmentedLabels: labels,
 			Addresses:       []string{weSpec.GetAddress()},
-			// WorkloadEntry / inline endpoints have no pod readiness concept; their
-			// health is managed by the remote cluster (e.g. cross-network endpoints),
-			// so treat them as ready and never filter them on readiness.
-			Ready: true,
+			// WorkloadEntry / inline endpoints have no pod readiness or termination
+			// concept; their health is managed by the remote cluster (e.g. cross-network
+			// endpoints), so treat them as ready, never terminating, and never filter
+			// them on local pod readiness/termination.
+			Ready:       true,
+			Terminating: false,
 		},
 
 		weight:      weSpec.GetWeight(),

--- a/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/endpoints.go
@@ -118,13 +118,16 @@ func endpointsFromWorkloads(
 
 	eps := ir.NewEndpointsForBackend(be)
 	for _, workload := range workloads {
-		// Skip NotReady pod-backed workloads so that ingress (and any other
-		// ServiceEntry consumer) does not send traffic to pods that Kubernetes has
-		// marked NotReady. This mirrors the EndpointSlice-based Service path, which
-		// skips endpoints whose Ready condition is not true, and lets locality
-		// failover promote endpoints in a peer cluster when all local pods are
-		// NotReady. WorkloadEntry and inline endpoints set Ready=true.
-		if !workload.Ready {
+		// Skip NotReady or Terminating pod-backed workloads so that ingress (and any
+		// other ServiceEntry consumer) does not send traffic to pods that Kubernetes
+		// has marked NotReady or has begun draining (a deletionTimestamp is set). This
+		// mirrors the EndpointSlice-based Service path, which skips endpoints whose
+		// Ready condition is not true (terminating endpoints included), and lets
+		// locality failover promote endpoints in a peer cluster when all local pods
+		// are NotReady or terminating. A terminating pod keeps its Ready condition True
+		// through its grace period, so Terminating must be checked separately from
+		// Ready. WorkloadEntry and inline endpoints set Ready=true, Terminating=false.
+		if !workload.Ready || workload.Terminating {
 			continue
 		}
 

--- a/pkg/kgateway/extensions2/plugins/serviceentry/endpoints_test.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/endpoints_test.go
@@ -75,3 +75,72 @@ func TestEndpointsFromWorkloads_SkipsNotReadyPods(t *testing.T) {
 	assert.False(t, got["10.0.0.2"], "NotReady pod endpoint should be excluded")
 	assert.Len(t, got, 2, "exactly the Ready pod and the WorkloadEntry endpoint should remain")
 }
+
+// TestEndpointsFromWorkloads_SkipsTerminatingPods verifies that endpointsFromWorkloads
+// excludes pod-backed workloads that are Terminating even though they are still Ready
+// (a terminating pod keeps its Ready condition True through its grace period), while
+// keeping Ready non-terminating pods and WorkloadEntry/inline endpoints (which are
+// always treated as Ready and never terminating). This is the behavior that lets
+// ingress drain a terminating local pod and fail over to a peer cluster, matching the
+// EndpointSlice/Service path and ztunnel.
+func TestEndpointsFromWorkloads_SkipsTerminatingPods(t *testing.T) {
+	se := &networkingclient.ServiceEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "autogen.server.server", Namespace: "istio-system"},
+		Spec: networking.ServiceEntry{
+			Hosts:      []string{"server.server.mesh.internal"},
+			Location:   networking.ServiceEntry_MESH_INTERNAL,
+			Resolution: networking.ServiceEntry_STATIC,
+			Ports: []*networking.ServicePort{
+				{Name: "http", Number: 80, Protocol: "HTTP", TargetPort: 9898},
+			},
+		},
+	}
+	be := BuildServiceEntryBackendObjectIR(se, "server.server.mesh.internal", 80, "HTTP", nil)
+
+	podWorkload := func(name, ip string, ready, terminating bool) selectedWorkload {
+		return selectedWorkload{
+			LocalityPod: krtcollections.LocalityPod{
+				Named:           krt.Named{Name: name, Namespace: "server"},
+				Addresses:       []string{ip},
+				AugmentedLabels: map[string]string{"app": "server"},
+				Ready:           ready,
+				Terminating:     terminating,
+			},
+		}
+	}
+
+	// A WorkloadEntry-backed workload (e.g. a cross-cluster endpoint). These have no
+	// pod readiness/termination concept; selectedWorkloadFromEntry marks them Ready=true
+	// and Terminating=false, so they must never be dropped by local pod state.
+	weWorkload := selectedWorkloadFromEntry(
+		"cross-cluster", "server",
+		nil, nil, nil,
+		&networking.WorkloadEntry{Address: "10.0.0.3"},
+		nil,
+	)
+	assert.True(t, weWorkload.Ready, "WorkloadEntry-backed workloads must be treated as Ready")
+	assert.False(t, weWorkload.Terminating, "WorkloadEntry-backed workloads must never be Terminating")
+
+	workloads := []selectedWorkload{
+		podWorkload("ready-pod", "10.0.0.1", true, false),
+		// Ready=true but Terminating=true: the terminating-pod case.
+		podWorkload("terminating-pod", "10.0.0.2", true, true),
+		weWorkload,
+	}
+
+	eps := endpointsFromWorkloads(se, be, workloads)
+	assert.NotNil(t, eps)
+
+	got := map[string]bool{}
+	for _, lbeps := range eps.LbEps {
+		for _, emd := range lbeps {
+			addr := emd.GetEndpoint().GetAddress().GetSocketAddress().GetAddress()
+			got[addr] = true
+		}
+	}
+
+	assert.True(t, got["10.0.0.1"], "Ready non-terminating pod endpoint should be included")
+	assert.True(t, got["10.0.0.3"], "WorkloadEntry endpoint should be included")
+	assert.False(t, got["10.0.0.2"], "Terminating pod endpoint should be excluded even though Ready=true")
+	assert.Len(t, got, 2, "exactly the Ready pod and the WorkloadEntry endpoint should remain")
+}

--- a/pkg/krtcollections/pods.go
+++ b/pkg/krtcollections/pods.go
@@ -133,6 +133,15 @@ type LocalityPod struct {
 	// Synthetic LocalityPods built from WorkloadEntries / inline endpoints set this
 	// to true, since pod readiness does not apply to them.
 	Ready bool
+	// Terminating reflects whether the pod has begun terminating (a deletionTimestamp
+	// is set). A terminating pod keeps its Ready condition True for the duration of its
+	// grace period / preStop, so readiness alone does not exclude it; it is excluded
+	// separately so ServiceEntry-derived endpoints drain it, mirroring the EndpointSlice
+	// controller which marks terminating endpoints not-ready, and ztunnel which drains
+	// them. Synthetic LocalityPods built from WorkloadEntries / inline endpoints set
+	// this to false, since pod termination does not apply to them (their health is
+	// managed by the remote cluster).
+	Terminating bool
 }
 
 // Addresses returns the first address if there are any.
@@ -147,6 +156,7 @@ func (c LocalityPod) Equals(in LocalityPod) bool {
 	return c.Named == in.Named &&
 		c.Locality == in.Locality &&
 		c.Ready == in.Ready &&
+		c.Terminating == in.Terminating &&
 		maps.Equal(c.AugmentedLabels, in.AugmentedLabels) &&
 		slices.Equal(c.Addresses, in.Addresses)
 }
@@ -301,6 +311,7 @@ func augmentPodLabels(nodes krt.Collection[NodeMetadata]) func(kctx krt.HandlerC
 			Locality:        l,
 			Addresses:       extractPodIPs(pod),
 			Ready:           isPodReadyConditionTrue(pod.Status),
+			Terminating:     pod.GetDeletionTimestamp() != nil,
 		}
 	}
 }


### PR DESCRIPTION
# Description

North-south traffic through kgateway to a global service (HTTPRoute → Istio `Hostname` backend → ServiceEntry-derived EDS) keeps routing to a **Terminating** local pod for the duration of its termination grace period, instead of failing over to a healthy peer-cluster endpoint. The east-west (ztunnel) path and the plain Kubernetes Service backend path both drain the pod correctly; only the ServiceEntry path does not.

**Root cause.** The ServiceEntry endpoint path filters workloads solely on the pod's `Ready` condition (`LocalityPod.Ready`, derived from `isPodReadyConditionTrue`). A pod that is terminating but still running keeps its `Ready` condition `True` through its `preStop` / grace period — kubelet does not flip it to false on deletion. The other terminal signal, `checkPodTerminal`, only covers `Phase == Failed || Succeeded`, so a `Running` terminating pod is not terminal either. Neither the pod's `deletionTimestamp` nor the EndpointSlice `terminating` condition is consulted. As a result the terminating pod stays in the Envoy EDS at `priority 0, health_flags::healthy`, the cross-cluster tier at `priority 1` is never promoted, and new requests continue to hit the draining pod.

**Change.** Carry a `Terminating` flag on `LocalityPod` (`deletionTimestamp != nil`; `false` for WorkloadEntry/inline/remote endpoints, whose health is managed by the remote cluster) and skip terminating pod-backed workloads in `endpointsFromWorkloads`, extending the existing readiness guard. Scoped to local pods only, so cross-cluster failover targets are never evicted.

# Change Type
/kind fix

# Changelog

```release-note
Fixed north-south traffic to a global service continuing to route to a local pod for the duration of its termination grace period. kgateway now drains a terminating pod (deletionTimestamp set) from ServiceEntry-derived endpoints and fails over to a healthy peer-cluster endpoint, consistent with the east-west (ztunnel) path and the Kubernetes Service backend path.
```

# Additional Notes

Extends the ServiceEntry readiness fix (#14222) to the terminating state. The EndpointSlice-based Service path and ztunnel already drain terminating pods; this brings the ServiceEntry path to parity. Verified with a new unit test (`TestEndpointsFromWorkloads_SkipsTerminatingPods`) and end-to-end on a 2-cluster ambient kind mesh (terminating local pod is removed from the kgateway EDS and N/S fails over to the peer cluster).
