### PR TITLE
chore: cleanup xds credential injection header mutation

### DIFF
--- a/docs/guides/transformation.md
+++ b/docs/guides/transformation.md
@@ -27,9 +27,7 @@ Here are the differences between [minijinja](https://github.com/mitsuhiko/miniji
 
 ## Strict Mode Validation
 
-Strict Mode Validation is not supported yet with Rustformation. This is due to build complexity to include the dynamic module in the control plane image. This will be addressed in future updates.
-
-If Strict Mode Validation is needed, see the [Classic Transformation Deprecation](#classic-transformation-deprecation) section below to switch back to Classic Transformation on x86 architecture.
+As of v2.4.0, Strict Mode Validation is supported with Rustformation.
 
 ## Initial arm64 support
 

--- a/docs/guides/transformation.md
+++ b/docs/guides/transformation.md
@@ -27,7 +27,9 @@ Here are the differences between [minijinja](https://github.com/mitsuhiko/miniji
 
 ## Strict Mode Validation
 
-As of v2.4.0, Strict Mode Validation is supported with Rustformation.
+Strict Mode Validation is not supported yet with Rustformation. This is due to build complexity to include the dynamic module in the control plane image. This will be addressed in future updates.
+
+If Strict Mode Validation is needed, see the [Classic Transformation Deprecation](#classic-transformation-deprecation) section below to switch back to Classic Transformation on x86 architecture.
 
 ## Initial arm64 support
 

--- a/pkg/kgateway/helm/envoy/templates/configmap.yaml
+++ b/pkg/kgateway/helm/envoy/templates/configmap.yaml
@@ -244,17 +244,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/pkg/kgateway/helm/envoy/templates/configmap.yaml
+++ b/pkg/kgateway/helm/envoy/templates/configmap.yaml
@@ -244,7 +244,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/base-gateway-tls-out.yaml
+++ b/test/deployer/testdata/base-gateway-tls-out.yaml
@@ -192,17 +192,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/base-gateway-tls-out.yaml
+++ b/test/deployer/testdata/base-gateway-tls-out.yaml
@@ -192,7 +192,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
@@ -165,7 +165,6 @@ data:
                           resource_api_version: V3
                       header_value_prefix: "Bearer "
                   overwrite: true
-                  overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
@@ -163,7 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
+                  overwrite: true
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-all-autoscalers-out.yaml
+++ b/test/deployer/testdata/envoy-all-autoscalers-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-all-autoscalers-out.yaml
+++ b/test/deployer/testdata/envoy-all-autoscalers-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-dns-resolver-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-dns-resolver-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-hpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-hpa-overlay-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-hpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-hpa-overlay-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
+++ b/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
+++ b/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-infrastructure-out.yaml
+++ b/test/deployer/testdata/envoy-infrastructure-out.yaml
@@ -169,7 +169,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-infrastructure-out.yaml
+++ b/test/deployer/testdata/envoy-infrastructure-out.yaml
@@ -169,17 +169,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-log-json-out.yaml
+++ b/test/deployer/testdata/envoy-log-json-out.yaml
@@ -170,7 +170,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-log-json-out.yaml
+++ b/test/deployer/testdata/envoy-log-json-out.yaml
@@ -170,17 +170,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-log-text-out.yaml
+++ b/test/deployer/testdata/envoy-log-text-out.yaml
@@ -166,7 +166,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-log-text-out.yaml
+++ b/test/deployer/testdata/envoy-log-text-out.yaml
@@ -166,17 +166,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-overlay-ordering-out.yaml
+++ b/test/deployer/testdata/envoy-overlay-ordering-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-overlay-ordering-out.yaml
+++ b/test/deployer/testdata/envoy-overlay-ordering-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-pdb-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-pdb-overlay-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-pdb-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-pdb-overlay-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
+++ b/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
@@ -168,7 +168,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
+++ b/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
@@ -168,17 +168,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
+++ b/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
@@ -166,7 +166,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
+++ b/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
@@ -166,17 +166,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/envoy-vpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-vpa-overlay-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/envoy-vpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-vpa-overlay-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/gwc-with-replicas-null-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-null-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/gwc-with-replicas-null-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-null-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/gwc-with-replicas-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/gwc-with-replicas-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
@@ -164,16 +164,6 @@ data:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
@@ -163,6 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/loadbalancer-class-out.yaml
+++ b/test/deployer/testdata/loadbalancer-class-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/loadbalancer-class-out.yaml
+++ b/test/deployer/testdata/loadbalancer-class-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/loadbalancer-static-ip-out.yaml
+++ b/test/deployer/testdata/loadbalancer-static-ip-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/loadbalancer-static-ip-out.yaml
+++ b/test/deployer/testdata/loadbalancer-static-ip-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/openshift-two-params-security-context-out.yaml
+++ b/test/deployer/testdata/openshift-two-params-security-context-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/openshift-two-params-security-context-out.yaml
+++ b/test/deployer/testdata/openshift-two-params-security-context-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/priority-class-name-out.yaml
+++ b/test/deployer/testdata/priority-class-name-out.yaml
@@ -163,7 +163,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/priority-class-name-out.yaml
+++ b/test/deployer/testdata/priority-class-name-out.yaml
@@ -163,17 +163,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/stats-matcher-exclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-exclusion-out.yaml
@@ -171,17 +171,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec

--- a/test/deployer/testdata/stats-matcher-exclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-exclusion-out.yaml
@@ -171,7 +171,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/stats-matcher-inclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-inclusion-out.yaml
@@ -175,7 +175,7 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
-                      header_value_prefix: Bearer
+                      header_value_prefix: "Bearer "
                   overwrite: true
               - name: envoy.filters.http.upstream_codec
                 typed_config:

--- a/test/deployer/testdata/stats-matcher-inclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-inclusion-out.yaml
@@ -175,17 +175,8 @@ data:
                           path_config_source:
                             path: "/etc/envoy/xds_service_account_token.json"
                           resource_api_version: V3
+                      header_value_prefix: Bearer
                   overwrite: true
-              - name: envoy.filters.http.header_mutation
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                  mutations:
-                    request_mutations:
-                      - append:
-                          append_action: OVERWRITE_IF_EXISTS
-                          header:
-                            key: "Authorization"
-                            value: "Bearer %REQ(Authorization)%"
               - name: envoy.filters.http.upstream_codec
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.upstream_codec.v3.UpstreamCodec


### PR DESCRIPTION
# Description

Closes https://github.com/kgateway-dev/kgateway/issues/13213
envoy 1.37 added the ability to add header prefix for the credential value. So, we don't need to use header mutation to add the "Bearer" prefix anymore.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```
