### PR TITLE
[2.3] fix: inject port into legacy XListenerSet status to fix required field validation

### DIFF
--- a/pkg/kgateway/proxy_syncer/inject_listener_ports_test.go
+++ b/pkg/kgateway/proxy_syncer/inject_listener_ports_test.go
@@ -1,0 +1,138 @@
+package proxy_syncer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestInjectListenerPorts(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusMap     map[string]any
+		specListeners []gwv1.ListenerEntry
+		wantPorts     map[string]int64 // listener name -> expected port
+	}{
+		{
+			name: "spec explicit port is injected as-is",
+			statusMap: map[string]any{
+				"listeners": []any{
+					map[string]any{"name": "http"},
+				},
+			},
+			specListeners: []gwv1.ListenerEntry{
+				{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 8080},
+			},
+			wantPorts: map[string]int64{"http": 8080},
+		},
+		{
+			name: "HTTP protocol with zero port defaults to 80",
+			statusMap: map[string]any{
+				"listeners": []any{
+					map[string]any{"name": "http"},
+				},
+			},
+			specListeners: []gwv1.ListenerEntry{
+				{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 0},
+			},
+			wantPorts: map[string]int64{"http": 80},
+		},
+		{
+			name: "HTTPS protocol with zero port defaults to 443",
+			statusMap: map[string]any{
+				"listeners": []any{
+					map[string]any{"name": "https"},
+				},
+			},
+			specListeners: []gwv1.ListenerEntry{
+				{Name: "https", Protocol: gwv1.HTTPSProtocolType, Port: 0},
+			},
+			wantPorts: map[string]int64{"https": 443},
+		},
+		{
+			name: "unknown protocol with zero port falls back to legacyPortFallback",
+			statusMap: map[string]any{
+				"listeners": []any{
+					map[string]any{"name": "unknown"},
+				},
+			},
+			specListeners: []gwv1.ListenerEntry{
+				{Name: "unknown", Protocol: gwv1.ProtocolType("unknown"), Port: 0},
+			},
+			wantPorts: map[string]int64{"unknown": legacyPortFallback},
+		},
+		{
+			name: "multiple listeners matched by name",
+			statusMap: map[string]any{
+				"listeners": []any{
+					map[string]any{"name": "http"},
+					map[string]any{"name": "https"},
+					map[string]any{"name": "admin"},
+				},
+			},
+			specListeners: []gwv1.ListenerEntry{
+				{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 0},
+				{Name: "https", Protocol: gwv1.HTTPSProtocolType, Port: 0},
+				{Name: "admin", Protocol: gwv1.HTTPProtocolType, Port: 9090},
+			},
+			wantPorts: map[string]int64{
+				"http":  80,
+				"https": 443,
+				"admin": 9090,
+			},
+		},
+		{
+			name: "status listener with no matching spec entry receives fallback port",
+			statusMap: map[string]any{
+				"listeners": []any{
+					map[string]any{"name": "orphan"},
+				},
+			},
+			specListeners: []gwv1.ListenerEntry{
+				{Name: "other", Protocol: gwv1.HTTPProtocolType, Port: 80},
+			},
+			wantPorts: map[string]int64{"orphan": legacyPortFallback},
+		},
+		{
+			name: "missing listeners key in statusMap is a no-op",
+			statusMap: map[string]any{
+				"conditions": []any{},
+			},
+			specListeners: []gwv1.ListenerEntry{
+				{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+			},
+			wantPorts: map[string]int64{},
+		},
+		{
+			name:          "empty listeners slice is a no-op",
+			statusMap:     map[string]any{"listeners": []any{}},
+			specListeners: []gwv1.ListenerEntry{},
+			wantPorts:     map[string]int64{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			injectListenerPorts(tt.statusMap, tt.specListeners)
+
+			listeners, _ := tt.statusMap["listeners"].([]any)
+			for _, entry := range listeners {
+				entryMap, ok := entry.(map[string]any)
+				if !ok {
+					continue
+				}
+				name, _ := entryMap["name"].(string)
+				wantPort, shouldHavePort := tt.wantPorts[name]
+				if shouldHavePort {
+					got, hasPort := entryMap["port"]
+					assert.True(t, hasPort, "listener %q should have port injected", name)
+					assert.Equal(t, wantPort, got, "listener %q port mismatch", name)
+				} else {
+					_, hasPort := entryMap["port"]
+					assert.False(t, hasPort, "listener %q should NOT have port injected", name)
+				}
+			}
+		})
+	}
+}

--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	reportssdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
 var _ manager.LeaderElectionRunnable = &StatusSyncer{}
@@ -646,8 +647,57 @@ func (s *StatusSyncer) patchListenerSetStatus(
 	if err != nil {
 		return err
 	}
+	// Legacy XListenerSet CRDs require "port" in status.listeners[*],
+	// but the promoted gwv1.ListenerEntryStatus type no longer carries it.
+	// Inject the value from spec before patching.
+	injectListenerPorts(statusMap, ls.Spec.Listeners)
 	legacyListenerSet.Object["status"] = statusMap
 	return s.mgr.GetClient().Status().Patch(ctx, legacyListenerSet, client.Merge)
+}
+
+// legacyPortFallback is used when a listener protocol requires an explicit port
+// but none is set, matching the v2.2.4 fallback behaviour. 65535 is an out-of-
+// range sentinel that satisfies the schema's required field without silently
+// routing traffic to a real port.
+const legacyPortFallback int64 = 65535
+
+// injectListenerPorts adds the "port" field to each entry in statusMap["listeners"]
+// by looking up the matching listener in specListeners by name.
+// This is needed because gwv1.ListenerEntryStatus no longer carries Port, but the
+// legacy XListenerSet CRD schema still requires it.
+// Listeners whose name does not match any spec entry receive legacyPortFallback
+// so that the patch payload always satisfies the schema's required constraint.
+func injectListenerPorts(statusMap map[string]any, specListeners []gwv1.ListenerEntry) {
+	listeners, ok := statusMap["listeners"].([]any)
+	if !ok {
+		return
+	}
+
+	// Precompute name→port to avoid O(n²) scan.
+	portByName := make(map[string]int64, len(specListeners))
+	for _, spec := range specListeners {
+		port, err := kubeutils.DetectListenerPortNumber(spec.Protocol, spec.Port)
+		if err != nil {
+			port = gwv1.PortNumber(legacyPortFallback)
+		}
+		portByName[string(spec.Name)] = int64(port)
+	}
+
+	for i, entry := range listeners {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := entryMap["name"].(string)
+		port, matched := portByName[name]
+		if !matched {
+			// No corresponding spec entry; use the fallback so the patch
+			// payload still satisfies the schema's required port constraint.
+			port = legacyPortFallback
+		}
+		entryMap["port"] = port
+		listeners[i] = entryMap
+	}
 }
 
 func (s *StatusSyncer) syncPolicyStatus(ctx context.Context, rm reports.ReportMap) {


### PR DESCRIPTION
# Description

Backport of https://github.com/kgateway-dev/kgateway/pull/14231

Fixes #14196.

Since v2.3.0 (PR #13671), `BuildListenerSetStatus` was migrated from `gwxv1a1.ListenerEntryStatus` to `gwv1.ListenerEntryStatus`. The promoted type no longer carries a `Port` field, but the legacy `XListenerSet` CRD schema still requires `status.listeners[*].port`. As a result, every reconcile cycle fails to patch XListenerSet status with:

```
XListenerSet.gateway.networking.x-k8s.io "<name>" is invalid: status.listeners[0].port: Required value
```

**Changes:**
- **`pkg/kgateway/proxy_syncer/status_syncer.go`**: In `patchListenerSetStatus`, inject `port` into the unstructured status map before patching the legacy XListenerSet. Adds `injectListenerPorts` helper that precomputes a name→port map from `ls.Spec.Listeners` using `kubeutils.DetectListenerPortNumber`, with a named `legacyPortFallback` constant (65535) for both unknown protocols and unmatched listeners — matching v2.2.4 behaviour. The promoted ListenerSet path (`legacyListenerSet == nil`) is untouched.
- **`pkg/kgateway/proxy_syncer/inject_listener_ports_test.go`**: 8 table-driven unit tests covering spec-explicit port, HTTP/HTTPS default ports, unknown-protocol fallback, multiple listeners, orphan listener (no spec match → fallback port), missing key, and empty slice.

# Change Type

/kind fix

# Changelog

```release-note
Fix XListenerSet status patch failures caused by missing required port field since v2.3.0.
```

# Additional Notes

The fix is intentionally scoped to the legacy XListenerSet code path only. Copilot review comments addressed: named constant for 65535, O(n²) → O(n) precomputed map, fallback port for unmatched listeners, and test improvements.