### PR TITLE
fix: compare pointer-bearing IR fields by value in Equals (HttpListenerPolicyIr, directResponse) (#14331) [v2.3.x backport]

### DIFF
--- a/pkg/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/directresponse/direct_response_plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -41,7 +42,13 @@ func (d *directResponse) Equals(in any) bool {
 	if !ok {
 		return false
 	}
-	return d.spec == d2.spec
+	// DirectResponseSpec contains pointer fields (Body, BodyFormat), so a struct
+	// `==` would compare those by pointer identity. Because the IR is rebuilt from
+	// a freshly decoded object on every recompute, equal specs get distinct
+	// pointers and `==` would spuriously report inequality, triggering needless
+	// re-translation. DirectResponseSpec is a plain (non-proto) API type, so a
+	// value-based DeepEqual is correct here.
+	return reflect.DeepEqual(d.spec, d2.spec)
 }
 
 type directResponsePluginGwPass struct {

--- a/pkg/kgateway/extensions2/plugins/directresponse/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/directresponse/equality_harness_test.go
@@ -1,0 +1,62 @@
+package directresponse
+
+// equality_harness_test.go verifies that directResponse.Equals detects a change
+// in every field and treats specs with equal content but distinct pointers as
+// equal. The reflexivity subtest guards against comparing DirectResponseSpec's
+// pointer fields (Body, BodyFormat) by identity instead of value.
+//
+// See test/testutils/equalstest for the harness API.
+
+import (
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+func baseHarnessDirectResponse() *directResponse {
+	return &directResponse{
+		spec: kgateway.DirectResponseSpec{
+			StatusCode: 503,
+			Body:       new("service unavailable"),
+			BodyFormat: &kgateway.BodyFormat{
+				ContentType: new("text/plain"),
+				Text:        new("oops"),
+			},
+		},
+	}
+}
+
+func TestHarnessDirectResponseEquals(t *testing.T) {
+	cases := []equalstest.Case[*directResponse]{
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.StatusCode = 500 },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.Body = new("different body") },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.Body = nil },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.BodyFormat.ContentType = new("application/json") },
+		},
+		{
+			Field:  "spec",
+			Mutate: func(d **directResponse) { (*d).spec.BodyFormat = nil },
+		},
+	}
+
+	equalstest.Run(
+		t,
+		baseHarnessDirectResponse,
+		func(a, b *directResponse) bool { return a.Equals(b) },
+		cases,
+		[]string{"ct"}, // +noKrtEquals, direct_response_plugin.go
+		equalstest.IncludeUnexported(),
+	)
+}

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
@@ -1,0 +1,199 @@
+package listenerpolicy
+
+// equality_harness_test.go verifies that HttpListenerPolicyIr.Equals detects a
+// change in every field. Because all fields of HttpListenerPolicyIr are
+// unexported, the harness is run with equalstest.IncludeUnexported so the
+// completeness check still fails when a field is added without a matching
+// Equals comparison — instead of silently dropping Envoy config updates.
+//
+// See test/testutils/equalstest for the harness API.
+
+import (
+	"testing"
+	"time"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoytracev3 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
+	healthcheckv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoyxffv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/http/original_ip_detection/xff/v3"
+	envoyuuidv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/request_id/uuid/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+// baseHarnessHttpListenerPolicyIr returns a fully-populated HttpListenerPolicyIr
+// so that every field can be mutated to a distinguishable value by a Case below.
+func baseHarnessHttpListenerPolicyIr() *HttpListenerPolicyIr {
+	return &HttpListenerPolicyIr{
+		upgradeConfigs: []*envoy_hcm.HttpConnectionManager_UpgradeConfig{
+			{UpgradeType: "websocket"},
+		},
+		useRemoteAddress:           new(true),
+		xffNumTrustedHops:          new(uint32(2)),
+		xffConfig:                  &envoyxffv3.XffConfig{XffNumTrustedHops: 1},
+		skipXffAppend:              new(true),
+		serverHeaderTransformation: new(envoy_hcm.HttpConnectionManager_OVERWRITE),
+		streamIdleTimeout:          new(5 * time.Second),
+		idleTimeout:                new(30 * time.Second),
+		http2ProtocolOptions: &envoycorev3.Http2ProtocolOptions{
+			MaxConcurrentStreams: wrapperspb.UInt32(100),
+		},
+		healthCheckPolicy:         &healthcheckv3.HealthCheck{PassThroughMode: wrapperspb.Bool(false)},
+		preserveHttp1HeaderCase:   new(true),
+		preserveExternalRequestId: new(true),
+		generateRequestId:         new(true),
+		accessLogConfig:           []proto.Message{wrapperspb.String("access-log")},
+		accessLogPolicies: []kgateway.AccessLog{
+			{FileSink: &kgateway.FileSink{Path: "/dev/stdout"}},
+		},
+		tracingProvider:      &envoytracev3.OpenTelemetryConfig{ServiceName: "svc"},
+		tracingConfig:        &envoy_hcm.HttpConnectionManager_Tracing{MaxPathTagLength: wrapperspb.UInt32(256)},
+		acceptHttp10:         new(true),
+		defaultHostForHttp10: new("example.com"),
+		earlyHeaderMutationExtensions: []*envoycorev3.TypedExtensionConfig{
+			{Name: "ext"},
+		},
+		maxRequestHeadersKb: new(uint32(96)),
+		maxHeadersCount:     new(uint32(100)),
+		uuidRequestIdConfig: &envoyuuidv3.UuidRequestIdConfig{PackTraceReason: wrapperspb.Bool(true)},
+		stripHostPortMode:   new(kgateway.StripMatchingHostPortMode),
+	}
+}
+
+// TestHarnessHttpListenerPolicyIrEquals exercises every field of
+// HttpListenerPolicyIr. The reflexivity check (base().Equals(base()), with two
+// independent sets of pointers) also guards the serverHeaderTransformation
+// regression: it compares enum values, not pointer identity.
+func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
+	cases := []equalstest.Case[*HttpListenerPolicyIr]{
+		{
+			Field: "upgradeConfigs",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).upgradeConfigs = []*envoy_hcm.HttpConnectionManager_UpgradeConfig{{UpgradeType: "h2c"}}
+			},
+		},
+		{
+			Field:  "useRemoteAddress",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).useRemoteAddress = new(false) },
+		},
+		{
+			Field:  "xffNumTrustedHops",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).xffNumTrustedHops = new(uint32(5)) },
+		},
+		{
+			Field:  "xffConfig",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).xffConfig = &envoyxffv3.XffConfig{XffNumTrustedHops: 9} },
+		},
+		{
+			Field:  "skipXffAppend",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).skipXffAppend = new(false) },
+		},
+		{
+			Field: "serverHeaderTransformation",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).serverHeaderTransformation = new(envoy_hcm.HttpConnectionManager_APPEND_IF_ABSENT)
+			},
+		},
+		{
+			Field:  "streamIdleTimeout",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).streamIdleTimeout = new(10 * time.Second) },
+		},
+		{
+			Field:  "idleTimeout",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).idleTimeout = new(60 * time.Second) },
+		},
+		{
+			Field: "http2ProtocolOptions",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).http2ProtocolOptions = &envoycorev3.Http2ProtocolOptions{MaxConcurrentStreams: wrapperspb.UInt32(200)}
+			},
+		},
+		{
+			Field: "healthCheckPolicy",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).healthCheckPolicy = &healthcheckv3.HealthCheck{PassThroughMode: wrapperspb.Bool(true)}
+			},
+		},
+		{
+			Field:  "preserveHttp1HeaderCase",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveHttp1HeaderCase = new(false) },
+		},
+		{
+			Field:  "preserveExternalRequestId",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).preserveExternalRequestId = new(false) },
+		},
+		{
+			Field:  "generateRequestId",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).generateRequestId = new(false) },
+		},
+		{
+			Field: "accessLogConfig",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).accessLogConfig = []proto.Message{wrapperspb.String("access-log-2")}
+			},
+		},
+		{
+			Field: "accessLogPolicies",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).accessLogPolicies = []kgateway.AccessLog{{FileSink: &kgateway.FileSink{Path: "/dev/stderr"}}}
+			},
+		},
+		{
+			Field: "tracingProvider",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).tracingProvider = &envoytracev3.OpenTelemetryConfig{ServiceName: "svc-2"}
+			},
+		},
+		{
+			Field: "tracingConfig",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).tracingConfig = &envoy_hcm.HttpConnectionManager_Tracing{MaxPathTagLength: wrapperspb.UInt32(512)}
+			},
+		},
+		{
+			Field:  "acceptHttp10",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).acceptHttp10 = new(false) },
+		},
+		{
+			Field:  "defaultHostForHttp10",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).defaultHostForHttp10 = new("other.com") },
+		},
+		{
+			Field: "earlyHeaderMutationExtensions",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).earlyHeaderMutationExtensions = []*envoycorev3.TypedExtensionConfig{{Name: "ext-2"}}
+			},
+		},
+		{
+			Field:  "maxRequestHeadersKb",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxRequestHeadersKb = new(uint32(128)) },
+		},
+		{
+			Field:  "maxHeadersCount",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).maxHeadersCount = new(uint32(200)) },
+		},
+		{
+			Field: "uuidRequestIdConfig",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).uuidRequestIdConfig = &envoyuuidv3.UuidRequestIdConfig{PackTraceReason: wrapperspb.Bool(false)}
+			},
+		},
+		{
+			Field:  "stripHostPortMode",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).stripHostPortMode = new(kgateway.StripAnyHostPortMode) },
+		},
+	}
+
+	equalstest.Run(
+		t,
+		baseHarnessHttpListenerPolicyIr,
+		func(a, b *HttpListenerPolicyIr) bool { return a.Equals(b) },
+		cases,
+		nil,
+		equalstest.IncludeUnexported(),
+	)
+}

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
@@ -132,7 +132,7 @@ func (d *HttpListenerPolicyIr) Equals(in any) bool {
 	}
 
 	// Check serverHeaderTransformation
-	if d.serverHeaderTransformation != d2.serverHeaderTransformation {
+	if !cmputils.PointerValsEqual(d.serverHeaderTransformation, d2.serverHeaderTransformation) {
 		return false
 	}
 

--- a/test/testutils/equalstest/equalstest.go
+++ b/test/testutils/equalstest/equalstest.go
@@ -1,0 +1,158 @@
+// Package equalstest verifies that an IR type's Equals method detects a
+// change in every exported field, so KRT collections never miss an update.
+package equalstest
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// Option configures the behavior of Run.
+type Option func(*config)
+
+type config struct {
+	includeUnexported bool
+}
+
+// IncludeUnexported makes the completeness check consider unexported fields in
+// addition to exported ones. Use it for IR types whose fields are all
+// unexported (e.g. plugin-internal PolicyIRs), where the default
+// exported-only check would enforce nothing. The test must live in the same
+// package as T so its Mutate closures can reach those fields.
+func IncludeUnexported() Option {
+	return func(c *config) { c.includeUnexported = true }
+}
+
+// Case mutates one logical field of T and states whether Equals must
+// report inequality afterwards.
+type Case[T any] struct {
+	// Field is the exported Go field name this case covers (e.g. "Listeners").
+	// Used to satisfy the completeness check.
+	Field string
+	// Mutate changes that field on the given instance.
+	Mutate func(*T)
+}
+
+// Run builds two fresh instances via base() for each case, applies
+// Mutate to one, and asserts:
+//  1. base().Equals(base()) is true (reflexivity on identical values)
+//  2. after mutation, Equals is false in both directions (detection + symmetry)
+//
+// It then reflects over T's exported fields (flattening embedded structs one
+// level) and fails if any field name is neither covered by a Case nor listed
+// in exempt — that is how "new field, forgot Equals" becomes a test failure.
+//
+// T must be a struct or a pointer to a struct; pointers are dereferenced one
+// level before field reflection.
+func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []Case[T], exempt []string, opts ...Option) {
+	t.Helper()
+
+	cfg := config{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// 1. Reflexivity check: two identical base instances must be equal.
+	t.Run("reflexivity", func(t *testing.T) {
+		t.Helper()
+		a := base()
+		b := base()
+		if !equals(a, b) {
+			t.Errorf("Equals(base(), base()) returned false; two identical instances must be equal")
+		}
+	})
+
+	// 2. Mutation cases: each mutation must cause Equals to return false.
+	for _, c := range cases {
+		t.Run("mutation/"+c.Field, func(t *testing.T) {
+			t.Helper()
+			orig := base()
+			mutated := base()
+			c.Mutate(&mutated)
+
+			if equals(orig, mutated) {
+				t.Errorf("Equals returned true after mutating field %q; Equals must detect this change", c.Field)
+			}
+			// Symmetry: a.Equals(b) must equal b.Equals(a)
+			if equals(mutated, orig) {
+				t.Errorf("Equals is not symmetric: Equals(orig, mutated)=false but Equals(mutated, orig)=true for field %q", c.Field)
+			}
+		})
+	}
+
+	// 3. Completeness check: every exported field of T must appear in a Case or in exempt.
+	covered := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		covered[c.Field] = true
+	}
+	exemptSet := make(map[string]bool, len(exempt))
+	for _, e := range exempt {
+		exemptSet[e] = true
+	}
+
+	typ := reflect.TypeFor[T]()
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		t.Fatalf("equalstest.Run: type %s is not a struct or pointer to struct", typ)
+	}
+
+	missing := uncoveredFields(typ, covered, exemptSet, cfg.includeUnexported)
+	if len(missing) > 0 {
+		t.Errorf(
+			"completeness check failed for %s: exported field(s) %v are neither covered by a mutation Case nor listed as exempt — add a Case or add the field name to exempt",
+			typeName(typ),
+			missing,
+		)
+	}
+}
+
+// uncoveredFields returns the exported field names of typ that are not present
+// in covered or exempt. It flattens anonymous (embedded) struct fields one
+// level deep, matching the same logic used by Run's completeness check.
+func uncoveredFields(typ reflect.Type, covered map[string]bool, exempt map[string]bool, includeUnexported bool) []string {
+	var missing []string
+	for _, field := range candidateFields(typ, includeUnexported) {
+		if !covered[field] && !exempt[field] {
+			missing = append(missing, field)
+		}
+	}
+	return missing
+}
+
+// candidateFields returns the field names of a struct type that the
+// completeness check should cover, flattening anonymous (embedded) struct
+// fields one level deep. Unexported fields are included only when
+// includeUnexported is set.
+func candidateFields(t reflect.Type, includeUnexported bool) []string {
+	var names []string
+	for f := range t.Fields() {
+		if !f.IsExported() && !includeUnexported {
+			continue
+		}
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			// Flatten embedded struct fields one level.
+			embedded := f.Type
+			for ef := range embedded.Fields() {
+				if ef.IsExported() || includeUnexported {
+					names = append(names, ef.Name)
+				}
+			}
+			// Also add the embedded type's own name so the test can explicitly
+			// target the whole embedding as a single field (e.g. "ObjectSource").
+			names = append(names, f.Name)
+			continue
+		}
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func typeName(t reflect.Type) string {
+	if t.PkgPath() != "" {
+		return fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
+	}
+	return t.Name()
+}

--- a/test/testutils/equalstest/equalstest_internal_test.go
+++ b/test/testutils/equalstest/equalstest_internal_test.go
@@ -1,0 +1,111 @@
+// Package equalstest white-box tests for unexported helpers.
+package equalstest
+
+import (
+	"reflect"
+	"testing"
+)
+
+// EmbeddedBase is an exported struct embedded inside internalFixture to test
+// that uncoveredFields flattens one level of anonymous embedding.
+type EmbeddedBase struct {
+	Embedded string
+}
+
+// internalFixture is a local fixture struct with a plain field and an exported
+// embedded struct, used exclusively for testing uncoveredFields.
+type internalFixture struct {
+	Plain string
+	EmbeddedBase
+}
+
+func TestUncoveredFields_UncoveredFieldIsFlagged(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	// Cover Plain and the embedding name EmbeddedBase, but not the flattened field Embedded.
+	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
+	exempt := map[string]bool{}
+
+	// "Embedded" comes from flattening EmbeddedBase; it is not in covered or exempt.
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 1 || missing[0] != "Embedded" {
+		t.Errorf("expected [Embedded] to be uncovered, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_ExemptFieldIsNotFlagged(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
+	exempt := map[string]bool{"Embedded": true}
+
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields when Embedded is exempt, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_EmbeddedStructNameAlsoReturned(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	// Cover the flattened field but leave the embedding name itself uncovered.
+	covered := map[string]bool{"Plain": true, "Embedded": true}
+	exempt := map[string]bool{}
+
+	// exportedFields emits both "Embedded" (flattened) and "EmbeddedBase" (the
+	// embedding name itself). With covered containing only "Embedded",
+	// "EmbeddedBase" must appear as uncovered.
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 1 || missing[0] != "EmbeddedBase" {
+		t.Errorf("expected [EmbeddedBase] to be uncovered, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_AllCoveredReturnsEmpty(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	// Cover every name that exportedFields produces for internalFixture.
+	covered := map[string]bool{"Plain": true, "Embedded": true, "EmbeddedBase": true}
+	exempt := map[string]bool{}
+
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields, got %v", missing)
+	}
+}
+
+// unexportedFixture has only unexported fields, modelling a plugin-internal
+// PolicyIR.
+type unexportedFixture struct {
+	exported   string //nolint:unused // referenced only via reflection
+	hidden     int    //nolint:unused // referenced only via reflection
+	alsoHidden bool   //nolint:unused // referenced only via reflection
+}
+
+func TestUncoveredFields_UnexportedSkippedByDefault(t *testing.T) {
+	typ := reflect.TypeFor[unexportedFixture]()
+	covered := map[string]bool{}
+	exempt := map[string]bool{}
+
+	// Without includeUnexported, unexported fields are not candidates, so
+	// nothing is flagged even with an empty cover set.
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields when unexported are skipped, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_UnexportedIncludedWhenRequested(t *testing.T) {
+	typ := reflect.TypeFor[unexportedFixture]()
+	covered := map[string]bool{"hidden": true}
+	exempt := map[string]bool{}
+
+	// With includeUnexported, all unexported fields are candidates; the two not
+	// covered must be flagged.
+	missing := uncoveredFields(typ, covered, exempt, true)
+	want := map[string]bool{"exported": true, "alsoHidden": true}
+	if len(missing) != len(want) {
+		t.Fatalf("expected %d uncovered fields, got %v", len(want), missing)
+	}
+	for _, m := range missing {
+		if !want[m] {
+			t.Errorf("unexpected uncovered field %q (got %v)", m, missing)
+		}
+	}
+}

--- a/test/testutils/equalstest/equalstest_test.go
+++ b/test/testutils/equalstest/equalstest_test.go
@@ -1,0 +1,115 @@
+package equalstest_test
+
+import (
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+// fixture is a tiny struct used exclusively for testing the harness itself.
+type fixture struct {
+	A string
+	B int
+	// C is deliberately ignored by fixtureEqualsMissingC to simulate a bug.
+	C string
+}
+
+// fixtureEqualsMissingC is a buggy Equals that misses field C.
+func fixtureEqualsMissingC(a, b fixture) bool {
+	return a.A == b.A && a.B == b.B
+}
+
+// fixtureEqualsCorrect compares all fields.
+func fixtureEqualsCorrect(a, b fixture) bool {
+	return a.A == b.A && a.B == b.B && a.C == b.C
+}
+
+func baseFixture() fixture {
+	return fixture{A: "hello", B: 42, C: "world"}
+}
+
+// TestHarnessSelfTest_CorrectEquals verifies that a complete case list over a
+// correct Equals implementation passes without any failures.
+func TestHarnessSelfTest_CorrectEquals(t *testing.T) {
+	cases := []equalstest.Case[fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f *fixture) { f.A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f *fixture) { f.B = 99 },
+		},
+		{
+			Field:  "C",
+			Mutate: func(f *fixture) { f.C = "changed" },
+		},
+	}
+	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, nil)
+}
+
+// TestHarnessSelfTest_ExemptField verifies that listing an uncovered field as
+// exempt prevents the completeness failure.
+func TestHarnessSelfTest_ExemptField(t *testing.T) {
+	cases := []equalstest.Case[fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f *fixture) { f.A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f *fixture) { f.B = 99 },
+		},
+	}
+	// C is listed as exempt; the completeness check must pass without a C Case.
+	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, []string{"C"})
+}
+
+// TestHarnessSelfTest_PointerToStruct verifies the harness accepts a
+// pointer-to-struct type parameter, dereferencing it for the completeness check.
+func TestHarnessSelfTest_PointerToStruct(t *testing.T) {
+	base := func() *fixture {
+		f := baseFixture()
+		return &f
+	}
+	equals := func(a, b *fixture) bool { return fixtureEqualsCorrect(*a, *b) }
+	cases := []equalstest.Case[*fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f **fixture) { (*f).A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f **fixture) { (*f).B = 99 },
+		},
+		{
+			Field:  "C",
+			Mutate: func(f **fixture) { (*f).C = "changed" },
+		},
+	}
+	equalstest.Run(t, base, equals, cases, nil)
+}
+
+// TestHarnessSelfTest_FixtureSanity validates the fixture functions themselves
+// so that higher-level tests can rely on them. In particular it confirms that
+// fixtureEqualsMissingC genuinely misses field C (modelling the bug) and that
+// fixtureEqualsCorrect catches it.
+func TestHarnessSelfTest_FixtureSanity(t *testing.T) {
+	t.Run("buggy_equals_misses_C", func(t *testing.T) {
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.C = "changed"
+		if !fixtureEqualsMissingC(orig, mutated) {
+			t.Error("expected fixtureEqualsMissingC to miss the C change, but it detected it")
+		}
+	})
+
+	t.Run("correct_equals_detects_C", func(t *testing.T) {
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.C = "changed"
+		if fixtureEqualsCorrect(orig, mutated) {
+			t.Error("expected fixtureEqualsCorrect to detect change in C, but it returned true")
+		}
+	})
+}


### PR DESCRIPTION
# Description

Backport of #14331 to `v2.3.x`.

Fixes two `Equals` methods on IR types that compared pointer-bearing fields by pointer identity instead of by value. Because these IRs are rebuilt from freshly decoded objects on every KRT recompute, equal-content specs get distinct pointers, so identity comparison spuriously reported inequality and triggered needless re-translation:

- `directResponse.Equals` compared `DirectResponseSpec` with `==`; `DirectResponseSpec` has pointer fields (`Body`, `BodyFormat`). Now uses a value-based `reflect.DeepEqual` (it is a plain, non-proto API type).
- `HttpListenerPolicyIr.Equals` compared `serverHeaderTransformation` (a `*enum`) with `!=`. Now uses `cmputils.PointerValsEqual`.

Also backports the `test/testutils/equalstest` completeness-harness and per-plugin harness tests that guard against this class of regression.

### Backport adaptations

The harness tests were written against `main`'s IR shape and were adapted to `v2.3.x`:

- `directResponse`'s `BodyFormat` lives in `api/v1alpha1/kgateway` on this branch (not `api/v1alpha1/shared`).
- `HttpListenerPolicyIr` on `v2.3.x` does not have the `localReplyConfig`, `maxRequestsPerConnection`, `forwardClientCertMode`, or `setCurrentClientCertDetails` fields, so those harness cases were dropped. All 24 fields present on `v2.3.x` are covered.

The source fix itself applied cleanly.

# Change Type

/kind fix

# Changelog 

```release-note
Fixed HttpListenerPolicy and DirectResponse being re-translated unnecessarily because their IR Equals methods compared pointer-bearing fields by identity instead of by value.
```
