### PR TITLE
chore(httproute): remove stale nil check TODO

### DIFF
--- a/pkg/kgateway/translator/httproute/gateway_http_route_translator.go
+++ b/pkg/kgateway/translator/httproute/gateway_http_route_translator.go
@@ -218,7 +218,7 @@ func setRouteAction(
 		}
 
 		httpBackend := ir.HttpBackend{
-			Backend:          *backend.Backend, // TODO: Nil check?
+			Backend:          *backend.Backend,
 			AttachedPolicies: backend.AttachedPolicies,
 		}
 		outputRoute.Backends = append(outputRoute.Backends, httpBackend)


### PR DESCRIPTION
# Description

`RoutesIndex.getBackends` assigns a non-nil `BackendRefIR` to every
non-delegating backend entry, including unresolved references. Delegating entries
are handled separately and continue before `Backend` is dereferenced.

The nil-check TODO in `setRouteAction` is therefore stale, so this removes it
without changing runtime behavior.

Fixes #14040

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

No API or codegen changes.
