### PR TITLE
ci: seed Go build caches for the v2 LTS branches

### DIFF
--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'v1.**.x'
+      - 'v[0-9]*.[0-9]*.x'
 
 env:
   CGO_ENABLED: '0'


### PR DESCRIPTION

Paste EXACTLY as below. Headings MUST be level-1 (`#`) or the
`kgateway-dev/pr-kind-labeler` action fails with "missing # Description section".

```markdown

The Cache Setup workflow (`.github/workflows/cache-setup.yaml`) exists to seed
the shared GitHub Actions Go build caches for the LTS release branches, so their
PR and unit jobs start with a warm `GOCACHE` instead of recompiling from scratch
(see the comment on line 4 of that file).

Its `push` trigger still targets the `v1.**.x` branch series. Because that
pattern has a literal `v1.` prefix, it can only match `v1.x` branches (the
newest, `v1.17.x`, last saw activity in 2024) and never the currently maintained
LTS branches `v2.2.x` and `v2.3.x`. As a result, the cache-seeding job is
silently skipped on every push to the current release branches, so the primary
Go build cache and the `-race` cache this workflow saves are never populated for
them, and their CI recompiles from cold, exactly the slowdown the workflow
exists to prevent.

This switches the filter to the generic release-branch glob already used by
`release.yaml` (`v[0-9]*.[0-9]*.x`), which matches `v2.2.x`, `v2.3.x`, and any
future release branch while still excluding main-only churn. This aligns
cache-setup.yaml with the rest of the version-aware CI (`release.yaml`,
`osv-scanner.yaml`, `nightly-tests.yaml` all target the v2.x branches); no new
convention is introduced.

No linked issue (found while auditing the workflow triggers).

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

- Diff is a single line at `.github/workflows/cache-setup.yaml:8`.
- Verified `make lint-actions` (actionlint) stays green on the changed file.
- No unit-test harness exists for workflow triggers; validated by construction
  (GitHub filter-glob semantics) and by parity with the sibling workflows.
```

---

## Notes / caveats (upstream-safe)

- The commit body already tells the same story; keep the PR title as the commit
  title so squash-merge stays clean.
- `/kind cleanup` chosen over `/kind flake` because nothing is flaky; this is
  stale config that never fires. `/kind flake` would also be defensible if a
  maintainer prefers it (the workflow is CI-perf), but cleanup is the honest fit.
