### PR TITLE
fix(examples): correct basic auth secret htpasswd newline

### DIFF
--- a/examples/example-basic-auth-traffic-policy.yaml
+++ b/examples/example-basic-auth-traffic-policy.yaml
@@ -67,7 +67,9 @@ metadata:
 type: Opaque
 stringData:
   # The .htpasswd key with htpasswd data (users alice and bob, password is password).
-  .htpasswd: alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=\nbob:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
+  .htpasswd: |-
+    alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
+    bob:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
 ---
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: TrafficPolicy
@@ -97,6 +99,26 @@ spec:
   basicAuth:
     users:
       - "gateway-user:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g="
+---
+# A public route that opts out of the gateway-level basic auth below
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: public-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: example-gateway
+  hostnames:
+    - "api.example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /public
+      backendRefs:
+        - name: backend-service
+          port: 8080
 ---
 # Route that disables the gateway-level basic auth
 apiVersion: gateway.kgateway.dev/v1alpha1


### PR DESCRIPTION
# Description

The Basic Auth TrafficPolicy example ships a broken Secret for its "Option 2:
Reference a Kubernetes secret" path. The Secret's `.htpasswd` value was written
as an unquoted YAML scalar with a literal `\n` between the two entries:

```yaml
stringData:
  .htpasswd: alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=\nbob:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
```

YAML does not interpret `\n` in a plain scalar, so `.htpasswd` holds a single
physical line joining both users. kgateway parses the Secret by splitting on
real newlines (`validateAndFilterSHAUsers` in
`pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go`), so it
sees one malformed entry whose hash field is 72 characters instead of 33, keeps
zero valid users, and the `basic-auth-secret` policy fails with:

```
basic auth: no valid users with {SHA} hash format found
```

Anyone copy-pasting Option 2 as-is hits this.

The fix emits the htpasswd data as a YAML block scalar (`|-`) so the Secret
carries two real lines and both SHA-1 users are accepted:

```yaml
stringData:
  .htpasswd: |-
    alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
    bob:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
```

While here, this also defines the `public-route` HTTPRoute that the
`basic-auth-disabled` TrafficPolicy targets. It was referenced but never
declared in the example, so applying the manifest produced a dangling reference.
The added route mirrors the existing `protected-route` (same gateway and
hostname, a distinct `/public` path) so the whole example applies cleanly.

This is an examples-only change; no Go, API, or generated code is touched.

(Context, not a fix link: issue #13390 "basic-auth example not working" was
closed NOT_PLANNED against a stale-version symptom. The literal-`\n` defect
corrected here is a separate, still-present problem in the same file, so this PR
does not close that issue.)

# Change Type

/kind documentation

# Changelog

```release-note
NONE
```

# Additional Notes

Verified against the real code path: decoding the example Secret with
`sigs.k8s.io/yaml` and running the actual `validateAndFilterSHAUsers` yields 0
valid users on the current file and 2 valid users after the fix. `make
fmt-yaml-changed` is a no-op on the result (block scalar and indentation match
the repo yamlfmt config).
