### PR TITLE
fix: synthesize placeholder clusters instead of deferring per-client xDS snapshot forever

### DIFF
--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -2,6 +2,7 @@ package proxy_syncer
 
 import (
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"sort"
 
@@ -217,12 +218,35 @@ func snapshotPerClient(
 			clusterResources.Items,
 			clustersForUcc.erroredClusters,
 		); len(missingClusters) > 0 {
-			logger.Info(
-				"defer building snapshot until all referenced clusters are ready",
+			// Do not defer the entire per-client snapshot indefinitely when a
+			// referenced cluster is absent from CDS. The "return nil" path only
+			// protects clients that already have a previously-published (last-good)
+			// snapshot; a brand-new or scaled-out proxy has no cached config, so it
+			// is starved of xDS, stalls at "cm init: initializing cds", fails its
+			// startup probe and crashloops. On a large shared gateway this is never
+			// satisfiable because it references clusters that are legitimately empty
+			// forever (ExternalName services and scale-to-zero backends).
+			//
+			// Instead, synthesize a STATIC placeholder cluster with an empty load
+			// assignment for each missing referenced cluster so CDS stays coherent
+			// and Envoy can initialize. Routes targeting a still-unresolved backend
+			// return 503 (no healthy upstream) until the real cluster is produced and
+			// replaces the placeholder on a later snapshot. Tradeoff: during a
+			// controller restart an established proxy may briefly 503 a route whose
+			// real cluster is a moment behind (self-heals on the next snapshot), which
+			// is far less harmful than new proxies never starting.
+			logger.Warn(
+				"referenced clusters missing; synthesizing placeholder clusters so the proxy can start",
 				"client", ucc.ResourceName(),
 				"missing_clusters", missingClusters,
 			)
-			return nil
+			patched := make(map[string]envoycachetypes.ResourceWithTTL, len(clusterResources.Items)+len(missingClusters))
+			maps.Copy(patched, clusterResources.Items)
+			for _, name := range missingClusters {
+				patched[name] = envoycachetypes.ResourceWithTTL{Resource: placeholderCluster(name)}
+			}
+			clusterResources.Items = patched
+			clusterResources.Version = fmt.Sprintf("%s-placeholders-%016x", clusterResources.Version, hashStrings(missingClusters))
 		}
 		// Exclude CLAs for STATIC clusters so ADS snapshot only contains resources Envoy will request.
 		endpointRes := filterEndpointResourcesForStaticClusters(clusterResources, clientEndpointResources.endpoints)
@@ -440,6 +464,39 @@ func endpointResourceNameForCluster(resource envoycachetypes.ResourceWithTTL) (s
 		return edsServiceName, true
 	}
 	return cluster.GetName(), true
+}
+
+// placeholderCluster returns a STATIC cluster with an empty load assignment,
+// used as a stand-in for a referenced-but-not-yet-produced cluster so that a
+// per-client xDS snapshot stays coherent and Envoy can initialize. Traffic to
+// it receives a 503 (no healthy upstream) until the real cluster is published
+// and replaces it on a later snapshot.
+func placeholderCluster(name string) *envoyclusterv3.Cluster {
+	return &envoyclusterv3.Cluster{
+		Name: name,
+		ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
+			Type: envoyclusterv3.Cluster_STATIC,
+		},
+		LoadAssignment: &envoyendpointv3.ClusterLoadAssignment{
+			ClusterName: name,
+			Endpoints:   []*envoyendpointv3.LocalityLbEndpoints{},
+		},
+	}
+}
+
+// hashStrings returns a stable, order-independent FNV-1a hash of the given
+// strings, used to fold the synthesized placeholder set into the CDS snapshot
+// version so that Envoy receives the placeholder update and, later, its
+// replacement.
+func hashStrings(ss []string) uint64 {
+	sorted := append([]string(nil), ss...)
+	sort.Strings(sorted)
+	h := fnv.New64a()
+	for _, s := range sorted {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+	return h.Sum64()
 }
 
 func stringSet(values []string) map[string]struct{} {

--- a/pkg/kgateway/proxy_syncer/perclient_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_test.go
@@ -156,7 +156,7 @@ func TestFilterEndpointResourcesForStaticClusters_MixedStaticAndNonStatic(t *tes
 	}
 }
 
-func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T) {
+func TestSnapshotPerClientSynthesizesPlaceholderForMissingClusters(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
@@ -226,10 +226,23 @@ func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T)
 		},
 	)
 
-	g.Consistently(func() int {
+	// A missing referenced cluster no longer defers the whole per-client
+	// snapshot; a STATIC placeholder is synthesized so the proxy can start
+	// immediately (routes to it 503 until the real cluster lands).
+	g.Eventually(func() int {
 		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
 
+	placeholderSnap := snapshots.List()[0].snap
+	g.Expect(placeholderSnap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
+	g.Expect(placeholderSnap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-b"))
+	placeholderB, ok := placeholderSnap.Resources[envoycachetypes.Cluster].Items["cluster-b"].Resource.(*envoyclusterv3.Cluster)
+	g.Expect(ok).To(gomega.BeTrue())
+	g.Expect(placeholderB.GetClusterDiscoveryType()).ToNot(gomega.BeNil())
+	g.Expect(placeholderB.GetType()).To(gomega.Equal(envoyclusterv3.Cluster_STATIC))
+	g.Expect(placeholderB.GetLoadAssignment().GetEndpoints()).To(gomega.BeEmpty())
+
+	// Once the real cluster is produced it replaces the placeholder.
 	clusterCol.UpdateObject(uccWithCluster{
 		Client:         ucc,
 		Name:           "cluster-b",
@@ -237,13 +250,23 @@ func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T)
 		ClusterVersion: 2,
 	})
 
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
-
-	snap := snapshots.List()[0].snap
-	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
-	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-b"))
+	g.Eventually(func() bool {
+		list := snapshots.List()
+		if len(list) != 1 {
+			return false
+		}
+		item, ok := list[0].snap.Resources[envoycachetypes.Cluster].Items["cluster-b"]
+		if !ok {
+			return false
+		}
+		c, ok := item.Resource.(*envoyclusterv3.Cluster)
+		if !ok {
+			return false
+		}
+		// The real cluster-b has no discovery type or load assignment set, unlike
+		// the synthesized placeholder.
+		return c.GetClusterDiscoveryType() == nil
+	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue())
 }
 
 func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testing.T) {

--- a/pkg/kgateway/proxy_syncer/perclient_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_test.go
@@ -242,11 +242,16 @@ func TestSnapshotPerClientSynthesizesPlaceholderForMissingClusters(t *testing.T)
 	g.Expect(placeholderB.GetType()).To(gomega.Equal(envoyclusterv3.Cluster_STATIC))
 	g.Expect(placeholderB.GetLoadAssignment().GetEndpoints()).To(gomega.BeEmpty())
 
-	// Once the real cluster is produced it replaces the placeholder.
+	// Once the real cluster is produced it replaces the placeholder. Keep a
+	// reference so we can assert the snapshot resource is exactly (proto-equal
+	// to) the cluster we injected, instead of relying on incidental unset
+	// fields. Use a non-EDS cluster: a real EDS cluster with no endpoints would
+	// legitimately be held back by findMissingReferencedEndpointResources.
+	realClusterB := &envoyclusterv3.Cluster{Name: "cluster-b"}
 	clusterCol.UpdateObject(uccWithCluster{
 		Client:         ucc,
 		Name:           "cluster-b",
-		Cluster:        &envoyclusterv3.Cluster{Name: "cluster-b"},
+		Cluster:        realClusterB,
 		ClusterVersion: 2,
 	})
 
@@ -263,9 +268,9 @@ func TestSnapshotPerClientSynthesizesPlaceholderForMissingClusters(t *testing.T)
 		if !ok {
 			return false
 		}
-		// The real cluster-b has no discovery type or load assignment set, unlike
-		// the synthesized placeholder.
-		return c.GetClusterDiscoveryType() == nil
+		// The synthesized STATIC placeholder (empty load assignment) has been
+		// replaced by the exact real cluster we injected.
+		return proto.Equal(c, realClusterB)
 	}, time.Second, 20*time.Millisecond).Should(gomega.BeTrue())
 }
 


### PR DESCRIPTION
# Description

**Motivation:** On a large shared Gateway, brand-new / scaled-out proxies never receive an xDS snapshot and crashloop (`cm init: initializing cds` → SIGTERM → `CrashLoopBackOff`). `snapshotPerClient` in `pkg/kgateway/proxy_syncer/perclient.go` defers (`return nil`) the whole per-client snapshot whenever a route-referenced cluster is missing from CDS. That deferral relies on the xDS cache retaining the client's previously-published snapshot; a first-time UCC has none, and because a shared gateway legitimately references always-empty clusters (ExternalName, KEDA/HPA scale-to-zero), the gate is never satisfiable, so those proxies never start.

**What changed:** instead of deferring, synthesize a STATIC placeholder cluster with an empty load assignment for each missing referenced cluster, so CDS stays coherent and Envoy can initialize. Routes to a still-unresolved backend return 503 (no healthy upstream) until the real cluster is produced and replaces the placeholder on a later snapshot. The synthesis is **surgical** — all resolvable clusters and the rest of the config (routes, listeners, other clusters) stay current; only routes targeting the specific missing backend are affected.

- `pkg/kgateway/proxy_syncer/perclient.go`: replace the `return nil` deferral on missing referenced CDS clusters with placeholder-cluster synthesis; fold the synthesized set into the CDS snapshot version. Add `placeholderCluster` and `hashStrings` helpers.
- `pkg/kgateway/proxy_syncer/perclient_test.go`: `TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady` → `TestSnapshotPerClientSynthesizesPlaceholderForMissingClusters`, asserting the placeholder is STATIC + empty and is later replaced by the exact real cluster (proto-equal) once produced.

**Related issues:** Fixes #14352

# Change Type

/kind bug_fix

# Changelog

```release-note
Fix new/scaled gateway proxy pods crashlooping at `cm init: initializing cds` when the gateway references always-empty clusters (ExternalName or scale-to-zero backends): the per-client xDS snapshot is now published best-effort with STATIC placeholder clusters instead of being deferred indefinitely.
```

# Behavior change / tradeoff

Placeholders are synthesized **unconditionally** in the per-client transform, which does not have access to the xDS `SnapshotCache`. The prior `return nil` path retained an established client's last-good snapshot during a transient missing-cluster window; with this change an established proxy can instead briefly receive a placeholder (503) for the routes targeting that one cluster, self-healing on the next snapshot.

This is a deliberate choice over gating synthesis on an existing cache entry, because that alternative:

1. **Gives no benefit on a controller restart** — the `SnapshotCache` is process-local and empty after restart, so every reconnecting proxy is "first-time" and gets placeholders anyway.
2. **Reintroduces the all-or-nothing staleness** for established proxies on a shared gateway that permanently references empty clusters: the "retain last-good" path freezes the *entire* snapshot (routes, listeners, all clusters) while *any* referenced cluster is missing, so those proxies would never receive unrelated config updates — the exact problem this PR fixes.

The change is surgical (only the missing cluster becomes a placeholder), so the impact of the tradeoff is limited to routes targeting a genuinely transiently-missing backend.

# Additional Notes

The `findMissingReferencedEndpointResources` (EDS) guard is intentionally left as-is in this PR — in our environments only the missing-referenced-clusters guard fires — but it shares the same class of problem and could receive the same treatment in a follow-up. Happy to also implement the cache-conditional variant if maintainers prefer preserving the transient last-good behavior despite the staleness tradeoff above.
