### PR TITLE
[2.3] fix: revert per-client xDS readiness gates in favor of a fir…

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -67,7 +67,7 @@ jobs:
           # May 29, 2026: ~4 minutes
           - cluster-name: 'cluster-seven'
             go-test-args: '-timeout=25m'
-            go-test-run-regex: '^TestAPIValidation$$|^TestKgateway$$/^OAuth$$|^TestKgateway$$/^TrafficPolicyStatus$$|^TestKgateway$$/^AttachedRoutes$$'
+            go-test-run-regex: '^TestAPIValidation$$|^TestKgateway$$/^OAuth$$|^TestKgateway$$/^TrafficPolicyStatus$$|^TestKgateway$$/^AttachedRoutes$$|^TestKgateway$$/^XdsStarvation$$'
             localstack: 'false'
           # May 29, 2026: ~5 minutes
           - cluster-name: 'cluster-eight'

--- a/Makefile
+++ b/Makefile
@@ -884,7 +884,7 @@ CLOUD_PROVIDER_KIND ?= false
 
 .PHONY: kind-create
 kind-create: ## Create a KinD cluster
-	$(KIND) get clusters | grep $(CLUSTER_NAME) || $(KIND) create cluster --name $(CLUSTER_NAME) --image kindest/node:$(CLUSTER_NODE_VERSION)
+	$(KIND) get clusters | grep -x $(CLUSTER_NAME) || $(KIND) create cluster --name $(CLUSTER_NAME) --image kindest/node:$(CLUSTER_NODE_VERSION)
 
 CONFORMANCE_CHANNEL ?= experimental
 CONFORMANCE_VERSION ?= v1.5.1

--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -3,22 +3,15 @@ package proxy_syncer
 import (
 	"fmt"
 	"maps"
-	"sort"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	envoytcpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/types/known/anypb"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	krtutil "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
@@ -133,65 +126,27 @@ func snapshotPerClient(
 		clustersForUcc := krt.FetchOne(kctx, clusterSnapshot, krt.FilterKey(ucc.ResourceName()))
 		clientEndpointResources := krt.FetchOne(kctx, endpointResources, krt.FilterKey(ucc.ResourceName()))
 
-		// Defer publishing a per-client snapshot until its per-client inputs
-		// are coherent. Three guards:
+		// HACK
+		// https://github.com/solo-io/gloo/pull/10611/files#diff-060acb7cdd3a287a3aef1dd864aae3e0193da17b6230c382b649ce9dc0eca80b
+		// This handler can fire before the per-client collections — driven
+		// by the same upstream events — have re-run, so FetchOne may briefly
+		// return nil even though results are imminent. Defer instead of
+		// publishing: returning nil surfaces as a Delete event in
+		// proxy_syncer.go's xDS subscriber, whose Delete branch is
+		// intentionally a no-op, so the xDS snapshot cache retains the
+		// last-published snapshot and Envoy keeps serving its previous,
+		// coherent config until a new snapshot overwrites it.
 		//
-		//  1. If per-client endpoints haven't been derived yet for this UCC,
-		//     return nil. This handler can fire before the per-client
-		//     collections — driven by the same upstream events — have
-		//     re-run, so FetchOne may briefly return nil even though results
-		//     are imminent. clustersForUcc is treated differently as a
-		//     defensive measure: a nil clusterSnapshot entry can in principle
-		//     mean either "not yet processed" or "this UCC legitimately has
-		//     zero backend clusters". In practice the latter is hard to hit
-		//     because finalBackends pulls in a BackendObjectIR for every
-		//     Service port in the cluster (kube-apiserver, kube-dns, the
-		//     gateway's own Service, etc.), so clustersForUcc is virtually
-		//     never nil in an operational cluster — even for a gateway whose
-		//     HTTPRoutes only emit RequestRedirect or direct responses.
-		//     Substituting an empty resource set keeps the function honest
-		//     against narrow edge cases (a freshly started controller before
-		//     Service informers have synced, or a configuration whose only
-		//     backends are non-K8s and all fail translation) without
-		//     weakening guards 2 and 3, which still defer if any specific
-		//     cluster reference is missing.
-		//
-		//  2. If any cluster referenced as a dataplane routing target
-		//     (RouteAction / TcpProxy) is not yet present or explicitly
-		//     errored, return nil (see findMissingReferencedClusters below).
-		//     Publishing before then would emit a partial CDS referenced by
-		//     listeners/routes and cause Envoy to return 500/NC on routes
-		//     whose clusters just happen to be in the same CDS response.
-		//
-		//  3. If any referenced EDS cluster has no matching ClusterLoadAssignment
-		//     in the EDS resources that would be sent, return nil. Publishing
-		//     CDS/RDS/LDS before EDS catches up can make Envoy drop all hosts for
-		//     a route that was healthy before a controller restart.
-		//
-		// Returning nil removes this UCC's entry from the output collection,
-		// which surfaces as a Delete event in proxy_syncer.go's xDS
-		// subscriber. That Delete branch is intentionally a no-op so the
-		// xDS snapshot cache retains the last-published Snapshot for this
-		// client. Envoy therefore keeps serving its previous, coherent
-		// config until a new coherent snapshot overwrites it. This is what
-		// prevents an unresolvable reference — a user BackendRef typo, a
-		// plugin bug — from stranding Envoy: there is no error response on
-		// valid traffic during the defer window, only continuity.
-		//
-		// BackendRef typos never reach this gate as real cluster names:
-		// IR-time resolution substitutes wellknown.BlackholeClusterName,
-		// which findMissingReferencedClusters explicitly skips.
-		//
-		// Historical context: https://github.com/solo-io/gloo/pull/10611.
-		if clustersForUcc == nil {
-			clustersForUcc = &clustersWithErrors{
-				clusters: envoycache.Resources{
-					Items: map[string]envoycachetypes.ResourceWithTTL{},
-				},
-			}
-		}
-		if clientEndpointResources == nil {
-			logger.Info("per-client endpoints not ready; deferring snapshot", "client", ucc.ResourceName())
+		// Between the first per-client cluster row landing and the last,
+		// published snapshots can still be partial — the reconnect-time race
+		// #13868 tried to close with whole-snapshot readiness gates. Those
+		// gates could stay unsatisfied indefinitely (stranding warm clients
+		// on stale endpoints and starving new pods into crashloops, #14184)
+		// and were reverted. The first-connect delay in
+		// pkg/krtcollections/uniqueclients.go keeps a client's first watch
+		// from observing that convergence window.
+		if clustersForUcc == nil || clientEndpointResources == nil {
+			logger.Info("per-client inputs not ready; deferring snapshot", "client", ucc.ResourceName())
 			return nil
 		}
 
@@ -208,33 +163,8 @@ func snapshotPerClient(
 			clusterResources.Version = fmt.Sprintf("%d", clustersForUcc.clustersHash^listenerRouteSnapshot.ClustersHash)
 			clusterResources.Items = clustersProto
 		}
-		if missingClusters := findMissingReferencedClusters(
-			listenerRouteSnapshot.ReferencedClusters,
-			clusterResources.Items,
-			clustersForUcc.erroredClusters,
-		); len(missingClusters) > 0 {
-			logger.Info(
-				"defer building snapshot until all referenced clusters are ready",
-				"client", ucc.ResourceName(),
-				"missing_clusters", missingClusters,
-			)
-			return nil
-		}
 		// Exclude CLAs for STATIC clusters so ADS snapshot only contains resources Envoy will request.
 		endpointRes := filterEndpointResourcesForStaticClusters(clusterResources, clientEndpointResources.endpoints)
-		if missingEndpointClusters := findMissingReferencedEndpointResources(
-			listenerRouteSnapshot.ReferencedClusters,
-			clusterResources.Items,
-			endpointRes.Items,
-			clustersForUcc.erroredClusters,
-		); len(missingEndpointClusters) > 0 {
-			logger.Info(
-				"defer building snapshot until all referenced EDS resources are ready",
-				"client", ucc.ResourceName(),
-				"missing_endpoint_clusters", missingEndpointClusters,
-			)
-			return nil
-		}
 
 		snap.erroredClusters = clustersForUcc.erroredClusters
 		snap.proxyKey = ucc.ResourceName()
@@ -331,220 +261,6 @@ func snapshotPerClient(
 	})
 
 	return xdsSnapshotsForUcc
-}
-
-// collectReferencedClusters returns the set of cluster names referenced as
-// dataplane routing targets (RouteAction and TcpProxy cluster / weighted-
-// cluster specifiers) by the given routes and listeners. It walks typed_config
-// extensions via protoreflect so it stays correct as Envoy adds new filter
-// types that embed dataplane-target clusters.
-//
-// Scope is intentionally narrowed to dataplane targets. Ancillary cluster
-// references (access-log GrpcService, JWT jwks HttpUri, ext_authz cluster,
-// ratelimit cluster, etc.) are deliberately ignored because:
-//
-//  1. The plugin that emits the filter is responsible for also emitting the
-//     ancillary cluster in the same per-gateway snapshot's ExtraClusters,
-//     so there is no reconnect race between listener and cluster — they
-//     arrive coherent or not at all.
-//  2. If a plugin emits an ancillary reference without declaring the
-//     cluster, that is a plugin bug. Gating on it would starve the entire
-//     gateway forever; publishing and letting the filter fail (or degrade
-//     per its failure_mode_allow) surfaces the bug without blocking valid
-//     traffic.
-//
-// This is computed once per GatewayXdsResources (shared across all connected
-// clients for that role) rather than per client — the proto walk and Any
-// unmarshalling are non-trivial on large LDS/RDS.
-func collectReferencedClusters(routes, listeners envoycache.Resources) map[string]struct{} {
-	referenced := make(map[string]struct{})
-	collectResourceClusterReferences(routes, referenced)
-	collectResourceClusterReferences(listeners, referenced)
-	return referenced
-}
-
-func findMissingReferencedClusters(
-	referencedClusters map[string]struct{},
-	clusters map[string]envoycachetypes.ResourceWithTTL,
-	erroredClusters []string,
-) []string {
-	erroredClusterSet := stringSet(erroredClusters)
-
-	missingClusters := make([]string, 0, len(referencedClusters))
-	for name := range referencedClusters {
-		if _, ok := clusters[name]; ok {
-			continue
-		}
-		if _, ok := erroredClusterSet[name]; ok {
-			continue
-		}
-		if name == wellknown.BlackholeClusterName {
-			continue
-		}
-		missingClusters = append(missingClusters, name)
-	}
-	sort.Strings(missingClusters)
-
-	return missingClusters
-}
-
-func findMissingReferencedEndpointResources(
-	referencedClusters map[string]struct{},
-	clusters map[string]envoycachetypes.ResourceWithTTL,
-	endpoints map[string]envoycachetypes.ResourceWithTTL,
-	erroredClusters []string,
-) []string {
-	erroredClusterSet := stringSet(erroredClusters)
-
-	missingEndpointClusters := make([]string, 0, len(referencedClusters))
-	for name := range referencedClusters {
-		if _, ok := erroredClusterSet[name]; ok {
-			continue
-		}
-		if name == wellknown.BlackholeClusterName {
-			continue
-		}
-
-		clusterResource, ok := clusters[name]
-		if !ok {
-			continue
-		}
-		endpointResourceName, requiresEndpointResource := endpointResourceNameForCluster(clusterResource)
-		if !requiresEndpointResource {
-			continue
-		}
-		if _, ok := endpoints[endpointResourceName]; ok {
-			continue
-		}
-		missingEndpointClusters = append(missingEndpointClusters, name)
-	}
-	sort.Strings(missingEndpointClusters)
-
-	return missingEndpointClusters
-}
-
-func endpointResourceNameForCluster(resource envoycachetypes.ResourceWithTTL) (string, bool) {
-	cluster, ok := resource.Resource.(*envoyclusterv3.Cluster)
-	if !ok {
-		return "", false
-	}
-	clusterType, ok := cluster.GetClusterDiscoveryType().(*envoyclusterv3.Cluster_Type)
-	if !ok || clusterType.Type != envoyclusterv3.Cluster_EDS {
-		return "", false
-	}
-	if edsServiceName := cluster.GetEdsClusterConfig().GetServiceName(); edsServiceName != "" {
-		return edsServiceName, true
-	}
-	return cluster.GetName(), true
-}
-
-func stringSet(values []string) map[string]struct{} {
-	out := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		out[value] = struct{}{}
-	}
-	return out
-}
-
-func collectResourceClusterReferences(resources envoycache.Resources, referencedClusters map[string]struct{}) {
-	for _, item := range resources.Items {
-		if item.Resource == nil {
-			continue
-		}
-		collectProtoClusterReferences(item.Resource, referencedClusters)
-	}
-}
-
-func collectProtoClusterReferences(msg proto.Message, referencedClusters map[string]struct{}) {
-	if msg == nil {
-		return
-	}
-
-	switch typedMsg := msg.(type) {
-	case *envoyroutev3.RouteAction:
-		switch clusterSpecifier := typedMsg.GetClusterSpecifier().(type) {
-		case *envoyroutev3.RouteAction_Cluster:
-			if clusterSpecifier.Cluster != "" {
-				referencedClusters[clusterSpecifier.Cluster] = struct{}{}
-			}
-		case *envoyroutev3.RouteAction_WeightedClusters:
-			if clusterSpecifier.WeightedClusters == nil {
-				break
-			}
-			for _, cluster := range clusterSpecifier.WeightedClusters.GetClusters() {
-				if cluster.GetName() != "" {
-					referencedClusters[cluster.GetName()] = struct{}{}
-				}
-			}
-		}
-	case *envoytcpv3.TcpProxy:
-		switch clusterSpecifier := typedMsg.GetClusterSpecifier().(type) {
-		case *envoytcpv3.TcpProxy_Cluster:
-			if clusterSpecifier.Cluster != "" {
-				referencedClusters[clusterSpecifier.Cluster] = struct{}{}
-			}
-		case *envoytcpv3.TcpProxy_WeightedClusters:
-			if clusterSpecifier.WeightedClusters == nil {
-				break
-			}
-			for _, cluster := range clusterSpecifier.WeightedClusters.GetClusters() {
-				if cluster.GetName() != "" {
-					referencedClusters[cluster.GetName()] = struct{}{}
-				}
-			}
-		}
-	}
-
-	collectNestedProtoClusterReferences(msg.ProtoReflect(), referencedClusters)
-}
-
-func collectNestedProtoClusterReferences(
-	msg protoreflect.Message,
-	referencedClusters map[string]struct{},
-) {
-	if !msg.IsValid() {
-		return
-	}
-
-	msg.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
-		switch {
-		case fd.IsList() && fd.Message() != nil:
-			list := v.List()
-			for i := 0; i < list.Len(); i++ {
-				collectProtoClusterReferencesFromValue(list.Get(i), referencedClusters)
-			}
-		case fd.IsMap() && fd.MapValue().Message() != nil:
-			m := v.Map()
-			m.Range(func(_ protoreflect.MapKey, value protoreflect.Value) bool {
-				collectProtoClusterReferencesFromValue(value, referencedClusters)
-				return true
-			})
-		case !fd.IsList() && !fd.IsMap() && fd.Message() != nil:
-			collectProtoClusterReferencesFromValue(v, referencedClusters)
-		}
-		return true
-	})
-}
-
-func collectProtoClusterReferencesFromValue(v protoreflect.Value, referencedClusters map[string]struct{}) {
-	msg := v.Message()
-	if !msg.IsValid() {
-		return
-	}
-
-	if anyMsg, ok := msg.Interface().(*anypb.Any); ok {
-		nestedMsg, err := anyMsg.UnmarshalNew()
-		if err != nil {
-			// Typed extensions whose Go types aren't linked into this binary will fail here;
-			// that's expected, but log at debug so genuinely malformed configs are diagnosable.
-			logger.Debug("skipping typed_config during cluster reference scan", "type_url", anyMsg.GetTypeUrl(), "error", err)
-			return
-		}
-		collectProtoClusterReferences(nestedMsg, referencedClusters)
-		return
-	}
-
-	collectProtoClusterReferences(msg.Interface(), referencedClusters)
 }
 
 // filterEndpointResourcesForStaticClusters returns endpoint resources excluding CLAs for clusters

--- a/pkg/kgateway/proxy_syncer/perclient_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_test.go
@@ -5,28 +5,16 @@ import (
 	"testing"
 	"time"
 
-	envoyaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	envoygrpcaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
-	envoyextauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
-	envoyjwtauthnv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
-	envoyhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	envoywellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/xds"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
@@ -156,185 +144,11 @@ func TestFilterEndpointResourcesForStaticClusters_MixedStaticAndNonStatic(t *tes
 	}
 }
 
-func TestSnapshotPerClientDefersUntilAllReferencedClustersAreReady(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
-	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
-
-	uccs := krt.NewStaticCollection[ir.UniqlyConnectedClient](nil, []ir.UniqlyConnectedClient{ucc})
-	routes := sliceToResources([]*envoyroutev3.RouteConfiguration{
-		{
-			Name: "route-config",
-			VirtualHosts: []*envoyroutev3.VirtualHost{
-				{
-					Name:    "vhost",
-					Domains: []string{"*"},
-					Routes: []*envoyroutev3.Route{
-						{
-							Name: "weighted-route",
-							Action: &envoyroutev3.Route_Route{
-								Route: &envoyroutev3.RouteAction{
-									ClusterSpecifier: &envoyroutev3.RouteAction_WeightedClusters{
-										WeightedClusters: &envoyroutev3.WeightedCluster{
-											Clusters: []*envoyroutev3.WeightedCluster_ClusterWeight{
-												{Name: "cluster-a", Weight: wrapperspb.UInt32(1)},
-												{Name: "cluster-b", Weight: wrapperspb.UInt32(1)},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
-	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{{
-		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
-		Routes:             routes,
-		Listeners:          listeners,
-		ReferencedClusters: collectReferencedClusters(routes, listeners),
-	}})
-	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
-		{
-			Client:         ucc,
-			Name:           "cluster-a",
-			Cluster:        &envoyclusterv3.Cluster{Name: "cluster-a"},
-			ClusterVersion: 1,
-		},
-	})
-	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, nil)
-
-	snapshots := snapshotPerClient(
-		krtutil.KrtOptions{},
-		uccs,
-		mostXdsSnapshots,
-		PerClientEnvoyEndpoints{
-			endpoints: endpointCol,
-			index: krtpkg.UnnamedIndex(endpointCol, func(ep UccWithEndpoints) []string {
-				return []string{ep.Client.ResourceName()}
-			}),
-		},
-		PerClientEnvoyClusters{
-			clusters: clusterCol,
-			index: krtpkg.UnnamedIndex(clusterCol, func(cluster uccWithCluster) []string {
-				return []string{cluster.Client.ResourceName()}
-			}),
-		},
-	)
-
-	g.Consistently(func() int {
-		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
-
-	clusterCol.UpdateObject(uccWithCluster{
-		Client:         ucc,
-		Name:           "cluster-b",
-		Cluster:        &envoyclusterv3.Cluster{Name: "cluster-b"},
-		ClusterVersion: 2,
-	})
-
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
-
-	snap := snapshots.List()[0].snap
-	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-a"))
-	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.HaveKey("cluster-b"))
-}
-
-func TestSnapshotPerClientDefersUntilReferencedEDSClustersHaveEndpoints(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
-	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
-
-	uccs := krt.NewStaticCollection[ir.UniqlyConnectedClient](nil, []ir.UniqlyConnectedClient{ucc})
-	routes := sliceToResources([]*envoyroutev3.RouteConfiguration{
-		{
-			Name: "route-config",
-			VirtualHosts: []*envoyroutev3.VirtualHost{
-				{
-					Name:    "vhost",
-					Domains: []string{"*"},
-					Routes: []*envoyroutev3.Route{
-						{
-							Name: "eds-route",
-							Action: &envoyroutev3.Route_Route{
-								Route: &envoyroutev3.RouteAction{
-									ClusterSpecifier: &envoyroutev3.RouteAction_Cluster{Cluster: "cluster-a"},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
-	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{{
-		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
-		Routes:             routes,
-		Listeners:          listeners,
-		ReferencedClusters: collectReferencedClusters(routes, listeners),
-	}})
-	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
-		{
-			Client: ucc,
-			Name:   "cluster-a",
-			Cluster: &envoyclusterv3.Cluster{
-				Name: "cluster-a",
-				ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{
-					Type: envoyclusterv3.Cluster_EDS,
-				},
-			},
-			ClusterVersion: 1,
-		},
-	})
-	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, nil)
-
-	snapshots := snapshotPerClient(
-		krtutil.KrtOptions{},
-		uccs,
-		mostXdsSnapshots,
-		PerClientEnvoyEndpoints{
-			endpoints: endpointCol,
-			index: krtpkg.UnnamedIndex(endpointCol, func(ep UccWithEndpoints) []string {
-				return []string{ep.Client.ResourceName()}
-			}),
-		},
-		PerClientEnvoyClusters{
-			clusters: clusterCol,
-			index: krtpkg.UnnamedIndex(clusterCol, func(cluster uccWithCluster) []string {
-				return []string{cluster.Client.ResourceName()}
-			}),
-		},
-	)
-
-	g.Consistently(func() int {
-		return len(snapshots.List())
-	}, 200*time.Millisecond, 20*time.Millisecond).Should(gomega.Equal(0))
-
-	endpointCol.UpdateObject(UccWithEndpoints{
-		Client: ucc,
-		Endpoints: &envoyendpointv3.ClusterLoadAssignment{
-			ClusterName: "cluster-a",
-		},
-		EndpointsHash: 3,
-		endpointsName: "cluster-a",
-	})
-
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, time.Second, 20*time.Millisecond).Should(gomega.Equal(1))
-
-	snap := snapshots.List()[0].snap
-	g.Expect(snap.Resources[envoycachetypes.Endpoint].Items).To(gomega.HaveKey("cluster-a"))
-}
-
+// TestSnapshotPerClientStillPublishesWhenReferencedClusterErrored pins the
+// fail-closed behavior for errored clusters: a cluster whose backend
+// translation failed is excluded from the CDS payload (routes to it get
+// 500/NC in Envoy) but does not prevent the rest of the snapshot from
+// publishing.
 func TestSnapshotPerClientStillPublishesWhenReferencedClusterErrored(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -373,10 +187,9 @@ func TestSnapshotPerClientStillPublishesWhenReferencedClusterErrored(t *testing.
 	})
 	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
 	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{{
-		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
-		Routes:             routes,
-		Listeners:          listeners,
-		ReferencedClusters: collectReferencedClusters(routes, listeners),
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "gw"},
+		Routes:         routes,
+		Listeners:      listeners,
 	}})
 	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
 		{
@@ -422,150 +235,11 @@ func TestSnapshotPerClientStillPublishesWhenReferencedClusterErrored(t *testing.
 	g.Expect(snap.snap.Resources[envoycachetypes.Cluster].Items).ToNot(gomega.HaveKey("cluster-b"))
 }
 
-// TestCollectReferencedClusters_ExcludesAncillaryReferences verifies that
-// cluster names reachable only through ancillary / control-plane
-// typed_config (access-log GrpcService, JWT jwks HttpUri, etc.) are
-// deliberately NOT treated as gated dataplane targets. The plugin that
-// emits these filters is responsible for also emitting the referenced
-// cluster in the same per-gateway snapshot's ExtraClusters, so there is
-// no reconnect race between them. Gating on ancillary references would
-// starve the gateway forever on a plugin bug — which is not what this
-// readiness guard is for.
-func TestCollectReferencedClusters_ExcludesAncillaryReferences(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	hcm := &envoyhttpv3.HttpConnectionManager{
-		AccessLog: []*envoyaccesslogv3.AccessLog{
-			{
-				Name: "envoy.access_loggers.http_grpc",
-				ConfigType: &envoyaccesslogv3.AccessLog_TypedConfig{
-					TypedConfig: mustMessageToAny(t, &envoygrpcaccesslogv3.HttpGrpcAccessLogConfig{
-						CommonConfig: &envoygrpcaccesslogv3.CommonGrpcAccessLogConfig{
-							TransportApiVersion: envoycorev3.ApiVersion_V3,
-							LogName:             "grpc-log",
-							GrpcService: &envoycorev3.GrpcService{
-								TargetSpecifier: &envoycorev3.GrpcService_EnvoyGrpc_{
-									EnvoyGrpc: &envoycorev3.GrpcService_EnvoyGrpc{
-										ClusterName: "access-log-cluster",
-									},
-								},
-							},
-						},
-					}),
-				},
-			},
-		},
-		HttpFilters: []*envoyhttpv3.HttpFilter{
-			{
-				Name: "envoy.filters.http.jwt_authn",
-				ConfigType: &envoyhttpv3.HttpFilter_TypedConfig{
-					TypedConfig: mustMessageToAny(t, &envoyjwtauthnv3.JwtAuthentication{
-						Providers: map[string]*envoyjwtauthnv3.JwtProvider{
-							"provider": {
-								JwksSourceSpecifier: &envoyjwtauthnv3.JwtProvider_RemoteJwks{
-									RemoteJwks: &envoyjwtauthnv3.RemoteJwks{
-										HttpUri: &envoycorev3.HttpUri{
-											Uri: "https://example.com/jwks",
-											HttpUpstreamType: &envoycorev3.HttpUri_Cluster{
-												Cluster: "jwks-cluster",
-											},
-											Timeout: durationpb.New(time.Second),
-										},
-									},
-								},
-							},
-						},
-					}),
-				},
-			},
-		},
-	}
-
-	listeners := sliceToResources([]*envoylistenerv3.Listener{
-		{
-			Name: "listener",
-			FilterChains: []*envoylistenerv3.FilterChain{
-				{
-					Filters: []*envoylistenerv3.Filter{
-						{
-							Name: envoywellknown.HTTPConnectionManager,
-							ConfigType: &envoylistenerv3.Filter_TypedConfig{
-								TypedConfig: mustMessageToAny(t, hcm),
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-
-	referenced := collectReferencedClusters(envoycache.Resources{}, listeners)
-
-	g.Expect(referenced).ToNot(gomega.HaveKey("access-log-cluster"),
-		"ancillary access-log cluster must not be treated as a gated dataplane target")
-	g.Expect(referenced).ToNot(gomega.HaveKey("jwks-cluster"),
-		"ancillary JWT jwks cluster must not be treated as a gated dataplane target")
-}
-
-// TestFindMissingReferencedClusters_HandlesScalarValueMaps verifies that the
-// protoreflect walker does not panic when it encounters a proto field of type
-// map<string, scalar> (e.g. map<string, string>). Without the IsMap/IsList
-// guard on the fall-through branch, such fields fall through to a code path
-// that calls v.Message() on a Map-kind Value and panics with
-// "type mismatch: cannot convert map to message".
-func TestFindMissingReferencedClusters_HandlesScalarValueMaps(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	hcm := &envoyhttpv3.HttpConnectionManager{
-		HttpFilters: []*envoyhttpv3.HttpFilter{
-			{
-				Name: "envoy.filters.http.ext_authz",
-				ConfigType: &envoyhttpv3.HttpFilter_TypedConfig{
-					TypedConfig: mustMessageToAny(t, &envoyextauthzv3.ExtAuthzPerRoute{
-						Override: &envoyextauthzv3.ExtAuthzPerRoute_CheckSettings{
-							CheckSettings: &envoyextauthzv3.CheckSettings{
-								ContextExtensions: map[string]string{
-									"key1": "value1",
-									"key2": "value2",
-								},
-							},
-						},
-					}),
-				},
-			},
-		},
-	}
-
-	listeners := sliceToResources([]*envoylistenerv3.Listener{
-		{
-			Name: "listener",
-			FilterChains: []*envoylistenerv3.FilterChain{
-				{
-					Filters: []*envoylistenerv3.Filter{
-						{
-							Name: envoywellknown.HTTPConnectionManager,
-							ConfigType: &envoylistenerv3.Filter_TypedConfig{
-								TypedConfig: mustMessageToAny(t, hcm),
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-
-	g.Expect(func() {
-		referenced := collectReferencedClusters(envoycache.Resources{}, listeners)
-		findMissingReferencedClusters(referenced, nil, nil)
-	}).ToNot(gomega.Panic())
-}
-
 // TestSnapshotPerClientPublishesEvenWithUnresolvableBackendRef verifies that
 // a user BackendRef typo — e.g. an HTTPRoute pointing at a Service that does
-// not exist — does not starve the readiness gate on startup. IR-time
+// not exist — does not prevent the snapshot from publishing. IR-time
 // resolution substitutes wellknown.BlackholeClusterName for the unresolved
-// target, and the gate explicitly skips blackhole so valid routes still
-// reach Envoy.
+// target, so valid routes still reach Envoy.
 func TestSnapshotPerClientPublishesEvenWithUnresolvableBackendRef(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -606,10 +280,9 @@ func TestSnapshotPerClientPublishesEvenWithUnresolvableBackendRef(t *testing.T) 
 	})
 	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
 	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{{
-		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
-		Routes:             routes,
-		Listeners:          listeners,
-		ReferencedClusters: collectReferencedClusters(routes, listeners),
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "gw"},
+		Routes:         routes,
+		Listeners:      listeners,
 	}})
 
 	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, []uccWithCluster{
@@ -650,10 +323,9 @@ func TestSnapshotPerClientPublishesEvenWithUnresolvableBackendRef(t *testing.T) 
 // verifies that a BackendRef pointing at a nonexistent Service arriving after
 // the control plane is already serving does not cause the per-client snapshot
 // to be withdrawn. IR translation substitutes blackhole for the unresolved
-// target, which the gate skips, so the snapshot re-publishes with the new
-// route set rather than being withdrawn. The existing good route keeps
-// flowing; the typo'd route blackholes in Envoy — no 500/NC for valid
-// traffic.
+// target, so the snapshot re-publishes with the new route set rather than
+// being withdrawn. The existing good route keeps flowing; the typo'd route
+// blackholes in Envoy — no 500/NC for valid traffic.
 func TestSnapshotPerClientKeepsPublishingWhenMisconfiguredBackendRefArrivesAtRuntime(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -680,10 +352,9 @@ func TestSnapshotPerClientKeepsPublishingWhenMisconfiguredBackendRefArrivesAtRun
 	})
 	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
 	initial := GatewayXdsResources{
-		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
-		Routes:             goodRoutes,
-		Listeners:          listeners,
-		ReferencedClusters: collectReferencedClusters(goodRoutes, listeners),
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "gw"},
+		Routes:         goodRoutes,
+		Listeners:      listeners,
 	}
 	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{initial})
 
@@ -750,7 +421,6 @@ func TestSnapshotPerClientKeepsPublishingWhenMisconfiguredBackendRefArrivesAtRun
 	})
 	updated := initial
 	updated.Routes = badRoutes
-	updated.ReferencedClusters = collectReferencedClusters(badRoutes, listeners)
 	mostXdsSnapshots.UpdateObject(updated)
 
 	g.Consistently(func() int {
@@ -759,104 +429,10 @@ func TestSnapshotPerClientKeepsPublishingWhenMisconfiguredBackendRefArrivesAtRun
 		"snapshot must stay published after an unresolvable BackendRef arrives; withdrawing it strands Envoy on restart")
 }
 
-// TestSnapshotPerClientPublishesWhenAllRoutesAreRedirectOnly pins the
-// defensive behaviour of snapshotPerClient when the per-client clusters
-// collection is empty for a UCC. In production this is hard to reach because
-// finalBackends emits a BackendObjectIR for every Service port in the
-// cluster, so the per-client clusters collection is non-empty even for a
-// gateway whose HTTPRoutes only use RequestRedirect or DirectResponse. The
-// test constructs that condition synthetically — zero entries in the cluster
-// collection and zero referenced clusters in the route config — to exercise
-// the branch that treats a nil clusterSnapshot entry as "zero clusters"
-// rather than "not yet computed". Without that branch the snapshot would
-// stall indefinitely whenever the path is reached (controller starting
-// before Service informers sync, or a deployment whose only backends are
-// non-K8s and all fail translation); with it, publishing proceeds because
-// the referenced-cluster gate has nothing to wait for.
-func TestSnapshotPerClientPublishesWhenAllRoutesAreRedirectOnly(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
-	ucc := ir.NewUniqlyConnectedClient(role, "", nil, ir.PodLocality{})
-	uccs := krt.NewStaticCollection[ir.UniqlyConnectedClient](nil, []ir.UniqlyConnectedClient{ucc})
-
-	// Routes with only a Redirect action — no cluster references.
-	routes := sliceToResources([]*envoyroutev3.RouteConfiguration{
-		{
-			Name: "route-config",
-			VirtualHosts: []*envoyroutev3.VirtualHost{{
-				Name:    "vhost",
-				Domains: []string{"*"},
-				Routes: []*envoyroutev3.Route{{
-					Name: "redirect-only",
-					Action: &envoyroutev3.Route_Redirect{
-						Redirect: &envoyroutev3.RedirectAction{
-							SchemeRewriteSpecifier: &envoyroutev3.RedirectAction_HttpsRedirect{HttpsRedirect: true},
-						},
-					},
-				}},
-			}},
-		},
-	})
-	listeners := sliceToResources([]*envoylistenerv3.Listener{{Name: "listener"}})
-	referencedClusters := collectReferencedClusters(routes, listeners)
-	g.Expect(referencedClusters).To(gomega.BeEmpty(), "redirect-only routes must not produce cluster references")
-
-	mostXdsSnapshots := krt.NewStaticCollection[GatewayXdsResources](nil, []GatewayXdsResources{{
-		NamespacedName:     types.NamespacedName{Namespace: "ns", Name: "gw"},
-		Routes:             routes,
-		Listeners:          listeners,
-		ReferencedClusters: referencedClusters,
-	}})
-
-	// No per-client clusters at all for this UCC — simulates a deployment with
-	// only redirect-only routes and no Service-backed backends contributing
-	// clusters. clusterSnapshot's collection handler returns nil for this UCC.
-	clusterCol := krt.NewStaticCollection[uccWithCluster](nil, nil)
-	endpointCol := krt.NewStaticCollection[UccWithEndpoints](nil, nil)
-
-	snapshots := snapshotPerClient(
-		krtutil.KrtOptions{},
-		uccs,
-		mostXdsSnapshots,
-		PerClientEnvoyEndpoints{
-			endpoints: endpointCol,
-			index: krtpkg.UnnamedIndex(endpointCol, func(ep UccWithEndpoints) []string {
-				return []string{ep.Client.ResourceName()}
-			}),
-		},
-		PerClientEnvoyClusters{
-			clusters: clusterCol,
-			index: krtpkg.UnnamedIndex(clusterCol, func(cluster uccWithCluster) []string {
-				return []string{cluster.Client.ResourceName()}
-			}),
-		},
-	)
-
-	g.Eventually(func() int {
-		return len(snapshots.List())
-	}, 2*time.Second, 20*time.Millisecond).Should(gomega.Equal(1),
-		"a snapshot must publish even when there are zero per-client clusters and zero referenced clusters")
-
-	snap := snapshots.List()[0].snap
-	g.Expect(snap.Resources[envoycachetypes.Cluster].Items).To(gomega.BeEmpty())
-	g.Expect(snap.Resources[envoycachetypes.Listener].Items).To(gomega.HaveKey("listener"))
-}
-
 func mapKeys[M ~map[K]V, K comparable, V any](m M) []K {
 	keys := make([]K, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
 	return keys
-}
-
-func mustMessageToAny(t *testing.T, msg proto.Message) *anypb.Any {
-	t.Helper()
-
-	out, err := utils.MessageToAny(msg)
-	if err != nil {
-		t.Fatalf("marshal Any: %v", err)
-	}
-	return out
 }

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -84,14 +84,6 @@ type GatewayXdsResources struct {
 
 	// Secrets are items in the SDS response payload.
 	Secrets envoycache.Resources
-
-	// ReferencedClusters is the set of cluster names referenced by Routes and
-	// Listeners. It is derived from the proto contents, so it is a pure function
-	// of Routes.Version and Listeners.Version (already covered by Equals). Used
-	// by per-client snapshotting to avoid redundantly walking protos for every
-	// connected client on each update.
-	// +noKrtEquals
-	ReferencedClusters map[string]struct{}
 }
 
 func (r GatewayXdsResources) ResourceName() string {
@@ -127,20 +119,17 @@ func sliceToResources[T proto.Message](slice []T) envoycache.Resources {
 
 func toResources(gw ir.Gateway, xdsSnap irtranslator.TranslationResult, r reports.ReportMap) *GatewayXdsResources {
 	c, ch := sliceToResourcesHash(xdsSnap.ExtraClusters)
-	routes := sliceToResources(xdsSnap.Routes)
-	listeners := sliceToResources(xdsSnap.Listeners)
 	return &GatewayXdsResources{
 		NamespacedName: types.NamespacedName{
 			Namespace: gw.Obj.GetNamespace(),
 			Name:      gw.Obj.GetName(),
 		},
-		reports:            r,
-		ClustersHash:       ch,
-		Clusters:           c,
-		Routes:             routes,
-		Listeners:          listeners,
-		Secrets:            sliceToResources(xdsSnap.Secrets),
-		ReferencedClusters: collectReferencedClusters(routes, listeners),
+		reports:      r,
+		ClustersHash: ch,
+		Clusters:     c,
+		Routes:       sliceToResources(xdsSnap.Routes),
+		Listeners:    sliceToResources(xdsSnap.Listeners),
+		Secrets:      sliceToResources(xdsSnap.Secrets),
 	}
 }
 
@@ -377,14 +366,13 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 				s.proxyTranslator.syncXds(ctx, snapWrap)
 			} else {
 				// Intentional no-op. When snapshotPerClient returns nil (its
-				// readiness guards deferred publishing), KRT surfaces a Delete
-				// for this UCC. Clearing the xDS cache here would withdraw
-				// Envoy's last coherent Snapshot for the duration of the defer,
-				// causing 500/NC on valid routes. Leaving the cache alone means
-				// Envoy keeps serving its previously-published config until a
-				// new coherent snapshot overwrites it — the "retain last good"
-				// behavior that prevents unresolvable cluster references from
-				// stranding live traffic.
+				// per-client inputs weren't derived yet, so it deferred
+				// publishing), KRT surfaces a Delete for this UCC. Clearing
+				// the xDS cache here would withdraw Envoy's last coherent
+				// Snapshot for the duration of the defer, causing 500/NC on
+				// valid routes. Leaving the cache alone means Envoy keeps
+				// serving its previously-published config until a new
+				// snapshot overwrites it — "retain last good".
 				//
 				// Known leak: this branch also fires when a UCC truly goes
 				// away (Envoy pod replaced on rollout, scaled down, etc.),

--- a/pkg/kgateway/setup/main_test.go
+++ b/pkg/kgateway/setup/main_test.go
@@ -1,0 +1,23 @@
+package setup_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// These tests drive live in-process ADS servers. Run them with the xDS
+	// first-connect grace period disabled (unless the environment explicitly
+	// sets one): the delay is a mitigation, not a correctness requirement, so
+	// the suite's eventually-consistent assertions must hold against the raw
+	// reconnect race the delay merely narrows — running at zero both surfaces
+	// bugs the grace period would mask and removes a fixed per-stream second
+	// from the suite's runtime. The delay contract itself is pinned by
+	// TestFirstConnectDelayGatesFirstRequestPerStream in pkg/krtcollections.
+	// The variable is read lazily on first stream connect, so setting it here
+	// (after package initialization, before any server runs) is effective.
+	if os.Getenv("KGW_XDS_FIRST_CONNECT_DELAY") == "" {
+		os.Setenv("KGW_XDS_FIRST_CONNECT_DELAY", "0")
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/krtcollections/export_test.go
+++ b/pkg/krtcollections/export_test.go
@@ -1,0 +1,13 @@
+package krtcollections
+
+import "time"
+
+// SetXdsFirstConnectDelayForTest overrides the first-connect delay slept on
+// new xDS streams and returns a function that restores the previous value.
+// The underlying value is atomic, so the override and restore cannot race
+// stream goroutines from a live test server that are still running.
+func SetXdsFirstConnectDelayForTest(d time.Duration) (restore func()) {
+	xdsFirstConnectDelay() // force the lazy env read so restore semantics are stable
+	prev := xdsFirstConnectDelayNanos.Swap(int64(d))
+	return func() { xdsFirstConnectDelayNanos.Store(prev) }
+}

--- a/pkg/krtcollections/uniqueclients.go
+++ b/pkg/krtcollections/uniqueclients.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -22,6 +24,45 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 )
+
+// xdsFirstConnectDelay is slept on the first DiscoveryRequest of every new
+// xDS stream, after the client has been registered (which kicks off
+// per-client translation) and before returning to go-control-plane, which
+// only then creates the stream's first watch. This gives the per-client
+// cluster and endpoint collections a head start so the first snapshot the
+// client observes is (almost always) fully converged rather than partially
+// translated — the reconnect-time race that #13868's whole-snapshot
+// readiness gates tried to close before they were reverted for causing
+// indefinite starvation (#14184). Each gRPC stream runs on its own
+// goroutine, so the sleep delays only this client and holds no locks; a
+// reconnecting warm Envoy keeps serving its existing config meanwhile.
+//
+// Stored as nanoseconds in an atomic so the test override cannot race the
+// stream goroutines that read it, and initialized lazily on first use so
+// test binaries can set the environment variable from TestMain (package
+// initialization would otherwise read the environment before any test code
+// runs). Override with KGW_XDS_FIRST_CONNECT_DELAY (Go duration, e.g. "2s";
+// "0" or negative disables).
+var (
+	xdsFirstConnectDelayNanos atomic.Int64
+	xdsFirstConnectDelayInit  sync.Once
+)
+
+func xdsFirstConnectDelay() time.Duration {
+	xdsFirstConnectDelayInit.Do(func() {
+		d := time.Second
+		if v := os.Getenv("KGW_XDS_FIRST_CONNECT_DELAY"); v != "" {
+			parsed, err := time.ParseDuration(v)
+			if err == nil {
+				d = parsed
+			} else {
+				slog.Warn("invalid KGW_XDS_FIRST_CONNECT_DELAY; using default", "value", v, "default", time.Second, "error", err)
+			}
+		}
+		xdsFirstConnectDelayNanos.Store(int64(d))
+	})
+	return time.Duration(xdsFirstConnectDelayNanos.Load())
+}
 
 type ConnectedClient struct {
 	uniqueClientName string
@@ -219,7 +260,7 @@ func NormalizeGatewayRole(originalRole, namespace string, labels map[string]stri
 	return xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, namespace, gwName)
 }
 
-func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.DiscoveryRequest, peer peerInfo) (string, bool, error) {
+func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.DiscoveryRequest, peer peerInfo) (ucName string, newStream, newUCC bool, err error) {
 	var pod *LocalityPod
 	// see if user wants to use pod locality info; this is only possible when podRef is set in getPeerInfo
 	if peer.podRef != nil {
@@ -232,7 +273,7 @@ func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.Disco
 	c, ok := x.clients[sid]
 	if !ok {
 		if err := logAndCheckEnvoyVersion(x.logger, r.GetNode()); err != nil {
-			return "", false, err
+			return "", false, false, err
 		}
 		var locality ir.PodLocality
 		var ns string
@@ -240,7 +281,7 @@ func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.Disco
 		if peer.podRef != nil {
 			if pod == nil {
 				// we need to use the pod locality info, so it's an error if we can't get the pod
-				return "", false, fmt.Errorf("pod not found for node %v", r.GetNode())
+				return "", false, false, fmt.Errorf("pod not found for node %v", r.GetNode())
 			} else {
 				locality = pod.Locality
 				ns = pod.Namespace
@@ -260,7 +301,7 @@ func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.Disco
 			addedNew = true
 		}
 	}
-	return c.uniqueClientName, addedNew, nil
+	return c.uniqueClientName, !ok, addedNew, nil
 }
 
 // OnStreamRequest is called once a request is received on a stream.
@@ -290,7 +331,7 @@ func (x *callbacks) OnStreamRequest(sid int64, r *envoy_service_discovery_v3.Dis
 }
 
 func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3.DiscoveryRequest, peer peerInfo) error {
-	ucc, isNew, err := x.add(sid, r, peer)
+	ucc, isNewStream, isNewUCC, err := x.add(sid, r, peer)
 	if err != nil {
 		x.logger.Debug("error processing xds client", "error", err)
 		return err
@@ -313,8 +354,13 @@ func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3
 	// the unique client resource name as well.
 	nodeMd.GetFields()[xds.RoleKey] = structpb.NewStringValue(ucc)
 	r.GetNode().Metadata = nodeMd
-	if isNew {
+	if isNewUCC {
 		x.trigger.TriggerRecomputation()
+	}
+	if delay := xdsFirstConnectDelay(); isNewStream && delay > 0 {
+		// See xdsFirstConnectDelay: give per-client translation a head start
+		// before go-control-plane creates this stream's first watch.
+		time.Sleep(delay)
 	}
 	return nil
 }

--- a/pkg/krtcollections/uniqueclients_delay_test.go
+++ b/pkg/krtcollections/uniqueclients_delay_test.go
@@ -1,0 +1,105 @@
+package krtcollections_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/xds"
+	. "github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// TestFirstConnectDelayGatesFirstRequestPerStream pins the contract of the
+// first-connect grace period, replacing the previous reliance on the (slow,
+// live-ADS) setup suite for this coverage:
+//
+//  1. the first DiscoveryRequest of a new stream does not return before the
+//     configured delay has elapsed — go-control-plane creates the stream's
+//     first watch only after OnStreamRequest returns, so this is what holds
+//     the first response back;
+//  2. the client is registered (kicking off per-client translation) BEFORE
+//     the sleep, so translation runs during the grace period, not after it;
+//  3. follow-up requests on the same stream do not sleep again;
+//  4. a new stream sleeps again (the delay is per stream, not per client);
+//  5. a zero delay disables the sleep entirely.
+func TestFirstConnectDelayGatesFirstRequestPerStream(t *testing.T) {
+	const delay = 200 * time.Millisecond
+	t.Cleanup(SetXdsFirstConnectDelayForTest(delay))
+	g := NewWithT(t)
+
+	cb, uccBuilder := NewUniquelyConnectedClients(nil, false)
+	ucc := uccBuilder(context.Background(), krtutil.KrtOptions{}, nil)
+	ucc.WaitUntilSynced(context.Background().Done())
+
+	req := &envoy_service_discovery_v3.DiscoveryRequest{
+		Node: &envoycorev3.Node{
+			Id: "delaypod.ns",
+			Metadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					xds.RoleKey: structpb.NewStringValue(wellknown.GatewayApiProxyValue + "~delay-test-role"),
+				},
+			},
+		},
+	}
+	clone := func() *envoy_service_discovery_v3.DiscoveryRequest {
+		return proto.Clone(req).(*envoy_service_discovery_v3.DiscoveryRequest)
+	}
+
+	// Watch for the client to become visible to the UCC collection while the
+	// first request is still blocked in the grace period.
+	observedAt := make(chan time.Time, 1)
+	go func() {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if len(ucc.List()) > 0 {
+				observedAt <- time.Now()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// (1) + (2): first request of a new stream absorbs the delay, and the
+	// client registers before the sleep completes.
+	start := time.Now()
+	g.Expect(cb.OnStreamRequest(1, clone())).To(Succeed())
+	returnedAt := time.Now()
+	g.Expect(returnedAt.Sub(start)).To(BeNumerically(">=", delay),
+		"the first request of a new stream must not return before the grace period elapses")
+
+	var registeredAt time.Time
+	g.Eventually(observedAt, "2s").Should(Receive(&registeredAt),
+		"the client must become visible to the UCC collection")
+	g.Expect(registeredAt.Before(returnedAt)).To(BeTrue(),
+		"registration (which kicks off per-client translation) must precede the sleep, not follow it")
+
+	// (3): a follow-up request on the same stream does not sleep. The bound
+	// is deliberately loose (half the delay) to stay robust on slow CI.
+	start = time.Now()
+	g.Expect(cb.OnStreamRequest(1, clone())).To(Succeed())
+	g.Expect(time.Since(start)).To(BeNumerically("<", delay/2),
+		"follow-up requests on an established stream must not sleep")
+
+	// (4): the same client reconnecting on a new stream sleeps again.
+	start = time.Now()
+	g.Expect(cb.OnStreamRequest(2, clone())).To(Succeed())
+	g.Expect(time.Since(start)).To(BeNumerically(">=", delay),
+		"a new stream must absorb the grace period even for an already-known client")
+
+	// (5): zero disables the sleep.
+	restore := SetXdsFirstConnectDelayForTest(0)
+	defer restore()
+	start = time.Now()
+	g.Expect(cb.OnStreamRequest(3, clone())).To(Succeed())
+	g.Expect(time.Since(start)).To(BeNumerically("<", delay/2),
+		"a zero delay must disable the first-connect sleep")
+}

--- a/pkg/krtcollections/uniqueclients_test.go
+++ b/pkg/krtcollections/uniqueclients_test.go
@@ -26,6 +26,10 @@ import (
 )
 
 func TestUniqueClients(t *testing.T) {
+	// Disable the first-connect delay: this test drives many new streams
+	// through OnStreamRequest and doesn't exercise snapshot publication.
+	t.Cleanup(SetXdsFirstConnectDelayForTest(0))
+
 	testCases := []struct {
 		name     string
 		inputs   []any

--- a/test/e2e/features/xds_starvation/suite.go
+++ b/test/e2e/features/xds_starvation/suite.go
@@ -1,0 +1,179 @@
+//go:build e2e
+
+// Package xds_starvation pins the anti-starvation properties of per-client
+// xDS publication (#14184): a gateway whose config contains a reference that
+// can never become ready (an ExternalName Service, which produces no
+// EndpointSlices) must still publish config, keep its pods Ready across
+// rollouts, and keep receiving updates across controller restarts. Under the
+// former whole-snapshot readiness gates (#13868, reverted) this exact shape
+// withheld the entire snapshot forever: warm proxies were stranded and fresh
+// pods crash-looped (#14352).
+package xds_starvation
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+	"github.com/kgateway-dev/kgateway/v2/test/gomega/transforms"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
+)
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+var (
+	setupManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	postrestartRouteManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "postrestart-route.yaml")
+
+	setup = base.TestCase{
+		Manifests: []string{
+			testdefaults.CurlPodManifest,
+			setupManifest,
+		},
+	}
+
+	testCases = map[string]*base.TestCase{
+		"TestServesDespiteNeverReadyReference":      {},
+		"TestGatewayRolloutSurvives":                {},
+		"TestControllerRestartDoesNotStrandClients": {},
+	}
+)
+
+const (
+	gatewayName      = "xds-starvation-gw"
+	gatewayNamespace = "default"
+	validHost        = "valid.example.com"
+	extnameHost      = "extname.example.com"
+	postrestartHost  = "postrestart.example.com"
+)
+
+var proxyObjectMeta = metav1.ObjectMeta{
+	Name:      gatewayName,
+	Namespace: gatewayNamespace,
+}
+
+type testingSuite struct {
+	*base.BaseTestingSuite
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+	}
+}
+
+func (s *testingSuite) AfterTest(suiteName, testName string) {
+	s.BaseTestingSuite.AfterTest(suiteName, testName)
+
+	if testutils.ShouldSkipCleanup(s.T()) {
+		return
+	}
+	err := s.TestInstallation.Actions.Kubectl().DeleteFileSafe(s.Ctx, postrestartRouteManifest)
+	s.Require().NoError(err, "can clean up %s", postrestartRouteManifest)
+}
+
+// TestServesDespiteNeverReadyReference is the core anti-starvation pin: with
+// a route to a never-ready ExternalName backend in the config, the gateway
+// still publishes, its pod becomes Ready, and the valid route serves. Under
+// the reverted gates, this exact configuration withheld the whole snapshot
+// and the curl below would never succeed. The never-ready route itself must
+// answer (with an upstream error), not hang the rest of the config.
+func (s *testingSuite) TestServesDespiteNeverReadyReference() {
+	s.assertEventuallyServesNginx(validHost)
+
+	// The never-ready route fails alone: any HTTP error status is acceptable
+	// (503 once the cluster settles; the point is the response arrives and
+	// nothing else was withheld).
+	s.assertEventuallyStatusAtLeast(extnameHost, http.StatusInternalServerError, 2*time.Minute)
+}
+
+// TestGatewayRolloutSurvives replaces every proxy pod while the never-ready
+// reference exists. Fresh pods have no cached snapshot to fall back on, so
+// under the reverted gates they were starved of all config and crash-looped
+// (#14352); now the rollout must complete and traffic must resume.
+func (s *testingSuite) TestGatewayRolloutSurvives() {
+	s.assertEventuallyServesNginx(validHost)
+
+	err := s.TestInstallation.Actions.Kubectl().RestartDeploymentAndWait(s.Ctx, gatewayName, "-n", gatewayNamespace)
+	s.Require().NoError(err, "a fresh gateway proxy pod must become Ready despite the never-ready reference")
+
+	s.assertEventuallyServesNginx(validHost)
+}
+
+// TestControllerRestartDoesNotStrandClients restarts the control plane while
+// the never-ready reference exists, then applies a new route. Under the
+// reverted gates a reconnecting warm proxy could be withheld indefinitely
+// (the gate re-evaluated to unsatisfiable on the fresh cache), freezing all
+// config updates; now the new route must become effective.
+func (s *testingSuite) TestControllerRestartDoesNotStrandClients() {
+	s.assertEventuallyServesNginx(validHost)
+
+	err := s.TestInstallation.Actions.Kubectl().RestartDeploymentAndWait(s.Ctx, "kgateway",
+		"-n", s.TestInstallation.Metadata.InstallNamespace)
+	s.Require().NoError(err, "can restart the kgateway controller")
+
+	// Existing traffic keeps flowing on the proxy's retained config.
+	s.assertEventuallyServesNginx(validHost)
+
+	// A route created after the restart must reach the (reconnected, warm) proxy.
+	err = s.TestInstallation.Actions.Kubectl().ApplyFile(s.Ctx, postrestartRouteManifest)
+	s.Require().NoError(err, "can create a route after the controller restart")
+	s.assertEventuallyServesNginx(postrestartHost)
+}
+
+func (s *testingSuite) assertEventuallyServesNginx(host string) {
+	const timeout = 2 * time.Minute
+	s.TestInstallation.AssertionsT(s.T()).Gomega.Eventually(func(g gomega.Gomega) {
+		statusCode, body, err := s.gatewayResponse(host)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "gateway request should complete")
+		g.Expect(statusCode).To(gomega.Equal(http.StatusOK), "gateway returned body: %s", body)
+		g.Expect(body).To(gomega.ContainSubstring(testdefaults.NginxResponse))
+	}).WithContext(s.Ctx).WithTimeout(timeout).WithPolling(time.Second).Should(gomega.Succeed())
+}
+
+// assertEventuallyStatusAtLeast asserts the host answers with an error status
+// >= the given code (e.g. 500/503 for a cluster that can never become ready).
+func (s *testingSuite) assertEventuallyStatusAtLeast(host string, status int, timeout time.Duration) {
+	s.TestInstallation.AssertionsT(s.T()).Gomega.Eventually(func(g gomega.Gomega) {
+		statusCode, body, err := s.gatewayResponse(host)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "gateway request should complete")
+		g.Expect(statusCode).To(gomega.BeNumerically(">=", status), "gateway returned body: %s", body)
+	}).WithContext(s.Ctx).WithTimeout(timeout).WithPolling(time.Second).Should(gomega.Succeed())
+}
+
+func (s *testingSuite) gatewayResponse(host string) (int, string, error) {
+	curlResponse, err := s.TestInstallation.ClusterContext.Cli.CurlFromPod(
+		s.Ctx,
+		testdefaults.CurlPodExecOpt,
+		curl.WithHost(kubeutils.ServiceFQDN(proxyObjectMeta)),
+		curl.WithHostHeader(host),
+		curl.WithPort(8080),
+		curl.WithPath("/"),
+		curl.WithConnectionTimeout(2),
+	)
+	if err != nil {
+		return 0, "", err
+	}
+
+	response := transforms.WithCurlResponse(curlResponse)
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return 0, "", fmt.Errorf("read gateway response body: %w", err)
+	}
+	return response.StatusCode, string(body), nil
+}

--- a/test/e2e/features/xds_starvation/suite.go
+++ b/test/e2e/features/xds_starvation/suite.go
@@ -41,6 +41,11 @@ var (
 	setup = base.TestCase{
 		Manifests: []string{
 			testdefaults.CurlPodManifest,
+			// The valid/postrestart routes reference the nginx Service in the
+			// "nginx" namespace, so it must exist before setupManifest applies
+			// the ReferenceGrant into it. (v2.3.x has no shared nginx-shared
+			// backend, so this suite provisions its own.)
+			testdefaults.NginxPodManifest,
 			setupManifest,
 		},
 	}

--- a/test/e2e/features/xds_starvation/testdata/postrestart-route.yaml
+++ b/test/e2e/features/xds_starvation/testdata/postrestart-route.yaml
@@ -1,0 +1,16 @@
+# Applied after a controller restart to prove warm clients still receive
+# config updates while the never-ready reference exists.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: xds-starvation-postrestart
+spec:
+  parentRefs:
+    - name: xds-starvation-gw
+  hostnames:
+    - "postrestart.example.com"
+  rules:
+    - backendRefs:
+        - name: nginx
+          namespace: nginx-shared
+          port: 8080

--- a/test/e2e/features/xds_starvation/testdata/postrestart-route.yaml
+++ b/test/e2e/features/xds_starvation/testdata/postrestart-route.yaml
@@ -12,5 +12,5 @@ spec:
   rules:
     - backendRefs:
         - name: nginx
-          namespace: nginx-shared
+          namespace: nginx
           port: 8080

--- a/test/e2e/features/xds_starvation/testdata/setup.yaml
+++ b/test/e2e/features/xds_starvation/testdata/setup.yaml
@@ -1,0 +1,73 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: xds-starvation-gw
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# A backend that can never become ready: an ExternalName Service produces no
+# EndpointSlices, so the referenced cluster never gets endpoints. This is the
+# steady-state shape (#14352) that made #13868's whole-snapshot readiness
+# gates permanently unsatisfiable; with the gates removed, routes to it fail
+# individually while everything else keeps publishing.
+apiVersion: v1
+kind: Service
+metadata:
+  name: never-resolves
+spec:
+  type: ExternalName
+  externalName: never.invalid
+  ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: xds-starvation-extname
+spec:
+  parentRefs:
+    - name: xds-starvation-gw
+  hostnames:
+    - "extname.example.com"
+  rules:
+    - backendRefs:
+        - name: never-resolves
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: xds-starvation-valid
+spec:
+  parentRefs:
+    - name: xds-starvation-gw
+  hostnames:
+    - "valid.example.com"
+  rules:
+    - backendRefs:
+        - name: nginx
+          namespace: nginx-shared
+          port: 8080
+---
+# Authorizes this suite's default-namespace HTTPRoutes to reference the shared nginx
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: xds-starvation-allow-default-httproutes
+  namespace: nginx-shared
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ""
+      kind: Service

--- a/test/e2e/features/xds_starvation/testdata/setup.yaml
+++ b/test/e2e/features/xds_starvation/testdata/setup.yaml
@@ -54,15 +54,15 @@ spec:
   rules:
     - backendRefs:
         - name: nginx
-          namespace: nginx-shared
+          namespace: nginx
           port: 8080
 ---
-# Authorizes this suite's default-namespace HTTPRoutes to reference the shared nginx
+# Authorizes this suite's default-namespace HTTPRoutes to reference the nginx backend
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: xds-starvation-allow-default-httproutes
-  namespace: nginx-shared
+  namespace: nginx
 spec:
   from:
     - group: gateway.networking.k8s.io

--- a/test/e2e/tests/kgateway_tests.go
+++ b/test/e2e/tests/kgateway_tests.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/trafficpolicystatus"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/transformation"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/websocket"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/xds_starvation"
 )
 
 func KubeGatewaySuiteRunner() e2e.SuiteRunner {
@@ -101,6 +102,7 @@ func KubeGatewaySuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("BasicAuth", basicauth.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("OAuth", oauth.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("WebSocket", websocket.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("XdsStarvation", xds_starvation.NewTestingSuite)
 
 	return kubeGatewaySuiteRunner
 }


### PR DESCRIPTION
…st-connect grace period (#14380)

# Description

Backport of #14380 (commit `714190cf85dcd8c06849f819053249ab8e0efbe7` on `main`) to `v2.3.x`. Part of #14184.

This is **not** a clean cherry-pick. The functional changes are byte-for-byte the main commit; the only adaptations reconcile branch divergence:

- `pkg/kgateway/proxy_syncer/perclient_test.go` — retargeted to `v2.3.x`'s older `ir.UniqlyConnectedClient` / `ir.NewUniqlyConnectedClient` spelling (`main` renamed these to `Uniquely…`). The `NewUniquelyConnectedClients` collection constructor is spelled the same on both branches and was left untouched.
- `.github/workflows/e2e.yaml` — appended `XdsStarvation` to `cluster-seven`'s existing run regex (which on `v2.3.x` already carries an extra `AttachedRoutes` entry) rather than replacing the line.
- `Makefile` — same `grep` -> `grep -x` fix in `kind-create`, re-anchored to a different line number.

No behavioral differences from the `main` commit.

# Change Type

/kind fix
# Changelog

```release-note
Reverted the per-client xDS whole-snapshot readiness gates, which could withhold a gateway's configuration indefinitely when it referenced a backend that can never become ready (for example an ExternalName Service) — stranding already-connected proxies on stale endpoints and crash-looping newly started proxy pods. Readiness is now handled by a bounded per-stream first-connect grace period (configurable via KGW_XDS_FIRST_CONNECT_DELAY, defaulting to 1s).
```
 # Additional Notes

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

