### PR TITLE
[v2.2.x] backport status read-only + observedGeneration + IR equality fixes (#14295, #14248, #14298, #14302)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -174,6 +174,10 @@ linters:
         linters:
           - forbidigo
         text: 'require testutils.Cleanup'
+      # unparam is often noisy in tests where helper signatures intentionally stay uniform.
+      - path: _test\.go$
+        linters:
+          - unparam
       # Skip client.Client forbidgo rule for e2e tests
       - path: test/e2e/
         linters:

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"sync/atomic"
 
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -183,28 +182,7 @@ func (r report) ResourceName() string {
 
 // do we really need this for a singleton?
 func (r report) Equals(in report) bool {
-	if !maps.Equal(r.reportMap.Gateways, in.reportMap.Gateways) {
-		return false
-	}
-	if !maps.EqualFunc(r.reportMap.ListenerSets, in.reportMap.ListenerSets,
-		func(a, b map[types.NamespacedName]*reports.ListenerSetReport) bool {
-			return maps.Equal(a, b)
-		}) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.HTTPRoutes, in.reportMap.HTTPRoutes) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.TCPRoutes, in.reportMap.TCPRoutes) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.TLSRoutes, in.reportMap.TLSRoutes) {
-		return false
-	}
-	if !maps.Equal(r.reportMap.Policies, in.reportMap.Policies) {
-		return false
-	}
-	return true
+	return reports.EqualReportMaps(r.reportMap, in.reportMap)
 }
 
 var logger = logging.New("proxy_syncer")
@@ -304,78 +282,11 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 func mergeProxyReports(
 	proxies []GatewayXdsResources,
 ) reports.ReportMap {
-	merged := reports.NewReportMap()
-	for _, p := range proxies {
-		// 1. merge GW Reports for all Proxies' status reports
-		maps.Copy(merged.Gateways, p.reports.Gateways)
-
-		// 2. merge LS Reports for all Proxies' status reports
-		maps.Copy(merged.ListenerSets, p.reports.ListenerSets)
-
-		// 3. merge httproute parentRefs into RouteReports
-		for rnn, rr := range p.reports.HTTPRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.HTTPRoutes[rnn]
-			if old == nil {
-				merged.HTTPRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.HTTPRoutes[rnn].Parents, rr.Parents)
-		}
-
-		// 4. merge tcproute parentRefs into RouteReports
-		for rnn, rr := range p.reports.TCPRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.TCPRoutes[rnn]
-			if old == nil {
-				merged.TCPRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.TCPRoutes[rnn].Parents, rr.Parents)
-		}
-
-		for rnn, rr := range p.reports.TLSRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.TLSRoutes[rnn]
-			if old == nil {
-				merged.TLSRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.TLSRoutes[rnn].Parents, rr.Parents)
-		}
-
-		for rnn, rr := range p.reports.GRPCRoutes {
-			// if we haven't encountered this route, just copy it over completely
-			old := merged.GRPCRoutes[rnn]
-			if old == nil {
-				merged.GRPCRoutes[rnn] = rr
-				continue
-			}
-			// else, this route has already been seen for a proxy, merge this proxy's parents
-			// into the merged report
-			maps.Copy(merged.GRPCRoutes[rnn].Parents, rr.Parents)
-		}
-
-		for key, report := range p.reports.Policies {
-			// if we haven't encountered this policy, just copy it over completely
-			old := merged.Policies[key]
-			if old == nil {
-				merged.Policies[key] = report
-				continue
-			}
-			// else, let's merge our parentRefs into the existing map
-			// obsGen will stay as-is...
-			maps.Copy(merged.Policies[key].Ancestors, report.Ancestors)
-		}
+	inputs := make([]reports.ReportMap, 0, len(proxies))
+	for _, proxy := range proxies {
+		inputs = append(inputs, proxy.reports)
 	}
-
-	return merged
+	return reports.MergeReportMaps(inputs...)
 }
 
 func (s *ProxySyncer) Start(ctx context.Context) error {

--- a/pkg/kgateway/proxy_syncer/status_syncer_gateway_test.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer_gateway_test.go
@@ -1,0 +1,116 @@
+package proxy_syncer
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+// TestSyncGatewayStatusPreservesControllerInvalidParameters verifies that
+// syncGatewayStatus does not clobber an Accepted=False/InvalidParameters
+// condition owned by the controller when the translated report only carries a
+// Programmed condition. This exercises the full write path through the client,
+// complementing the builder-level coverage in pkg/reports.
+func TestSyncGatewayStatusPreservesControllerInvalidParameters(t *testing.T) {
+	ctx := context.Background()
+	const controllerName = "kgateway.dev/kgateway"
+	gatewayKey := types.NamespacedName{Namespace: "default", Name: "gw"}
+
+	gateway := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  gatewayKey.Namespace,
+			Name:       gatewayKey.Name,
+			Generation: 2,
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "kgateway",
+			Listeners: []gwv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+		Status: gwv1.GatewayStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(gwv1.GatewayConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(gwv1.GatewayReasonInvalidParameters),
+				Message:            "invalid gateway parameters",
+				ObservedGeneration: 2,
+			}},
+		},
+	}
+	gatewayClass := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "kgateway"},
+		Spec: gwv1.GatewayClassSpec{
+			ControllerName: gwv1.GatewayController(controllerName),
+		},
+	}
+
+	kubeClient := newFakeGatewayStatusClient(t, gateway, gatewayClass)
+
+	rm := reports.NewReportMap()
+	translatedGateway := gateway.DeepCopy()
+	translatedGateway.Status = gwv1.GatewayStatus{}
+	gwReporter := reports.NewReporter(&rm).Gateway(translatedGateway)
+	gwReporter.SetCondition(reporter.GatewayCondition{
+		Type:    gwv1.GatewayConditionProgrammed,
+		Status:  metav1.ConditionTrue,
+		Reason:  gwv1.GatewayReasonProgrammed,
+		Message: reports.GatewayProgrammedMessage,
+	})
+
+	syncer := &StatusSyncer{
+		mgr:            statusSyncerTestManager{client: kubeClient},
+		controllerName: controllerName,
+	}
+	syncer.syncGatewayStatus(ctx, slog.New(slog.DiscardHandler), rm)
+
+	updated := &gwv1.Gateway{}
+	require.NoError(t, kubeClient.Get(ctx, gatewayKey, updated))
+
+	accepted := apimeta.FindStatusCondition(updated.Status.Conditions, string(gwv1.GatewayConditionAccepted))
+	require.NotNil(t, accepted)
+	require.Equal(t, metav1.ConditionFalse, accepted.Status)
+	require.Equal(t, string(gwv1.GatewayReasonInvalidParameters), accepted.Reason)
+	require.Equal(t, "invalid gateway parameters", accepted.Message)
+
+	programmed := apimeta.FindStatusCondition(updated.Status.Conditions, string(gwv1.GatewayConditionProgrammed))
+	require.NotNil(t, programmed)
+	require.Equal(t, metav1.ConditionTrue, programmed.Status)
+	require.Equal(t, string(gwv1.GatewayReasonProgrammed), programmed.Reason)
+}
+
+func newFakeGatewayStatusClient(t *testing.T, objs ...ctrlclient.Object) ctrlclient.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, gwv1.Install(scheme))
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&gwv1.Gateway{}).
+		WithObjects(objs...).
+		Build()
+}
+
+type statusSyncerTestManager struct {
+	manager.Manager
+	client ctrlclient.Client
+}
+
+func (m statusSyncerTestManager) GetClient() ctrlclient.Client {
+	return m.client
+}

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -286,11 +286,8 @@ func (l Secret) MarshalJSON() ([]byte, error) {
 // TODO: why is this in backend.go?
 type Listener struct {
 	gwv1.Listener
-	// +krtEqualsTodo compare parent reference in listener equality
-	Parent client.Object
-	// +krtEqualsTodo include attached listener policies in equality
-	AttachedPolicies AttachedPolicies
-	// +krtEqualsTodo include policy ancestor reference in equality
+	Parent            client.Object
+	AttachedPolicies  AttachedPolicies
 	PolicyAncestorRef gwv1.ParentReference
 }
 
@@ -303,9 +300,23 @@ func (listener Listener) GetParentReporter(reporter reporter.Reporter) reporter.
 	}
 }
 
-// TODO: need to reevaluate DeepEqual usage
 func (c Listener) Equals(in Listener) bool {
-	return reflect.DeepEqual(c, in)
+	// Use versionEquals for Parent (raw *gwv1.Gateway or *gwv1.ListenerSet) so that
+	// status-only writes (which bump resourceVersion but not generation) do not cause
+	// reflect.DeepEqual to return false and trigger unnecessary re-translations.
+	if (c.Parent == nil) != (in.Parent == nil) {
+		return false
+	}
+	// Currently, only Gateway and ListenerSet's Equals() calls Listener.Equals(),
+	// and both of those check versionEquals on the Parent before calling Listener.Equals(),
+	// so, this versionEquals check is somewhat redundant, but it's safer to have it here in
+	// case Listener.Equals() is called directly in the future without a Parent version check.
+	if c.Parent != nil && !versionEquals(c.Parent, in.Parent) {
+		return false
+	}
+	return reflect.DeepEqual(c.Listener, in.Listener) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		reflect.DeepEqual(c.PolicyAncestorRef, in.PolicyAncestorRef)
 }
 
 type GatewayForDeployer struct {

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -1,0 +1,632 @@
+package ir
+
+// equality_harness_test.go verifies that the Equals() implementations on core
+// IR types detect every exported field mutation. This enforces that adding a
+// field without updating Equals fails here instead of silently dropping Envoy
+// config updates.
+//
+// See test/testutils/equalstest for the harness API.
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+// harnessTestPolicyIR is a minimal PolicyIR for harness tests.
+// (gw_test.go defines mockPolicyIR for its own tests; this is a separate type
+// to avoid confusion and allow independent evolution.)
+type harnessTestPolicyIR struct {
+	val string
+}
+
+func (f *harnessTestPolicyIR) CreationTime() time.Time { return time.Time{} }
+func (f *harnessTestPolicyIR) Equals(in any) bool {
+	other, ok := in.(*harnessTestPolicyIR)
+	if !ok {
+		return false
+	}
+	return f.val == other.val
+}
+
+func baseHarnessPolicyAtt() PolicyAtt {
+	return PolicyAtt{
+		GroupKind:  schema.GroupKind{Group: "example.com", Kind: "MyPolicy"},
+		Generation: 1,
+		PolicyIr:   &harnessTestPolicyIR{val: "base"},
+		PolicyRef: &AttachedPolicyRef{
+			Group:     "example.com",
+			Kind:      "MyPolicy",
+			Name:      "my-policy",
+			Namespace: "default",
+		},
+		InheritedPolicyPriority: apiannotations.ShallowMergePreferParent,
+		Errors:                  []error{errors.New("base error")},
+		HierarchicalPriority:    5,
+		PrecedenceWeight:        10,
+		// MergeOrigins is +noKrtEquals and listed as exempt below.
+	}
+}
+
+func TestHarnessPolicyAttEquals(t *testing.T) {
+	cases := []equalstest.Case[PolicyAtt]{
+		{
+			Field:  "GroupKind",
+			Mutate: func(p *PolicyAtt) { p.GroupKind = schema.GroupKind{Group: "other.io", Kind: "Other"} },
+		},
+		{
+			Field:  "Generation",
+			Mutate: func(p *PolicyAtt) { p.Generation = 99 },
+		},
+		{
+			Field:  "PolicyIr",
+			Mutate: func(p *PolicyAtt) { p.PolicyIr = &harnessTestPolicyIR{val: "mutated"} },
+		},
+		{
+			Field:  "PolicyRef",
+			Mutate: func(p *PolicyAtt) { p.PolicyRef = &AttachedPolicyRef{Name: "other-policy"} },
+		},
+		{
+			Field:  "InheritedPolicyPriority",
+			Mutate: func(p *PolicyAtt) { p.InheritedPolicyPriority = apiannotations.DeepMergePreferChild },
+		},
+		{
+			Field:  "Errors",
+			Mutate: func(p *PolicyAtt) { p.Errors = []error{errors.New("different error")} },
+		},
+		{
+			Field:  "HierarchicalPriority",
+			Mutate: func(p *PolicyAtt) { p.HierarchicalPriority = 99 },
+		},
+		{
+			Field:  "PrecedenceWeight",
+			Mutate: func(p *PolicyAtt) { p.PrecedenceWeight = 99 },
+		},
+	}
+	equalstest.Run(
+		t, baseHarnessPolicyAtt, func(a, b PolicyAtt) bool { return a.Equals(b) }, cases,
+		[]string{"MergeOrigins"}, // +noKrtEquals, gw.go:105
+	)
+}
+
+func baseHarnessAttachedPolicies() AttachedPolicies {
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+	return AttachedPolicies{
+		Policies: map[schema.GroupKind][]PolicyAtt{
+			gk: {baseHarnessPolicyAtt()},
+		},
+	}
+}
+
+func TestHarnessAttachedPoliciesEquals(t *testing.T) {
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+	gk2 := schema.GroupKind{Group: "other.io", Kind: "OtherPolicy"}
+
+	cases := []equalstest.Case[AttachedPolicies]{
+		{
+			Field: "Policies",
+			// Add a new entry under a different GroupKind.
+			Mutate: func(a *AttachedPolicies) {
+				a.Policies[gk2] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			Field: "Policies",
+			// Change a PolicyAtt within an existing slice.
+			Mutate: func(a *AttachedPolicies) {
+				pa := baseHarnessPolicyAtt()
+				pa.Generation = 99
+				a.Policies[gk] = []PolicyAtt{pa}
+			},
+		},
+		{
+			Field: "Policies",
+			// Remove an entry.
+			Mutate: func(a *AttachedPolicies) {
+				delete(a.Policies, gk)
+			},
+		},
+	}
+
+	// AttachedPolicies has a single exported field: Policies (map).
+	// All cases target it; no exempt fields needed.
+	equalstest.Run(t, baseHarnessAttachedPolicies, func(a, b AttachedPolicies) bool { return a.Equals(b) }, cases, nil)
+}
+
+func baseGatewayObj() *gwv1.Gateway {
+	return &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			ResourceVersion: "1",
+			UID:             "uid-1",
+		},
+	}
+}
+
+func baseHarnessListener() Listener {
+	port := gwv1.PortNumber(80)
+	return Listener{
+		Listener: gwv1.Listener{
+			Name:     "http",
+			Port:     port,
+			Protocol: gwv1.HTTPProtocolType,
+		},
+	}
+}
+
+func baseHarnessListenerSet() ListenerSet {
+	return ListenerSet{
+		ObjectSource: ObjectSource{
+			Group:     "gateway.networking.k8s.io",
+			Kind:      "ListenerSet",
+			Namespace: "default",
+			Name:      "my-listenerset",
+		},
+		Listeners: Listeners{baseHarnessListener()},
+		Obj: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "1",
+				UID:             "ls-uid-1",
+			},
+		},
+		Err: nil,
+	}
+}
+
+func baseHarnessGateway() Gateway {
+	ls := baseHarnessListenerSet()
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "ListenerSet"}
+	return Gateway{
+		ObjectSource: ObjectSource{
+			Group:     "gateway.networking.k8s.io",
+			Kind:      "Gateway",
+			Namespace: "default",
+			Name:      "my-gateway",
+		},
+		Listeners:           Listeners{baseHarnessListener()},
+		AllowedListenerSets: GVKListenerSets{gvk: ListenerSets{ls}},
+		DeniedListenerSets:  GVKListenerSets{},
+		Obj:                 baseGatewayObj(),
+		AttachedListenerPolicies: AttachedPolicies{
+			Policies: map[schema.GroupKind][]PolicyAtt{},
+		},
+		AttachedHttpPolicies: AttachedPolicies{
+			Policies: map[schema.GroupKind][]PolicyAtt{},
+		},
+		PerConnectionBufferLimitBytes: uint32ptr(65535),
+		FrontendTLSConfig:             nil,
+	}
+}
+
+func TestHarnessGatewayEquals(t *testing.T) {
+	gvk2 := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "OtherSet"}
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+
+	cases := []equalstest.Case[Gateway]{
+		{
+			// ObjectSource is embedded; cover it by mutating one of its fields.
+			Field: "ObjectSource",
+			Mutate: func(g *Gateway) {
+				g.ObjectSource.Name = "other-gateway"
+			},
+		},
+		{
+			// Listeners: length change only; per-field Listener mutations are
+			// covered by TestHarnessListenerEquals.
+			Field: "Listeners",
+			Mutate: func(g *Gateway) {
+				g.Listeners = append(g.Listeners, baseHarnessListener())
+			},
+		},
+		{
+			Field: "AllowedListenerSets",
+			Mutate: func(g *Gateway) {
+				g.AllowedListenerSets[gvk2] = ListenerSets{baseHarnessListenerSet()}
+			},
+		},
+		{
+			Field: "DeniedListenerSets",
+			Mutate: func(g *Gateway) {
+				ls := baseHarnessListenerSet()
+				ls.ObjectSource.Name = "denied-set"
+				g.DeniedListenerSets[gvk2] = ListenerSets{ls}
+			},
+		},
+		{
+			// Obj: mutate ResourceVersion so versionEquals (backend.go:523) detects the change.
+			// versionEquals uses ResourceVersion when Generation == 0.
+			Field: "Obj",
+			Mutate: func(g *Gateway) {
+				obj := baseGatewayObj()
+				obj.ResourceVersion = "999"
+				g.Obj = obj
+			},
+		},
+		{
+			Field: "AttachedListenerPolicies",
+			Mutate: func(g *Gateway) {
+				g.AttachedListenerPolicies.Policies[gk] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			Field: "AttachedHttpPolicies",
+			Mutate: func(g *Gateway) {
+				g.AttachedHttpPolicies.Policies[gk] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			Field: "PerConnectionBufferLimitBytes",
+			Mutate: func(g *Gateway) {
+				g.PerConnectionBufferLimitBytes = uint32ptr(32768)
+			},
+		},
+		{
+			Field: "FrontendTLSConfig",
+			Mutate: func(g *Gateway) {
+				g.FrontendTLSConfig = &FrontendTLSConfigIR{}
+			},
+		},
+	}
+
+	// ObjectSource is an embedded struct; the harness flattens its exported
+	// fields (Group, Kind, Namespace, Name) plus adds the embedding name itself.
+	// We cover the embedding via the "ObjectSource" case above; exempt the four
+	// individual flattened names to avoid requiring redundant cases.
+	equalstest.Run(
+		t,
+		baseHarnessGateway,
+		func(a, b Gateway) bool { return a.Equals(b) },
+		cases,
+		[]string{"Group", "Kind", "Namespace", "Name"}, // embedded ObjectSource fields covered by "ObjectSource" case
+	)
+}
+
+func TestHarnessListenerSetEquals(t *testing.T) {
+	cases := []equalstest.Case[ListenerSet]{
+		{
+			// ObjectSource embedding — cover via name mutation.
+			Field: "ObjectSource",
+			Mutate: func(ls *ListenerSet) {
+				ls.ObjectSource.Name = "other-listenerset"
+			},
+		},
+		{
+			// Listeners: length change only; per-field Listener mutations are
+			// covered by TestHarnessListenerEquals.
+			Field: "Listeners",
+			Mutate: func(ls *ListenerSet) {
+				ls.Listeners = append(ls.Listeners, baseHarnessListener())
+			},
+		},
+		{
+			// Obj: mutate ResourceVersion so versionEquals detects the change.
+			// versionEquals uses ResourceVersion when Generation == 0.
+			Field: "Obj",
+			Mutate: func(ls *ListenerSet) {
+				ls.Obj = &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						ResourceVersion: "999",
+						UID:             "ls-uid-1",
+					},
+				}
+			},
+		},
+		{
+			Field: "Err",
+			Mutate: func(ls *ListenerSet) {
+				ls.Err = errors.New("construction failed")
+			},
+		},
+	}
+
+	equalstest.Run(
+		t,
+		baseHarnessListenerSet,
+		func(a, b ListenerSet) bool { return a.Equals(b) },
+		cases,
+		[]string{"Group", "Kind", "Namespace", "Name"}, // embedded ObjectSource fields covered by "ObjectSource" case
+	)
+}
+
+func baseHarnessBackendRefIR() BackendRefIR {
+	backend := NewBackendObjectIR(ObjectSource{
+		Namespace: "default",
+		Name:      "my-service",
+		Kind:      "Service",
+	}, 8080, "")
+	backend.Obj = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-service",
+			Namespace:       "default",
+			UID:             "svc-uid-1",
+			ResourceVersion: "1",
+		},
+	}
+	return BackendRefIR{
+		ClusterName:   "service_default_my-service_8080",
+		Weight:        1,
+		BackendObject: &backend,
+		Err:           nil,
+	}
+}
+
+func TestHarnessBackendRefIREquals(t *testing.T) {
+	cases := []equalstest.Case[BackendRefIR]{
+		{
+			Field:  "ClusterName",
+			Mutate: func(b *BackendRefIR) { b.ClusterName = "other_cluster" },
+		},
+		{
+			Field:  "Weight",
+			Mutate: func(b *BackendRefIR) { b.Weight = 50 },
+		},
+		{
+			Field:  "BackendObject",
+			Mutate: func(b *BackendRefIR) { b.BackendObject = nil },
+		},
+		{
+			Field:  "Err",
+			Mutate: func(b *BackendRefIR) { b.Err = errors.New("backend not found") },
+		},
+	}
+
+	equalstest.Run(t, baseHarnessBackendRefIR, func(a, b BackendRefIR) bool { return a.Equals(b) }, cases, nil)
+}
+
+func baseHarnessGatewayExtension() GatewayExtension {
+	grpcSvcName := gwv1.ObjectName("ext-auth-svc")
+	return GatewayExtension{
+		ObjectSource: ObjectSource{
+			Group:     "gateway.kgateway.io",
+			Kind:      "GatewayExtension",
+			Namespace: "default",
+			Name:      "my-extension",
+		},
+		ExtAuth: &kgateway.ExtAuthProvider{
+			GrpcService: &kgateway.ExtGrpcService{
+				BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Name: grpcSvcName,
+					},
+				},
+			},
+		},
+		ExtProc: nil,
+		RateLimit: &kgateway.RateLimitProvider{
+			Domain: "my-domain",
+		},
+		JWT:              nil,
+		OAuth2:           nil,
+		PrecedenceWeight: 5,
+	}
+}
+
+// TestHarnessGatewayExtensionEquals drives the ObjectSource fix in Step 4.
+// The "ObjectSource" mutation case will FAIL until Step 4 adds the comparison.
+func TestHarnessGatewayExtensionEquals(t *testing.T) {
+	differentSvcName := gwv1.ObjectName("different-svc")
+	cases := []equalstest.Case[GatewayExtension]{
+		{
+			// ObjectSource: mutate Name. This case passes only after Step 4.
+			Field: "ObjectSource",
+			Mutate: func(e *GatewayExtension) {
+				e.ObjectSource.Name = "other-extension"
+			},
+		},
+		{
+			Field: "ExtAuth",
+			Mutate: func(e *GatewayExtension) {
+				e.ExtAuth = &kgateway.ExtAuthProvider{
+					GrpcService: &kgateway.ExtGrpcService{
+						BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: differentSvcName,
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			Field: "ExtProc",
+			Mutate: func(e *GatewayExtension) {
+				e.ExtProc = &kgateway.ExtProcProvider{}
+			},
+		},
+		{
+			Field: "RateLimit",
+			Mutate: func(e *GatewayExtension) {
+				e.RateLimit = &kgateway.RateLimitProvider{Domain: "other-domain"}
+			},
+		},
+		{
+			Field: "JWT",
+			Mutate: func(e *GatewayExtension) {
+				e.JWT = &kgateway.JWT{}
+			},
+		},
+		{
+			Field: "OAuth2",
+			Mutate: func(e *GatewayExtension) {
+				e.OAuth2 = &kgateway.OAuth2Provider{}
+			},
+		},
+		{
+			Field:  "PrecedenceWeight",
+			Mutate: func(e *GatewayExtension) { e.PrecedenceWeight = 99 },
+		},
+	}
+
+	// ObjectSource is embedded; exempt its flattened field names since we cover
+	// them via the "ObjectSource" case.
+	equalstest.Run(
+		t,
+		baseHarnessGatewayExtension,
+		func(a, b GatewayExtension) bool { return a.Equals(b) },
+		cases,
+		[]string{"Group", "Kind", "Namespace", "Name"}, // embedded ObjectSource fields
+	)
+}
+
+// baseHarnessFullListener returns a fully-populated Listener for the
+// TestHarnessListenerEquals test. It is separate from baseHarnessListener (which
+// is minimal and used by Gateway/ListenerSet tests) so that adding fields here
+// does not break those tests.
+func baseHarnessFullListener() Listener {
+	hostname := gwv1.Hostname("example.com")
+	port := gwv1.PortNumber(443)
+	proto := gwv1.HTTPSProtocolType
+	gk := schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+	return Listener{
+		Listener: gwv1.Listener{
+			Name:     "https",
+			Hostname: &hostname,
+			Port:     port,
+			Protocol: proto,
+		},
+		Parent: &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "my-gateway",
+				Namespace:       "default",
+				ResourceVersion: "1",
+			},
+		},
+		AttachedPolicies: AttachedPolicies{
+			Policies: map[schema.GroupKind][]PolicyAtt{
+				gk: {baseHarnessPolicyAtt()},
+			},
+		},
+		PolicyAncestorRef: gwv1.ParentReference{
+			Group:     new(gwv1.Group("gateway.networking.k8s.io")),
+			Kind:      new(gwv1.Kind("Gateway")),
+			Name:      gwv1.ObjectName("my-gateway"),
+			Namespace: new(gwv1.Namespace("default")),
+		},
+	}
+}
+
+func TestHarnessListenerEquals(t *testing.T) {
+	cases := []equalstest.Case[Listener]{
+		{
+			// The embedded gwv1.Listener contributes flattened field names (Name,
+			// Hostname, Port, Protocol, TLS, AllowedRoutes) plus the embedding name
+			// "Listener". Cover the embedding via a Port mutation; the flattened
+			// names are exempted below.
+			Field: "Listener",
+			Mutate: func(l *Listener) {
+				l.Listener.Port = gwv1.PortNumber(80)
+			},
+		},
+		{
+			// Bump the parent's ResourceVersion → versionEquals detects a change
+			// (the base parent has Generation 0, so versionEquals falls back to
+			// ResourceVersion + UID).
+			Field: "Parent",
+			Mutate: func(l *Listener) {
+				l.Parent = &gwv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "my-gateway",
+						Namespace:       "default",
+						ResourceVersion: "2",
+					},
+				}
+			},
+		},
+		{
+			// Add a policy to AttachedPolicies → unequal.
+			Field: "AttachedPolicies",
+			Mutate: func(l *Listener) {
+				gk2 := schema.GroupKind{Group: "other.io", Kind: "OtherPolicy"}
+				l.AttachedPolicies.Policies[gk2] = []PolicyAtt{baseHarnessPolicyAtt()}
+			},
+		},
+		{
+			// Change PolicyAncestorRef.Name → unequal.
+			Field: "PolicyAncestorRef",
+			Mutate: func(l *Listener) {
+				l.PolicyAncestorRef = gwv1.ParentReference{
+					Group:     new(gwv1.Group("gateway.networking.k8s.io")),
+					Kind:      new(gwv1.Kind("Gateway")),
+					Name:      gwv1.ObjectName("other-gateway"),
+					Namespace: new(gwv1.Namespace("default")),
+				}
+			},
+		},
+	}
+
+	// gwv1.Listener is embedded; the harness flattens its exported field names
+	// (Name, Hostname, Port, Protocol, TLS, AllowedRoutes) plus the embedding
+	// name "Listener". We cover the embedding via the "Listener" case above;
+	// exempt the individual flattened names to avoid requiring redundant cases.
+	equalstest.Run(
+		t,
+		baseHarnessFullListener,
+		func(a, b Listener) bool { return a.Equals(b) },
+		cases,
+		[]string{"Name", "Hostname", "Port", "Protocol", "TLS", "AllowedRoutes"}, // embedded gwv1.Listener fields covered by "Listener" case
+		// Suppress the gk field from the AttachedPolicies map closure; the
+		// "AttachedPolicies" case above exercises it at the struct level.
+	)
+}
+
+// TestListenerEqualsIgnoresStatusOnlyParentUpdates verifies that a status-only
+// write to the parent (which bumps ResourceVersion but not Generation) does NOT
+// make two Listeners compare unequal, while a spec change (which bumps
+// Generation) does. This mirrors the versionEquals semantics used in
+// Listener.Equals to avoid spurious re-translations on status writes.
+func TestListenerEqualsIgnoresStatusOnlyParentUpdates(t *testing.T) {
+	base := baseHarnessFullListener()
+	base.Parent = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			UID:             types.UID("my-gateway-uid"),
+			ResourceVersion: "1",
+			Generation:      1,
+		},
+	}
+
+	// Status-only write: ResourceVersion bumps, Generation does not → equal.
+	statusOnly := baseHarnessFullListener()
+	statusOnly.Parent = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			UID:             types.UID("my-gateway-uid"),
+			ResourceVersion: "2",
+			Generation:      1,
+		},
+	}
+	if !base.Equals(statusOnly) {
+		t.Error("Listener.Equals returned false for a status-only parent update (ResourceVersion bumped, Generation unchanged); expected true")
+	}
+
+	// Spec change: Generation bumps → unequal.
+	specChange := baseHarnessFullListener()
+	specChange.Parent = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-gateway",
+			Namespace:       "default",
+			UID:             types.UID("my-gateway-uid"),
+			ResourceVersion: "3",
+			Generation:      2,
+		},
+	}
+	if base.Equals(specChange) {
+		t.Error("Listener.Equals returned true for a parent spec change (Generation bumped); expected false")
+	}
+}
+
+//go:fix inline
+func uint32ptr(v uint32) *uint32 { return new(v) }

--- a/pkg/pluginsdk/ir/gatewayextension.go
+++ b/pkg/pluginsdk/ir/gatewayextension.go
@@ -46,6 +46,9 @@ func (e GatewayExtension) ResourceName() string {
 }
 
 func (e GatewayExtension) Equals(other GatewayExtension) bool {
+	if e.ObjectSource != other.ObjectSource {
+		return false
+	}
 	if !reflect.DeepEqual(e.ExtAuth, other.ExtAuth) {
 		return false
 	}

--- a/pkg/reports/observed_generation_test.go
+++ b/pkg/reports/observed_generation_test.go
@@ -1,0 +1,272 @@
+package reports_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+	pluginreporter "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+)
+
+// BuildGWStatus must stamp the generation the report was built for, not the
+// live object's generation. The status syncer is triggered only by report
+// changes and reads the live Gateway from a separate (controller-runtime)
+// cache than the one translation uses (the istio KRT cache). If it stamped the
+// live generation, a skew between those two caches could freeze
+// observedGeneration: the report-change trigger fires once, the stale live read
+// stamps the wrong generation, and nothing re-triggers the sync. Sourcing the
+// generation from the report keeps the trigger and the stamp consistent.
+func TestGatewayStatusStampsObservedGenerationFromReport(t *testing.T) {
+	newGateway := func(generation int64) *gwv1.Gateway {
+		return &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "example-gateway",
+				Namespace:  "default",
+				Generation: generation,
+			},
+			Spec: gwv1.GatewaySpec{
+				Listeners: []gwv1.Listener{
+					{Name: "http"},
+				},
+			},
+		}
+	}
+
+	// Report ahead of the live object: translation observed generation 2 but the
+	// syncer's cache still sees generation 1. This is the freeze case that
+	// regressed in #14295 - the published status must reflect the report's
+	// generation (2), not the stale live read (1).
+	t.Run("report ahead of stale live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		gw := newGateway(2)
+		statusReporter.Gateway(gw)
+
+		// Simulate the syncer's cache lagging behind translation's.
+		gw.Generation = 1
+		status := rm.BuildGWStatus(context.Background(), *gw, nil)
+		require.NotNil(t, status)
+
+		requireAllObservedGenerations(t, status, 2)
+	})
+
+	// Report behind the live object: the syncer's cache already sees generation
+	// 2, but translation has only processed generation 1. observedGeneration must
+	// stay at the generation actually translated (1) rather than prematurely
+	// claiming a generation whose status has not been computed yet.
+	t.Run("report behind live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		gw := newGateway(1)
+		statusReporter.Gateway(gw)
+
+		gw.Generation = 2
+		status := rm.BuildGWStatus(context.Background(), *gw, nil)
+		require.NotNil(t, status)
+
+		requireAllObservedGenerations(t, status, 1)
+	})
+}
+
+func requireAllObservedGenerations(t *testing.T, status *gwv1.GatewayStatus, want int64) {
+	t.Helper()
+
+	for _, condition := range status.Conditions {
+		require.Equal(t, want, condition.ObservedGeneration)
+	}
+	for _, listenerStatus := range status.Listeners {
+		for _, condition := range listenerStatus.Conditions {
+			require.Equal(t, want, condition.ObservedGeneration)
+		}
+	}
+}
+
+// BuildRouteStatus must stamp the generation the report was built for, not the
+// live object's generation, for the same cross-cache reason as Gateway status:
+// the route is re-read by the syncer from a separate cache than translation
+// used, and stamping the live read can freeze observedGeneration on a skew.
+func TestRouteStatusStampsObservedGenerationFromReport(t *testing.T) {
+	newRoute := func(generation int64) *gwv1.HTTPRoute {
+		return &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "example-route",
+				Namespace:  "default",
+				Generation: generation,
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{
+						{
+							Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+							Kind:      new(gwv1.Kind("Gateway")),
+							Name:      "example-gateway",
+							Namespace: new(gwv1.Namespace("default")),
+						},
+					},
+				},
+			},
+		}
+	}
+
+	requireParentObservedGeneration := func(t *testing.T, status *gwv1.RouteStatus, want int64) {
+		t.Helper()
+		require.NotNil(t, status)
+		require.Len(t, status.Parents, 1)
+		for _, condition := range status.Parents[0].Conditions {
+			require.Equal(t, want, condition.ObservedGeneration)
+		}
+	}
+
+	// Report ahead of a stale live read: translation observed generation 2 but
+	// the syncer's cache still returns generation 1. The published status must
+	// reflect the report's generation (2).
+	t.Run("report ahead of stale live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		route := newRoute(2)
+		statusReporter.Route(route).ParentRef(&route.Spec.ParentRefs[0])
+
+		route.Generation = 1
+		status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
+		requireParentObservedGeneration(t, status, 2)
+	})
+
+	// Report behind the live read: observedGeneration must stay at the generation
+	// actually translated (1) rather than prematurely claiming generation 2.
+	t.Run("report behind live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		route := newRoute(1)
+		statusReporter.Route(route).ParentRef(&route.Spec.ParentRefs[0])
+
+		route.Generation = 2
+		status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
+		requireParentObservedGeneration(t, status, 1)
+	})
+}
+
+func TestPolicyStatusRefreshesObservedGenerationOnReporterReuse(t *testing.T) {
+	rm := reports.NewReportMap()
+	statusReporter := reports.NewReporter(&rm)
+
+	key := pluginreporter.PolicyKey{
+		Group:     gwv1.GroupVersion.Group,
+		Kind:      "BackendTLSPolicy",
+		Namespace: "default",
+		Name:      "tls-policy",
+	}
+	ancestorRef := gwv1.ParentReference{
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      "example-gateway",
+		Namespace: new(gwv1.Namespace("default")),
+	}
+
+	statusReporter.Policy(key, 1).AncestorRef(ancestorRef)
+	statusReporter.Policy(key, 2).AncestorRef(ancestorRef)
+
+	status := rm.BuildPolicyStatus(context.Background(), key, "kgateway.dev/kgateway", gwv1.PolicyStatus{})
+	require.NotNil(t, status)
+	require.Len(t, status.Ancestors, 1)
+
+	for _, condition := range status.Ancestors[0].Conditions {
+		require.Equal(t, int64(2), condition.ObservedGeneration)
+	}
+
+	requireCondition(t, status.Ancestors[0].Conditions, string(shared.PolicyConditionAccepted), metav1.ConditionFalse, string(shared.PolicyReasonPending))
+	requireCondition(t, status.Ancestors[0].Conditions, string(shared.PolicyConditionAttached), metav1.ConditionFalse, string(shared.PolicyReasonPending))
+}
+
+func requireCondition(
+	t *testing.T,
+	conditions []metav1.Condition,
+	conditionType string,
+	status metav1.ConditionStatus,
+	reason string,
+) {
+	t.Helper()
+
+	condition := metaFindStatusCondition(conditions, conditionType)
+	require.NotNil(t, condition)
+	require.Equal(t, status, condition.Status)
+	require.Equal(t, reason, condition.Reason)
+}
+
+func metaFindStatusCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// BuildListenerSetStatus must stamp the generation the report was built for, not
+// the live object's, for the same cross-cache reason as Gateway and Route
+// status.
+func TestListenerSetStatusStampsObservedGenerationFromReport(t *testing.T) {
+	newListenerSet := func(generation int64) *gwxv1a1.XListenerSet {
+		ls := &gwxv1a1.XListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test",
+				Namespace:  "default",
+				Generation: generation,
+			},
+		}
+		ls.Spec.Listeners = []gwxv1a1.ListenerEntry{
+			{Name: "http"},
+		}
+		return ls
+	}
+
+	requireAllObservedGenerations := func(t *testing.T, status *gwxv1a1.ListenerSetStatus, want int64) {
+		t.Helper()
+		require.NotNil(t, status)
+		for _, condition := range status.Conditions {
+			require.Equal(t, want, condition.ObservedGeneration)
+		}
+		for _, listenerStatus := range status.Listeners {
+			for _, condition := range listenerStatus.Conditions {
+				require.Equal(t, want, condition.ObservedGeneration)
+			}
+		}
+	}
+
+	// Report ahead of a stale live read: the published status must reflect the
+	// report's generation (2), not the stale live read (1).
+	t.Run("report ahead of stale live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		ls := newListenerSet(2)
+		statusReporter.ListenerSet(ls)
+
+		ls.Generation = 1
+		status := rm.BuildListenerSetStatus(context.Background(), *ls)
+		requireAllObservedGenerations(t, status, 2)
+	})
+
+	// Report behind the live read: observedGeneration must stay at the generation
+	// actually translated (1).
+	t.Run("report behind live object", func(t *testing.T) {
+		rm := reports.NewReportMap()
+		statusReporter := reports.NewReporter(&rm)
+
+		ls := newListenerSet(1)
+		statusReporter.ListenerSet(ls)
+
+		ls.Generation = 2
+		status := rm.BuildListenerSetStatus(context.Background(), *ls)
+		requireAllObservedGenerations(t, status, 1)
+	})
+}

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -50,6 +50,8 @@ func (r *statusReporter) Policy(key reporter.PolicyKey, observedGeneration int64
 	pr := r.report.policy(key)
 	if pr == nil {
 		pr = r.report.newPolicyReport(key, observedGeneration)
+	} else {
+		pr.observedGeneration = observedGeneration
 	}
 	return pr
 }
@@ -122,7 +124,7 @@ func (r *ReportMap) BuildPolicyStatus(
 			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)
 			continue
 		}
-		addMissingAncestorRefConditions(parentStatusReport)
+		ancestorConditions := ancestorRefConditionsWithDefaults(parentStatusReport.Conditions)
 
 		// Get the status of the current parentRef conditions if they exist
 		var currentParentRefConditions []metav1.Condition
@@ -134,7 +136,7 @@ func (r *ReportMap) BuildPolicyStatus(
 		}
 
 		// Build and append the Attached Condition.Type
-		existingConditions := addAttachmentCondition(parentStatusReport)
+		existingConditions := addAttachmentCondition(ancestorConditions, parentStatusReport.AttachmentState)
 
 		finalConditions := make([]metav1.Condition, 0, len(existingConditions))
 		for _, pCondition := range existingConditions {
@@ -206,43 +208,39 @@ func (r *ReportMap) BuildPolicyStatus(
 // If no report is found, nil is returned, signaling this parentRef is unknown to the report
 func (r *PolicyReport) getAncestorRefOrNil(parentRef *gwv1.ParentReference) *AncestorRefReport {
 	key := getParentRefKey(parentRef)
-	if r.Ancestors == nil {
-		r.Ancestors = make(map[ParentRefKey]*AncestorRefReport)
-	}
 	return r.Ancestors[key]
 }
 
-// addMissingAncestorRefConditions initializes the AncestorRefReport with a default Pending
-// condition reason for the Accepted and Attached conditions.
-// Positive conditions will be added when the policy is processed and attached to targeted resources.
-func addMissingAncestorRefConditions(report *AncestorRefReport) {
-	if cond := meta.FindStatusCondition(report.Conditions, string(shared.PolicyConditionAccepted)); cond == nil {
-		meta.SetStatusCondition(&report.Conditions, metav1.Condition{
+func ancestorRefConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
+	if cond := meta.FindStatusCondition(out, string(shared.PolicyConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
 			Type:   string(shared.PolicyConditionAccepted),
 			Status: metav1.ConditionFalse,
 			Reason: string(shared.PolicyReasonPending),
 		})
 	}
-	if cond := meta.FindStatusCondition(report.Conditions, string(shared.PolicyConditionAttached)); cond == nil {
-		meta.SetStatusCondition(&report.Conditions, metav1.Condition{
+	if cond := meta.FindStatusCondition(out, string(shared.PolicyConditionAttached)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
 			Type:   string(shared.PolicyConditionAttached),
 			Status: metav1.ConditionFalse,
 			Reason: string(shared.PolicyReasonPending),
 		})
 	}
+	return out
 }
 
-func addAttachmentCondition(report *AncestorRefReport) []metav1.Condition {
-	if report.AttachmentState == reporter.PolicyAttachmentStatePending {
+func addAttachmentCondition(conditions []metav1.Condition, attachmentState reporter.PolicyAttachmentState) []metav1.Condition {
+	if attachmentState == reporter.PolicyAttachmentStatePending {
 		// no attachment state set, return the conditions as is
-		return report.Conditions
+		return conditions
 	}
 
 	// avoid modifying the existing Conditions on the report
-	existing := slices.Clone(report.Conditions)
+	existing := slices.Clone(conditions)
 
 	switch {
-	case report.AttachmentState.Has(reporter.PolicyAttachmentStateOverridden):
+	case attachmentState.Has(reporter.PolicyAttachmentStateOverridden):
 		meta.SetStatusCondition(&existing, metav1.Condition{
 			Type:    string(shared.PolicyConditionAttached),
 			Status:  metav1.ConditionFalse,
@@ -250,7 +248,7 @@ func addAttachmentCondition(report *AncestorRefReport) []metav1.Condition {
 			Message: reporter.PolicyOverriddenMsg,
 		})
 
-	case report.AttachmentState.Has(reporter.PolicyAttachmentStateMerged):
+	case attachmentState.Has(reporter.PolicyAttachmentStateMerged):
 		meta.SetStatusCondition(&existing, metav1.Condition{
 			Type:    string(shared.PolicyConditionAttached),
 			Status:  metav1.ConditionTrue,
@@ -258,7 +256,7 @@ func addAttachmentCondition(report *AncestorRefReport) []metav1.Condition {
 			Message: reporter.PolicyMergedMsg,
 		})
 
-	case report.AttachmentState.Has(reporter.PolicyAttachmentStateAttached):
+	case attachmentState.Has(reporter.PolicyAttachmentStateAttached):
 		meta.SetStatusCondition(&existing, metav1.Condition{
 			Type:    string(shared.PolicyConditionAttached),
 			Status:  metav1.ConditionTrue,

--- a/pkg/reports/report_map.go
+++ b/pkg/reports/report_map.go
@@ -1,0 +1,284 @@
+package reports
+
+import (
+	"maps"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// MergeReportMaps returns a report map owned by the caller. The returned reports
+// do not alias the input report objects, so later status rendering and status
+// marker processing can safely mutate the merged map without writing into
+// per-translation reports.
+func MergeReportMaps(inputs ...ReportMap) ReportMap {
+	merged := NewReportMap()
+	for _, input := range inputs {
+		for key, report := range input.Gateways {
+			merged.Gateways[key] = cloneGatewayReport(report)
+		}
+		for gvk, reportsByName := range input.ListenerSets {
+			if merged.ListenerSets[gvk] == nil {
+				merged.ListenerSets[gvk] = make(map[types.NamespacedName]*ListenerSetReport, len(reportsByName))
+			}
+			for key, report := range reportsByName {
+				merged.ListenerSets[gvk][key] = cloneListenerSetReport(report)
+			}
+		}
+		mergeRouteReportMap(merged.HTTPRoutes, input.HTTPRoutes)
+		mergeRouteReportMap(merged.GRPCRoutes, input.GRPCRoutes)
+		mergeRouteReportMap(merged.TCPRoutes, input.TCPRoutes)
+		mergeRouteReportMap(merged.TLSRoutes, input.TLSRoutes)
+		for key, report := range input.Policies {
+			existing := merged.Policies[key]
+			if existing == nil {
+				merged.Policies[key] = clonePolicyReport(report)
+				continue
+			}
+			mergeAncestorReports(existing, report)
+		}
+	}
+	return merged
+}
+
+func mergeRouteReportMap(dst, src map[types.NamespacedName]*RouteReport) {
+	for key, report := range src {
+		existing := dst[key]
+		if existing == nil {
+			dst[key] = cloneRouteReport(report)
+			continue
+		}
+		mergeParentReports(existing, report)
+	}
+}
+
+func mergeParentReports(dst, src *RouteReport) {
+	if dst == nil || src == nil {
+		return
+	}
+	if len(src.Parents) == 0 {
+		return
+	}
+	if dst.Parents == nil {
+		dst.Parents = make(map[ParentRefKey]*ParentRefReport, len(src.Parents))
+	}
+	for key, report := range src.Parents {
+		dst.Parents[key] = cloneParentRefReport(report)
+	}
+}
+
+func mergeAncestorReports(dst, src *PolicyReport) {
+	if dst == nil || src == nil {
+		return
+	}
+	if len(src.Ancestors) == 0 {
+		return
+	}
+	if dst.Ancestors == nil {
+		dst.Ancestors = make(map[ParentRefKey]*AncestorRefReport, len(src.Ancestors))
+	}
+	for key, report := range src.Ancestors {
+		dst.Ancestors[key] = cloneAncestorRefReport(report)
+	}
+}
+
+func cloneGatewayReport(in *GatewayReport) *GatewayReport {
+	if in == nil {
+		return nil
+	}
+	return &GatewayReport{
+		conditions:         slices.Clone(in.conditions),
+		listeners:          cloneListenerReports(in.listeners),
+		observedGeneration: in.observedGeneration,
+	}
+}
+
+func cloneListenerSetReport(in *ListenerSetReport) *ListenerSetReport {
+	if in == nil {
+		return nil
+	}
+	return &ListenerSetReport{
+		conditions:         slices.Clone(in.conditions),
+		listeners:          cloneListenerReports(in.listeners),
+		observedGeneration: in.observedGeneration,
+	}
+}
+
+func cloneListenerReports(in map[string]*ListenerReport) map[string]*ListenerReport {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]*ListenerReport, len(in))
+	for key, report := range in {
+		if report == nil {
+			out[key] = nil
+			continue
+		}
+		status := report.Status
+		status.Conditions = slices.Clone(status.Conditions)
+		status.SupportedKinds = slices.Clone(status.SupportedKinds)
+		out[key] = &ListenerReport{Status: status}
+	}
+	return out
+}
+
+func cloneRouteReport(in *RouteReport) *RouteReport {
+	if in == nil {
+		return nil
+	}
+	out := &RouteReport{observedGeneration: in.observedGeneration}
+	if in.Parents != nil {
+		out.Parents = make(map[ParentRefKey]*ParentRefReport, len(in.Parents))
+		for key, report := range in.Parents {
+			out.Parents[key] = cloneParentRefReport(report)
+		}
+	}
+	return out
+}
+
+func cloneParentRefReport(in *ParentRefReport) *ParentRefReport {
+	if in == nil {
+		return nil
+	}
+	return &ParentRefReport{Conditions: slices.Clone(in.Conditions)}
+}
+
+func clonePolicyReport(in *PolicyReport) *PolicyReport {
+	if in == nil {
+		return nil
+	}
+	out := &PolicyReport{observedGeneration: in.observedGeneration}
+	if in.Ancestors != nil {
+		out.Ancestors = make(map[ParentRefKey]*AncestorRefReport, len(in.Ancestors))
+		for key, report := range in.Ancestors {
+			out.Ancestors[key] = cloneAncestorRefReport(report)
+		}
+	}
+	return out
+}
+
+func cloneAncestorRefReport(in *AncestorRefReport) *AncestorRefReport {
+	if in == nil {
+		return nil
+	}
+	return &AncestorRefReport{
+		Conditions:      slices.Clone(in.Conditions),
+		AttachmentState: in.AttachmentState,
+	}
+}
+
+// EqualReportMaps compares report maps by semantic report contents rather than
+// report pointer identity. LastTransitionTime is intentionally ignored so
+// timestamp-only status changes do not cause KRT churn.
+func EqualReportMaps(a, b ReportMap) bool {
+	return maps.EqualFunc(a.Gateways, b.Gateways, gatewayReportEqual) &&
+		listenerSetMapsEqual(a.ListenerSets, b.ListenerSets) &&
+		maps.EqualFunc(a.HTTPRoutes, b.HTTPRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.GRPCRoutes, b.GRPCRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.TCPRoutes, b.TCPRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.TLSRoutes, b.TLSRoutes, routeReportEqual) &&
+		maps.EqualFunc(a.Policies, b.Policies, policyReportEqual)
+}
+
+func listenerSetMapsEqual(
+	a, b map[schema.GroupVersionKind]map[types.NamespacedName]*ListenerSetReport,
+) bool {
+	return maps.EqualFunc(a, b, func(a, b map[types.NamespacedName]*ListenerSetReport) bool {
+		return maps.EqualFunc(a, b, listenerSetReportEqual)
+	})
+}
+
+func gatewayReportEqual(a, b *GatewayReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		conditionsEqual(a.conditions, b.conditions) &&
+		maps.EqualFunc(a.listeners, b.listeners, listenerReportEqual)
+}
+
+func listenerSetReportEqual(a, b *ListenerSetReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		conditionsEqual(a.conditions, b.conditions) &&
+		maps.EqualFunc(a.listeners, b.listeners, listenerReportEqual)
+}
+
+func listenerReportEqual(a, b *ListenerReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return listenerStatusEqual(a.Status, b.Status)
+}
+
+func listenerStatusEqual(a, b gwv1.ListenerStatus) bool {
+	return a.Name == b.Name &&
+		a.AttachedRoutes == b.AttachedRoutes &&
+		slices.EqualFunc(a.SupportedKinds, b.SupportedKinds, routeGroupKindEqual) &&
+		conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func routeGroupKindEqual(a, b gwv1.RouteGroupKind) bool {
+	return ptrValueEqual(a.Group, b.Group) && a.Kind == b.Kind
+}
+
+func ptrValueEqual[T comparable](a, b *T) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func routeReportEqual(a, b *RouteReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		maps.EqualFunc(a.Parents, b.Parents, parentRefReportEqual)
+}
+
+func parentRefReportEqual(a, b *ParentRefReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func policyReportEqual(a, b *PolicyReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.observedGeneration == b.observedGeneration &&
+		maps.EqualFunc(a.Ancestors, b.Ancestors, ancestorRefReportEqual)
+}
+
+func ancestorRefReportEqual(a, b *AncestorRefReport) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.AttachmentState == b.AttachmentState &&
+		conditionsEqual(a.Conditions, b.Conditions)
+}
+
+func conditionsEqual(a, b []metav1.Condition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, condition := range a {
+		other := meta.FindStatusCondition(b, condition.Type)
+		if other == nil ||
+			condition.Status != other.Status ||
+			condition.Reason != other.Reason ||
+			condition.Message != other.Message ||
+			condition.ObservedGeneration != other.ObservedGeneration {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/reports/report_map_test.go
+++ b/pkg/reports/report_map_test.go
@@ -1,0 +1,285 @@
+package reports
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+)
+
+// testCondition builds a condition with all the fields EqualReportMaps cares about,
+// plus a LastTransitionTime which it must ignore.
+func testCondition(condType string, status metav1.ConditionStatus, reason, message string, observedGen int64, transition time.Time) metav1.Condition {
+	return metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: observedGen,
+		LastTransitionTime: metav1.NewTime(transition),
+	}
+}
+
+var (
+	testGatewayKey = types.NamespacedName{Namespace: "default", Name: "gw"}
+	testRouteKey   = types.NamespacedName{Namespace: "default", Name: "route"}
+	testLSKey      = types.NamespacedName{Namespace: "default", Name: "ls"}
+	testPolicyKey  = reporter.PolicyKey{Group: "example.com", Kind: "Policy", Namespace: "default", Name: "policy"}
+	testParentKey  = ParentRefKey{
+		Group:          gwv1.GroupVersion.Group,
+		Kind:           "Gateway",
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "gw"},
+	}
+)
+
+// fullReportMap builds a ReportMap that exercises every report kind (gateways,
+// nested listener sets, all four route kinds and policies) with the
+// given LastTransitionTime stamped on every condition. Callers vary only the
+// transition time to assert it is ignored by EqualReportMaps.
+func fullReportMap(transition time.Time) ReportMap {
+	rm := NewReportMap()
+
+	rm.Gateways[testGatewayKey] = &GatewayReport{
+		observedGeneration: 5,
+		conditions: []metav1.Condition{
+			testCondition(string(gwv1.GatewayConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", 5, transition),
+		},
+		listeners: map[string]*ListenerReport{
+			"http": {Status: gwv1.ListenerStatus{
+				Name:           "http",
+				AttachedRoutes: 3,
+				SupportedKinds: []gwv1.RouteGroupKind{{Kind: "HTTPRoute"}},
+				Conditions: []metav1.Condition{
+					testCondition(string(gwv1.ListenerConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", 5, transition),
+				},
+			}},
+		},
+	}
+
+	rm.ListenerSets[wellknown.XListenerSetGVK] = map[types.NamespacedName]*ListenerSetReport{
+		testLSKey: {
+			observedGeneration: 4,
+			conditions: []metav1.Condition{
+				testCondition(string(gwv1.GatewayConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", 4, transition),
+			},
+			listeners: map[string]*ListenerReport{
+				"http": {Status: gwv1.ListenerStatus{
+					Name: "http",
+					Conditions: []metav1.Condition{
+						testCondition(string(gwv1.ListenerConditionProgrammed), metav1.ConditionTrue, "Programmed", "programmed", 4, transition),
+					},
+				}},
+			},
+		},
+	}
+
+	routeReport := func(gen int64) *RouteReport {
+		return &RouteReport{
+			observedGeneration: gen,
+			Parents: map[ParentRefKey]*ParentRefReport{
+				testParentKey: {Conditions: []metav1.Condition{
+					testCondition(string(gwv1.RouteConditionAccepted), metav1.ConditionTrue, "Accepted", "accepted", gen, transition),
+				}},
+			},
+		}
+	}
+	rm.HTTPRoutes[testRouteKey] = routeReport(1)
+	rm.GRPCRoutes[testRouteKey] = routeReport(2)
+	rm.TCPRoutes[testRouteKey] = routeReport(3)
+	rm.TLSRoutes[testRouteKey] = routeReport(4)
+
+	rm.Policies[testPolicyKey] = &PolicyReport{
+		observedGeneration: 2,
+		Ancestors: map[ParentRefKey]*AncestorRefReport{
+			testParentKey: {
+				AttachmentState: reporter.PolicyAttachmentStateAttached,
+				Conditions: []metav1.Condition{
+					testCondition("Accepted", metav1.ConditionTrue, "Valid", "valid", 2, transition),
+				},
+			},
+		},
+	}
+
+	return rm
+}
+
+func TestEqualReportMaps_EmptyMapsAreEqual(t *testing.T) {
+	assert.True(t, EqualReportMaps(NewReportMap(), NewReportMap()))
+}
+
+func TestEqualReportMaps_IdenticalMapsAreEqual(t *testing.T) {
+	now := time.Now()
+	assert.True(t, EqualReportMaps(fullReportMap(now), fullReportMap(now)))
+}
+
+// TestEqualReportMaps_IgnoresLastTransitionTime is the central promise: a status
+// rebuild that changes only condition timestamps must not be treated as a change,
+// otherwise KRT would churn on every reconcile.
+func TestEqualReportMaps_IgnoresLastTransitionTime(t *testing.T) {
+	a := fullReportMap(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	b := fullReportMap(time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC))
+	assert.True(t, EqualReportMaps(a, b), "maps differing only in LastTransitionTime must be equal")
+}
+
+// TestEqualReportMaps_DetectsConditionFieldChanges asserts the fields that DO
+// matter (Status/Reason/Message/ObservedGeneration) each break equality, even
+// though LastTransitionTime does not.
+func TestEqualReportMaps_DetectsConditionFieldChanges(t *testing.T) {
+	now := time.Now()
+	cases := map[string]func(*metav1.Condition){
+		"status":             func(c *metav1.Condition) { c.Status = metav1.ConditionFalse },
+		"reason":             func(c *metav1.Condition) { c.Reason = "Different" },
+		"message":            func(c *metav1.Condition) { c.Message = "different" },
+		"observedGeneration": func(c *metav1.Condition) { c.ObservedGeneration = 999 },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := fullReportMap(now)
+			b := fullReportMap(now)
+			mutate(&b.Gateways[testGatewayKey].conditions[0])
+			assert.False(t, EqualReportMaps(a, b), "change to condition %s must break equality", name)
+		})
+	}
+}
+
+func TestEqualReportMaps_DetectsConditionAddedOrRemoved(t *testing.T) {
+	now := time.Now()
+
+	a := fullReportMap(now)
+	b := fullReportMap(now)
+	b.Gateways[testGatewayKey].conditions = append(b.Gateways[testGatewayKey].conditions,
+		testCondition(string(gwv1.GatewayConditionProgrammed), metav1.ConditionTrue, "Programmed", "programmed", 5, now))
+	assert.False(t, EqualReportMaps(a, b), "an extra condition must break equality")
+
+	// A condition of the same type but absent on one side must also break equality.
+	c := fullReportMap(now)
+	c.Gateways[testGatewayKey].conditions = nil
+	assert.False(t, EqualReportMaps(a, c))
+}
+
+func TestEqualReportMaps_DetectsGatewayScalarChanges(t *testing.T) {
+	now := time.Now()
+
+	og := fullReportMap(now)
+	og.Gateways[testGatewayKey].observedGeneration = 6
+	assert.False(t, EqualReportMaps(fullReportMap(now), og), "observedGeneration change must break equality")
+}
+
+func TestEqualReportMaps_DetectsListenerStatusChanges(t *testing.T) {
+	now := time.Now()
+
+	routes := fullReportMap(now)
+	routes.Gateways[testGatewayKey].listeners["http"].Status.AttachedRoutes = 100
+	assert.False(t, EqualReportMaps(fullReportMap(now), routes), "AttachedRoutes change must break equality")
+
+	kinds := fullReportMap(now)
+	kinds.Gateways[testGatewayKey].listeners["http"].Status.SupportedKinds = []gwv1.RouteGroupKind{{Kind: "GRPCRoute"}}
+	assert.False(t, EqualReportMaps(fullReportMap(now), kinds), "SupportedKinds change must break equality")
+
+	added := fullReportMap(now)
+	added.Gateways[testGatewayKey].listeners["https"] = &ListenerReport{Status: gwv1.ListenerStatus{Name: "https"}}
+	assert.False(t, EqualReportMaps(fullReportMap(now), added), "extra listener must break equality")
+}
+
+// TestEqualReportMaps_ListenerSetGVKMaps covers the nested
+// GVK -> NamespacedName -> report map comparison for ListenerSets.
+func TestEqualReportMaps_ListenerSetGVKMaps(t *testing.T) {
+	now := time.Now()
+
+	t.Run("equal when content matches", func(t *testing.T) {
+		assert.True(t, EqualReportMaps(fullReportMap(now), fullReportMap(now)))
+	})
+
+	t.Run("different GVK key", func(t *testing.T) {
+		b := fullReportMap(now)
+		report := b.ListenerSets[wellknown.XListenerSetGVK][testLSKey]
+		delete(b.ListenerSets, wellknown.XListenerSetGVK)
+		otherGVK := schema.GroupVersionKind{Group: "other.io", Version: "v1", Kind: "OtherListenerSet"}
+		b.ListenerSets[otherGVK] = map[types.NamespacedName]*ListenerSetReport{testLSKey: report}
+		assert.False(t, EqualReportMaps(fullReportMap(now), b), "moving a report under a different GVK must break equality")
+	})
+
+	t.Run("different NamespacedName within GVK", func(t *testing.T) {
+		b := fullReportMap(now)
+		report := b.ListenerSets[wellknown.XListenerSetGVK][testLSKey]
+		delete(b.ListenerSets[wellknown.XListenerSetGVK], testLSKey)
+		b.ListenerSets[wellknown.XListenerSetGVK][types.NamespacedName{Namespace: "default", Name: "other-ls"}] = report
+		assert.False(t, EqualReportMaps(fullReportMap(now), b), "different listener set name must break equality")
+	})
+
+	t.Run("condition change within listener set", func(t *testing.T) {
+		b := fullReportMap(now)
+		b.ListenerSets[wellknown.XListenerSetGVK][testLSKey].conditions[0].Status = metav1.ConditionFalse
+		assert.False(t, EqualReportMaps(fullReportMap(now), b))
+	})
+
+	t.Run("ignores LastTransitionTime within listener set", func(t *testing.T) {
+		a := fullReportMap(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		b := fullReportMap(now)
+		// Wipe every difference except the listener-set timestamps, which differ via fullReportMap.
+		assert.True(t, EqualReportMaps(a, b))
+	})
+
+	t.Run("extra GVK entry", func(t *testing.T) {
+		b := fullReportMap(now)
+		extraGVK := schema.GroupVersionKind{Group: "other.io", Version: "v1", Kind: "OtherListenerSet"}
+		b.ListenerSets[extraGVK] = map[types.NamespacedName]*ListenerSetReport{
+			testLSKey: {observedGeneration: 1},
+		}
+		assert.False(t, EqualReportMaps(fullReportMap(now), b))
+	})
+}
+
+func TestEqualReportMaps_DetectsRouteChanges(t *testing.T) {
+	now := time.Now()
+
+	gen := fullReportMap(now)
+	gen.HTTPRoutes[testRouteKey].observedGeneration = 100
+	assert.False(t, EqualReportMaps(fullReportMap(now), gen), "route observedGeneration change must break equality")
+
+	cond := fullReportMap(now)
+	cond.TCPRoutes[testRouteKey].Parents[testParentKey].Conditions[0].Reason = "Different"
+	assert.False(t, EqualReportMaps(fullReportMap(now), cond), "parent condition change must break equality")
+
+	parent := fullReportMap(now)
+	parent.GRPCRoutes[testRouteKey].Parents[ParentRefKey{Kind: "Gateway", NamespacedName: types.NamespacedName{Name: "extra"}}] = &ParentRefReport{}
+	assert.False(t, EqualReportMaps(fullReportMap(now), parent), "extra parent must break equality")
+}
+
+func TestEqualReportMaps_DetectsPolicyChanges(t *testing.T) {
+	now := time.Now()
+
+	gen := fullReportMap(now)
+	gen.Policies[testPolicyKey].observedGeneration = 100
+	assert.False(t, EqualReportMaps(fullReportMap(now), gen), "policy observedGeneration change must break equality")
+
+	state := fullReportMap(now)
+	state.Policies[testPolicyKey].Ancestors[testParentKey].AttachmentState = reporter.PolicyAttachmentStateMerged
+	assert.False(t, EqualReportMaps(fullReportMap(now), state), "ancestor AttachmentState change must break equality")
+
+	cond := fullReportMap(now)
+	cond.Policies[testPolicyKey].Ancestors[testParentKey].Conditions[0].Message = "different"
+	assert.False(t, EqualReportMaps(fullReportMap(now), cond), "ancestor condition change must break equality")
+}
+
+// TestEqualReportMaps_NilReportPointers verifies that a nil report value compares
+// distinct from a populated one but equal to another nil under the same key.
+func TestEqualReportMaps_NilReportPointers(t *testing.T) {
+	a := NewReportMap()
+	a.Gateways[testGatewayKey] = nil
+	b := NewReportMap()
+	b.Gateways[testGatewayKey] = nil
+	assert.True(t, EqualReportMaps(a, b), "two nil reports under the same key must be equal")
+
+	c := fullReportMap(time.Now())
+	d := NewReportMap()
+	d.Gateways[testGatewayKey] = nil
+	assert.False(t, EqualReportMaps(c, d), "nil vs populated report must not be equal")
+}

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -107,7 +107,9 @@ func (r *ReportMap) newGatewayReport(gateway *gwv1.Gateway) *GatewayReport {
 	return gr
 }
 
-// Returns a ListenerSetReport for the provided ListenerSet, nil if there is not a report present.
+// ListenerSet is a pure lookup that returns the ListenerSetReport for the provided
+// ListenerSet, or nil if a report is not present. It must not mutate the ReportMap:
+// lazily creating the per-GVK map here would change ReportMap equality on a read.
 // This is different than the Reporter.ListenerSet() method, as we need to understand when
 // reports are not generated for a ListenerSet that has been translated.
 //
@@ -117,11 +119,11 @@ func (r *ReportMap) ListenerSet(listenerSet client.Object) *ListenerSetReport {
 	if gvk.Empty() {
 		gvk = wellknown.XListenerSetGVK
 	}
-	if r.ListenerSets[gvk] == nil {
-		r.ListenerSets[gvk] = make(map[types.NamespacedName]*ListenerSetReport)
+	lsByGVK := r.ListenerSets[gvk]
+	if lsByGVK == nil {
+		return nil
 	}
-	key := key(listenerSet)
-	return r.ListenerSets[gvk][key]
+	return lsByGVK[key(listenerSet)]
 }
 
 func (r *ReportMap) newListenerSetReport(listenerSet client.Object) *ListenerSetReport {
@@ -141,7 +143,10 @@ func (r *ReportMap) newListenerSetReport(listenerSet client.Object) *ListenerSet
 	return lsr
 }
 
-// route returns a RouteReport for the provided route object, nil if a report is not present.
+// route is a pure lookup that returns a RouteReport for the provided route object,
+// or nil if a report is not present. The observedGeneration is set at report
+// creation time (newRouteReport) and when the route is translated
+// (statusReporter.Route).
 // This is different than the Reporter.Route() method, as we need to understand when
 // reports are not generated for a route that has been translated. Supported object types are:
 //
@@ -313,6 +318,8 @@ func (r *statusReporter) Gateway(gateway *gwv1.Gateway) reporter.GatewayReporter
 	gr := r.report.Gateway(gateway)
 	if gr == nil {
 		gr = r.report.newGatewayReport(gateway)
+	} else {
+		gr.observedGeneration = gateway.Generation
 	}
 	return gr
 }
@@ -321,6 +328,8 @@ func (r *statusReporter) ListenerSet(listenerSet client.Object) reporter.Listene
 	lsr := r.report.ListenerSet(listenerSet)
 	if lsr == nil {
 		lsr = r.report.newListenerSetReport(listenerSet)
+	} else {
+		lsr.observedGeneration = listenerSet.GetGeneration()
 	}
 	return lsr
 }
@@ -329,6 +338,8 @@ func (r *statusReporter) Route(obj metav1.Object) reporter.RouteReporter {
 	rr := r.report.route(obj)
 	if rr == nil {
 		rr = r.report.newRouteReport(obj)
+	} else {
+		rr.observedGeneration = obj.GetGeneration()
 	}
 	return rr
 }
@@ -362,9 +373,6 @@ func getParentRefKey(parentRef *gwv1.ParentReference) ParentRefKey {
 // If no report is found, nil is returned, signaling this parentRef is unknown to the report
 func (r *RouteReport) getParentRefOrNil(parentRef *gwv1.ParentReference) *ParentRefReport {
 	key := getParentRefKey(parentRef)
-	if r.Parents == nil {
-		r.Parents = make(map[ParentRefKey]*ParentRefReport)
-	}
 	return r.Parents[key]
 }
 

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
-	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
@@ -39,7 +38,7 @@ const (
 // TODO: refactor this struct + methods to better reflect the usage now in proxy_syncer
 
 func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attachedRoutes map[string]uint) *gwv1.GatewayStatus {
-	gwReport := r.Gateway(&gw)
+	gwReport := r.GatewayNamespaceName(key(&gw))
 	if gwReport == nil {
 		return nil
 	}
@@ -49,20 +48,25 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 	var invalidMessages []string
 
 	for _, lis := range gw.Spec.Listeners {
-		lisReport := gwReport.listener(string(lis.Name))
-		AddMissingListenerConditions(lisReport)
+		listenerStatus := listenerStatusFromGatewayReport(gwReport, lis)
 		// Get attached routes for this listener
 		if attachedRoutes != nil {
 			if count, exists := attachedRoutes[string(lis.Name)]; exists {
-				lisReport.Status.AttachedRoutes = int32(count) //nolint:gosec // G115: route count is always non-negative
+				listenerStatus.AttachedRoutes = int32(count) //nolint:gosec // G115: route count is always non-negative
 			}
 		}
 
-		finalConditions := make([]metav1.Condition, 0, len(lisReport.Status.Conditions))
+		finalConditions := make([]metav1.Condition, 0, len(listenerStatus.Conditions))
 		oldLisStatusIndex := slices.IndexFunc(gw.Status.Listeners, func(l gwv1.ListenerStatus) bool {
 			return l.Name == lis.Name
 		})
-		for _, lisCondition := range lisReport.Status.Conditions {
+		for _, lisCondition := range listenerStatus.Conditions {
+			// Stamp the generation the report was built for, not the live object's
+			// generation. The report is produced by translation (istio cache) while
+			// the syncer reads the Gateway from a separate controller-runtime cache;
+			// using the live generation here lets the two caches disagree and freeze
+			// observedGeneration when they skew. The report's generation is internally
+			// consistent with the conditions it carries.
 			lisCondition.ObservedGeneration = gwReport.observedGeneration
 
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -81,10 +85,12 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 				}
 			}
 		}
-		lisReport.Status.Conditions = finalConditions
+		listenerStatus.Conditions = finalConditions
 
-		finalListeners = append(finalListeners, lisReport.Status)
+		finalListeners = append(finalListeners, listenerStatus)
 	}
+
+	gwConditions := slices.Clone(gwReport.GetConditions())
 
 	// If any listeners have Programmed=False, set Gateway Accepted=True with ListenersNotValid reason
 	if len(invalidListeners) > 0 {
@@ -93,18 +99,21 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 			message = fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidListeners, ", "))
 		}
 
-		gwReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+		meta.SetStatusCondition(&gwConditions, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonListenersNotValid,
+			Reason:  string(gwv1.GatewayReasonListenersNotValid),
 			Message: message,
 		})
 	}
 
-	addMissingGatewayConditions(r.Gateway(&gw), &gw)
+	gwConditions = gatewayConditionsWithDefaults(gwConditions, &gw)
 
 	finalConditions := make([]metav1.Condition, 0)
-	for _, gwCondition := range gwReport.GetConditions() {
+	for _, gwCondition := range gwConditions {
+		// See note above: stamp the report's generation, not the live object's, so a
+		// skew between the translation cache and the syncer's cache cannot freeze
+		// observedGeneration.
 		gwCondition.ObservedGeneration = gwReport.observedGeneration
 
 		// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -128,6 +137,42 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 	return &finalGwStatus
 }
 
+func listenerStatusFromGatewayReport(report *GatewayReport, listener gwv1.Listener) gwv1.ListenerStatus {
+	var listeners map[string]*ListenerReport
+	if report != nil {
+		listeners = report.listeners
+	}
+	return listenerStatusFromReports(listeners, listener)
+}
+
+func listenerStatusFromListenerSetReport(report *ListenerSetReport, listener gwv1.Listener) gwv1.ListenerStatus {
+	var listeners map[string]*ListenerReport
+	if report != nil {
+		listeners = report.listeners
+	}
+	return listenerStatusFromReports(listeners, listener)
+}
+
+func listenerStatusFromReports(listeners map[string]*ListenerReport, listener gwv1.Listener) gwv1.ListenerStatus {
+	status := newListenerStatus(string(listener.Name))
+	if listeners != nil {
+		if listenerReport := listeners[string(listener.Name)]; listenerReport != nil {
+			status = listenerReport.Status
+			status.Conditions = slices.Clone(listenerReport.Status.Conditions)
+			status.SupportedKinds = slices.Clone(listenerReport.Status.SupportedKinds)
+		}
+	}
+	status.Conditions = listenerConditionsWithDefaults(status.Conditions)
+	return status
+}
+
+func newListenerStatus(name string) gwv1.ListenerStatus {
+	return gwv1.ListenerStatus{
+		Name:           gwv1.SectionName(name),
+		SupportedKinds: []gwv1.RouteGroupKind{},
+	}
+}
+
 func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwxv1a1.XListenerSet) *gwxv1a1.ListenerSetStatus {
 	lsReport := r.ListenerSet(&ls)
 	if lsReport == nil {
@@ -149,14 +194,15 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwxv1a1.XList
 	if !listenerSetRejected(lsReport) {
 		for _, l := range ls.Spec.Listeners {
 			lis := utils.ToListener(l)
-			lisReport := lsReport.listener(string(lis.Name))
-			AddMissingListenerConditions(lisReport)
+			listenerStatus := listenerStatusFromListenerSetReport(lsReport, lis)
 
-			finalConditions := make([]metav1.Condition, 0, len(lisReport.Status.Conditions))
+			finalConditions := make([]metav1.Condition, 0, len(listenerStatus.Conditions))
 			oldLisStatusIndex := slices.IndexFunc(ls.Status.Listeners, func(l gwxv1a1.ListenerEntryStatus) bool {
 				return l.Name == lis.Name
 			})
-			for _, lisCondition := range lisReport.Status.Conditions {
+			for _, lisCondition := range listenerStatus.Conditions {
+				// Stamp the report's generation, not the live object's, for the same
+				// cross-cache reason as Gateway and Route status.
 				lisCondition.ObservedGeneration = lsReport.observedGeneration
 
 				// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -175,10 +221,12 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwxv1a1.XList
 					}
 				}
 			}
-			lisReport.Status.Conditions = finalConditions
-			finalListeners = append(finalListeners, lisReport.Status)
+			listenerStatus.Conditions = finalConditions
+			finalListeners = append(finalListeners, listenerStatus)
 		}
 	}
+
+	lsConditions := slices.Clone(lsReport.GetConditions())
 
 	// If any listeners have Programmed=False, set ListenerSet Accepted=True with ListenersNotValid reason
 	if len(invalidListeners) > 0 {
@@ -187,18 +235,19 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwxv1a1.XList
 			message = fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidListeners, ", "))
 		}
 
-		lsReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+		meta.SetStatusCondition(&lsConditions, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonListenersNotValid,
+			Reason:  string(gwv1.GatewayReasonListenersNotValid),
 			Message: message,
 		})
 	}
 
-	AddMissingListenerSetConditions(r.ListenerSet(&ls))
+	lsConditions = listenerSetConditionsWithDefaults(lsConditions)
 
 	finalConditions := make([]metav1.Condition, 0)
-	for _, lsCondition := range lsReport.GetConditions() {
+	for _, lsCondition := range lsConditions {
+		// See note above: stamp the report's generation, not the live object's.
 		lsCondition.ObservedGeneration = lsReport.observedGeneration
 
 		// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -265,6 +314,13 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 		return nil
 	}
 
+	// Stamp the generation the report was built for, not the live object's. As
+	// with Gateway status, the route is re-read by the syncer from a separate
+	// cache than the one translation used; sourcing the generation from the
+	// report keeps the sync trigger and the published value consistent and
+	// avoids freezing observedGeneration on a cache skew.
+	observedGeneration := routeReport.observedGeneration
+
 	slog.Debug("building status", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
 
 	var existingStatus gwv1.RouteStatus
@@ -315,7 +371,7 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 			// probably because it's a parent that we don't control (e.g. Gateway from diff. controller)
 			continue
 		}
-		addMissingParentRefConditions(parentStatusReport)
+		parentConditions := parentRefConditionsWithDefaults(parentStatusReport.Conditions)
 
 		// Get the status of the current parentRef conditions if they exist
 		var currentParentRefConditions []metav1.Condition
@@ -326,9 +382,9 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 			currentParentRefConditions = existingStatus.Parents[currentParentRefIdx].Conditions
 		}
 
-		finalConditions := make([]metav1.Condition, 0, len(parentStatusReport.Conditions))
-		for _, pCondition := range parentStatusReport.Conditions {
-			pCondition.ObservedGeneration = routeReport.observedGeneration
+		finalConditions := make([]metav1.Condition, 0, len(parentConditions))
+		for _, pCondition := range parentConditions {
+			pCondition.ObservedGeneration = observedGeneration
 
 			// Copy old condition to preserve LastTransitionTime, if it exists
 			if cond := meta.FindStatusCondition(currentParentRefConditions, pCondition.Type); cond != nil {
@@ -403,113 +459,123 @@ func ParentString(ref gwv1.ParentReference) string {
 		ptr.OrEmpty(ref.Namespace))
 }
 
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingGatewayConditions(gwReport *GatewayReport, gw *gwv1.Gateway) {
+func gatewayConditionsWithDefaults(conditions []metav1.Condition, gw *gwv1.Gateway) []metav1.Condition {
+	out := slices.Clone(conditions)
 	// If the existing Gateway status contains an Accepted=False with Reason=InvalidParameters,
 	// we don't want to override it with a true Accepted status. The controller will set Accepted=True
 	// when the GatewayParameters are valid again. Otherwise there is a race condition between the controller and reporter.
 	// HACK: This is because both the controller and reporter set Accepted status.
 	existingAccepted := meta.FindStatusCondition(gw.Status.Conditions, string(gwv1.GatewayConditionAccepted))
 	hasInvalidParams := existingAccepted != nil && existingAccepted.Status == metav1.ConditionFalse && existingAccepted.Reason == string(gwv1.GatewayReasonInvalidParameters)
-	if !hasInvalidParams && meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionAccepted)) == nil {
-		gwReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+	if !hasInvalidParams && meta.FindStatusCondition(out, string(gwv1.GatewayConditionAccepted)) == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonAccepted,
+			Reason:  string(gwv1.GatewayReasonAccepted),
 			Message: GatewayAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionProgrammed)); cond == nil {
-		gwReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionProgrammed,
+	if cond := meta.FindStatusCondition(out, string(gwv1.GatewayConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionProgrammed),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonProgrammed,
+			Reason:  string(gwv1.GatewayReasonProgrammed),
 			Message: GatewayProgrammedMessage,
 		})
 	}
+	return out
 }
 
 // Reports will initially only contain negative conditions found during translation,
 // so all missing conditions are assumed to be positive. Here we will add all missing conditions
 // to a given report, i.e. set healthy conditions
 func AddMissingListenerSetConditions(lsReport *ListenerSetReport) {
-	if cond := meta.FindStatusCondition(lsReport.GetConditions(), string(gwv1.GatewayConditionAccepted)); cond == nil {
-		lsReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionAccepted,
+	lsReport.conditions = listenerSetConditionsWithDefaults(lsReport.conditions)
+}
+
+func listenerSetConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
+	if cond := meta.FindStatusCondition(out, string(gwv1.GatewayConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonAccepted,
+			Reason:  string(gwv1.GatewayReasonAccepted),
 			Message: ListenerSetAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lsReport.GetConditions(), string(gwv1.GatewayConditionProgrammed)); cond == nil {
-		lsReport.SetCondition(reporter.GatewayCondition{
-			Type:    gwv1.GatewayConditionProgrammed,
+	if cond := meta.FindStatusCondition(out, string(gwv1.GatewayConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.GatewayConditionProgrammed),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.GatewayReasonProgrammed,
+			Reason:  string(gwv1.GatewayReasonProgrammed),
 			Message: ListenerSetProgrammedMessage,
 		})
 	}
+	return out
 }
 
 // Reports will initially only contain negative conditions found during translation,
 // so all missing conditions are assumed to be positive. Here we will add all missing conditions
 // to a given report, i.e. set healthy conditions
 func AddMissingListenerConditions(lisReport *ListenerReport) {
+	lisReport.Status.Conditions = listenerConditionsWithDefaults(lisReport.Status.Conditions)
+}
+
+func listenerConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
 	// set healthy conditions for Condition Types not set yet (i.e. no negative status yet, we can assume positive)
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionAccepted)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionAccepted,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.ListenerReasonAccepted,
+			Reason:  string(gwv1.ListenerReasonAccepted),
 			Message: ListenerAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionConflicted)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionConflicted,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionConflicted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionConflicted),
 			Status:  metav1.ConditionFalse,
-			Reason:  gwv1.ListenerReasonNoConflicts,
+			Reason:  string(gwv1.ListenerReasonNoConflicts),
 			Message: ListenerNoConflictsMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionResolvedRefs)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionResolvedRefs,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionResolvedRefs)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionResolvedRefs),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.ListenerReasonResolvedRefs,
+			Reason:  string(gwv1.ListenerReasonResolvedRefs),
 			Message: ValidRefsMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionProgrammed)); cond == nil {
-		lisReport.SetCondition(reporter.ListenerCondition{
-			Type:    gwv1.ListenerConditionProgrammed,
+	if cond := meta.FindStatusCondition(out, string(gwv1.ListenerConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.ListenerConditionProgrammed),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.ListenerReasonProgrammed,
+			Reason:  string(gwv1.ListenerReasonProgrammed),
 			Message: ListenerProgrammedMessage,
 		})
 	}
+	return out
 }
 
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingParentRefConditions(report *ParentRefReport) {
-	if cond := meta.FindStatusCondition(report.Conditions, string(gwv1.RouteConditionAccepted)); cond == nil {
-		report.SetCondition(reporter.RouteCondition{
-			Type:    gwv1.RouteConditionAccepted,
+func parentRefConditionsWithDefaults(conditions []metav1.Condition) []metav1.Condition {
+	out := slices.Clone(conditions)
+	if cond := meta.FindStatusCondition(out, string(gwv1.RouteConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.RouteConditionAccepted),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.RouteReasonAccepted,
+			Reason:  string(gwv1.RouteReasonAccepted),
 			Message: RouteAcceptedMessage,
 		})
 	}
-	if cond := meta.FindStatusCondition(report.Conditions, string(gwv1.RouteConditionResolvedRefs)); cond == nil {
-		report.SetCondition(reporter.RouteCondition{
-			Type:    gwv1.RouteConditionResolvedRefs,
+	if cond := meta.FindStatusCondition(out, string(gwv1.RouteConditionResolvedRefs)); cond == nil {
+		meta.SetStatusCondition(&out, metav1.Condition{
+			Type:    string(gwv1.RouteConditionResolvedRefs),
 			Status:  metav1.ConditionTrue,
-			Reason:  gwv1.RouteReasonResolvedRefs,
+			Reason:  string(gwv1.RouteReasonResolvedRefs),
 			Message: ValidRefsMessage,
 		})
 	}
+	return out
 }

--- a/pkg/reports/status_purity_test.go
+++ b/pkg/reports/status_purity_test.go
@@ -1,0 +1,204 @@
+package reports
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+	pluginreporter "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+)
+
+func TestBuildGWStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "gw",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gwv1.GatewaySpec{
+			Listeners: []gwv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+	}
+
+	rep.Gateway(gw).Listener(&gw.Spec.Listeners[0])
+	gr := rm.GatewayNamespaceName(key(gw))
+	require.NotNil(t, gr)
+	beforeCond := slicesCloneConditions(gr.conditions)
+	beforeListenerCond := slicesCloneConditions(gr.listeners["http"].Status.Conditions)
+
+	status := rm.BuildGWStatus(context.Background(), *gw, nil)
+	require.NotNil(t, status)
+
+	require.Equal(t, beforeCond, gr.conditions, "BuildGWStatus must not mutate GatewayReport conditions")
+	require.Equal(t, beforeListenerCond, gr.listeners["http"].Status.Conditions, "BuildGWStatus must not mutate ListenerReport conditions")
+}
+
+func TestBuildRouteStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	parentRef := gwv1.ParentReference{
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      "gw",
+		Namespace: new(gwv1.Namespace("default")),
+	}
+	route := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "route",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{parentRef}},
+		},
+	}
+
+	rep.Route(route).ParentRef(&parentRef).SetCondition(pluginreporter.RouteCondition{
+		Type:   gwv1.RouteConditionAccepted,
+		Status: metav1.ConditionFalse,
+		Reason: gwv1.RouteReasonNoMatchingParent,
+	})
+	rr := rm.HTTPRoutes[types.NamespacedName{Namespace: route.Namespace, Name: route.Name}]
+	before := cloneParentConditionsForTest(rr)
+
+	status := rm.BuildRouteStatus(context.Background(), route, "kgateway.dev/kgateway")
+	require.NotNil(t, status)
+
+	require.Equal(t, before, cloneParentConditionsForTest(rr), "BuildRouteStatus must not mutate RouteReport condition slices")
+}
+
+func TestBuildPolicyStatusDoesNotMutateReportMapEntry(t *testing.T) {
+	rm := NewReportMap()
+	rep := NewReporter(&rm)
+
+	policyKey := pluginreporter.PolicyKey{Group: "example.com", Kind: "Policy", Namespace: "default", Name: "policy"}
+	ancestorRef := gwv1.ParentReference{
+		Group:     new(gwv1.Group(gwv1.GroupVersion.Group)),
+		Kind:      new(gwv1.Kind("Gateway")),
+		Name:      "gw",
+		Namespace: new(gwv1.Namespace("default")),
+	}
+	rep.Policy(policyKey, 1).AncestorRef(ancestorRef)
+	pr := rm.Policies[policyKey]
+	before := cloneAncestorConditionsForTest(pr)
+
+	status := rm.BuildPolicyStatus(context.Background(), policyKey, "kgateway.dev/kgateway", gwv1.PolicyStatus{})
+	require.NotNil(t, status)
+	requireConditionForTest(t, status.Ancestors[0].Conditions, string(shared.PolicyConditionAttached))
+
+	require.Equal(t, before, cloneAncestorConditionsForTest(pr), "BuildPolicyStatus must not mutate PolicyReport condition slices")
+}
+
+func TestMergeReportMapsOwnsRouteAndPolicyReports(t *testing.T) {
+	routeKey := types.NamespacedName{Namespace: "default", Name: "route"}
+	policyKey := pluginreporter.PolicyKey{Group: "example.com", Kind: "Policy", Namespace: "default", Name: "policy"}
+
+	first := NewReportMap()
+	firstReporter := NewReporter(&first)
+	firstRoute := &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: routeKey.Namespace, Name: routeKey.Name}}
+	firstParent := gwv1.ParentReference{Name: "gw-a"}
+	firstReporter.Route(firstRoute).ParentRef(&firstParent).SetCondition(pluginreporter.RouteCondition{
+		Type:   gwv1.RouteConditionAccepted,
+		Status: metav1.ConditionTrue,
+		Reason: gwv1.RouteReasonAccepted,
+	})
+	firstAncestor := gwv1.ParentReference{Name: "policy-gw-a"}
+	firstReporter.Policy(policyKey, 1).AncestorRef(firstAncestor).SetCondition(pluginreporter.PolicyCondition{
+		Type:   string(shared.PolicyConditionAccepted),
+		Status: metav1.ConditionTrue,
+		Reason: string(shared.PolicyReasonValid),
+	})
+
+	second := NewReportMap()
+	secondReporter := NewReporter(&second)
+	secondRoute := &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: routeKey.Namespace, Name: routeKey.Name}}
+	secondParent := gwv1.ParentReference{Name: "gw-b"}
+	secondReporter.Route(secondRoute).ParentRef(&secondParent).SetCondition(pluginreporter.RouteCondition{
+		Type:   gwv1.RouteConditionResolvedRefs,
+		Status: metav1.ConditionTrue,
+		Reason: gwv1.RouteReasonResolvedRefs,
+	})
+	secondAncestor := gwv1.ParentReference{Name: "policy-gw-b"}
+	secondReporter.Policy(policyKey, 1).AncestorRef(secondAncestor).SetAttachmentState(pluginreporter.PolicyAttachmentStateAttached)
+
+	merged := MergeReportMaps(first, second)
+	require.Len(t, merged.HTTPRoutes[routeKey].Parents, 2)
+	require.Len(t, merged.Policies[policyKey].Ancestors, 2)
+
+	for _, parent := range merged.HTTPRoutes[routeKey].Parents {
+		parent.Conditions = append(parent.Conditions, metav1.Condition{Type: "mutated"})
+		break
+	}
+	for _, ancestor := range merged.Policies[policyKey].Ancestors {
+		ancestor.Conditions = append(ancestor.Conditions, metav1.Condition{Type: "mutated"})
+		break
+	}
+
+	require.NotContains(t, conditionTypesFromParents(first.HTTPRoutes[routeKey]), "mutated")
+	require.NotContains(t, conditionTypesFromParents(second.HTTPRoutes[routeKey]), "mutated")
+	require.NotContains(t, conditionTypesFromAncestors(first.Policies[policyKey]), "mutated")
+	require.NotContains(t, conditionTypesFromAncestors(second.Policies[policyKey]), "mutated")
+}
+
+func slicesCloneConditions(in []metav1.Condition) []metav1.Condition {
+	return append([]metav1.Condition(nil), in...)
+}
+
+func cloneParentConditionsForTest(rr *RouteReport) map[string][]metav1.Condition {
+	out := map[string][]metav1.Condition{}
+	for key, parent := range rr.Parents {
+		out[key.String()] = slicesCloneConditions(parent.Conditions)
+	}
+	return out
+}
+
+func cloneAncestorConditionsForTest(pr *PolicyReport) map[string][]metav1.Condition {
+	out := map[string][]metav1.Condition{}
+	for key, ancestor := range pr.Ancestors {
+		out[key.String()] = slicesCloneConditions(ancestor.Conditions)
+	}
+	return out
+}
+
+func requireConditionForTest(t *testing.T, conditions []metav1.Condition, conditionType string) {
+	t.Helper()
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return
+		}
+	}
+	t.Fatalf("expected condition %q", conditionType)
+}
+
+func conditionTypesFromParents(rr *RouteReport) []string {
+	var out []string
+	for _, parent := range rr.Parents {
+		for _, condition := range parent.Conditions {
+			out = append(out, condition.Type)
+		}
+	}
+	return out
+}
+
+func conditionTypesFromAncestors(pr *PolicyReport) []string {
+	var out []string
+	for _, ancestor := range pr.Ancestors {
+		for _, condition := range ancestor.Conditions {
+			out = append(out, condition.Type)
+		}
+	}
+	return out
+}

--- a/test/testutils/equalstest/equalstest.go
+++ b/test/testutils/equalstest/equalstest.go
@@ -1,0 +1,158 @@
+// Package equalstest verifies that an IR type's Equals method detects a
+// change in every exported field, so KRT collections never miss an update.
+package equalstest
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// Option configures the behavior of Run.
+type Option func(*config)
+
+type config struct {
+	includeUnexported bool
+}
+
+// IncludeUnexported makes the completeness check consider unexported fields in
+// addition to exported ones. Use it for IR types whose fields are all
+// unexported (e.g. plugin-internal PolicyIRs), where the default
+// exported-only check would enforce nothing. The test must live in the same
+// package as T so its Mutate closures can reach those fields.
+func IncludeUnexported() Option {
+	return func(c *config) { c.includeUnexported = true }
+}
+
+// Case mutates one logical field of T and states whether Equals must
+// report inequality afterwards.
+type Case[T any] struct {
+	// Field is the exported Go field name this case covers (e.g. "Listeners").
+	// Used to satisfy the completeness check.
+	Field string
+	// Mutate changes that field on the given instance.
+	Mutate func(*T)
+}
+
+// Run builds two fresh instances via base() for each case, applies
+// Mutate to one, and asserts:
+//  1. base().Equals(base()) is true (reflexivity on identical values)
+//  2. after mutation, Equals is false in both directions (detection + symmetry)
+//
+// It then reflects over T's exported fields (flattening embedded structs one
+// level) and fails if any field name is neither covered by a Case nor listed
+// in exempt — that is how "new field, forgot Equals" becomes a test failure.
+//
+// T must be a struct or a pointer to a struct; pointers are dereferenced one
+// level before field reflection.
+func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []Case[T], exempt []string, opts ...Option) {
+	t.Helper()
+
+	cfg := config{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// 1. Reflexivity check: two identical base instances must be equal.
+	t.Run("reflexivity", func(t *testing.T) {
+		t.Helper()
+		a := base()
+		b := base()
+		if !equals(a, b) {
+			t.Errorf("Equals(base(), base()) returned false; two identical instances must be equal")
+		}
+	})
+
+	// 2. Mutation cases: each mutation must cause Equals to return false.
+	for _, c := range cases {
+		t.Run("mutation/"+c.Field, func(t *testing.T) {
+			t.Helper()
+			orig := base()
+			mutated := base()
+			c.Mutate(&mutated)
+
+			if equals(orig, mutated) {
+				t.Errorf("Equals returned true after mutating field %q; Equals must detect this change", c.Field)
+			}
+			// Symmetry: a.Equals(b) must equal b.Equals(a)
+			if equals(mutated, orig) {
+				t.Errorf("Equals is not symmetric: Equals(orig, mutated)=false but Equals(mutated, orig)=true for field %q", c.Field)
+			}
+		})
+	}
+
+	// 3. Completeness check: every exported field of T must appear in a Case or in exempt.
+	covered := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		covered[c.Field] = true
+	}
+	exemptSet := make(map[string]bool, len(exempt))
+	for _, e := range exempt {
+		exemptSet[e] = true
+	}
+
+	typ := reflect.TypeFor[T]()
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		t.Fatalf("equalstest.Run: type %s is not a struct or pointer to struct", typ)
+	}
+
+	missing := uncoveredFields(typ, covered, exemptSet, cfg.includeUnexported)
+	if len(missing) > 0 {
+		t.Errorf(
+			"completeness check failed for %s: exported field(s) %v are neither covered by a mutation Case nor listed as exempt — add a Case or add the field name to exempt",
+			typeName(typ),
+			missing,
+		)
+	}
+}
+
+// uncoveredFields returns the exported field names of typ that are not present
+// in covered or exempt. It flattens anonymous (embedded) struct fields one
+// level deep, matching the same logic used by Run's completeness check.
+func uncoveredFields(typ reflect.Type, covered map[string]bool, exempt map[string]bool, includeUnexported bool) []string {
+	var missing []string
+	for _, field := range candidateFields(typ, includeUnexported) {
+		if !covered[field] && !exempt[field] {
+			missing = append(missing, field)
+		}
+	}
+	return missing
+}
+
+// candidateFields returns the field names of a struct type that the
+// completeness check should cover, flattening anonymous (embedded) struct
+// fields one level deep. Unexported fields are included only when
+// includeUnexported is set.
+func candidateFields(t reflect.Type, includeUnexported bool) []string {
+	var names []string
+	for f := range t.Fields() {
+		if !f.IsExported() && !includeUnexported {
+			continue
+		}
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			// Flatten embedded struct fields one level.
+			embedded := f.Type
+			for ef := range embedded.Fields() {
+				if ef.IsExported() || includeUnexported {
+					names = append(names, ef.Name)
+				}
+			}
+			// Also add the embedded type's own name so the test can explicitly
+			// target the whole embedding as a single field (e.g. "ObjectSource").
+			names = append(names, f.Name)
+			continue
+		}
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func typeName(t reflect.Type) string {
+	if t.PkgPath() != "" {
+		return fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
+	}
+	return t.Name()
+}

--- a/test/testutils/equalstest/equalstest_internal_test.go
+++ b/test/testutils/equalstest/equalstest_internal_test.go
@@ -1,0 +1,111 @@
+// Package equalstest white-box tests for unexported helpers.
+package equalstest
+
+import (
+	"reflect"
+	"testing"
+)
+
+// EmbeddedBase is an exported struct embedded inside internalFixture to test
+// that uncoveredFields flattens one level of anonymous embedding.
+type EmbeddedBase struct {
+	Embedded string
+}
+
+// internalFixture is a local fixture struct with a plain field and an exported
+// embedded struct, used exclusively for testing uncoveredFields.
+type internalFixture struct {
+	Plain string
+	EmbeddedBase
+}
+
+func TestUncoveredFields_UncoveredFieldIsFlagged(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	// Cover Plain and the embedding name EmbeddedBase, but not the flattened field Embedded.
+	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
+	exempt := map[string]bool{}
+
+	// "Embedded" comes from flattening EmbeddedBase; it is not in covered or exempt.
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 1 || missing[0] != "Embedded" {
+		t.Errorf("expected [Embedded] to be uncovered, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_ExemptFieldIsNotFlagged(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	covered := map[string]bool{"Plain": true, "EmbeddedBase": true}
+	exempt := map[string]bool{"Embedded": true}
+
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields when Embedded is exempt, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_EmbeddedStructNameAlsoReturned(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	// Cover the flattened field but leave the embedding name itself uncovered.
+	covered := map[string]bool{"Plain": true, "Embedded": true}
+	exempt := map[string]bool{}
+
+	// exportedFields emits both "Embedded" (flattened) and "EmbeddedBase" (the
+	// embedding name itself). With covered containing only "Embedded",
+	// "EmbeddedBase" must appear as uncovered.
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 1 || missing[0] != "EmbeddedBase" {
+		t.Errorf("expected [EmbeddedBase] to be uncovered, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_AllCoveredReturnsEmpty(t *testing.T) {
+	typ := reflect.TypeFor[internalFixture]()
+	// Cover every name that exportedFields produces for internalFixture.
+	covered := map[string]bool{"Plain": true, "Embedded": true, "EmbeddedBase": true}
+	exempt := map[string]bool{}
+
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields, got %v", missing)
+	}
+}
+
+// unexportedFixture has only unexported fields, modelling a plugin-internal
+// PolicyIR.
+type unexportedFixture struct {
+	exported   string //nolint:unused // referenced only via reflection
+	hidden     int    //nolint:unused // referenced only via reflection
+	alsoHidden bool   //nolint:unused // referenced only via reflection
+}
+
+func TestUncoveredFields_UnexportedSkippedByDefault(t *testing.T) {
+	typ := reflect.TypeFor[unexportedFixture]()
+	covered := map[string]bool{}
+	exempt := map[string]bool{}
+
+	// Without includeUnexported, unexported fields are not candidates, so
+	// nothing is flagged even with an empty cover set.
+	missing := uncoveredFields(typ, covered, exempt, false)
+	if len(missing) != 0 {
+		t.Errorf("expected no uncovered fields when unexported are skipped, got %v", missing)
+	}
+}
+
+func TestUncoveredFields_UnexportedIncludedWhenRequested(t *testing.T) {
+	typ := reflect.TypeFor[unexportedFixture]()
+	covered := map[string]bool{"hidden": true}
+	exempt := map[string]bool{}
+
+	// With includeUnexported, all unexported fields are candidates; the two not
+	// covered must be flagged.
+	missing := uncoveredFields(typ, covered, exempt, true)
+	want := map[string]bool{"exported": true, "alsoHidden": true}
+	if len(missing) != len(want) {
+		t.Fatalf("expected %d uncovered fields, got %v", len(want), missing)
+	}
+	for _, m := range missing {
+		if !want[m] {
+			t.Errorf("unexpected uncovered field %q (got %v)", m, missing)
+		}
+	}
+}

--- a/test/testutils/equalstest/equalstest_test.go
+++ b/test/testutils/equalstest/equalstest_test.go
@@ -1,0 +1,115 @@
+package equalstest_test
+
+import (
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/test/testutils/equalstest"
+)
+
+// fixture is a tiny struct used exclusively for testing the harness itself.
+type fixture struct {
+	A string
+	B int
+	// C is deliberately ignored by fixtureEqualsMissingC to simulate a bug.
+	C string
+}
+
+// fixtureEqualsMissingC is a buggy Equals that misses field C.
+func fixtureEqualsMissingC(a, b fixture) bool {
+	return a.A == b.A && a.B == b.B
+}
+
+// fixtureEqualsCorrect compares all fields.
+func fixtureEqualsCorrect(a, b fixture) bool {
+	return a.A == b.A && a.B == b.B && a.C == b.C
+}
+
+func baseFixture() fixture {
+	return fixture{A: "hello", B: 42, C: "world"}
+}
+
+// TestHarnessSelfTest_CorrectEquals verifies that a complete case list over a
+// correct Equals implementation passes without any failures.
+func TestHarnessSelfTest_CorrectEquals(t *testing.T) {
+	cases := []equalstest.Case[fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f *fixture) { f.A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f *fixture) { f.B = 99 },
+		},
+		{
+			Field:  "C",
+			Mutate: func(f *fixture) { f.C = "changed" },
+		},
+	}
+	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, nil)
+}
+
+// TestHarnessSelfTest_ExemptField verifies that listing an uncovered field as
+// exempt prevents the completeness failure.
+func TestHarnessSelfTest_ExemptField(t *testing.T) {
+	cases := []equalstest.Case[fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f *fixture) { f.A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f *fixture) { f.B = 99 },
+		},
+	}
+	// C is listed as exempt; the completeness check must pass without a C Case.
+	equalstest.Run(t, baseFixture, fixtureEqualsCorrect, cases, []string{"C"})
+}
+
+// TestHarnessSelfTest_PointerToStruct verifies the harness accepts a
+// pointer-to-struct type parameter, dereferencing it for the completeness check.
+func TestHarnessSelfTest_PointerToStruct(t *testing.T) {
+	base := func() *fixture {
+		f := baseFixture()
+		return &f
+	}
+	equals := func(a, b *fixture) bool { return fixtureEqualsCorrect(*a, *b) }
+	cases := []equalstest.Case[*fixture]{
+		{
+			Field:  "A",
+			Mutate: func(f **fixture) { (*f).A = "changed" },
+		},
+		{
+			Field:  "B",
+			Mutate: func(f **fixture) { (*f).B = 99 },
+		},
+		{
+			Field:  "C",
+			Mutate: func(f **fixture) { (*f).C = "changed" },
+		},
+	}
+	equalstest.Run(t, base, equals, cases, nil)
+}
+
+// TestHarnessSelfTest_FixtureSanity validates the fixture functions themselves
+// so that higher-level tests can rely on them. In particular it confirms that
+// fixtureEqualsMissingC genuinely misses field C (modelling the bug) and that
+// fixtureEqualsCorrect catches it.
+func TestHarnessSelfTest_FixtureSanity(t *testing.T) {
+	t.Run("buggy_equals_misses_C", func(t *testing.T) {
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.C = "changed"
+		if !fixtureEqualsMissingC(orig, mutated) {
+			t.Error("expected fixtureEqualsMissingC to miss the C change, but it detected it")
+		}
+	})
+
+	t.Run("correct_equals_detects_C", func(t *testing.T) {
+		orig := baseFixture()
+		mutated := baseFixture()
+		mutated.C = "changed"
+		if fixtureEqualsCorrect(orig, mutated) {
+			t.Error("expected fixtureEqualsCorrect to detect change in C, but it returned true")
+		}
+	})
+}


### PR DESCRIPTION
# Description

Backports the status read-only refactor, observedGeneration stamping, and IR equality fixes to the `v2.2.x` release branch.

This is a backport of `0c1acd49075d75d2b8bdb5374e9a34550d05d64c` (the `v2.3.x` backport of #14295, #14248, #14298, #14302).

Because v2.2.x's reports subsystem predates the read-only status refactor and pins **gateway-api v1.4.1** (the source commit was built against **v1.5.1**), this is an **adapted** backport rather than a clean cherry-pick. Scope was kept deliberately conservative — the three headline fixes only, with v2.2.x's existing status output behavior otherwise preserved.

### Adaptations from the source commit

- Kept v2.2.x's `gwxv1a1.XListenerSet` API surface (the source used the older `gwv1.ListenerSet`) throughout `BuildListenerSetStatus` and its tests.
- Dropped the v1.5-only Gateway-level `ResolvedRefs` condition defaulting — `GatewayConditionResolvedRefs` et al. do not exist in gateway-api v1.4.1.
- Dropped net-new behavior that isn't part of these PRs, to avoid changing v2.2.x status output: the invalid-address / insecure-frontend gateway conditions and the "No valid listeners" ListenerSet rejection.
- Dropped the `attachedListenerSets` `GatewayReport` field (not present in v2.2.x) from `report_map.go` and its test.
- Ported the prerequisite `test/testutils/equalstest` helper (already present on v2.3.x, absent on v2.2.x) so the IR equality harness compiles.

### Verification

- `go build -tags e2e ./...` passes.
- Unit tests pass: `pkg/reports/...`, `pkg/pluginsdk/ir/...`, `pkg/kgateway/proxy_syncer/...`, `test/testutils/equalstest/...`.
- Gateway translator golden tests pass (`pkg/kgateway/translator/gateway/...`), confirming status output behavior is unchanged.

# Change Type

/kind fix

# Changelog

```release-note
NONE
```

### Additional Notes

Because of the gateway-api version gap and the reports refactor not being present on v2.2.x, this could not be applied as a mechanical cherry-pick. Reviewers should pay particular attention to the ListenerSet status path (`BuildListenerSetStatus`) and the conservative scoping decisions listed above.