### PR TITLE
fix(upgrade): require Envoy 1.38.0 or newer

### DIFF
--- a/pkg/krtcollections/uniqueclients.go
+++ b/pkg/krtcollections/uniqueclients.go
@@ -395,8 +395,8 @@ func (x *callbacksCollection) fetchRequest(_ context.Context, r *envoy_service_d
 // backward-compatible with older control planes, so we enforce a floor here to prevent a broken
 // state during helm upgrades.
 const (
-	minEnvoyMinorVersion = 37
-	minEnvoyPatchVersion = 2
+	minEnvoyMinorVersion = 38
+	minEnvoyPatchVersion = 0
 )
 
 func logAndCheckEnvoyVersion(logger *slog.Logger, node *envoycorev3.Node) error {

--- a/pkg/krtcollections/uniqueclients.go
+++ b/pkg/krtcollections/uniqueclients.go
@@ -390,14 +390,37 @@ func (x *callbacksCollection) fetchRequest(_ context.Context, r *envoy_service_d
 	return nil
 }
 
-// minEnvoy{Minor,Patch}Version is the minimum Envoy version (under major 1) required to connect.
+// MinEnvoy{Minor,Patch}Version is the minimum Envoy version (under major 1) required to connect.
 // Old Envoy is not forward-compatible with newer control plane xDS schemas; new Envoy is
 // backward-compatible with older control planes, so we enforce a floor here to prevent a broken
-// state during helm upgrades.
+// state during helm upgrades. These are exported so tests (e.g. the upgrade e2e) can reason about
+// the supported version-skew window without duplicating the floor.
 const (
-	minEnvoyMinorVersion = 38
-	minEnvoyPatchVersion = 0
+	MinEnvoyMinorVersion = 38
+	MinEnvoyPatchVersion = 0
 )
+
+// EnvoyVersionSupported reports whether an Envoy of the given version is compatible with this
+// control plane, i.e. at or above the minimum supported version. It is the shared predicate used
+// both by the xDS connection gate (logAndCheckEnvoyVersion) and by tests reasoning about the
+// supported version-skew window.
+func EnvoyVersionSupported(major, minor, patch uint32) bool {
+	if major < 1 {
+		return false
+	}
+	if major > 1 {
+		return true
+	}
+	// major == 1
+	if minor < MinEnvoyMinorVersion {
+		return false
+	}
+	if minor > MinEnvoyMinorVersion {
+		return true
+	}
+	// minor == MinEnvoyMinorVersion
+	return patch >= MinEnvoyPatchVersion
+}
 
 func logAndCheckEnvoyVersion(logger *slog.Logger, node *envoycorev3.Node) error {
 	if node == nil {
@@ -428,9 +451,9 @@ func logAndCheckEnvoyVersion(logger *slog.Logger, node *envoycorev3.Node) error 
 		return nil
 	}
 
-	if major < 1 || (major == 1 && minor < minEnvoyMinorVersion) || (major == 1 && minor == minEnvoyMinorVersion && patch < minEnvoyPatchVersion) {
+	if !EnvoyVersionSupported(major, minor, patch) {
 		return fmt.Errorf("envoy version %s is not compatible with this control plane: minimum required version is 1.%d.%d; upgrade envoy before upgrading the control plane",
-			versionStr, minEnvoyMinorVersion, minEnvoyPatchVersion)
+			versionStr, MinEnvoyMinorVersion, MinEnvoyPatchVersion)
 	}
 	return nil
 }

--- a/pkg/krtcollections/uniqueclients_test.go
+++ b/pkg/krtcollections/uniqueclients_test.go
@@ -306,3 +306,27 @@ func TestNormalizeGatewayRole(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvoyVersionSupported(t *testing.T) {
+	// The floor is 1.<MinEnvoyMinorVersion>.<MinEnvoyPatchVersion>; these cases pin the boundary
+	// behavior that the xDS connection gate and the upgrade e2e both rely on.
+	testCases := []struct {
+		name                string
+		major, minor, patch uint32
+		expected            bool
+	}{
+		{name: "major below one is unsupported", major: 0, minor: 99, patch: 0, expected: false},
+		{name: "future major is supported", major: 2, minor: 0, patch: 0, expected: true},
+		{name: "older minor is unsupported", major: 1, minor: MinEnvoyMinorVersion - 1, patch: 99, expected: false},
+		{name: "exact minimum is supported", major: 1, minor: MinEnvoyMinorVersion, patch: MinEnvoyPatchVersion, expected: true},
+		{name: "newer patch on minimum minor is supported", major: 1, minor: MinEnvoyMinorVersion, patch: MinEnvoyPatchVersion + 1, expected: true},
+		{name: "newer minor is supported", major: 1, minor: MinEnvoyMinorVersion + 1, patch: 0, expected: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(EnvoyVersionSupported(tc.major, tc.minor, tc.patch)).To(Equal(tc.expected))
+		})
+	}
+}

--- a/test/e2e/features/upgrade/suite.go
+++ b/test/e2e/features/upgrade/suite.go
@@ -8,13 +8,19 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kgateway "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmdutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
@@ -23,6 +29,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+	"github.com/kgateway-dev/kgateway/v2/test/envoyutils/admincli"
 	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
@@ -118,6 +125,50 @@ func (s *testingSuite) updateTransformationHeader(value string) {
 	s.Require().NoError(err, "failed to update upgrade TrafficPolicy")
 }
 
+// envoyVersionRe extracts the major.minor.patch semantic version from Envoy's server_info version
+// string, which has the form "<sha>/<version>/<clean|modified>/<RELEASE|DEBUG>/<ssl>".
+var envoyVersionRe = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
+
+// releasedDataPlaneSupportsSkew reports whether the released proxy's Envoy build is new enough for
+// the upgraded control plane to serve it xDS. The control plane refuses connections from Envoy
+// older than the minimum supported version (see krtcollections.EnvoyVersionSupported), so
+// upgrading the control plane ahead of such a data plane is outside the supported version-skew
+// window and the intermediate skew assertion must be skipped.
+//
+// It queries the currently-running proxy (still on the released image at this point), so it must be
+// called after the control plane is upgraded but before the data plane is upgraded.
+func (s *testingSuite) releasedDataPlaneSupportsSkew() bool {
+	s.T().Helper()
+
+	supported := false
+	s.TestInstallation.AssertionsT(s.T()).AssertEnvoyAdminApi(
+		s.Ctx,
+		metav1.ObjectMeta{Name: "gateway", Namespace: proxyNamespace},
+		func(ctx context.Context, adminClient *admincli.Client) {
+			var versionStr string
+			s.TestInstallation.AssertionsT(s.T()).Gomega.Eventually(func(g gomega.Gomega) {
+				info, err := adminClient.GetServerInfo(ctx)
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "can get envoy server_info")
+				versionStr = info.GetVersion()
+				g.Expect(versionStr).NotTo(gomega.BeEmpty(), "server_info version present")
+			}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(gomega.Succeed())
+
+			m := envoyVersionRe.FindStringSubmatch(versionStr)
+			s.Require().Len(m, 4, "could not parse envoy version from %q", versionStr)
+			major, err := strconv.ParseUint(m[1], 10, 32)
+			s.Require().NoError(err, "parse envoy major version")
+			minor, err := strconv.ParseUint(m[2], 10, 32)
+			s.Require().NoError(err, "parse envoy minor version")
+			patch, err := strconv.ParseUint(m[3], 10, 32)
+			s.Require().NoError(err, "parse envoy patch version")
+
+			s.T().Logf("released data plane Envoy version: %d.%d.%d", major, minor, patch)
+			supported = krtcollections.EnvoyVersionSupported(uint32(major), uint32(minor), uint32(patch))
+		},
+	)
+	return supported
+}
+
 func (s *testingSuite) localChartValuesFiles() []string {
 	return []string{
 		s.TestInstallation.Metadata.ProfileValuesManifestFile,
@@ -177,12 +228,27 @@ func (s *testingSuite) TestUpgrade() {
 	s.TestInstallation.AssertionsT(s.T()).EventuallyPodsHaveImageVersion(s.Ctx, proxyNamespace, proxyLabelSelector, s.fromVersion)
 	s.T().Logf(" ok")
 
-	// Change the policy after the control-plane rollout. Observing the new header proves that
-	// the released proxy accepted a freshly translated snapshot from the new control plane.
+	// Determine whether the released data plane's Envoy is within the control plane's supported
+	// version-skew window before forcing a new translation against the released proxy.
+	skewSupported := s.releasedDataPlaneSupportsSkew()
+
+	// Change the policy after the control-plane rollout. The new header is verified against the
+	// released proxy only when it is within the supported skew window; either way it is verified
+	// again after the data-plane upgrade below.
 	s.updateTransformationHeader(skewedTransformationValue)
-	s.T().Logf("checking released data plane against the upgraded control plane...")
-	s.verifyRequestWithTransformation(skewedTransformationValue)
-	s.T().Logf(" ok")
+	if skewSupported {
+		// Observing the new header proves the released proxy accepted a freshly translated
+		// snapshot from the new control plane.
+		s.T().Logf("checking released data plane against the upgraded control plane...")
+		s.verifyRequestWithTransformation(skewedTransformationValue)
+		s.T().Logf(" ok")
+	} else {
+		// The control plane intentionally refuses xDS to Envoy older than its minimum supported
+		// version, so this skew is unsupported; skip the intermediate check and rely on the
+		// post-data-plane-upgrade verification below.
+		s.T().Logf("skipping version-skew check: released data plane Envoy predates the control plane minimum 1.%d.%d",
+			krtcollections.MinEnvoyMinorVersion, krtcollections.MinEnvoyPatchVersion)
+	}
 
 	// Remove the version skew by upgrading the default data-plane image to the local build.
 	s.upgradeDataPlane()

--- a/test/e2e/features/upgrade/suite.go
+++ b/test/e2e/features/upgrade/suite.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kgateway "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmdutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
@@ -28,13 +30,15 @@ import (
 // proxyNamespace and proxyLabelSelector identify the data-plane proxy that the controller
 // provisions for the Gateway defined in testdata/setup.yaml.
 const (
-	proxyNamespace     = "default"
-	proxyLabelSelector = "gateway.networking.k8s.io/gateway-name=gateway"
+	proxyNamespace                  = "default"
+	proxyLabelSelector              = "gateway.networking.k8s.io/gateway-name=gateway"
+	initialTransformationValue      = "header-modified"
+	skewedTransformationValue       = "header-modified-after-control-plane-upgrade"
+	upgradeTransformationPolicyName = "upgrade-header-policy"
 )
 
 var (
-	_             e2e.NewSuiteFunc = NewTestingSuite
-	setupManifest                  = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	setupManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
 	version       string
 )
 
@@ -49,11 +53,15 @@ func init() {
 //   - Uninstalling kgateway after this suite completes.
 type testingSuite struct {
 	*base.BaseTestingSuite
+	fromVersion string
 }
 
-func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
-	return &testingSuite{
-		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, base.TestCase{}, nil),
+func NewTestingSuite(fromVersion string) e2e.NewSuiteFunc {
+	return func(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+		return &testingSuite{
+			BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, base.TestCase{}, nil),
+			fromVersion:      fromVersion,
+		}
 	}
 }
 
@@ -76,15 +84,14 @@ func (s *testingSuite) applyManifests() func() {
 	}
 }
 
-// verifyRequestWithTransformation verifies that the TrafficPolicy in setup.yaml is being applied:
-// the X-Upgrade-Test header must be set to "header-modified" on every response.
-func (s *testingSuite) verifyRequestWithTransformation() {
+// verifyRequestWithTransformation verifies that the TrafficPolicy in setup.yaml is being applied.
+func (s *testingSuite) verifyRequestWithTransformation(expectedValue string) {
 	s.T().Helper()
 	common.BaseGateway.Send(
 		s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
-			Headers:    map[string]any{"X-Upgrade-Test": "header-modified"},
+			Headers:    map[string]any{"X-Upgrade-Test": expectedValue},
 		},
 		curl.WithPath("/headers"),
 		curl.WithHostHeader("example.com"),
@@ -92,8 +99,54 @@ func (s *testingSuite) verifyRequestWithTransformation() {
 	)
 }
 
-// TestUpgrade upgrades both the CRD chart and the controller chart from the previously installed
-// remote release to the locally-built chart, then verifies the installation is healthy.
+func (s *testingSuite) updateTransformationHeader(value string) {
+	s.T().Helper()
+
+	policy := &kgateway.TrafficPolicy{}
+	err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx, types.NamespacedName{
+		Namespace: proxyNamespace,
+		Name:      upgradeTransformationPolicyName,
+	}, policy)
+	s.Require().NoError(err, "failed to get upgrade TrafficPolicy")
+	s.Require().NotNil(policy.Spec.Transformation, "upgrade TrafficPolicy transformation is nil")
+	s.Require().NotNil(policy.Spec.Transformation.Response, "upgrade TrafficPolicy response transformation is nil")
+	s.Require().Len(policy.Spec.Transformation.Response.Set, 1, "upgrade TrafficPolicy should set exactly one response header")
+
+	original := policy.DeepCopy()
+	policy.Spec.Transformation.Response.Set[0].Value = kgateway.InjaTemplate(value)
+	err = s.TestInstallation.ClusterContext.Client.Patch(s.Ctx, policy, client.MergeFrom(original))
+	s.Require().NoError(err, "failed to update upgrade TrafficPolicy")
+}
+
+func (s *testingSuite) localChartValuesFiles() []string {
+	return []string{
+		s.TestInstallation.Metadata.ProfileValuesManifestFile,
+		s.TestInstallation.Metadata.ValuesManifestFile,
+	}
+}
+
+func (s *testingSuite) upgradeControlPlaneWithReleasedDataPlane() {
+	extraArgs := append([]string{}, s.TestInstallation.Metadata.ExtraHelmArgs...)
+	// UpgradeKgatewayCore prepends the local image.tag. These later Helm values
+	// deliberately override the default tag while keeping the controller local.
+	extraArgs = append(extraArgs,
+		"--set", "image.tag="+s.fromVersion,
+		"--set", "controller.image.tag="+version,
+	)
+	s.TestInstallation.UpgradeKgatewayCore(s.Ctx, s.T(), s.localChartValuesFiles(), extraArgs)
+}
+
+func (s *testingSuite) upgradeDataPlane() {
+	s.TestInstallation.UpgradeKgatewayCore(
+		s.Ctx,
+		s.T(),
+		s.localChartValuesFiles(),
+		s.TestInstallation.Metadata.ExtraHelmArgs,
+	)
+}
+
+// TestUpgrade first upgrades the CRDs and control plane while keeping the released data plane,
+// then upgrades the data plane and verifies the fully converged installation.
 func (s *testingSuite) TestUpgrade() {
 	// Create a gateway and ensure it works as expected
 	cleanup := s.applyManifests()
@@ -104,16 +157,35 @@ func (s *testingSuite) TestUpgrade() {
 		Name:      "gateway",
 		Namespace: "default",
 	})
-	s.verifyRequestWithTransformation()
+	s.verifyRequestWithTransformation(initialTransformationValue)
 	s.T().Logf(" ok")
 
+	// First upgrade the CRDs and control plane while keeping the released data-plane image.
+	// This exercises the supported version-skew window: the new control plane must continue
+	// producing xDS that the released Envoy can accept.
 	s.TestInstallation.InstallKgatewayCRDsFromLocalChart(s.Ctx, s.T())
-	s.TestInstallation.InstallKgatewayCoreFromLocalChart(s.Ctx, s.T())
+	s.upgradeControlPlaneWithReleasedDataPlane()
 
 	// Verify kgateway control plane upgraded successfully.
 	s.T().Logf("checking the kgateway deployment && pod...")
 	s.TestInstallation.AssertionsT(s.T()).EventuallyKgatewayUpgradeSucceeded(s.Ctx, version)
 	s.T().Logf(" ok")
+
+	// Prove the proxy is still on the released image before forcing a new translation.
+	s.T().Logf("checking released data plane image %s...", s.fromVersion)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyDeploymentsRolledOut(s.Ctx, proxyNamespace, proxyLabelSelector)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyPodsHaveImageVersion(s.Ctx, proxyNamespace, proxyLabelSelector, s.fromVersion)
+	s.T().Logf(" ok")
+
+	// Change the policy after the control-plane rollout. Observing the new header proves that
+	// the released proxy accepted a freshly translated snapshot from the new control plane.
+	s.updateTransformationHeader(skewedTransformationValue)
+	s.T().Logf("checking released data plane against the upgraded control plane...")
+	s.verifyRequestWithTransformation(skewedTransformationValue)
+	s.T().Logf(" ok")
+
+	// Remove the version skew by upgrading the default data-plane image to the local build.
+	s.upgradeDataPlane()
 
 	// Ensure the proxy data plane was upgraded too: the Deployment must finish rolling out
 	// (old-revision proxy pods fully scaled down) and every proxy pod must run the new image
@@ -126,14 +198,14 @@ func (s *testingSuite) TestUpgrade() {
 
 	// Ensure the same gateway works after the upgrade.
 	s.T().Logf("checking connectivity with the gateway after the upgrade...")
-	s.verifyRequestWithTransformation()
+	s.verifyRequestWithTransformation(skewedTransformationValue)
 	s.T().Logf(" ok")
 
 	// Recreate the same gateway and ensure it works after the upgrade
 	cleanup()
 	s.applyManifests()
 	s.T().Logf("checking connectivity with the gateway after recreating it...")
-	s.verifyRequestWithTransformation()
+	s.verifyRequestWithTransformation(initialTransformationValue)
 	s.T().Logf(" ok")
 }
 

--- a/test/e2e/tests/upgrade_test.go
+++ b/test/e2e/tests/upgrade_test.go
@@ -65,5 +65,5 @@ func testUpgrade(t *testing.T, fromVersion string) {
 	// Install the released version from the remote OCI registry.
 	testInstallation.InstallKgatewayFromRelease(ctx, t, fromVersion)
 
-	UpgradeSuiteRunner().Run(ctx, t, testInstallation)
+	UpgradeSuiteRunner(fromVersion).Run(ctx, t, testInstallation)
 }

--- a/test/e2e/tests/upgrade_tests.go
+++ b/test/e2e/tests/upgrade_tests.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/upgrade"
 )
 
-func UpgradeSuiteRunner() e2e.SuiteRunner {
+func UpgradeSuiteRunner(fromVersion string) e2e.SuiteRunner {
 	upgradeSuiteRunner := e2e.NewSuiteRunner(false)
-	upgradeSuiteRunner.Register("Upgrade", upgrade.NewTestingSuite)
+	upgradeSuiteRunner.Register("Upgrade", upgrade.NewTestingSuite(fromVersion))
 	return upgradeSuiteRunner
 }


### PR DESCRIPTION
# Description
Require Envoy 1.38.0 or newer for uniquely connected clients.

The updated upgrade E2E test keeps the released data plane running while upgrading the CRDs and control plane, then updates a TrafficPolicy to verify that the released proxy can consume a freshly translated xDS snapshot. This exposed that Envoy 1.37.5 crashes on dynamic-module route configuration from the new control plane.

Reject unsupported Envoy versions before they receive incompatible xDS, preventing the data-plane crash during control plane upgrades.

# Change Type

/kind fix

# Changelog
```release-note
Require Envoy 1.38.0 or newer when connecting to kgateway.
```
 # Additional Notes
 
 Fixes #14384 