### PR TITLE
fix: Send PerRouteConfigName and FilterName for dynamic modules

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin.go
@@ -102,8 +102,9 @@ func constructHttpACL(in *kgateway.TrafficPolicy, out *trafficPolicySpecIr) erro
 			DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 				Name: httpACLModuleName,
 			},
-			FilterName:   httpACLFilterName,
-			FilterConfig: filterCfg,
+			FilterName:         httpACLFilterName,
+			PerRouteConfigName: httpACLFilterName,
+			FilterConfig:       filterCfg,
 		},
 	}
 	return nil

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/http_acl_plugin_test.go
@@ -19,8 +19,9 @@ func TestHttpACLIREquals(t *testing.T) {
 			DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 				Name: httpACLModuleName,
 			},
-			FilterName:   httpACLFilterName,
-			FilterConfig: filterCfg,
+			FilterName:         httpACLFilterName,
+			PerRouteConfigName: httpACLFilterName,
+			FilterConfig:       filterCfg,
 		}
 	}
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
@@ -249,8 +249,9 @@ func mergeRustformation(
 				DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 					Name: RustformationModuleName,
 				},
-				FilterName:   RustformationFilterName,
-				FilterConfig: filterCfg,
+				FilterName:         RustformationFilterName,
+				PerRouteConfigName: RustformationFilterName,
+				FilterConfig:       filterCfg,
 			}}
 		}
 		p1Json, err := utils.AnyToJson(p1.spec.rustformation.config.FilterConfig)
@@ -712,8 +713,9 @@ func mergeHttpACL(
 				DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 					Name: httpACLModuleName,
 				},
-				FilterName:   httpACLFilterName,
-				FilterConfig: filterCfg,
+				FilterName:         httpACLFilterName,
+				PerRouteConfigName: httpACLFilterName,
+				FilterConfig:       filterCfg,
 			}}
 		}
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin.go
@@ -85,8 +85,9 @@ func toRustFormationPerRouteConfig(t *kgateway.TransformationPolicy) (*dynamicmo
 		DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 			Name: RustformationModuleName,
 		},
-		FilterName:   RustformationFilterName,
-		FilterConfig: filterCfg,
+		FilterName:         RustformationFilterName,
+		PerRouteConfigName: RustformationFilterName,
+		FilterConfig:       filterCfg,
 	}
 
 	return rustCfg, nil
@@ -119,7 +120,8 @@ func GenerateBlankTransformationConfigPerRoute() *dynamicmodulesv3.DynamicModule
 		DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 			Name: RustformationModuleName,
 		},
-		FilterName: RustformationFilterName,
+		FilterName:         RustformationFilterName,
+		PerRouteConfigName: RustformationFilterName,
 		FilterConfig: utils.MustMessageToAny(&wrapperspb.StringValue{
 			Value: "{}",
 		}),
@@ -162,7 +164,8 @@ func generateDynamicMetadata(ns string, kv map[string]kgateway.InjaTemplate) *dy
 		DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 			Name: RustformationModuleName,
 		},
-		FilterName: RustformationFilterName,
+		FilterName:         RustformationFilterName,
+		PerRouteConfigName: RustformationFilterName,
 		FilterConfig: utils.MustMessageToAny(&wrapperspb.StringValue{
 			Value: string(b),
 		}),

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/transformation_plugin_test.go
@@ -23,8 +23,9 @@ func TestRustformationIREquals(t *testing.T) {
 			DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 				Name: RustformationModuleName,
 			},
-			FilterName:   RustformationFilterName,
-			FilterConfig: filterCfg,
+			FilterName:         RustformationFilterName,
+			PerRouteConfigName: RustformationFilterName,
+			FilterConfig:       filterCfg,
 		}
 	}
 
@@ -90,7 +91,8 @@ func TestRustformationIREquals(t *testing.T) {
 				DynamicModuleConfig: &extensiondynamicmodulev3.DynamicModuleConfig{
 					Name: RustformationModuleName,
 				},
-				FilterName: RustformationFilterName,
+				FilterName:         RustformationFilterName,
+				PerRouteConfigName: RustformationFilterName,
 			},
 		}
 		assert.True(t, transformation.Equals(transformation), "transformation should equal itself")

--- a/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
@@ -94,6 +94,7 @@ routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"x-foo-req","value":"abc"}]},"response":{"set":[{"name":"x-foo-resp","value":"xyz"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
   - domains:
     - www.example.com
     name: listener~8080~www_example_com
@@ -118,3 +119,4 @@ routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"x-foo-req","value":"abc"}]},"response":{"set":[{"name":"x-foo-resp","value":"xyz"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
@@ -93,6 +93,7 @@ routes:
         value: '{"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}],"body":{"parseAs":"AsJson","value":"{{
           body }}"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example-gateway-only.com
@@ -129,3 +130,4 @@ routes:
             value: '{"request":{"add":[{"name":"x-greatness","value":"{{ length(headers(\":path\"))
               }}"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
@@ -93,6 +93,7 @@ routes:
         value: '{"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}],"body":{"parseAs":"AsJson","value":"{{
           body }}"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example.com

--- a/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
@@ -100,6 +100,7 @@ routes:
               }}"}],"body":{"parseAs":"AsString","value":"request-response"}},"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}],"body":{"parseAs":"AsJson","value":"{{
               body }}"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
   - domains:
     - www.example-request.com
     name: listener~8080~www_example-request_com
@@ -125,6 +126,7 @@ routes:
             value: '{"request":{"set":[{"name":"x-greatness","value":"{{length(headers(\":path\"))
               }}"}],"body":{"parseAs":"AsJson","value":"requested"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
   - domains:
     - www.example-response.com
     name: listener~8080~www_example-response_com
@@ -149,3 +151,4 @@ routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"original-greatness","value":"{{request_headers(\"x-greatness\")}}"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation

--- a/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
@@ -95,3 +95,4 @@ routes:
             value: '{"response":{"set":[{"name":"x-kgateway-response","value":"{{
               request_header(\"x-kgateway-request\") }}"}],"remove":["x-kgateway-request"]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/gateway-with-route-override.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/gateway-with-route-override.yaml
@@ -86,6 +86,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:
@@ -105,6 +106,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
       envoy.filters.http.basic_auth:
         '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
         users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/inline-users-route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/inline-users-route.yaml
@@ -81,6 +81,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/route-disable.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/route-disable.yaml
@@ -92,6 +92,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -105,6 +106,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
       envoy.filters.http.basic_auth:
         '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
         users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/secret-ref.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/basic-auth/secret-ref.yaml
@@ -81,6 +81,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.basic_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
           users:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/policy_deep_merge.yaml
@@ -96,6 +96,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"a"},{"name":"source","value":"example"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /a/2
       metadata:
@@ -116,6 +117,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"example"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
   - domains:
     - foo.com
     name: listener~80~foo_com
@@ -141,6 +143,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"foo"},{"name":"source","value":"b"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /b/2
       metadata:
@@ -161,6 +164,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"source","value":"foo"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy.yaml
@@ -95,6 +95,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"x-foo-req","value":"abc"}]},"response":{"set":[{"name":"x-foo-resp","value":"xyz"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         prefix: /
       name: listener~80~example_com-route-2-httproute-example-route-infra-0-0-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_filter_override_merge.yaml
@@ -182,6 +182,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ext_proc/a/extproc-ext1:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -222,6 +223,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"def","value":"custom-value-def"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance.yaml
@@ -95,6 +95,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         prefix: /
       metadata:
@@ -115,6 +116,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ignore.yaml
@@ -95,6 +95,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         prefix: /
       metadata:
@@ -115,6 +116,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_inheritance_child_override_ok.yaml
@@ -102,6 +102,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:
@@ -137,6 +138,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_disabled.yaml
@@ -167,6 +167,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ext_proc/a/extproc-ext:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -205,6 +206,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/delegation/traffic_policy_multi_level_inheritance_override_enabled.yaml
@@ -222,6 +222,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"a1","value":"a1"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ext_proc/a/extproc-ext:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -264,6 +265,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"mid","value":"mid"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ext_proc/b/extproc-ext:
           '@type': type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
           overrides: {}
@@ -304,6 +306,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"example","value":"example"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_all.yaml
@@ -92,6 +92,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:
@@ -127,6 +128,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/discovery-namespace-selector/base_select_infra.yaml
@@ -88,6 +88,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/gateway-http-acl.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/gateway-http-acl.yaml
@@ -69,6 +69,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"allow","denyResponse":{"blockedByHeaderName":"X-Blocked-By","statusCode":403},"rules":[{"action":"deny","cidrs":["10.0.0.0/8"],"name":"block-internal-range"},{"action":"allow","cidrs":["10.1.0.0/16"],"name":"allow-trusted-subnet"},{"action":"deny","cidrs":["2001:db8::/32"],"name":"block-ipv6-range"},{"action":"deny","cidrs":["192.168.1.100"],"name":"block-single-ipv4"},{"action":"deny","cidrs":["2001:db8::1"],"name":"block-single-ipv6"}]}'
       filterName: http-acl
+      perRouteConfigName: http-acl
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/httproute-http-acl.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/httproute-http-acl.yaml
@@ -75,6 +75,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["2001:db8::/32"]},{"action":"allow","cidrs":["192.168.1.100"]},{"action":"allow","cidrs":["2001:db8::1"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -95,6 +96,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["2001:db8::/32"]},{"action":"allow","cidrs":["192.168.1.100"]},{"action":"allow","cidrs":["2001:db8::1"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/route-http-acl.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-acl/route-http-acl.yaml
@@ -81,6 +81,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["192.168.0.0/16"]},{"action":"deny","cidrs":["2001:db8::/32"]},{"action":"deny","cidrs":["192.168.1.100"]},{"action":"deny","cidrs":["2001:db8::1"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace-extension.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace-extension.yaml
@@ -135,6 +135,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace.yaml
@@ -159,6 +159,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
   - domains:
     - denied.example.com
     name: listener~80~denied_example_com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-and-route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-and-route.yaml
@@ -192,6 +192,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -220,6 +221,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -243,6 +245,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-configmap.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-configmap.yaml
@@ -131,6 +131,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-disable.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-disable.yaml
@@ -129,6 +129,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -157,6 +158,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -180,6 +182,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-listener.yaml
@@ -166,6 +166,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 - ignorePortInHostMatching: true
   name: listener~8081
   virtualHosts:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode.yaml
@@ -132,6 +132,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway.yaml
@@ -129,6 +129,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute-remote-jwks.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute-remote-jwks.yaml
@@ -169,6 +169,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute.yaml
@@ -137,6 +137,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /bar
       metadata:
@@ -160,6 +161,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/listenerset.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/listenerset.yaml
@@ -260,6 +260,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 - ignorePortInHostMatching: true
   name: listener~8083
   virtualHosts:
@@ -296,6 +297,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/rbac.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/rbac.yaml
@@ -230,6 +230,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/gw:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/remote-jwks-async.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/remote-jwks-async.yaml
@@ -153,6 +153,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/route.yaml
@@ -155,6 +155,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/reference-grant-mode/strict-extensionref-with-grant.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/reference-grant-mode/strict-extensionref-with-grant.yaml
@@ -117,6 +117,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-invalid-out.yaml
@@ -117,6 +117,7 @@ Routes:
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -145,6 +146,7 @@ Routes:
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-invalid-out.yaml
@@ -132,6 +132,7 @@ Routes:
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - secure.example.com
@@ -171,6 +172,7 @@ Routes:
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 - ignorePortInHostMatching: true
   name: listener~8081
   virtualHosts:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/gateway-listener-merge-invalid-out.yaml
@@ -101,6 +101,7 @@ Routes:
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
   - domains:
     - api.a.example.com
     metadata:
@@ -126,6 +127,7 @@ Routes:
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
   - domains:
     - backend.b.example.com
     name: listener~8080~backend_b_example_com
@@ -161,6 +163,7 @@ Routes:
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
   - domains:
     - www.b.example.com
     name: listener~8080~www_b_example_com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/httproute-invalid-out.yaml
@@ -76,6 +76,7 @@ Routes:
             value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
               }"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /api
       metadata:
@@ -97,6 +98,7 @@ Routes:
             value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
               }"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/multi-target-invalid-out.yaml
@@ -194,6 +194,7 @@ Routes:
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_gateway_template
           }"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -222,6 +223,7 @@ Routes:
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_gateway_template
           }"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -250,6 +252,7 @@ Routes:
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_gateway_template
           }"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-invalid-out.yaml
@@ -125,6 +125,7 @@ Routes:
         value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
           }"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - www.example.com
@@ -166,6 +167,7 @@ Routes:
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/attachment/xlistenerset-listener-invalid-out.yaml
@@ -141,6 +141,7 @@ Routes:
           value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
             }"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/policy/policy-template-structure-invalid-out.yaml
@@ -76,6 +76,7 @@ Routes:
             value: '{"request":{"body":{"parseAs":"AsJson","value":"{{ invalid_template
               }}"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     gwtest/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/status/basic.yaml
@@ -137,6 +137,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.cors:
           '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
           allowOriginStringMatch:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-conflict-fallback-to-shallow-merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-conflict-fallback-to-shallow-merge.yaml
@@ -71,6 +71,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["192.168.0.0/16"]}]}'
       filterName: http-acl
+      perRouteConfigName: http-acl
   virtualHosts:
   - domains:
     - test.com
@@ -96,6 +97,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["172.16.0.0/12"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
     - match:
         pathSeparatedPrefix: /route-1
       metadata:
@@ -117,6 +119,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["138.16.0.0/12"]},{"action":"deny","cidrs":["11.11.0.0/16"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
     - match:
         pathSeparatedPrefix: /route-2
       name: listener~8080~test_com-route-2-httproute-test-default-2-0-rule2-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-deep.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-deep.yaml
@@ -71,6 +71,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["192.168.0.0/16"]},{"action":"allow","cidrs":["10.0.0.0/8"]}]}'
       filterName: http-acl
+      perRouteConfigName: http-acl
   virtualHosts:
   - domains:
     - test.com
@@ -97,6 +98,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["10.10.0.0/16"]},{"action":"deny","cidrs":["172.16.0.0/12"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
     - match:
         pathSeparatedPrefix: /route-1
       name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-shallow.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-merge-shallow.yaml
@@ -69,6 +69,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"defaultAction":"deny","rules":[{"cidrs":["192.168.0.0/16"],"action":"allow"}]}'
       filterName: http-acl
+      perRouteConfigName: http-acl
   virtualHosts:
   - domains:
     - test.com
@@ -94,6 +95,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"cidrs":["10.10.0.0/16"],"action":"deny"}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
     - match:
         pathSeparatedPrefix: /route-1
       name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-route-delegation.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/acl-route-delegation.yaml
@@ -76,6 +76,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["192.168.0.0/16"]},{"action":"allow","cidrs":["10.0.0.0/8"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
   - domains:
     - dpp.test.com
     name: listener~8080~dpp_test_com
@@ -101,6 +102,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]},{"action":"allow","cidrs":["192.168.0.0/16"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
   - domains:
     - spc.test.com
     name: listener~8080~spc_test_com
@@ -125,6 +127,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"allow","rules":[{"action":"deny","cidrs":["192.168.0.0/16"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
   - domains:
     - spp.test.com
     name: listener~8080~spp_test_com
@@ -149,6 +152,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"defaultAction":"deny","rules":[{"action":"allow","cidrs":["10.0.0.0/8"]}]}'
           filterName: http-acl
+          perRouteConfigName: http-acl
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-gateway.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-gateway.yaml
@@ -73,6 +73,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
     envoy.filters.http.api_key_auth:
       '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
       credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-httproute.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-httproute.yaml
@@ -79,6 +79,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:
@@ -110,6 +111,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override-section.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override-section.yaml
@@ -73,6 +73,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
     envoy.filters.http.api_key_auth:
       '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
       credentials:
@@ -115,6 +116,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-override.yaml
@@ -73,6 +73,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
     envoy.filters.http.api_key_auth:
       '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
       credentials:
@@ -109,6 +110,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:
@@ -139,6 +141,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-route.yaml
@@ -79,6 +79,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref-with-refgrant.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref-with-refgrant.yaml
@@ -79,6 +79,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-secretref.yaml
@@ -79,6 +79,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-selector-with-refgrant.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-selector-with-refgrant.yaml
@@ -79,6 +79,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.api_key_auth:
           '@type': type.googleapis.com/envoy.extensions.filters.http.api_key_auth.v3.ApiKeyAuthPerRoute
           credentials:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-cross-namespace.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-cross-namespace.yaml
@@ -175,6 +175,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - allowed.example.com
@@ -203,6 +204,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
   - domains:
     - denied.example.com
     name: listener~80~denied_example_com
@@ -244,6 +246,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - listener.example.com
@@ -272,6 +275,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-deep-merge.yaml
@@ -226,6 +226,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - test.com
@@ -264,6 +265,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-1
       metadata:
@@ -284,6 +286,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         global_disable/ext_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -308,6 +311,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc-full-config.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc-full-config.yaml
@@ -146,6 +146,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /example-route
       metadata:
@@ -173,6 +174,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-grpc.yaml
@@ -313,6 +313,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -346,6 +347,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-0
       metadata:
@@ -371,6 +373,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-1
       metadata:
@@ -391,6 +394,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         global_disable/ext_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -406,6 +410,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
   - domains:
     - no-auth.example.com
     name: listener~80~no-auth_example_com
@@ -435,6 +440,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - tls.example.com
@@ -464,6 +470,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /example-route-tls-section-name
       metadata:
@@ -487,6 +494,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /example-tls-sibling-route
       name: tls1~tls_example_com-route-2-httproute-example-tls-sibling-route-infra-0-0-matcher-0
@@ -516,6 +524,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 - ignorePortInHostMatching: true
   metadata:
     filterMetadata:
@@ -535,6 +544,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - no-auth-tls.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http-full-config.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http-full-config.yaml
@@ -164,6 +164,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /example-route
       metadata:
@@ -191,6 +192,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     infra/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-http.yaml
@@ -325,6 +325,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - example.com
@@ -358,6 +359,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-0
       metadata:
@@ -383,6 +385,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-2-1
       metadata:
@@ -403,6 +406,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         global_disable/ext_auth:
           '@type': type.googleapis.com/envoy.config.route.v3.FilterConfig
           config: {}
@@ -418,6 +422,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
   - domains:
     - no-auth.example.com
     name: listener~80~no-auth_example_com
@@ -447,6 +452,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - tls.example.com
@@ -476,6 +482,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /example-route-tls-section-name
       metadata:
@@ -499,6 +506,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /example-tls-sibling-route
       name: tls1~tls_example_com-route-2-httproute-example-tls-sibling-route-infra-0-0-matcher-0
@@ -528,6 +536,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 - ignorePortInHostMatching: true
   metadata:
     filterMetadata:
@@ -547,6 +556,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - no-auth-tls.example.com

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based.yaml
@@ -127,6 +127,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         ratelimit/local:
           '@type': type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
           filterEnabled:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/label_based_global_policy.yaml
@@ -133,6 +133,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.cors:
           '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
           allowOriginStringMatch:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/merge.yaml
@@ -88,6 +88,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"response":{"add":[{"name":"abc","value":"custom-value-abc"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
         envoy.filters.http.cors:
           '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
           allowOriginStringMatch:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2-jwks-backend.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2-jwks-backend.yaml
@@ -179,6 +179,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Secrets:
 - genericSecret:
     secret:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/oauth2.yaml
@@ -354,6 +354,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - test.com
@@ -387,6 +388,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-1
       metadata:
@@ -413,6 +415,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-2
       name: listener~8080~test_com-route-2-httproute-test-default-2-0-rule2-matcher-0
@@ -434,6 +437,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Secrets:
 - genericSecret:
     secret:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-deep-merge.yaml
@@ -71,6 +71,7 @@ Routes:
         '@type': type.googleapis.com/google.protobuf.StringValue
         value: '{"request":{"set":[{"name":"source","value":"gateway-attachment-1"},{"name":"source","value":"gateway-attachment-2"}]},"response":{"set":[{"name":"source","value":"gateway-attachment-1"},{"name":"source","value":"gateway-attachment-2"}]}}'
       filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
     - test.com
@@ -103,6 +104,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"source","value":"route-attachment-2"},{"name":"source","value":"route-attachment-1"}]},"response":{"set":[{"name":"source","value":"route-attachment-2"},{"name":"source","value":"route-attachment-1"}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
     - match:
         pathSeparatedPrefix: /route-1
       name: listener~8080~test_com-route-1-httproute-test-default-1-0-rule1-matcher-0
@@ -124,6 +126,7 @@ Routes:
           '@type': type.googleapis.com/google.protobuf.StringValue
           value: '{"request":{"set":[{"name":"source","value":"listener-attachment-1"},{"name":"source","value":"listener-attachment-2"}]},"response":{"set":[{"name":"source","value":"listener-attachment-1"},{"name":"source","value":"listener-attachment-2"}]}}'
         filterName: rustformation
+        perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-set-metadata.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-set-metadata.yaml
@@ -79,6 +79,7 @@ Routes:
               header(\"x-user-id\") }}"}],"dynamicMetadata":[{"namespace":"com.example.auth","key":"user-id-response","value":{"stringValue":"{{
               header(\"x-user-id\") }}"}}]}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/test:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-skip-body-buffering.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/transformation-skip-body-buffering.yaml
@@ -75,6 +75,7 @@ Routes:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: '{"request":{"set":[{"name":"source","value":"route-attachment-1"}],"body":{"parseAs":"None"}},"response":{"set":[{"name":"source","value":"route-attachment-1"}],"body":{"parseAs":"None"}}}'
           filterName: rustformation
+          perRouteConfigName: rustformation
 Statuses:
   gateways:
     default/test:

--- a/test/e2e/features/upgrade/suite.go
+++ b/test/e2e/features/upgrade/suite.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kgateway "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmdutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
@@ -28,13 +30,15 @@ import (
 // proxyNamespace and proxyLabelSelector identify the data-plane proxy that the controller
 // provisions for the Gateway defined in testdata/setup.yaml.
 const (
-	proxyNamespace     = "default"
-	proxyLabelSelector = "gateway.networking.k8s.io/gateway-name=gateway"
+	proxyNamespace                  = "default"
+	proxyLabelSelector              = "gateway.networking.k8s.io/gateway-name=gateway"
+	initialTransformationValue      = "header-modified"
+	skewedTransformationValue       = "header-modified-after-control-plane-upgrade"
+	upgradeTransformationPolicyName = "upgrade-header-policy"
 )
 
 var (
-	_             e2e.NewSuiteFunc = NewTestingSuite
-	setupManifest                  = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	setupManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
 	version       string
 )
 
@@ -49,11 +53,15 @@ func init() {
 //   - Uninstalling kgateway after this suite completes.
 type testingSuite struct {
 	*base.BaseTestingSuite
+	fromVersion string
 }
 
-func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
-	return &testingSuite{
-		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, base.TestCase{}, nil),
+func NewTestingSuite(fromVersion string) e2e.NewSuiteFunc {
+	return func(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+		return &testingSuite{
+			BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, base.TestCase{}, nil),
+			fromVersion:      fromVersion,
+		}
 	}
 }
 
@@ -76,15 +84,14 @@ func (s *testingSuite) applyManifests() func() {
 	}
 }
 
-// verifyRequestWithTransformation verifies that the TrafficPolicy in setup.yaml is being applied:
-// the X-Upgrade-Test header must be set to "header-modified" on every response.
-func (s *testingSuite) verifyRequestWithTransformation() {
+// verifyRequestWithTransformation verifies that the TrafficPolicy in setup.yaml is being applied.
+func (s *testingSuite) verifyRequestWithTransformation(expectedValue string) {
 	s.T().Helper()
 	common.BaseGateway.Send(
 		s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
-			Headers:    map[string]any{"X-Upgrade-Test": "header-modified"},
+			Headers:    map[string]any{"X-Upgrade-Test": expectedValue},
 		},
 		curl.WithPath("/headers"),
 		curl.WithHostHeader("example.com"),
@@ -92,8 +99,54 @@ func (s *testingSuite) verifyRequestWithTransformation() {
 	)
 }
 
-// TestUpgrade upgrades both the CRD chart and the controller chart from the previously installed
-// remote release to the locally-built chart, then verifies the installation is healthy.
+func (s *testingSuite) updateTransformationHeader(value string) {
+	s.T().Helper()
+
+	policy := &kgateway.TrafficPolicy{}
+	err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx, types.NamespacedName{
+		Namespace: proxyNamespace,
+		Name:      upgradeTransformationPolicyName,
+	}, policy)
+	s.Require().NoError(err, "failed to get upgrade TrafficPolicy")
+	s.Require().NotNil(policy.Spec.Transformation, "upgrade TrafficPolicy transformation is nil")
+	s.Require().NotNil(policy.Spec.Transformation.Response, "upgrade TrafficPolicy response transformation is nil")
+	s.Require().Len(policy.Spec.Transformation.Response.Set, 1, "upgrade TrafficPolicy should set exactly one response header")
+
+	original := policy.DeepCopy()
+	policy.Spec.Transformation.Response.Set[0].Value = kgateway.InjaTemplate(value)
+	err = s.TestInstallation.ClusterContext.Client.Patch(s.Ctx, policy, client.MergeFrom(original))
+	s.Require().NoError(err, "failed to update upgrade TrafficPolicy")
+}
+
+func (s *testingSuite) localChartValuesFiles() []string {
+	return []string{
+		s.TestInstallation.Metadata.ProfileValuesManifestFile,
+		s.TestInstallation.Metadata.ValuesManifestFile,
+	}
+}
+
+func (s *testingSuite) upgradeControlPlaneWithReleasedDataPlane() {
+	extraArgs := append([]string{}, s.TestInstallation.Metadata.ExtraHelmArgs...)
+	// UpgradeKgatewayCore prepends the local image.tag. These later Helm values
+	// deliberately override the default tag while keeping the controller local.
+	extraArgs = append(extraArgs,
+		"--set", "image.tag="+s.fromVersion,
+		"--set", "controller.image.tag="+version,
+	)
+	s.TestInstallation.UpgradeKgatewayCore(s.Ctx, s.T(), s.localChartValuesFiles(), extraArgs)
+}
+
+func (s *testingSuite) upgradeDataPlane() {
+	s.TestInstallation.UpgradeKgatewayCore(
+		s.Ctx,
+		s.T(),
+		s.localChartValuesFiles(),
+		s.TestInstallation.Metadata.ExtraHelmArgs,
+	)
+}
+
+// TestUpgrade first upgrades the CRDs and control plane while keeping the released data plane,
+// then upgrades the data plane and verifies the fully converged installation.
 func (s *testingSuite) TestUpgrade() {
 	// Create a gateway and ensure it works as expected
 	cleanup := s.applyManifests()
@@ -104,16 +157,35 @@ func (s *testingSuite) TestUpgrade() {
 		Name:      "gateway",
 		Namespace: "default",
 	})
-	s.verifyRequestWithTransformation()
+	s.verifyRequestWithTransformation(initialTransformationValue)
 	s.T().Logf(" ok")
 
+	// First upgrade the CRDs and control plane while keeping the released data-plane image.
+	// This exercises the supported version-skew window: the new control plane must continue
+	// producing xDS that the released Envoy can accept.
 	s.TestInstallation.InstallKgatewayCRDsFromLocalChart(s.Ctx, s.T())
-	s.TestInstallation.InstallKgatewayCoreFromLocalChart(s.Ctx, s.T())
+	s.upgradeControlPlaneWithReleasedDataPlane()
 
 	// Verify kgateway control plane upgraded successfully.
 	s.T().Logf("checking the kgateway deployment && pod...")
 	s.TestInstallation.AssertionsT(s.T()).EventuallyKgatewayUpgradeSucceeded(s.Ctx, version)
 	s.T().Logf(" ok")
+
+	// Prove the proxy is still on the released image before forcing a new translation.
+	s.T().Logf("checking released data plane image %s...", s.fromVersion)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyDeploymentsRolledOut(s.Ctx, proxyNamespace, proxyLabelSelector)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyPodsHaveImageVersion(s.Ctx, proxyNamespace, proxyLabelSelector, s.fromVersion)
+	s.T().Logf(" ok")
+
+	// Change the policy after the control-plane rollout. Observing the new header proves that
+	// the released proxy accepted a freshly translated snapshot from the new control plane.
+	s.updateTransformationHeader(skewedTransformationValue)
+	s.T().Logf("checking released data plane against the upgraded control plane...")
+	s.verifyRequestWithTransformation(skewedTransformationValue)
+	s.T().Logf(" ok")
+
+	// Remove the version skew by upgrading the default data-plane image to the local build.
+	s.upgradeDataPlane()
 
 	// Ensure the proxy data plane was upgraded too: the Deployment must finish rolling out
 	// (old-revision proxy pods fully scaled down) and every proxy pod must run the new image
@@ -126,14 +198,14 @@ func (s *testingSuite) TestUpgrade() {
 
 	// Ensure the same gateway works after the upgrade.
 	s.T().Logf("checking connectivity with the gateway after the upgrade...")
-	s.verifyRequestWithTransformation()
+	s.verifyRequestWithTransformation(skewedTransformationValue)
 	s.T().Logf(" ok")
 
 	// Recreate the same gateway and ensure it works after the upgrade
 	cleanup()
 	s.applyManifests()
 	s.T().Logf("checking connectivity with the gateway after recreating it...")
-	s.verifyRequestWithTransformation()
+	s.verifyRequestWithTransformation(initialTransformationValue)
 	s.T().Logf(" ok")
 }
 

--- a/test/e2e/tests/upgrade_test.go
+++ b/test/e2e/tests/upgrade_test.go
@@ -65,5 +65,5 @@ func testUpgrade(t *testing.T, fromVersion string) {
 	// Install the released version from the remote OCI registry.
 	testInstallation.InstallKgatewayFromRelease(ctx, t, fromVersion)
 
-	UpgradeSuiteRunner().Run(ctx, t, testInstallation)
+	UpgradeSuiteRunner(fromVersion).Run(ctx, t, testInstallation)
 }

--- a/test/e2e/tests/upgrade_tests.go
+++ b/test/e2e/tests/upgrade_tests.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/upgrade"
 )
 
-func UpgradeSuiteRunner() e2e.SuiteRunner {
+func UpgradeSuiteRunner(fromVersion string) e2e.SuiteRunner {
 	upgradeSuiteRunner := e2e.NewSuiteRunner(false)
-	upgradeSuiteRunner.Register("Upgrade", upgrade.NewTestingSuite)
+	upgradeSuiteRunner.Register("Upgrade", upgrade.NewTestingSuite(fromVersion))
 	return upgradeSuiteRunner
 }


### PR DESCRIPTION
# Description

PR #14223 migrated dynamic module per-route configs from the deprecated `per_route_config_name` field to the new `filter_name` field on `DynamicModuleFilterPerRoute`. However, older Envoy versions only read the deprecated `per_route_config_name` field, so setting only `filter_name` breaks per-route dynamic module configuration (transformations and HTTP ACL) on those versions.

This PR sets **both** fields to the same value so the config works across Envoy versions:

- HTTP ACL per-route dynamic module configs now set `PerRouteConfigName` in addition to `FilterName`.
- Rustformation/transformation per-route configs (including the blank per-route config and dynamic metadata config) now set `PerRouteConfigName` in addition to `FilterName`.
- Merge default configs and unit test fixtures updated accordingly.
- Golden YAML outputs regenerated to include `perRouteConfigName` alongside `filterName`.

The deprecated field can be dropped again once the minimum supported Envoy version reads `filter_name`.

# Change Type

/kind fix

# Changelog

```release-note
NONE
```
