### PR TITLE
Fix status not reporting on newly created resources

### DIFF
--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -927,7 +927,7 @@ func (s *StatusSyncer) syncBackendStatus(ctx context.Context, rm reports.ReportM
 			finishMetrics(err)
 			continue
 		}
-		// A NotFound here means the backend is gone; if it's recreated we'll retranslate
+		// A NotFound here means the backend is gone. If it's recreated we'll retranslate
 		// it. Fall through so the sync is still recorded as completed, keeping the
 		// started/completed status-sync metrics balanced.
 

--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -577,11 +577,13 @@ func (s *StatusSyncer) syncGatewayStatus(ctx context.Context, logger *slog.Logge
 		})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				// the gateway is gone; if it's recreated we'll retranslate it
-				finishMetrics(nil)
-				continue
+				// the gateway is gone; if it's recreated we'll retranslate it. Fall
+				// through so the sync is still recorded as completed, keeping the
+				// started/completed status-sync metrics balanced.
+				err = nil
+			} else {
+				logger.Error("failed to update gateway status after retries", "error", err, "gateway", gwnn.String())
 			}
-			logger.Error("failed to update gateway status after retries", "error", err, "gateway", gwnn.String())
 		}
 
 		// Record metrics for this gateway
@@ -811,7 +813,9 @@ func (s *StatusSyncer) syncPolicyStatus(ctx context.Context, rm reports.ReportMa
 			retry.LastErrorOnly(true),
 		)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
+			// Policy plugins surface a missing object as the pluginsdk.ErrNotFound
+			// sentinel rather than a k8s apierror, so check both.
+			if errors.Is(err, plug.ErrNotFound) || apierrors.IsNotFound(err) {
 				// the policy is gone; if it's recreated we'll retranslate it
 				continue
 			}
@@ -862,14 +866,17 @@ func (s *StatusSyncer) syncPolicyStatus(ctx context.Context, rm reports.ReportMa
 			retry.LastErrorOnly(true),
 		)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				// the policy is gone; if it's recreated we'll retranslate it
-				finishMetrics(nil)
+			// Policy plugins surface a missing object as the pluginsdk.ErrNotFound
+			// sentinel rather than a k8s apierror, so check both.
+			if !errors.Is(err, plug.ErrNotFound) && !apierrors.IsNotFound(err) {
+				logger.Error("error updating policy status", "error", err, "group_kind", gk, "resource_ref", nsName)
+				finishMetrics(errors.Join(err, statusErr))
 				continue
 			}
-			logger.Error("error updating policy status", "error", err, "group_kind", gk, "resource_ref", nsName)
-			finishMetrics(errors.Join(err, statusErr))
-			continue
+			// the policy is gone; if it's recreated we'll retranslate it. Fall through
+			// so the sync is still recorded as completed, keeping the started/completed
+			// status-sync metrics balanced.
+			statusErr = nil
 		}
 
 		metrics.EndResourceStatusSync(metrics.ResourceSyncDetails{
@@ -915,16 +922,14 @@ func (s *StatusSyncer) syncBackendStatus(ctx context.Context, rm reports.ReportM
 			retry.DelayType(retry.BackOffDelay),
 			retry.LastErrorOnly(true),
 		)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				// the backend is gone; if it's recreated we'll retranslate it
-				finishMetrics(nil)
-				continue
-			}
+		if err != nil && !apierrors.IsNotFound(err) {
 			logger.Error("all attempts failed at updating Backend status", "error", err, "backend", nsName)
 			finishMetrics(err)
 			continue
 		}
+		// A NotFound here means the backend is gone; if it's recreated we'll retranslate
+		// it. Fall through so the sync is still recorded as completed, keeping the
+		// started/completed status-sync metrics balanced.
 
 		metrics.EndResourceStatusSync(metrics.ResourceSyncDetails{
 			Namespace:    nsName.Namespace,

--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	utilretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -159,16 +160,16 @@ func (s *StatusSyncer) syncRouteStatus(ctx context.Context, logger *slog.Logger,
 		getRouteFunc func(context.Context, client.ObjectKey) (client.Object, error),
 		statusUpdater func(route client.Object) (*gwv1.RouteStatus, error),
 	) error {
-		return retry.Do(
+		err := retry.Do(
 			func() (rErr error) {
 				route, err := getRouteFunc(ctx, routeKey)
 				if err != nil {
-					if apierrors.IsNotFound(err) {
-						// the route is not found, we can't report status on it
-						// if it's recreated, we'll retranslate it anyway
-						return nil
+					// NotFound is retried too: for a just-created route the report can
+					// arrive before the object shows up in the manager's informer cache,
+					// and nothing retriggers this sync if the write is dropped.
+					if !apierrors.IsNotFound(err) {
+						logger.Error("error getting route", "error", err, "resource_ref", routeKey, "route_type", routeType)
 					}
-					logger.Error("error getting route", "error", err, "resource_ref", routeKey, "route_type", routeType)
 					return err
 				}
 
@@ -291,7 +292,13 @@ func (s *StatusSyncer) syncRouteStatus(ctx context.Context, logger *slog.Logger,
 			retry.Attempts(5),
 			retry.Delay(100*time.Millisecond),
 			retry.DelayType(retry.BackOffDelay),
+			retry.LastErrorOnly(true),
 		)
+		if apierrors.IsNotFound(err) {
+			// the route is gone; if it's recreated we'll retranslate it
+			return nil
+		}
+		return err
 	}
 
 	// Helper function to build route status and update if needed
@@ -487,11 +494,21 @@ func (s *StatusSyncer) syncGatewayStatus(ctx context.Context, logger *slog.Logge
 
 		var statusErr error
 
-		err := utilretry.RetryOnConflict(utilretry.DefaultRetry, func() error {
+		// NotFound is retried in addition to conflicts: for a just-created Gateway the
+		// report can arrive before the object shows up in the manager's informer cache,
+		// and nothing retriggers this sync if the write is dropped. The backoff matches
+		// the retry budget of the other status syncers (~1.5s total).
+		retriable := func(err error) bool {
+			return apierrors.IsConflict(err) || apierrors.IsNotFound(err)
+		}
+		backoff := wait.Backoff{Duration: 100 * time.Millisecond, Factor: 2, Steps: 5}
+		err := utilretry.OnError(backoff, retriable, func() error {
 			// Fetch the latest Gateway
 			var gw gwv1.Gateway
 			if err := s.mgr.GetClient().Get(ctx, gwnn, &gw); err != nil {
-				logger.Info("error getting gateway", "error", err, "gateway", gwnn.String())
+				if !apierrors.IsNotFound(err) {
+					logger.Info("error getting gateway", "error", err, "gateway", gwnn.String())
+				}
 				return err
 			}
 
@@ -559,6 +576,11 @@ func (s *StatusSyncer) syncGatewayStatus(ctx context.Context, logger *slog.Logge
 			return nil
 		})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// the gateway is gone; if it's recreated we'll retranslate it
+				finishMetrics(nil)
+				continue
+			}
 			logger.Error("failed to update gateway status after retries", "error", err, "gateway", gwnn.String())
 		}
 
@@ -645,9 +667,15 @@ func (s *StatusSyncer) syncListenerSetStatus(ctx context.Context, logger *slog.L
 		retry.Attempts(5),
 		retry.Delay(100*time.Millisecond),
 		retry.DelayType(retry.BackOffDelay),
+		retry.LastErrorOnly(true),
 	)
 	if err != nil {
-		logger.Error("all attempts failed at updating listener set statuses", "error", err)
+		if apierrors.IsNotFound(err) {
+			// a listener set is gone; if it's recreated we'll retranslate it
+			logger.Debug("listener set not found during status sync", "error", err)
+		} else {
+			logger.Error("all attempts failed at updating listener set statuses", "error", err)
+		}
 	}
 	logger.Debug("synced listener sets status for listener set", "count", len(rm.ListenerSets))
 }
@@ -767,8 +795,26 @@ func (s *StatusSyncer) syncPolicyStatus(ctx context.Context, rm reports.ReportMa
 			logger.Debug("PatchPolicyStatus handler not registered for policy", "group_kind", gk, "resource", nsName) //nolint:sloglint // ignore PascalCase at start
 			continue
 		}
-		currentStatus, err := plugin.GetPolicyStatus(ctx, nsName)
+		// NotFound is retried: for a just-created policy the report can arrive before
+		// the object shows up in the informer cache, and nothing retriggers this sync
+		// if the write is dropped.
+		var currentStatus gwv1.PolicyStatus
+		err := retry.Do(
+			func() error {
+				var getErr error
+				currentStatus, getErr = plugin.GetPolicyStatus(ctx, nsName)
+				return getErr
+			},
+			retry.Attempts(5),
+			retry.Delay(100*time.Millisecond),
+			retry.DelayType(retry.BackOffDelay),
+			retry.LastErrorOnly(true),
+		)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// the policy is gone; if it's recreated we'll retranslate it
+				continue
+			}
 			logger.Error("error getting policy status", "error", err, "resource_ref", nsName)
 			continue
 		}
@@ -813,8 +859,14 @@ func (s *StatusSyncer) syncPolicyStatus(ctx context.Context, rm reports.ReportMa
 			retry.Attempts(5),
 			retry.Delay(100*time.Millisecond),
 			retry.DelayType(retry.BackOffDelay),
+			retry.LastErrorOnly(true),
 		)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// the policy is gone; if it's recreated we'll retranslate it
+				finishMetrics(nil)
+				continue
+			}
 			logger.Error("error updating policy status", "error", err, "group_kind", gk, "resource_ref", nsName)
 			finishMetrics(errors.Join(err, statusErr))
 			continue
@@ -843,11 +895,12 @@ func (s *StatusSyncer) syncBackendStatus(ctx context.Context, rm reports.ReportM
 			func() error {
 				backend := new(kgateway.Backend)
 				if err := s.mgr.GetClient().Get(ctx, nsName, backend); err != nil {
-					if apierrors.IsNotFound(err) {
-						// the backend is gone; if it's recreated we'll retranslate it
-						return nil
+					// NotFound is retried too: for a just-created Backend the report can
+					// arrive before the object shows up in the manager's informer cache,
+					// and nothing retriggers this sync if the write is dropped.
+					if !apierrors.IsNotFound(err) {
+						logger.Error("error getting backend", "error", err, "resource_ref", nsName)
 					}
-					logger.Error("error getting backend", "error", err, "resource_ref", nsName)
 					return err
 				}
 				status := rm.BuildBackendStatus(ctx, backend, backend.Status)
@@ -860,8 +913,14 @@ func (s *StatusSyncer) syncBackendStatus(ctx context.Context, rm reports.ReportM
 			retry.Attempts(5),
 			retry.Delay(100*time.Millisecond),
 			retry.DelayType(retry.BackOffDelay),
+			retry.LastErrorOnly(true),
 		)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// the backend is gone; if it's recreated we'll retranslate it
+				finishMetrics(nil)
+				continue
+			}
 			logger.Error("all attempts failed at updating Backend status", "error", err, "backend", nsName)
 			finishMetrics(err)
 			continue

--- a/test/e2e/common/base.go
+++ b/test/e2e/common/base.go
@@ -10,6 +10,7 @@ import (
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/util/assert"
+	"istio.io/istio/pkg/test/util/retry"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -32,7 +33,12 @@ func SetupBaseConfig(ctx context.Context, t *testing.T, installation *e2e.TestIn
 			t.Logf("failed to delete base config manifests %v: %v", manifests, err)
 		}
 	})
-	err := installation.ClusterContext.IstioClient.ApplyYAMLFiles("", manifests...)
+	// Retry the apply: a gotestsum rerun starts a fresh process while the previous
+	// process's cleanup may still be deleting the namespaces these manifests create,
+	// and applying into a terminating namespace is rejected by the API server.
+	err := retry.UntilSuccess(func() error {
+		return installation.ClusterContext.IstioClient.ApplyYAMLFiles("", manifests...)
+	}, retry.Timeout(2*time.Minute), retry.Delay(2*time.Second))
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
# Description

Fixes a status sync bug where a resource's status could be silently dropped and never written, plus an e2e test-harness race that amplified the resulting flake.

The status syncer reads objects back through the controller manager's informer cache, which is independent of the KRT watch that produces status reports. For a just-created resource, the report can arrive before the object shows up in the manager's cache, so the `Get` returns NotFound. The syncers treated NotFound as "the resource was deleted" and skipped the write. Since the report singletons only re-enqueue when the report content changes, nothing retriggered the write and the resource was left without status indefinitely.

This surfaced as the `TestKgateway/Backends/TestConfigureBackingDestinationsWithUpstream` flake: the Backend was translated and served to Envoy, but its `Accepted` condition never appeared.

Changes:

- `syncBackendStatus`, `syncRouteStatus`, `syncPolicyStatus`: retry NotFound with the existing backoff (5 attempts, ~1.5s) instead of skipping; a terminal NotFound (genuinely deleted resource) is still skipped silently.
- `syncGatewayStatus`: replace `RetryOnConflict` with `retry.OnError` retrying conflicts and NotFound, with a backoff matching the other syncers.
- `syncListenerSetStatus`: NotFound was already retried at the block level; a terminal NotFound is now logged at debug instead of error.
- `test/e2e/common/base.go`: retry the base config apply so a gotestsum rerun tolerates the previous test process's namespace deletion still completing (`unable to create new content in namespace ... because it is being terminated`), which previously failed the whole `TestKgateway` parent and caused an unfiltered rerun of every suite.

# Change Type

/kind flake

# Changelog

```release-note
Fixed a race where the status of a newly created Backend, Route, Gateway, or policy could be silently dropped and never written if the status report was processed before the object appeared in the controller's informer cache.
```

# Additional Notes

Root cause analysis from CI run 29359422203 (cluster-four): the Backend `nginx-static` had its xDS cluster served to Envoy but never received a status, while the controller log was quiet for the full 60s assertion window — confirming the write was dropped once and never retried.