### PR TITLE
test(nightly): various skipping and deflaking

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -159,15 +159,18 @@ jobs:
       # v2.2.x is built against Gateway API 1.4 and refuses to start on 1.5 (#13872), so the
       # v2.2.x x v1.5.1 lanes need special handling: skip the standard channel entirely, and
       # run the experimental channel with the version check bypassed to keep forward-compat
-      # signal. This is done with step guards rather than a matrix `exclude:` because every
-      # dimension here is object-valued and object-valued excludes are unreliable
-      # (actions/runner#1512).
+      # signal. The experimental channel is further limited to the max lane: Gateway API 1.5.1
+      # experimental CRDs use the isIP() CEL function, added in Kubernetes 1.31, but the min
+      # lane runs k8s 1.30, so the CRDs cannot install there. This is done with step guards
+      # rather than a matrix `exclude:` because every dimension here is object-valued and
+      # object-valued excludes are unreliable (actions/runner#1512).
       - name: Determine run plan
         id: guard
         env:
           REF: ${{ matrix.ref.checkout_ref }}
           GW_API_VERSION: ${{ matrix.gateway-api-version.version }}
           GW_API_CHANNEL: ${{ matrix.gateway-api-version.channel }}
+          VERSIONS_LABEL: ${{ matrix.env-versions.label }}
         shell: bash
         run: |
           run=true
@@ -175,12 +178,19 @@ jobs:
           if [[ "${REF}" == "v2.2.x" && "${GW_API_VERSION}" == "v1.5.1" ]]; then
             case "${GW_API_CHANNEL}" in
               standard)     run=false ;;
-              experimental) bypass_version_check=true ;;
+              experimental)
+                if [[ "${VERSIONS_LABEL}" == "min" ]]; then
+                  # k8s 1.30 lacks the isIP() CEL function required by the 1.5.1 experimental CRDs.
+                  run=false
+                else
+                  bypass_version_check=true
+                fi
+                ;;
             esac
           fi
           echo "run=${run}" >> "${GITHUB_OUTPUT}"
           echo "bypass_version_check=${bypass_version_check}" >> "${GITHUB_OUTPUT}"
-          echo "ref=${REF} gw-api=${GW_API_VERSION}-${GW_API_CHANNEL} -> run=${run} bypass_version_check=${bypass_version_check}"
+          echo "ref=${REF} gw-api=${GW_API_VERSION}-${GW_API_CHANNEL} versions=${VERSIONS_LABEL} -> run=${run} bypass_version_check=${bypass_version_check}"
       # Bake KGW_SKIP_GATEWAY_API_VERSION_CHECK into the chart before setup-kind-cluster
       # packages it (hack/kind/setup-kind.sh runs `make package-kgateway-charts` from source),
       # so the controller starts despite the unsupported Gateway API version.

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -159,11 +159,15 @@ jobs:
       # v2.2.x is built against Gateway API 1.4 and refuses to start on 1.5 (#13872), so the
       # v2.2.x x v1.5.1 lanes need special handling: skip the standard channel entirely, and
       # run the experimental channel with the version check bypassed to keep forward-compat
-      # signal. The experimental channel is further limited to the max lane: Gateway API 1.5.1
-      # experimental CRDs use the isIP() CEL function, added in Kubernetes 1.31, but the min
-      # lane runs k8s 1.30, so the CRDs cannot install there. This is done with step guards
-      # rather than a matrix `exclude:` because every dimension here is object-valued and
-      # object-valued excludes are unreliable (actions/runner#1512).
+      # signal. The experimental channel is further limited to the max lane: the Gateway API
+      # 1.5.1 experimental CRDs use the isIP() CEL function (added in Kubernetes 1.31), but
+      # v2.2.x's min lane currently runs k8s 1.30, so those CRDs fail to install there.
+      # (main/v2.3.x min lanes run k8s 1.31+, which is why only v2.2.x is skipped.) The
+      # per-lane Kubernetes versions live in .github/workflows/.env/nightly-tests/; the guard
+      # keys off the min/max label, so if v2.2.x's min lane is bumped to >=1.31 this skip can
+      # be dropped. This is done with step guards rather than a matrix `exclude:` because every
+      # dimension here is object-valued and object-valued excludes are unreliable
+      # (actions/runner#1512).
       - name: Determine run plan
         id: guard
         env:
@@ -180,7 +184,8 @@ jobs:
               standard)     run=false ;;
               experimental)
                 if [[ "${VERSIONS_LABEL}" == "min" ]]; then
-                  # k8s 1.30 lacks the isIP() CEL function required by the 1.5.1 experimental CRDs.
+                  # v2.2.x's min lane currently runs k8s 1.30, which lacks the isIP() CEL
+                  # function (added in k8s 1.31) the 1.5.1 experimental CRDs require.
                   run=false
                 else
                   bypass_version_check=true

--- a/test/e2e/features/http_acl/suite.go
+++ b/test/e2e/features/http_acl/suite.go
@@ -458,7 +458,10 @@ func (s *testingSuite) TestHttpACLDynamicMetadata() {
 		assert.Contains(c, logs, `"blocked_by":"block-internal-range"`)
 		assert.Contains(c, logs, `"blocked_by":"rule"`)
 		assert.Contains(c, logs, `"blocked_by":"default"`)
-	}, 5*time.Second, 100*time.Millisecond)
+		// Envoy flushes access logs to stdout asynchronously; allow the same
+		// window other suites use for container-log assertions so a slow node
+		// doesn't produce a false negative.
+	}, 30*time.Second, 100*time.Millisecond)
 }
 
 // TestHttpACLLargeRuleset verifies the control plane can accept and apply a TrafficPolicy

--- a/test/e2e/features/internalredirect/suite.go
+++ b/test/e2e/features/internalredirect/suite.go
@@ -28,8 +28,12 @@ var testCases = map[string]*base.TestCase{
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	// The setup HTTPRoutes use named rules (spec.rules[].name) so that the
+	// TrafficPolicy can target a specific rule via sectionName. That field is
+	// only available in experimental >= 1.2.0 and standard >= 1.4.0, so skip the
+	// suite on older standard channels where applying the setup would fail.
 	return &testingSuite{
-		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases, base.WithMinGwApiVersion(base.GwApiRequireRouteNames)),
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

#14261 uses a "recent" feature of GW API. Last night's nightly tests flaked.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind flake

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
