### PR TITLE
fix: React to changed ServiceEntry VIPs for ingress-use-waypoint

### DIFF
--- a/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/backends.go
@@ -12,6 +12,7 @@ import (
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/slices"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
@@ -20,6 +21,22 @@ import (
 )
 
 const dnsClusterExtensionName = "envoy.clusters.dns"
+
+// serviceEntryBackendIR makes the resolved addresses participate in backend
+// equality. Addresses can change in Status without bumping generation, so
+// without this a status-only update looks unchanged and never reaches the
+// static cluster.
+type serviceEntryBackendIR struct {
+	addresses []string
+}
+
+func (s *serviceEntryBackendIR) Equals(in any) bool {
+	other, ok := in.(*serviceEntryBackendIR)
+	if !ok {
+		return false
+	}
+	return slices.Equal(s.addresses, other.addresses)
+}
 
 func (s *serviceEntryPlugin) initServiceEntryBackend(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
 	se, ok := in.Obj.(*networkingclient.ServiceEntry)
@@ -132,6 +149,8 @@ func BuildServiceEntryBackendObjectIR(
 	backend.AppProtocol = ir.ParseAppProtocol(new(svcProtocol))
 	backend.CanonicalHostname = hostname
 	backend.Obj = se
+	// Carry resolved addresses so a status-only VIP update re-emits the backend.
+	backend.ObjIr = &serviceEntryBackendIR{addresses: ServiceEntryAddresses(se)}
 
 	// include ourselves as alias to fix issues with one-to-many se-to-backend
 	backend.Aliases = []ir.ObjectSource{objSrc}

--- a/pkg/kgateway/extensions2/plugins/serviceentry/backends_test.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/backends_test.go
@@ -1,0 +1,78 @@
+package serviceentry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networking "istio.io/api/networking/v1alpha3"
+	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// serviceEntryWithStatusAddrs builds a ServiceEntry with a fixed spec and the
+// given auto-allocated VIPs in Status.Addresses.
+func serviceEntryWithStatusAddrs(generation int64, statusAddrs ...string) *networkingclient.ServiceEntry {
+	se := &networkingclient.ServiceEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "autogen.server.server",
+			Namespace:  "istio-system",
+			Generation: generation,
+			UID:        "uid-1",
+		},
+		Spec: networking.ServiceEntry{
+			Hosts:      []string{"server.server.mesh.internal"},
+			Location:   networking.ServiceEntry_MESH_INTERNAL,
+			Resolution: networking.ServiceEntry_STATIC,
+			Ports: []*networking.ServicePort{
+				{Name: "http", Number: 80, Protocol: "HTTP", TargetPort: 9898},
+			},
+		},
+	}
+	for _, addr := range statusAddrs {
+		se.Status.Addresses = append(se.Status.Addresses, &networking.ServiceEntryAddress{
+			Value: addr,
+			Host:  "server.server.mesh.internal",
+		})
+	}
+	return se
+}
+
+func backendFor(se *networkingclient.ServiceEntry) interface {
+	Equals(any) bool
+} {
+	be := BuildServiceEntryBackendObjectIR(se, "server.server.mesh.internal", 80, "HTTP", nil)
+	return be.ObjIr
+}
+
+// A status-only VIP write must flip backend equality, otherwise the empty
+// backend is never reprogrammed with the allocated address.
+func TestServiceEntryBackendIR_ReactsToStatusVIP(t *testing.T) {
+	beforeVIP := backendFor(serviceEntryWithStatusAddrs(1))
+	afterVIP := backendFor(serviceEntryWithStatusAddrs(1, "240.240.0.1"))
+
+	assert.NotNil(t, beforeVIP, "ServiceEntry backend must set ObjIr")
+	assert.NotNil(t, afterVIP, "ServiceEntry backend must set ObjIr")
+
+	assert.False(t, beforeVIP.Equals(afterVIP),
+		"a ServiceEntry gaining an auto-allocated VIP in its status must NOT be considered equal")
+	assert.False(t, afterVIP.Equals(beforeVIP),
+		"equality must be symmetric for the status VIP change")
+}
+
+// Identical resolved addresses must compare equal so no-op status writes don't
+// churn Envoy config.
+func TestServiceEntryBackendIR_StableWhenStatusUnchanged(t *testing.T) {
+	a := backendFor(serviceEntryWithStatusAddrs(1, "240.240.0.1"))
+	b := backendFor(serviceEntryWithStatusAddrs(1, "240.240.0.1"))
+
+	assert.True(t, a.Equals(b), "identical resolved addresses must compare equal")
+}
+
+// Adding a second (e.g. IPv6) address must also be detected as a change.
+func TestServiceEntryBackendIR_ReactsToAdditionalVIP(t *testing.T) {
+	single := backendFor(serviceEntryWithStatusAddrs(1, "240.240.0.1"))
+	dual := backendFor(serviceEntryWithStatusAddrs(1, "240.240.0.1", "2001:2::f0f0:1"))
+
+	assert.False(t, single.Equals(dual),
+		"gaining an additional auto-allocated address must be detected as a change")
+}

--- a/test/e2e/features/waypoint/cases_ingress.go
+++ b/test/e2e/features/waypoint/cases_ingress.go
@@ -3,6 +3,9 @@
 package waypoint
 
 import (
+	"strings"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
@@ -77,6 +80,47 @@ func (s *testingSuite) TestIngressHTTPRouteNamespaceLabel() {
 		Name:      "gw",
 		Namespace: testNamespace,
 	}), "example.com", expected, "GET")
+}
+
+// TestIngressHTTPRouteServiceEntryAutoAllocatedVIP checks that an
+// ingress-use-waypoint route to a ServiceEntry whose VIP is auto-allocated into
+// status.addresses reaches the backend once the VIP is assigned.
+func (s *testingSuite) TestIngressHTTPRouteServiceEntryAutoAllocatedVIP() {
+	if !s.ingressUseWaypoint {
+		s.T().Skip("only relevant when ingress-use-waypoint is enabled")
+	}
+
+	s.setNamespaceWaypointOrFail(testNamespace)
+	s.applyOrFail("httproute-ingress-serviceentry.yaml", testNamespace)
+
+	vip := s.waitForServiceEntryVIP("se-autoalloc", testNamespace)
+	s.T().Logf("ServiceEntry se-autoalloc got auto-allocated VIP %q", vip)
+
+	// Positive control: the mesh path through the waypoint is healthy.
+	s.assertCurlInner(fromCurl, "se-autoalloc.serviceentry.com", "", hasHTTPRoute, "")
+
+	// Ingress to the ServiceEntry Hostname backend must reach the backend via the waypoint.
+	s.assertCurlInner(fromCurl, kubeutils.ServiceFQDN(metav1.ObjectMeta{
+		Name:      "gw",
+		Namespace: testNamespace,
+	}), "example.com", hasHTTPRoute, "")
+}
+
+// waitForServiceEntryVIP waits for Istio to auto-allocate a VIP into the
+// ServiceEntry's status.addresses and returns it.
+func (s *testingSuite) waitForServiceEntryVIP(name, namespace string) string {
+	var vip string
+	s.Require().Eventually(func() bool {
+		out, _, err := s.testInstallation.ClusterContext.Cli.Execute(s.ctx,
+			"get", "serviceentry", name, "-n", namespace,
+			"-o", "jsonpath={.status.addresses[0].value}")
+		if err != nil {
+			return false
+		}
+		vip = strings.TrimSpace(out)
+		return vip != ""
+	}, readyTimeout, 2*time.Second, "ServiceEntry %s/%s never got an auto-allocated VIP", namespace, name)
+	return vip
 }
 
 func (s *testingSuite) setIngressUseWaypointLabel(kind, name, namespace string) {

--- a/test/e2e/features/waypoint/testdata/httproute-ingress-serviceentry.yaml
+++ b/test/e2e/features/waypoint/testdata/httproute-ingress-serviceentry.yaml
@@ -1,0 +1,79 @@
+##################################################################################################
+# ServiceEntry with NO spec.addresses, so Istio IP auto-allocation writes the VIP into
+# status.addresses only. This exercises the ingress-use-waypoint path where the backend VIP
+# is known solely from status (see the empty-STATIC-cluster 503 regression).
+##################################################################################################
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: se-autoalloc
+  labels:
+    istio.io/ingress-use-waypoint: "true"
+spec:
+  hosts:
+  - se-autoalloc.serviceentry.com
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+  - number: 8080
+    name: http
+    protocol: HTTP
+    targetPort: 5678
+  workloadSelector:
+    labels:
+      app: svc-a
+---
+# Route attached to the ServiceEntry hostname. The waypoint applies it, adding the
+# traversed-waypoint header so a response proves traffic went through the waypoint.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hr-se-autoalloc-waypoint-header
+spec:
+  parentRefs:
+  - name: se-autoalloc.serviceentry.com
+    group: networking.istio.io
+    kind: Hostname
+  rules:
+  - backendRefs:
+    - name: se-autoalloc.serviceentry.com
+      group: networking.istio.io
+      kind: Hostname
+      port: 8080
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        add:
+        - name: "traversed-waypoint"
+          value: "true"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+# North-south route: ingress Gateway -> ServiceEntry hostname backend.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ingress-to-se-autoalloc
+spec:
+  parentRefs:
+  - name: gw
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: se-autoalloc.serviceentry.com
+      group: networking.istio.io
+      kind: Hostname
+      port: 8080


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

When an `ingress-use-waypoint` HTTPRoute targets a `ServiceEntry` via a `Hostname` backendRef, and that ServiceEntry relies on Istio IP auto-allocation (no `spec.addresses`), the ingress returned 503s for newly created ServiceEntries.

Istio writes the auto-allocated VIP to `ServiceEntry.status.addresses`, which does not bump the object's `generation`. `BackendObjectIR.Equals` compares the source object by generation (labels/annotations), so the status-only VIP update was treated as no change: the backend built before the VIP was allocated kept an empty static cluster and was never reprogrammed. Any metadata edit to the ServiceEntry (e.g. adding an annotation) worked around it by forcing a re-evaluation.

The ServiceEntry backend now carries its resolved addresses (which include `status.addresses`) in `BackendObjectIR.ObjIr`, so a change to those addresses flips backend equality and the static cluster is reprogrammed with the allocated VIP.

Fixes #14390

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix 503s for ingress-use-waypoint routes to auto-allocated ServiceEntries.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
