### PR TITLE
[v2.3.x] fix: include retry and timeouts in TrafficPolicy.Validate() (#14320)

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -206,6 +206,8 @@ func (p *TrafficPolicy) Validate() error {
 	validators = append(validators, p.spec.cors.Validate)
 	validators = append(validators, p.spec.headerModifiers.Validate)
 	validators = append(validators, p.spec.buffer.Validate)
+	validators = append(validators, p.spec.retry.Validate)
+	validators = append(validators, p.spec.timeouts.Validate)
 	validators = append(validators, p.spec.autoHostRewrite.Validate)
 	validators = append(validators, p.spec.rbac.Validate)
 	validators = append(validators, p.spec.jwt.Validate)


### PR DESCRIPTION
# Description

Backport of #14320 to the v2.3.x release branch.

`TrafficPolicy.Validate()` was not running the `retry` and `timeouts` sub-validators, so invalid retry/timeout configuration could slip through validation. This adds both validators to the aggregated list, matching the other policy sub-validators.

Cherry-picked from e1a95bdb3f1e582664872df32297b77f1c79ec67.

# Change Type

/kind fix

# Changelog
```release-note
Fixed TrafficPolicy validation to include retry and timeout configuration.
```