### PR TITLE
test: Deflake Gateway API conformance runs

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/ptr"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -85,6 +86,7 @@ func TestConformance(t *testing.T) {
 		options.SkipTests = append(options.SkipTests, string(features.GatewayStaticAddressesFeature.Name))
 	}
 	options.Debug = true
+	options.TimeoutConfig.MaxTimeToConsistency = 60 * time.Second
 
 	t.Logf("Running conformance tests with\nprofiles: %+v\n", profiles)
 	conformance.RunConformanceWithOptions(t, options)


### PR DESCRIPTION
# Description

Deflake Gateway API conformance runs by increasing the request convergence window from 30s to 60s.

The failing merge queue job showed experimental frontend client certificate validation tests starting requests before the per-test Gateway proxy was fully reachable. Once the proxy became ready, later TLS client certificate checks passed, so this gives the conformance harness enough room for first-use proxy provisioning instead of failing on startup timing.

Failing job: https://github.com/kgateway-dev/kgateway/actions/runs/28607763679/job/84832291872

# Change Type

/kind flake

# Changelog

```release-note
NONE
```

# Additional Notes

