### PR TITLE
refactor: replace sort package with slices package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar
+    - depguard
     - forbidigo
     - ginkgolinter
     - gomodguard
@@ -63,6 +64,14 @@ linters:
               isFirstField: Ignore
               useProtobuf: Forbid
               usePatchStrategy: Ignore
+    depguard:
+      rules:
+        default:
+          files:
+            - "$all"
+          deny:
+            - pkg: "sort"
+              desc: "Should be replaced with slices package"
     forbidigo:
       forbid:
         - pattern: anypb.New

--- a/pkg/deployer/values_helpers.go
+++ b/pkg/deployer/values_helpers.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/netip"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
-	"istio.io/istio/pkg/slices"
+	istioslices "istio.io/istio/pkg/slices"
 	corev1 "k8s.io/api/core/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -86,7 +86,7 @@ func SanitizePortName(name string) string {
 }
 
 func AppendPortValue(gwPorts []HelmPort, port int32, name string, gwp *kgateway.GatewayParameters) []HelmPort {
-	if slices.IndexFunc(gwPorts, func(p HelmPort) bool { return *p.Port == port }) != -1 {
+	if istioslices.IndexFunc(gwPorts, func(p HelmPort) bool { return *p.Port == port }) != -1 {
 		return gwPorts
 	}
 
@@ -99,7 +99,7 @@ func AppendPortValue(gwPorts []HelmPort, port int32, name string, gwp *kgateway.
 	if gwp != nil && gwp.Spec.GetKube().GetService().GetType() != nil {
 		serviceType := *(gwp.Spec.GetKube().GetService().GetType())
 		if serviceType == corev1.ServiceTypeNodePort || serviceType == corev1.ServiceTypeLoadBalancer {
-			if idx := slices.IndexFunc(gwp.Spec.GetKube().GetService().GetPorts(), func(p kgateway.Port) bool {
+			if idx := istioslices.IndexFunc(gwp.Spec.GetKube().GetService().GetPorts(), func(p kgateway.Port) bool {
 				return p.GetPort() == port
 			}); idx != -1 {
 				nodePort = gwp.Spec.GetKube().GetService().GetPorts()[idx].GetNodePort()
@@ -154,7 +154,7 @@ func GetServiceValues(svcConfig *kgateway.Service) *HelmService {
 // Returns the IP address if exactly one valid IP address is found, nil if no addresses are specified,
 // or an error if more than one address is specified or no valid IP address is found.
 func GetLoadBalancerIPFromGatewayAddresses(gw *gwv1.Gateway) (*string, error) {
-	ipAddresses := slices.MapFilter(gw.Spec.Addresses, func(addr gwv1.GatewaySpecAddress) *string {
+	ipAddresses := istioslices.MapFilter(gw.Spec.Addresses, func(addr gwv1.GatewaySpecAddress) *string {
 		if addr.Type == nil || *addr.Type == gwv1.IPAddressType {
 			return &addr.Value
 		}
@@ -338,6 +338,6 @@ func ComponentLogLevelsToString(vals map[string]string) (string, error) {
 		}
 		parts = append(parts, fmt.Sprintf("%s:%s", k, v))
 	}
-	sort.Strings(parts)
+	slices.Sort(parts)
 	return strings.Join(parts, ","), nil
 }

--- a/pkg/kgateway/admin/logging.go
+++ b/pkg/kgateway/admin/logging.go
@@ -3,7 +3,7 @@ package admin
 import (
 	"fmt"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
@@ -27,7 +27,7 @@ func getLoggingDescription() string {
 	for comp := range componentLevels {
 		components = append(components, comp)
 	}
-	sort.Strings(components) // Sort alphabetically
+	slices.Sort(components) // Sort alphabetically
 
 	for _, comp := range components {
 		componentSelector.WriteString(fmt.Sprintf(`<option value="%s">%s (Current: %s)</option>`, comp, comp, logging.LevelToString(componentLevels[comp])))

--- a/pkg/kgateway/admin/server.go
+++ b/pkg/kgateway/admin/server.go
@@ -2,13 +2,14 @@ package admin
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 	"time"
 
@@ -130,8 +131,8 @@ func index(profileDescriptions map[string]dynamicProfileDescription) func(w http
 			})
 		}
 
-		sort.Slice(profiles, func(i, j int) bool {
-			return profiles[i].Name < profiles[j].Name
+		slices.SortFunc(profiles, func(a, b profile) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
 
 		// Adding other profiles exposed from within this package

--- a/pkg/kgateway/endpoints/prioritize.go
+++ b/pkg/kgateway/endpoints/prioritize.go
@@ -2,7 +2,7 @@ package endpoints
 
 import (
 	"log/slog"
-	"sort"
+	"slices"
 	"strings"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/api/label"
 	"istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pkg/slices"
+	istioslices "istio.io/istio/pkg/slices"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
@@ -158,7 +158,7 @@ func prioritizeWithLbInfo(logger *slog.Logger, ep ir.EndpointsForBackend, lbInfo
 
 // ensure we don't send invalid endpoints to envoy and cause NACKs
 func filterInvalidEps(eps []ir.EndpointWithMd) []ir.EndpointWithMd {
-	return slices.Filter(eps, func(ewm ir.EndpointWithMd) bool {
+	return istioslices.Filter(eps, func(ewm ir.EndpointWithMd) bool {
 		sock := ewm.GetEndpoint().GetAddress().GetSocketAddress()
 		if sock != nil && sock.GetAddress() == "" {
 			return false
@@ -205,7 +205,7 @@ func applyFailoverPriorityPerLocality(
 	for priority := range priorityMap {
 		priorities = append(priorities, priority)
 	}
-	sort.Ints(priorities)
+	slices.Sort(priorities)
 
 	out := make([]*envoyendpointv3.LocalityLbEndpoints, len(priorityMap))
 	for i, priority := range priorities {
@@ -273,7 +273,7 @@ func applyLocalityFailover(
 	for priority := range priorityMap {
 		priorities = append(priorities, priority)
 	}
-	sort.Ints(priorities)
+	slices.Sort(priorities)
 	// 2.2 adjust LocalityLbEndpoints priority
 	// if the index and value of priorities array is not equal.
 	for i, priority := range priorities {

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt.go
@@ -1,6 +1,7 @@
 package trafficpolicy
 
 import (
+	"cmp"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
@@ -10,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"sort"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	jwtauthnv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
@@ -477,7 +477,9 @@ func buildJwtRequirementFromProviders(
 	}
 
 	// sort for idempotency
-	sort.Slice(reqs, func(i, j int) bool { return reqs[i].GetProviderName() < reqs[j].GetProviderName() })
+	slices.SortFunc(reqs, func(a, b *jwtauthnv3.JwtRequirement) int {
+		return cmp.Compare(a.GetProviderName(), b.GetProviderName())
+	})
 
 	var jwtReqs *jwtauthnv3.JwtRequirement
 	// if there is only one requirement, return it directly

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
@@ -2,7 +2,7 @@ package trafficpolicy
 
 import (
 	"encoding/json"
-	"sort"
+	"slices"
 
 	extensiondynamicmodulev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/dynamic_modules/v3"
 	dynamicmodulesv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_modules/v3"
@@ -135,7 +135,7 @@ func generateDynamicMetadata(ns string, kv map[string]kgateway.InjaTemplate) *dy
 	for k := range kv {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	for _, k := range keys {
 		v := kv[k]

--- a/pkg/kgateway/extensions2/pluginutils/headers.go
+++ b/pkg/kgateway/extensions2/pluginutils/headers.go
@@ -1,9 +1,10 @@
 package pluginutils
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 
 	mutation_rulesv3 "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -146,7 +147,9 @@ func resolveHeader(
 		for k, v := range secret.Data {
 			pairs = append(pairs, gwv1.HTTPHeader{Name: gwv1.HTTPHeaderName(k), Value: string(v)})
 		}
-		sort.Slice(pairs, func(i, j int) bool { return pairs[i].Name < pairs[j].Name })
+		slices.SortFunc(pairs, func(a, b gwv1.HTTPHeader) int {
+			return cmp.Compare(string(a.Name), string(b.Name))
+		})
 		return pairs, nil
 	}
 

--- a/pkg/kgateway/proxy_syncer/effective_endpoints.go
+++ b/pkg/kgateway/proxy_syncer/effective_endpoints.go
@@ -1,8 +1,9 @@
 package proxy_syncer
 
 import (
+	"cmp"
 	"hash/fnv"
-	"sort"
+	"slices"
 	"strconv"
 
 	"istio.io/istio/pkg/kube/krt"
@@ -54,11 +55,11 @@ func backendEndpointVersionHash(backend *ir.BackendObjectIR) uint64 {
 	for groupKind := range backend.AttachedPolicies.Policies {
 		groupKinds = append(groupKinds, groupKind)
 	}
-	sort.Slice(groupKinds, func(i, j int) bool {
-		if groupKinds[i].Group == groupKinds[j].Group {
-			return groupKinds[i].Kind < groupKinds[j].Kind
+	slices.SortFunc(groupKinds, func(a, b schema.GroupKind) int {
+		if a.Group != b.Group {
+			return cmp.Compare(a.Group, b.Group)
 		}
-		return groupKinds[i].Group < groupKinds[j].Group
+		return cmp.Compare(a.Kind, b.Kind)
 	})
 
 	for _, groupKind := range groupKinds {

--- a/pkg/kgateway/proxy_syncer/local_cluster.go
+++ b/pkg/kgateway/proxy_syncer/local_cluster.go
@@ -1,9 +1,10 @@
 package proxy_syncer
 
 import (
+	"cmp"
 	"fmt"
 	"hash/fnv"
-	"sort"
+	"slices"
 	"strings"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -120,14 +121,14 @@ func buildLocalClusterLoadAssignment(
 		})
 	}
 
-	sort.Slice(localEndpoints, func(i, j int) bool {
-		if localEndpoints[i].locality != localEndpoints[j].locality {
-			return localEndpoints[i].locality.String() < localEndpoints[j].locality.String()
+	slices.SortFunc(localEndpoints, func(a, b localClusterEndpoint) int {
+		if a.locality != b.locality {
+			return cmp.Compare(a.locality.String(), b.locality.String())
 		}
-		if localEndpoints[i].resourceName != localEndpoints[j].resourceName {
-			return localEndpoints[i].resourceName < localEndpoints[j].resourceName
+		if a.resourceName != b.resourceName {
+			return cmp.Compare(a.resourceName, b.resourceName)
 		}
-		return localEndpoints[i].address < localEndpoints[j].address
+		return cmp.Compare(a.address, b.address)
 	})
 
 	endpointsByLocality := make(map[ir.PodLocality][]localClusterEndpoint)

--- a/pkg/kgateway/proxy_syncer/perclient_clusters_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_clusters_test.go
@@ -3,7 +3,7 @@ package proxy_syncer
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -61,7 +61,7 @@ func clusterNamesForClient(c PerClientEnvoyClusters, ucc ir.UniquelyConnectedCli
 	for _, f := range fetched {
 		names = append(names, f.Name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 

--- a/pkg/kgateway/proxy_syncer/status.go
+++ b/pkg/kgateway/proxy_syncer/status.go
@@ -2,7 +2,7 @@ package proxy_syncer
 
 import (
 	"errors"
-	"sort"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -187,7 +187,7 @@ func GenerateBackendStatusReport(backends []ir.BackendObjectIR, clusters []uccWi
 				gen: backend.Obj.GetGeneration(),
 			}
 			if es := translationErrs[k]; es != nil {
-				sort.Strings(es.msgs)
+				slices.Sort(es.msgs)
 				for _, m := range es.msgs {
 					errs = append(errs, errors.New(m))
 				}

--- a/pkg/kgateway/setup/setup_test.go
+++ b/pkg/kgateway/setup/setup_test.go
@@ -2,6 +2,7 @@ package setup_test
 
 import (
 	"bytes"
+	stdcmp "cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -1041,8 +1041,8 @@ func anyJsonRoundTrip[T any, PT interface {
 func sortResource[T fmt.Stringer](resources []T) []T {
 	// clone the slice
 	resources = append([]T(nil), resources...)
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].String() < resources[j].String()
+	slices.SortFunc(resources, func(a, b T) int {
+		return stdcmp.Compare(a.String(), b.String())
 	})
 	return resources
 }
@@ -1053,21 +1053,21 @@ func sortResource[T fmt.Stringer](resources []T) []T {
 // output. The comparison logic (equalset) is order-independent, so this only
 // affects serialization, not correctness.
 func sortLocalityLbEndpoints(eps []*envoyendpointv3.LocalityLbEndpoints) {
-	sort.SliceStable(eps, func(i, j int) bool {
-		li, lj := eps[i].GetLocality(), eps[j].GetLocality()
-		if li.GetRegion() != lj.GetRegion() {
-			return li.GetRegion() < lj.GetRegion()
+	slices.SortStableFunc(eps, func(a, b *envoyendpointv3.LocalityLbEndpoints) int {
+		la, lb := a.GetLocality(), b.GetLocality()
+		if la.GetRegion() != lb.GetRegion() {
+			return stdcmp.Compare(la.GetRegion(), lb.GetRegion())
 		}
-		if li.GetZone() != lj.GetZone() {
-			return li.GetZone() < lj.GetZone()
+		if la.GetZone() != lb.GetZone() {
+			return stdcmp.Compare(la.GetZone(), lb.GetZone())
 		}
-		if li.GetSubZone() != lj.GetSubZone() {
-			return li.GetSubZone() < lj.GetSubZone()
+		if la.GetSubZone() != lb.GetSubZone() {
+			return stdcmp.Compare(la.GetSubZone(), lb.GetSubZone())
 		}
-		if eps[i].GetPriority() != eps[j].GetPriority() {
-			return eps[i].GetPriority() < eps[j].GetPriority()
+		if a.GetPriority() != b.GetPriority() {
+			return stdcmp.Compare(a.GetPriority(), b.GetPriority())
 		}
-		return localityLbEndpointAddrs(eps[i]) < localityLbEndpointAddrs(eps[j])
+		return stdcmp.Compare(localityLbEndpointAddrs(a), localityLbEndpointAddrs(b))
 	})
 }
 
@@ -1078,7 +1078,7 @@ func localityLbEndpointAddrs(e *envoyendpointv3.LocalityLbEndpoints) string {
 	for _, lb := range e.GetLbEndpoints() {
 		addrs = append(addrs, lb.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
 	}
-	sort.Strings(addrs)
+	slices.Sort(addrs)
 	return strings.Join(addrs, ",")
 }
 

--- a/pkg/kgateway/translator/irtranslator/endpoint_plugins.go
+++ b/pkg/kgateway/translator/irtranslator/endpoint_plugins.go
@@ -1,7 +1,8 @@
 package irtranslator
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -27,14 +28,14 @@ func OrderedEndpointPlugins(policies sdk.ContributesPolicies) []sdk.EndpointPlug
 		})
 	}
 
-	sort.SliceStable(entries, func(i, j int) bool {
-		if entries[i].groupKind.Group != entries[j].groupKind.Group {
-			return entries[i].groupKind.Group < entries[j].groupKind.Group
+	slices.SortStableFunc(entries, func(a, b endpointPluginEntry) int {
+		if a.groupKind.Group != b.groupKind.Group {
+			return cmp.Compare(a.groupKind.Group, b.groupKind.Group)
 		}
-		if entries[i].groupKind.Kind != entries[j].groupKind.Kind {
-			return entries[i].groupKind.Kind < entries[j].groupKind.Kind
+		if a.groupKind.Kind != b.groupKind.Kind {
+			return cmp.Compare(a.groupKind.Kind, b.groupKind.Kind)
 		}
-		return entries[i].name < entries[j].name
+		return cmp.Compare(a.name, b.name)
 	})
 
 	endpointPlugins := make([]sdk.EndpointPlugin, 0, len(entries))

--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -2,7 +2,6 @@ package irtranslator
 
 import (
 	"fmt"
-	"sort"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -180,7 +179,7 @@ func convertCustomNetworkFilters(customNetworkFilters []ir.CustomEnvoyFilter) []
 }
 
 func sortNetworkFilters(filters filters.StagedNetworkFilterList) []*envoylistenerv3.Filter {
-	sort.Sort(filters)
+	filters.Sort()
 	var sortedFilters []*envoylistenerv3.Filter
 	for _, filter := range filters {
 		sortedFilters = append(sortedFilters, filter.Filter)
@@ -405,7 +404,7 @@ func convertCustomHttpFilters(customHttpFilters []ir.CustomEnvoyFilter) []filter
 }
 
 func sortHttpFilters(filters filters.StagedHttpFilterList) []*envoyhttp.HttpFilter {
-	sort.Sort(filters)
+	filters.Sort()
 	var sortedFilters []*envoyhttp.HttpFilter
 	for _, filter := range filters {
 		if len(sortedFilters) > 0 && proto.Equal(sortedFilters[len(sortedFilters)-1], filter.Filter) {
@@ -418,7 +417,7 @@ func sortHttpFilters(filters filters.StagedHttpFilterList) []*envoyhttp.HttpFilt
 }
 
 func sortUpstreamHttpFilters(filters filters.StagedUpstreamHttpFilterList) []*envoyhttp.HttpFilter {
-	sort.Sort(filters)
+	filters.Sort()
 	var sortedFilters []*envoyhttp.HttpFilter
 	for _, filter := range filters {
 		if len(sortedFilters) > 0 && proto.Equal(sortedFilters[len(sortedFilters)-1], filter.Filter) {

--- a/pkg/kgateway/translator/irtranslator/gateway.go
+++ b/pkg/kgateway/translator/irtranslator/gateway.go
@@ -1,8 +1,9 @@
 package irtranslator
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 	"strconv"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -10,7 +11,7 @@ import (
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	"istio.io/istio/pkg/slices"
+	istioslices "istio.io/istio/pkg/slices"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -82,7 +83,7 @@ func findOriginalListenerName(gw ir.GatewayIR, listener ir.ListenerIR) string {
 }
 
 func getReporterForFilterChain(gw ir.GatewayIR, reporter sdkreporter.Reporter, filterChainName string) sdkreporter.ListenerReporter {
-	listener := slices.FindFunc(gw.SourceObject.Listeners, func(l ir.Listener) bool {
+	listener := istioslices.FindFunc(gw.SourceObject.Listeners, func(l ir.Listener) bool {
 		return filterChainName == query.GenerateRouteKey(l.Parent, string(l.Name))
 	})
 	if listener == nil {
@@ -192,8 +193,8 @@ func (t *Translator) ComputeListener(
 		}
 	}
 	// sort filter chains for idempotency
-	sort.Slice(ret.GetFilterChains(), func(i, j int) bool {
-		return ret.GetFilterChains()[i].GetName() < ret.GetFilterChains()[j].GetName()
+	slices.SortFunc(ret.GetFilterChains(), func(a, b *envoylistenerv3.FilterChain) int {
+		return cmp.Compare(a.GetName(), b.GetName())
 	})
 	if hasTls {
 		ret.ListenerFilters = append(ret.GetListenerFilters(), tlsInspectorFilter())

--- a/pkg/kgateway/translator/listener/gateway_listener_translator.go
+++ b/pkg/kgateway/translator/listener/gateway_listener_translator.go
@@ -1,12 +1,12 @@
 package listener
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"istio.io/istio/pkg/kube/krt"
@@ -793,7 +793,9 @@ func (httpFilterChain *httpFilterChain) translateHttpFilterChain(
 		}
 
 		// ensure we sort the routes before creating the vhost
-		sort.Stable(vhostRoutes)
+		slices.SortStableFunc(vhostRoutes, func(a, b *routeutils.SortableRoute) int {
+			return a.CompareTo(b)
+		})
 
 		// ensure we don't create duplicate vhosts
 		vhostName := makeVhostName(ctx, parentName, host)
@@ -811,8 +813,8 @@ func (httpFilterChain *httpFilterChain) translateHttpFilterChain(
 		})
 	}
 	// sort vhosts, to make sure the resource is stable
-	sort.Slice(virtualHosts, func(i, j int) bool {
-		return virtualHosts[i].Name < virtualHosts[j].Name
+	slices.SortFunc(virtualHosts, func(a, b *ir.VirtualHost) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	// TODO: Make a similar change for other filter chains ???
@@ -865,7 +867,9 @@ func (hfc *httpsFilterChain) translateHttpsFilterChain(
 		virtualHosts     = []*ir.VirtualHost{}
 	)
 	for host, vhostRoutes := range routesByHost {
-		sort.Stable(vhostRoutes)
+		slices.SortStableFunc(vhostRoutes, func(a, b *routeutils.SortableRoute) int {
+			return a.CompareTo(b)
+		})
 		vhostName := makeVhostName(ctx, hfc.gatewayListenerName, host)
 		if !virtualHostNames[vhostName] {
 			virtualHostNames[vhostName] = true
@@ -910,8 +914,8 @@ func (hfc *httpsFilterChain) translateHttpsFilterChain(
 			return nil, err
 		}
 	}
-	sort.Slice(virtualHosts, func(i, j int) bool {
-		return virtualHosts[i].Name < virtualHosts[j].Name
+	slices.SortFunc(virtualHosts, func(a, b *ir.VirtualHost) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return &ir.HttpFilterChainIR{

--- a/pkg/kgateway/translator/routeutils/sortable_route.go
+++ b/pkg/kgateway/translator/routeutils/sortable_route.go
@@ -34,6 +34,26 @@ func (a SortableRoutes) Less(i, j int) bool {
 	return !routeWrapperLessFunc(a[i], a[j])
 }
 
+// CompareTo compares two SortableRoutes for ordering.
+// Returns -1 if a should sort before b, 1 if after, 0 if equal.
+// Higher precedence weight sorts first; for equal weight, route specificity is compared.
+func (a *SortableRoute) CompareTo(b *SortableRoute) int {
+	if a.Route.PrecedenceWeight != b.Route.PrecedenceWeight {
+		if a.Route.PrecedenceWeight > b.Route.PrecedenceWeight {
+			return -1
+		}
+		return 1
+	}
+	// routeWrapperLessFunc returns true if a is lower priority than b
+	if routeWrapperLessFunc(a, b) {
+		return 1
+	}
+	if routeWrapperLessFunc(b, a) {
+		return -1
+	}
+	return 0
+}
+
 func (a SortableRoutes) ToRoutes() []ir.HttpRouteRuleMatchIR {
 	routes := make([]ir.HttpRouteRuleMatchIR, 0, len(a))
 	for _, route := range a {

--- a/pkg/metrics/cmd/findmetrics/main.go
+++ b/pkg/metrics/cmd/findmetrics/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"cmp"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -11,7 +12,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -61,8 +62,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	sort.Slice(metrics, func(i, j int) bool {
-		return metrics[i].fullName() < metrics[j].fullName()
+	slices.SortFunc(metrics, func(a, b metricInfo) int {
+		return cmp.Compare(a.fullName(), b.fullName())
 	})
 
 	if outputMarkdown != nil && *outputMarkdown {

--- a/pkg/pluginsdk/filters/stages.go
+++ b/pkg/pluginsdk/filters/stages.go
@@ -107,7 +107,7 @@ func (s StagedFilterList[WellKnown, FilterType]) Len() int {
 	return len(s)
 }
 
-// filters by Relative Stage, Weighting, Name, Config Type-Url, Config Value, and (to ensure stability) index.
+// filters by Relative Stage, Weighting, Name, Config Type-Url, and Config Value.
 // The assumption is that if two filters are in the same stage, their order doesn't matter, and we
 // just need to make sure it is stable.
 func (s StagedFilterList[WellKnown, FilterType]) Less(i, j int) bool {
@@ -119,7 +119,7 @@ func (s StagedFilterList[WellKnown, FilterType]) Swap(i, j int) {
 }
 
 // CompareStagedFilters compares two staged filters for sorting.
-// Filters are ordered by stage, then weight (descending for same type), then name, type URL, config value, and index.
+// Filters are ordered by stage, then weight (descending for same type), then name, type URL, and config value.
 func CompareStagedFilters[WellKnown ~int, FilterType Filter](a, b StagedFilter[WellKnown, FilterType]) int {
 	if compare := FilterStageComparison(a.Stage, b.Stage); compare != 0 {
 		return compare
@@ -148,9 +148,10 @@ func CompareStagedFilters[WellKnown ~int, FilterType Filter](a, b StagedFilter[W
 	return 0
 }
 
-// Sort sorts the StagedFilterList in place using slices.SortFunc.
+// Sort sorts the StagedFilterList in place using slices.SortStableFunc to preserve
+// the relative order of equal elements.
 func (s StagedFilterList[WellKnown, FilterType]) Sort() {
-	slices.SortFunc(s, CompareStagedFilters[WellKnown, FilterType])
+	slices.SortStableFunc(s, CompareStagedFilters[WellKnown, FilterType])
 }
 
 // SortStable sorts the StagedFilterList in place using slices.SortStableFunc.

--- a/pkg/pluginsdk/filters/stages.go
+++ b/pkg/pluginsdk/filters/stages.go
@@ -2,8 +2,9 @@ package filters
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -12,11 +13,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
-)
-
-var (
-	_ sort.Interface = new(StagedHttpFilterList)
-	_ sort.Interface = new(StagedNetworkFilterList)
 )
 
 // WellKnownFilterStages are represented by an integer that reflects their relative ordering
@@ -44,7 +40,7 @@ const (
 	TransformationStage WellKnownUpstreamHTTPFilterStage = iota // Transformation stage
 )
 
-// FilterStageComparison helps implement the sort.Interface Less function for use in other implementations of sort.Interface
+// FilterStageComparison helps implement filter ordering for use in sort comparisons.
 // returns -1 if less than, 0 if equal, 1 if greater than
 // It is not sufficient to return a Less bool because calling functions need to know if equal or greater when Less is false
 func FilterStageComparison[WellKnown ~int](a, b FilterStage[WellKnown]) int {
@@ -115,38 +111,51 @@ func (s StagedFilterList[WellKnown, FilterType]) Len() int {
 // The assumption is that if two filters are in the same stage, their order doesn't matter, and we
 // just need to make sure it is stable.
 func (s StagedFilterList[WellKnown, FilterType]) Less(i, j int) bool {
-	if compare := FilterStageComparison(s[i].Stage, s[j].Stage); compare != 0 {
-		return compare < 0
-	}
-
-	// If the filters are of the same type, compare their weights. Higher weights are ordered
-	// before lower weights.
-	if s[i].Filter.GetTypedConfig().GetTypeUrl() == s[j].Filter.GetTypedConfig().GetTypeUrl() {
-		if s[i].Weight > s[j].Weight {
-			return true
-		} else if s[i].Weight < s[j].Weight {
-			return false
-		}
-	}
-
-	if compare := strings.Compare(s[i].Filter.GetName(), s[j].Filter.GetName()); compare != 0 {
-		return compare < 0
-	}
-
-	if compare := strings.Compare(s[i].Filter.GetTypedConfig().GetTypeUrl(), s[j].Filter.GetTypedConfig().GetTypeUrl()); compare != 0 {
-		return compare < 0
-	}
-
-	if compare := bytes.Compare(s[i].Filter.GetTypedConfig().GetValue(), s[j].Filter.GetTypedConfig().GetValue()); compare != 0 {
-		return compare < 0
-	}
-
-	// ensure stability
-	return i < j
+	return CompareStagedFilters(s[i], s[j]) < 0
 }
 
 func (s StagedFilterList[WellKnown, FilterType]) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
+}
+
+// CompareStagedFilters compares two staged filters for sorting.
+// Filters are ordered by stage, then weight (descending for same type), then name, type URL, config value, and index.
+func CompareStagedFilters[WellKnown ~int, FilterType Filter](a, b StagedFilter[WellKnown, FilterType]) int {
+	if compare := FilterStageComparison(a.Stage, b.Stage); compare != 0 {
+		return compare
+	}
+
+	// If the filters are of the same type, compare their weights. Higher weights are ordered
+	// before lower weights.
+	if a.Filter.GetTypedConfig().GetTypeUrl() == b.Filter.GetTypedConfig().GetTypeUrl() {
+		if a.Weight != b.Weight {
+			return -cmp.Compare(a.Weight, b.Weight)
+		}
+	}
+
+	if compare := strings.Compare(a.Filter.GetName(), b.Filter.GetName()); compare != 0 {
+		return compare
+	}
+
+	if compare := strings.Compare(a.Filter.GetTypedConfig().GetTypeUrl(), b.Filter.GetTypedConfig().GetTypeUrl()); compare != 0 {
+		return compare
+	}
+
+	if compare := bytes.Compare(a.Filter.GetTypedConfig().GetValue(), b.Filter.GetTypedConfig().GetValue()); compare != 0 {
+		return compare
+	}
+
+	return 0
+}
+
+// Sort sorts the StagedFilterList in place using slices.SortFunc.
+func (s StagedFilterList[WellKnown, FilterType]) Sort() {
+	slices.SortFunc(s, CompareStagedFilters[WellKnown, FilterType])
+}
+
+// SortStable sorts the StagedFilterList in place using slices.SortStableFunc.
+func (s StagedFilterList[WellKnown, FilterType]) SortStable() {
+	slices.SortStableFunc(s, CompareStagedFilters[WellKnown, FilterType])
 }
 
 type (

--- a/test/e2e/features/loadtesting/attachedroutes_suite.go
+++ b/test/e2e/features/loadtesting/attachedroutes_suite.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -639,7 +639,7 @@ func formatValidationCallerMetrics(byCaller map[string]ValidationCallerMetrics) 
 	for caller := range byCaller {
 		callers = append(callers, caller)
 	}
-	sort.Strings(callers)
+	slices.Sort(callers)
 
 	parts := make([]string, 0, len(callers))
 	for _, caller := range callers {

--- a/test/e2e/features/loadtesting/startup_suite.go
+++ b/test/e2e/features/loadtesting/startup_suite.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -254,7 +254,7 @@ func (s *LoadTestingSuite) controllerPodSnapshot(namespace string, selector *met
 		))
 	}
 
-	sort.Strings(snapshots)
+	slices.Sort(snapshots)
 	return strings.Join(snapshots, " | ")
 }
 
@@ -289,8 +289,8 @@ func (s *LoadTestingSuite) recentControllerEvents(namespace string, selector *me
 		return "no recent controller pod events"
 	}
 
-	sort.Slice(matchingEvents, func(i, j int) bool {
-		return eventTime(matchingEvents[i]).Before(eventTime(matchingEvents[j]))
+	slices.SortFunc(matchingEvents, func(a, b corev1.Event) int {
+		return eventTime(a).Compare(eventTime(b))
 	})
 
 	const maxEvents = 8

--- a/test/e2e/tests/shards_test.go
+++ b/test/e2e/tests/shards_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -47,7 +47,7 @@ func TestAllE2ETestsInShards(t *testing.T) {
 	}
 
 	if len(missing) > 0 {
-		sort.Strings(missing)
+		slices.Sort(missing)
 		t.Errorf("E2E tests not covered by e2e.yaml:\n  %s\n\nUpdate .github/workflows/e2e.yaml to include these tests",
 			strings.Join(missing, "\n  "))
 	}
@@ -159,7 +159,7 @@ func discoverE2ETestPaths(t *testing.T) []string {
 		}
 	}
 
-	sort.Strings(paths)
+	slices.Sort(paths)
 	return paths
 }
 

--- a/test/translator/status.go
+++ b/test/translator/status.go
@@ -3,7 +3,7 @@ package translator
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -298,7 +298,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.Gateways {
 		gatewayKeys = append(gatewayKeys, k)
 	}
-	sort.Strings(gatewayKeys)
+	slices.Sort(gatewayKeys)
 	for _, k := range gatewayKeys {
 		sorted.Gateways[k] = statuses.Gateways[k]
 	}
@@ -308,7 +308,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.ListenerSets {
 		listenerSetKeys = append(listenerSetKeys, k)
 	}
-	sort.Strings(listenerSetKeys)
+	slices.Sort(listenerSetKeys)
 	for _, k := range listenerSetKeys {
 		sorted.ListenerSets[k] = statuses.ListenerSets[k]
 	}
@@ -318,7 +318,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.HTTPRoutes {
 		httpRouteKeys = append(httpRouteKeys, k)
 	}
-	sort.Strings(httpRouteKeys)
+	slices.Sort(httpRouteKeys)
 	for _, k := range httpRouteKeys {
 		sorted.HTTPRoutes[k] = statuses.HTTPRoutes[k]
 	}
@@ -328,7 +328,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.TCPRoutes {
 		tcpRouteKeys = append(tcpRouteKeys, k)
 	}
-	sort.Strings(tcpRouteKeys)
+	slices.Sort(tcpRouteKeys)
 	for _, k := range tcpRouteKeys {
 		sorted.TCPRoutes[k] = statuses.TCPRoutes[k]
 	}
@@ -338,7 +338,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.TLSRoutes {
 		tlsRouteKeys = append(tlsRouteKeys, k)
 	}
-	sort.Strings(tlsRouteKeys)
+	slices.Sort(tlsRouteKeys)
 	for _, k := range tlsRouteKeys {
 		sorted.TLSRoutes[k] = statuses.TLSRoutes[k]
 	}
@@ -348,7 +348,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.GRPCRoutes {
 		grpcRouteKeys = append(grpcRouteKeys, k)
 	}
-	sort.Strings(grpcRouteKeys)
+	slices.Sort(grpcRouteKeys)
 	for _, k := range grpcRouteKeys {
 		sorted.GRPCRoutes[k] = statuses.GRPCRoutes[k]
 	}
@@ -358,7 +358,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.Policies {
 		policyKeys = append(policyKeys, k)
 	}
-	sort.Strings(policyKeys)
+	slices.Sort(policyKeys)
 	for _, k := range policyKeys {
 		sorted.Policies[k] = statuses.Policies[k]
 	}
@@ -368,7 +368,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	for k := range statuses.Backends {
 		backendKeys = append(backendKeys, k)
 	}
-	sort.Strings(backendKeys)
+	slices.Sort(backendKeys)
 	for _, k := range backendKeys {
 		sorted.Backends[k] = statuses.Backends[k]
 	}

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -1,6 +1,7 @@
 package translator
 
 import (
+	stdcmp "cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,7 +9,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -367,17 +368,17 @@ func sortProxy(proxy *irtranslator.TranslationResult) *irtranslator.TranslationR
 		return nil
 	}
 
-	sort.Slice(proxy.Listeners, func(i, j int) bool {
-		return proxy.Listeners[i].GetName() < proxy.Listeners[j].GetName()
+	slices.SortFunc(proxy.Listeners, func(a, b *envoylistenerv3.Listener) int {
+		return stdcmp.Compare(a.GetName(), b.GetName())
 	})
-	sort.Slice(proxy.Routes, func(i, j int) bool {
-		return proxy.Routes[i].GetName() < proxy.Routes[j].GetName()
+	slices.SortFunc(proxy.Routes, func(a, b *envoyroutev3.RouteConfiguration) int {
+		return stdcmp.Compare(a.GetName(), b.GetName())
 	})
-	sort.Slice(proxy.ExtraClusters, func(i, j int) bool {
-		return proxy.ExtraClusters[i].GetName() < proxy.ExtraClusters[j].GetName()
+	slices.SortFunc(proxy.ExtraClusters, func(a, b *envoyclusterv3.Cluster) int {
+		return stdcmp.Compare(a.GetName(), b.GetName())
 	})
-	sort.Slice(proxy.Secrets, func(i, j int) bool {
-		return proxy.Secrets[i].GetName() < proxy.Secrets[j].GetName()
+	slices.SortFunc(proxy.Secrets, func(a, b *envoytlsv3.Secret) int {
+		return stdcmp.Compare(a.GetName(), b.GetName())
 	})
 
 	// Sort credentials in routes to ensure deterministic output
@@ -443,8 +444,8 @@ func sortCredentialsInAny(config *anypb.Any) {
 
 	// Sort credentials by client name
 	if len(apiKeyAuth.Credentials) > 0 {
-		sort.Slice(apiKeyAuth.Credentials, func(i, j int) bool {
-			return apiKeyAuth.Credentials[i].Client < apiKeyAuth.Credentials[j].Client
+		slices.SortFunc(apiKeyAuth.Credentials, func(a, b *envoyapikeyauthv3.Credential) int {
+			return stdcmp.Compare(a.Client, b.Client)
 		})
 
 		// Marshal back to Any and update the config
@@ -470,8 +471,8 @@ func sortClusters(clusters []*envoyclusterv3.Cluster) []*envoyclusterv3.Cluster 
 	if len(clusters) == 0 {
 		return clusters
 	}
-	sort.Slice(clusters, func(i, j int) bool {
-		return clusters[i].GetName() < clusters[j].GetName()
+	slices.SortFunc(clusters, func(a, b *envoyclusterv3.Cluster) int {
+		return stdcmp.Compare(a.GetName(), b.GetName())
 	})
 	return clusters
 }


### PR DESCRIPTION
# Description

Replace all usage of Go's `sort` package with the modern `slices` and `cmp` packages (Go 1.21+) for more concise and readable sorting code.

# Changes

- `sort.Strings` → `slices.Sort`
- `sort.Ints` → `slices.Sort`
- `sort.Slice` → `slices.SortFunc` with `cmp.Compare`
- `sort.SliceStable` → `slices.SortStableFunc`
- `sort.Sort`/`sort.Stable` on `sort.Interface` types → new `Sort()`/`CompareTo()` methods using `slices.SortStableFunc` internally
- Added `CompareStagedFilters` generic helper for `StagedFilterList`
- Added `depguard` linter rule to forbid future use of the `sort` package

For files importing `istio.io/istio/pkg/slices`, the istio import is aliased to `istioslices` to avoid conflict with stdlib `slices`.

# Change Type

/kind cleanup

# Changelog

```release-note
Refactor: replace sort package with slices package for cleaner sorting code.
```

# Additional Notes

- All unit tests pass
- Build and go vet clean