### PR TITLE
feat: expose TLS and connection attributes in Jinja transformation templates

### DIFF
--- a/internal/envoy_modules/filters/rustformation/src/lib.rs
+++ b/internal/envoy_modules/filters/rustformation/src/lib.rs
@@ -220,6 +220,69 @@ impl<EHF: EnvoyHttpFilter> TransformationOps for EnvoyTransformationOps<'_, EHF>
         self.envoy_filter
             .set_dynamic_metadata_string(namespace, key, value);
     }
+
+    fn get_connection_attribute(&mut self, attribute_name: &str) -> Option<String> {
+        let attribute_id = match attribute_name {
+            "connection.id" => abi::envoy_dynamic_module_type_attribute_id::ConnectionId,
+            "connection.mtls" => abi::envoy_dynamic_module_type_attribute_id::ConnectionMtls,
+            "connection.requested_server_name" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionRequestedServerName
+            }
+            "connection.tls_version" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionTlsVersion
+            }
+            "connection.subject_local_certificate" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionSubjectLocalCertificate
+            }
+            "connection.subject_peer_certificate" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionSubjectPeerCertificate
+            }
+            "connection.dns_san_local_certificate" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionDnsSanLocalCertificate
+            }
+            "connection.dns_san_peer_certificate" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionDnsSanPeerCertificate
+            }
+            "connection.uri_san_local_certificate" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionUriSanLocalCertificate
+            }
+            "connection.uri_san_peer_certificate" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionUriSanPeerCertificate
+            }
+            "connection.sha256_peer_certificate_digest" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionSha256PeerCertificateDigest
+            }
+            "connection.transport_failure_reason" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionTransportFailureReason
+            }
+            "connection.termination_details" => {
+                abi::envoy_dynamic_module_type_attribute_id::ConnectionTerminationDetails
+            }
+            _ => return None,
+        };
+
+        let value = self.envoy_filter.get_attribute_string(attribute_id)?;
+        if attribute_id == abi::envoy_dynamic_module_type_attribute_id::ConnectionMtls {
+            return Some(match value.as_slice() {
+                [] => "false".to_string(),
+                [1, ..] => "true".to_string(),
+                bytes => std::str::from_utf8(bytes)
+                    .ok()
+                    .map(|value| {
+                        matches!(
+                            value.trim().to_ascii_lowercase().as_str(),
+                            "1" | "true" | "yes" | "on"
+                        )
+                        .to_string()
+                    })
+                    .unwrap_or_else(|| "false".to_string()),
+            });
+        }
+
+        std::str::from_utf8(value.as_slice())
+            .ok()
+            .map(ToString::to_string)
+    }
 }
 
 impl FilterConfig {

--- a/internal/envoy_modules/filters/rustformation/src/tests.rs
+++ b/internal/envoy_modules/filters/rustformation/src/tests.rs
@@ -321,3 +321,218 @@ fn test_json_body_extracted_from_received_when_buffered_is_empty() {
         abi::envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
     );
 }
+
+#[test]
+fn test_connection_attributes_are_available_to_jinja() {
+    let mut envoy_filter = envoy_proxy_dynamic_modules_rust_sdk::MockEnvoyHttpFilter::default();
+    let json_str = r#"
+    {
+      "request": {
+        "set": [
+          { "name": "X-TLS-Version", "value": "{{ connection.tls_version }}" },
+          { "name": "X-mTLS", "value": "{{ connection.mtls }}" }
+        ]
+      }
+    }
+    "#;
+    let filter_conf = FilterConfig::new(json_str).expect("Failed to parse filter config json");
+    let mut filter = filter_conf.new_http_filter(&mut envoy_filter);
+
+    envoy_filter
+        .expect_get_most_specific_route_config()
+        .returning(|| None);
+    envoy_filter
+        .expect_get_request_headers()
+        .returning(|| vec![(EnvoyBuffer::new(b"host"), EnvoyBuffer::new(b"example.com"))]);
+
+    envoy_filter
+        .expect_get_attribute_string()
+        .times(13)
+        .returning(|attribute| match attribute {
+            abi::envoy_dynamic_module_type_attribute_id::ConnectionTlsVersion => {
+                Some(EnvoyBuffer::new(b"TLSv1.3"))
+            }
+            abi::envoy_dynamic_module_type_attribute_id::ConnectionMtls => {
+                Some(EnvoyBuffer::new(&[1]))
+            }
+            _ => None,
+        });
+
+    let mut seq = Sequence::new();
+    envoy_filter
+        .expect_set_request_header()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|key, value: &[u8]| {
+            assert_eq!(key, "X-TLS-Version");
+            assert_eq!(value, b"TLSv1.3");
+            true
+        });
+    envoy_filter
+        .expect_set_request_header()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|key, value: &[u8]| {
+            assert_eq!(key, "X-mTLS");
+            assert_eq!(value, b"true");
+            true
+        });
+
+    assert_eq!(
+        filter.on_request_headers(&mut envoy_filter, true),
+        abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+    );
+}
+
+/// Verifies that when Envoy returns an empty byte buffer for connection.mtls,
+/// it is normalized to the string "false".
+#[test]
+fn test_connection_mtls_empty_bytes_returns_false() {
+    let mut envoy_filter = envoy_proxy_dynamic_modules_rust_sdk::MockEnvoyHttpFilter::default();
+    let json_str = r#"
+    {
+      "request": {
+        "set": [
+          { "name": "X-mTLS", "value": "{{ connection.mtls }}" }
+        ]
+      }
+    }
+    "#;
+    let filter_conf = FilterConfig::new(json_str).expect("Failed to parse filter config json");
+    let mut filter = filter_conf.new_http_filter(&mut envoy_filter);
+
+    envoy_filter
+        .expect_get_most_specific_route_config()
+        .returning(|| None);
+    envoy_filter
+        .expect_get_request_headers()
+        .returning(|| vec![(EnvoyBuffer::new(b"host"), EnvoyBuffer::new(b"example.com"))]);
+
+    envoy_filter
+        .expect_get_attribute_string()
+        .times(13)
+        .returning(|attribute| match attribute {
+            abi::envoy_dynamic_module_type_attribute_id::ConnectionMtls => {
+                Some(EnvoyBuffer::new(&[]))
+            }
+            _ => None,
+        });
+
+    envoy_filter
+        .expect_set_request_header()
+        .times(1)
+        .returning(|key, value: &[u8]| {
+            assert_eq!(key, "X-mTLS");
+            assert_eq!(value, b"false");
+            true
+        });
+
+    assert_eq!(
+        filter.on_request_headers(&mut envoy_filter, true),
+        abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+    );
+}
+
+/// Verifies that connection attributes are also available in response transformations.
+#[test]
+fn test_connection_attributes_in_response_transformation() {
+    let mut envoy_filter = envoy_proxy_dynamic_modules_rust_sdk::MockEnvoyHttpFilter::default();
+    let json_str = r#"
+    {
+      "response": {
+        "set": [
+          { "name": "X-TLS-Version", "value": "{{ connection.tls_version }}" }
+        ]
+      }
+    }
+    "#;
+    let filter_conf = FilterConfig::new(json_str).expect("Failed to parse filter config json");
+    let mut filter = filter_conf.new_http_filter(&mut envoy_filter);
+
+    envoy_filter
+        .expect_get_most_specific_route_config()
+        .returning(|| None);
+    envoy_filter
+        .expect_get_request_headers()
+        .returning(|| vec![(EnvoyBuffer::new(b"host"), EnvoyBuffer::new(b"example.com"))]);
+    envoy_filter.expect_get_response_headers().returning(|| {
+        vec![(
+            EnvoyBuffer::new(b"content-type"),
+            EnvoyBuffer::new(b"text/plain"),
+        )]
+    });
+
+    envoy_filter
+        .expect_get_attribute_string()
+        .times(13)
+        .returning(|attribute| match attribute {
+            abi::envoy_dynamic_module_type_attribute_id::ConnectionTlsVersion => {
+                Some(EnvoyBuffer::new(b"TLSv1.2"))
+            }
+            _ => None,
+        });
+
+    envoy_filter
+        .expect_set_response_header()
+        .times(1)
+        .returning(|key, value: &[u8]| {
+            assert_eq!(key, "X-TLS-Version");
+            assert_eq!(value, b"TLSv1.2");
+            true
+        });
+
+    // Request headers pass through (no request transform configured).
+    assert_eq!(
+        filter.on_request_headers(&mut envoy_filter, true),
+        abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+    );
+    assert_eq!(
+        filter.on_response_headers(&mut envoy_filter, true),
+        abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+    );
+}
+
+/// Verifies that when templates do NOT reference connection attributes,
+/// get_attribute_string is never called (the USES_CONNECTION flag optimization).
+#[test]
+fn test_no_connection_lookups_when_templates_do_not_reference_connection() {
+    let mut envoy_filter = envoy_proxy_dynamic_modules_rust_sdk::MockEnvoyHttpFilter::default();
+    let json_str = r#"
+    {
+      "request": {
+        "set": [
+          { "name": "X-Static", "value": "hello" }
+        ]
+      }
+    }
+    "#;
+    let filter_conf = FilterConfig::new(json_str).expect("Failed to parse filter config json");
+    let mut filter = filter_conf.new_http_filter(&mut envoy_filter);
+
+    envoy_filter
+        .expect_get_most_specific_route_config()
+        .returning(|| None);
+    envoy_filter
+        .expect_get_request_headers()
+        .returning(|| vec![(EnvoyBuffer::new(b"host"), EnvoyBuffer::new(b"example.com"))]);
+
+    // get_attribute_string should NEVER be called when connection is not referenced.
+    envoy_filter
+        .expect_get_attribute_string()
+        .times(0)
+        .returning(|_| None);
+
+    envoy_filter
+        .expect_set_request_header()
+        .times(1)
+        .returning(|key, value: &[u8]| {
+            assert_eq!(key, "X-Static");
+            assert_eq!(value, b"hello");
+            true
+        });
+
+    assert_eq!(
+        filter.on_request_headers(&mut envoy_filter, true),
+        abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+    );
+}

--- a/internal/envoy_modules/lib/transformation/src/jinja.rs
+++ b/internal/envoy_modules/lib/transformation/src/jinja.rs
@@ -31,6 +31,8 @@ bitflags! {
         /// pre-parsed map with lowercase keys stored under `STATE_LOOKUP_KEY_COOKIES_I`.
         /// May be combined with `USES_GET_COOKIE` in the same transform.
         const USES_GET_COOKIE_I = 0b10;
+        /// A template references the Envoy connection attribute namespace.
+        const USES_CONNECTION = 0b100;
     }
 }
 use base64::{
@@ -176,7 +178,73 @@ pub fn compute_transform_flags(transform: &LocalTransform) -> TransformFlags {
     if all_templates().any(|s| s.contains("get_cookie_i(")) {
         flags |= TransformFlags::USES_GET_COOKIE_I;
     }
+    if references_connection(transform) {
+        flags |= TransformFlags::USES_CONNECTION;
+    }
     flags
+}
+
+fn references_connection(transform: &LocalTransform) -> bool {
+    let contains_connection = |s: &str| s.contains("connection");
+
+    transform
+        .add
+        .iter()
+        .chain(transform.set.iter())
+        .any(|pair| contains_connection(&pair.name) || contains_connection(&pair.value))
+        || transform
+            .body
+            .as_ref()
+            .is_some_and(|body| contains_connection(&body.value))
+        || transform.dynamic_metadata.iter().any(|metadata| {
+            contains_connection(&metadata.namespace)
+                || contains_connection(&metadata.key)
+                || metadata
+                    .value
+                    .string_value
+                    .as_deref()
+                    .is_some_and(contains_connection)
+        })
+}
+
+fn parse_mtls_value(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn get_connection_value<T: TransformationOps>(ops: &mut T) -> Option<minijinja::Value> {
+    let attributes = [
+        "connection.id",
+        "connection.mtls",
+        "connection.requested_server_name",
+        "connection.tls_version",
+        "connection.subject_local_certificate",
+        "connection.subject_peer_certificate",
+        "connection.dns_san_local_certificate",
+        "connection.dns_san_peer_certificate",
+        "connection.uri_san_local_certificate",
+        "connection.uri_san_peer_certificate",
+        "connection.sha256_peer_certificate_digest",
+        "connection.transport_failure_reason",
+        "connection.termination_details",
+    ];
+
+    let mut connection = HashMap::new();
+    for attribute in attributes {
+        if let Some(value) = ops.get_connection_attribute(attribute) {
+            let key = attribute.strip_prefix("connection.").unwrap_or(attribute);
+            let value = if attribute == "connection.mtls" {
+                minijinja::Value::from(parse_mtls_value(&value))
+            } else {
+                minijinja::Value::from(value)
+            };
+            connection.insert(key.to_string(), value);
+        }
+    }
+
+    (!connection.is_empty()).then(|| minijinja::Value::from(connection))
 }
 
 fn trim_outer_quotes(s: &str) -> &str {
@@ -564,6 +632,11 @@ pub fn transform_request<T: TransformationOps>(
             minijinja::Value::from_serialize(&cookies_i),
         );
     }
+    if transform_flags.contains(TransformFlags::USES_CONNECTION) {
+        if let Some(connection) = get_connection_value(&mut ops) {
+            m.insert("connection".to_string(), connection);
+        }
+    }
 
     let mut parsed_body_as_json = false;
     if flags.contains(ProcessFlags::BODY) {
@@ -706,6 +779,11 @@ pub fn transform_response<T: TransformationOps>(
             STATE_LOOKUP_KEY_COOKIES_I.to_string(),
             minijinja::Value::from_serialize(&cookies_i),
         );
+    }
+    if transform_flags.contains(TransformFlags::USES_CONNECTION) {
+        if let Some(connection) = get_connection_value(&mut ops) {
+            m.insert("connection".to_string(), connection);
+        }
     }
 
     let mut parsed_body_as_json = false;

--- a/internal/envoy_modules/lib/transformation/src/lib.rs
+++ b/internal/envoy_modules/lib/transformation/src/lib.rs
@@ -134,6 +134,9 @@ pub trait TransformationOps {
     fn drain_response_body(&mut self, number_of_bytes: usize) -> bool;
     fn append_response_body(&mut self, data: &[u8]) -> bool;
     fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str);
+    fn get_connection_attribute(&mut self, _attribute_name: &str) -> Option<String> {
+        None
+    }
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
# Description

### Problem

Currently, Jinja transformation templates in `TrafficPolicy` only have access to request/response headers and body data. There is no way to access connection-level metadata such as the TLS version, mTLS status, or client certificate details.

This limitation makes it difficult to build:

- Security-aware routing
- Conditional header injection
- Connection-aware logging
- Transformations based on TLS or client certificate information

---

## Solution

This change adds support for accessing Envoy connection and TLS attributes directly inside Jinja transformation templates through a new `connection` object.

Users can now reference connection metadata in both request and response transformations, for example:

```jinja
{{ connection.tls_version }}
{{ connection.mtls }}
{{ connection.sha256_peer_certificate_digest }}
```

---

## What Changed

### 1. Extended `TransformationOps`

Added a new method:

```rust
get_connection_attribute(...)
```

to the `TransformationOps` trait.

The method includes a default no-op implementation returning `None`, making the change fully backward compatible. Existing filter implementations (such as `http-acl`) require no modifications.

---

### 2. Implemented Connection Attribute Lookup

Implemented the actual lookup inside the `rustformation` filter.

The implementation maps 13 supported connection attribute names (for example, `"connection.tls_version"`) to their corresponding Envoy ABI enum variants and retrieves their values at runtime.

---

### 3. Added `connection` to Jinja Context

Injected a new `connection` object into both request and response Jinja template contexts.

This enables templates such as:

```jinja
{{ connection.tls_version }}
{{ connection.mtls }}
{{ connection.subject_peer_certificate }}
```

to work during both request and response transformations.

---

### 4. Robust Handling of `connection.mtls`

Envoy returns the `mtls` attribute as a raw byte instead of a string.

The implementation now:

- Handles raw byte values
- Handles string representations
- Normalizes the value into a proper boolean before exposing it to Jinja templates

Examples:

| Envoy Value | Template Value |
| ------------ | -------------- |
| `[1]` | `true` |
| `[]` | `false` |

---

## Supported Connection Attributes

The following attributes are now available inside Jinja templates:

- `connection.id`
- `connection.mtls`
- `connection.requested_server_name`
- `connection.tls_version`
- `connection.subject_local_certificate`
- `connection.subject_peer_certificate`
- `connection.dns_san_local_certificate`
- `connection.dns_san_peer_certificate`
- `connection.uri_san_local_certificate`
- `connection.uri_san_peer_certificate`
- `connection.sha256_peer_certificate_digest`
- `connection.transport_failure_reason`
- `connection.termination_details`

---

## Example Usage

```yaml
apiVersion: gateway.kgateway.dev/v1alpha1
kind: TrafficPolicy

spec:
  targetRefs:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
      name: my-route

  transformation:
    request:
      set:
        - name: X-TLS-Version
          value: "{{ connection.tls_version }}"

        - name: X-mTLS
          value: "{{ connection.mtls }}"

        - name: X-Client-Cert-Digest
          value: "{{ connection.sha256_peer_certificate_digest }}"
```

---

## Behavior

- Connection attributes are available in **both request and response** transformations.
- Attributes that are unavailable for a connection (for example, TLS fields on a plaintext connection) are omitted from the template context instead of rendering as empty strings.
- Existing implementations of `TransformationOps` remain unaffected because the new trait method provides a default implementation.

---

## Testing

Added unit tests covering:

- Request transformation context
- Response transformation context
- `connection.mtls` handling with raw byte values
- `connection.mtls` handling with empty buffers
- Boolean normalization behavior

- All local unit tests and translator test suites run and pass successfully.
---

## Compatibility

- **Backward compatible**
- No breaking API changes
- Existing filters continue to compile without modification

---

## Scope

Only Rust code was modified.

- No Go code changes
- Feature is fully contained within:

```
internal/envoy_modules/
```

---

## Change Type

```
/kind feature
```

---

## Changelog

### ```release-note

Added support for accessing TLS and connection attributes (such as TLS version, mTLS status, and client certificate details) inside Jinja transformation templates through a new `connection` object.
```
---
```
## Issue

Fixes: #14260 