### PR TITLE
chore: Bump Gateway API to v1.6.1

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -144,9 +144,9 @@ jobs:
           - file: "./.github/workflows/.env/nightly-tests/min_versions.env"
             label: min
         gateway-api-version:
-          - version: 'v1.6.0'
+          - version: 'v1.6.1'
             channel: experimental
-          - version: 'v1.6.0'
+          - version: 'v1.6.1'
             channel: standard
           - version: 'v1.5.1'
             channel: experimental

--- a/Makefile
+++ b/Makefile
@@ -1038,7 +1038,7 @@ kind-create: ## Create a KinD cluster
 	$(KIND) get clusters | grep -x $(CLUSTER_NAME) || $(KIND) create cluster --name $(CLUSTER_NAME) --image kindest/node:$(CLUSTER_NODE_VERSION)
 
 CONFORMANCE_CHANNEL ?= experimental
-CONFORMANCE_VERSION ?= v1.6.0
+CONFORMANCE_VERSION ?= v1.6.1
 .PHONY: gw-api-crds
 gw-api-crds: ## Install the Gateway API CRDs. HACK: Use SSA to avoid the issue with the CRD annotations being too long.
 ifeq ($(shell echo $(CONFORMANCE_VERSION) | grep -q '^v[0-9]' && echo yes),yes)
@@ -1233,7 +1233,7 @@ run-load-tests-production: ## Run production load tests (5000 routes)
 CONFORMANCE_GATEWAY_CLASS ?= kgateway
 CONFORMANCE_REPORT_ARGS ?= -report-output=$(TEST_ASSET_DIR)/conformance/$(VERSION)-report.yaml -organization=kgateway-dev -project=kgateway -version=$(VERSION) -url=github.com/kgateway-dev/kgateway -contact=github.com/kgateway-dev/kgateway/issues/new/choose
 # This test uses port 9091 which is reserved for the metrics port. The test passes if the port in the conformance test is changed
-CONFORMANCE_SKIP_TESTS := -skip-tests=TCPRouteMultipleRoutesAttachment
+CONFORMANCE_SKIP_TESTS := 
 CONFORMANCE_ARGS := -gateway-class=$(CONFORMANCE_GATEWAY_CLASS) $(CONFORMANCE_SKIP_TESTS) $(CONFORMANCE_REPORT_ARGS)
 
 CONFORMANCE_TEST_DIR ?= ./test/conformance/...

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/gateway-api v1.6.0
+	sigs.k8s.io/gateway-api v1.6.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -64,7 +64,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	k8s.io/apiserver v0.36.1
 	k8s.io/cli-runtime v0.36.1
-	sigs.k8s.io/gateway-api/conformance v1.6.0
+	sigs.k8s.io/gateway-api/conformance v1.6.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1652,12 +1652,12 @@ sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
-sigs.k8s.io/gateway-api v1.6.0 h1:735YBRj5NXFrOGX0GoSjwzUIzbz8kiEOfADsqHFmHgE=
-sigs.k8s.io/gateway-api v1.6.0/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
+sigs.k8s.io/gateway-api v1.6.1 h1:mock6phZbI6rvZerwrVNk7hVNymQgHo+6sJ81Ia7ftY=
+sigs.k8s.io/gateway-api v1.6.1/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
 sigs.k8s.io/gateway-api-inference-extension v1.5.0 h1:w9Awt60cmI1vM7Y6N81h8wDCBP0WkmxpdI7GKY0v070=
 sigs.k8s.io/gateway-api-inference-extension v1.5.0/go.mod h1:ZeIlzI43XH2qWKipFq/Qa12yB2s/D+Xp1XJVlpMxklA=
-sigs.k8s.io/gateway-api/conformance v1.6.0 h1:jyH7Jtx46hEeBQnmSErn2cbp0k4OmT3FLRBnu77c4Ko=
-sigs.k8s.io/gateway-api/conformance v1.6.0/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
+sigs.k8s.io/gateway-api/conformance v1.6.1 h1:hjJJBYhGlLLDAkpbiL8wYP2JmTbc5D6t/DromATFXbI=
+sigs.k8s.io/gateway-api/conformance v1.6.1/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.32.0 h1:p9hscbj98u/qyrjVpjId86LI70nQmbSsipV7wCG10Xk=

--- a/hack/utils/oss_compliance/osa_provided.md
+++ b/hack/utils/oss_compliance/osa_provided.md
@@ -61,8 +61,8 @@ Name|Version|License
 [k8s.io/kubectl](https://k8s.io/kubectl)|v0.36.1|Apache License 2.0
 [k8s.io/utils](https://k8s.io/utils)|v0.0.0-20260319190234-28399d86e0b5|Apache License 2.0
 [sigs.k8s.io/controller-runtime](https://sigs.k8s.io/controller-runtime)|v0.24.1|Apache License 2.0
-[sigs.k8s.io/gateway-api](https://sigs.k8s.io/gateway-api)|v1.6.0|Apache License 2.0
-[gateway-api/conformance](https://sigs.k8s.io/gateway-api/conformance)|v1.6.0|Apache License 2.0
+[sigs.k8s.io/gateway-api](https://sigs.k8s.io/gateway-api)|v1.6.1|Apache License 2.0
+[gateway-api/conformance](https://sigs.k8s.io/gateway-api/conformance)|v1.6.1|Apache License 2.0
 [sigs.k8s.io/yaml](https://sigs.k8s.io/yaml)|v1.6.0|MIT License
 [cmd/goimports](https://golang.org/x/tools/cmd/goimports)|latest|MIT License
 [gogo/protobuf](https://github.com/gogo/protobuf)|latest|MIT License

--- a/pkg/kgateway/crds/gateway-crds.yaml
+++ b/pkg/kgateway/crds/gateway-crds.yaml
@@ -24,7 +24,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct
@@ -135,12 +135,12 @@ spec:
 
                   Support Levels:
 
-                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+                  * Extended: Kubernetes Service referenced by backendRefs used on a Route.
+                    - HTTPRoute, GRPCRoute, TLSRoute with termination
+                    - Filters that needs a backend of type Service, like Mirror and External Authorization
 
-                  * Implementation-Specific: Services not connected via HTTPRoute, and any
-                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                  * Implementation-Specific: Implementations MAY use BackendTLSPolicy for:
                     - Services not referenced by any Route (e.g., infrastructure services)
-                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
                     - Service mesh workload-to-service communication
                     - Other resource types beyond Service
 
@@ -829,12 +829,12 @@ spec:
 
                   Support Levels:
 
-                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+                  * Extended: Kubernetes Service referenced by backendRefs used on a Route.
+                    - HTTPRoute, GRPCRoute, TLSRoute with termination
+                    - Filters that needs a backend of type Service, like Mirror and External Authorization
 
-                  * Implementation-Specific: Services not connected via HTTPRoute, and any
-                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                  * Implementation-Specific: Implementations MAY use BackendTLSPolicy for:
                     - Services not referenced by any Route (e.g., infrastructure services)
-                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
                     - Service mesh workload-to-service communication
                     - Other resource types beyond Service
 
@@ -1431,12 +1431,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -1446,7 +1440,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
@@ -1497,6 +1491,9 @@ spec:
           Gateway is not deleted while in use.
 
           GatewayClass is a Cluster level resource.
+
+          A GatewayClass name SHOULD be compliant with RFC 1035, consisting of a maximum of 63 lower case alphanumeric
+          characters or hyphens ('-'), and MUST start and end with an alphanumeric character.
         properties:
           apiVersion:
             description: |-
@@ -1950,12 +1947,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -1965,7 +1956,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: gateways.gateway.networking.k8s.io
 spec:
@@ -2000,6 +1991,8 @@ spec:
         description: |-
           Gateway represents an instance of a service-traffic handling infrastructure
           by binding Listeners to a set of IP addresses.
+          A Gateway name SHOULD be compliant with RFC 1035, consisting of a maximum of 63 lower case alphanumeric
+          characters or hyphens ('-'), and MUST start and end with an alphanumeric character.
         properties:
           apiVersion:
             description: |-
@@ -2233,7 +2226,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional
@@ -2454,6 +2447,12 @@ spec:
                   For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
                   request to "foo.example.com" SHOULD only be routed using routes attached
                   to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+
+                  If traffic to a Gateway does not match any Listener's hostname (or if
+                  the Listener does not specify a hostname and the request does not match
+                  any attached Route), the request MUST be rejected. The specific mechanism
+                  for rejection depends on the protocol: HTTP returns a 404 status code,
+                  while gRPC returns an Unimplemented status code.
 
                   This concept is known as "Listener Isolation", and it is an Extended feature
                   of Gateway API. Implementations that do not support Listener Isolation MUST
@@ -3095,7 +3094,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                maxItems: 8
+                                maxItems: 16
                                 minItems: 1
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -3260,7 +3259,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                      maxItems: 8
+                                      maxItems: 16
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
@@ -3884,7 +3883,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional
@@ -4105,6 +4104,12 @@ spec:
                   For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
                   request to "foo.example.com" SHOULD only be routed using routes attached
                   to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+
+                  If traffic to a Gateway does not match any Listener's hostname (or if
+                  the Listener does not specify a hostname and the request does not match
+                  any attached Route), the request MUST be rejected. The specific mechanism
+                  for rejection depends on the protocol: HTTP returns a 404 status code,
+                  while gRPC returns an Unimplemented status code.
 
                   This concept is known as "Listener Isolation", and it is an Extended feature
                   of Gateway API. Implementations that do not support Listener Isolation MUST
@@ -4746,7 +4751,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                maxItems: 8
+                                maxItems: 16
                                 minItems: 1
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -4911,7 +4916,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                      maxItems: 8
+                                      maxItems: 16
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
@@ -5283,12 +5288,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -5298,7 +5297,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: grpcroutes.gateway.networking.k8s.io
 spec:
@@ -5975,6 +5974,10 @@ spec:
                                         Support: Extended for Kubernetes Service
 
                                         Support: Implementation-specific for any other resource
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
                                       properties:
                                         group:
                                           default: ""
@@ -6642,6 +6645,10 @@ spec:
                                   Support: Extended for Kubernetes Service
 
                                   Support: Implementation-specific for any other resource
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
                                 properties:
                                   group:
                                     default: ""
@@ -7198,15 +7205,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token
@@ -7566,12 +7564,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -7581,7 +7573,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: httproutes.gateway.networking.k8s.io
 spec:
@@ -8066,9 +8058,9 @@ spec:
                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
                                         response header are separated by a comma (",").
 
-                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        When the `allowHeaders` field is configured with one or more headers, the
                                         gateway must return the `Access-Control-Allow-Headers` response header
-                                        which value is present in the `AllowHeaders` field.
+                                        which value is present in the `allowHeaders` field.
 
                                         If any header name in the `Access-Control-Request-Headers` request header
                                         is not included in the list of header names specified by the response
@@ -8080,21 +8072,20 @@ spec:
                                         client side.
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
-                                        If config contains the wildcard "*" in allowHeaders and the request is
-                                        not credentialed, the `Access-Control-Allow-Headers` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Headers from the request.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Headers` response header. When
-                                        also the `AllowCredentials` field is true and `AllowHeaders` field
-                                        is specified with the `*` wildcard, the gateway must specify one or more
-                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                        header. The value of the header `Access-Control-Allow-Headers` is same as
-                                        the `Access-Control-Request-Headers` header provided by the client. If
-                                        the header `Access-Control-Request-Headers` is not included in the
-                                        request, the gateway will omit the `Access-Control-Allow-Headers`
-                                        response header, instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Headers` request header.
+
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                        return one or more header names matching the value of the
+                                        `Access-Control-Request-Headers` request header.
+                                        If the `Access-Control-Request-Headers` header is not present in the
+                                        request, the gateway must omit the `Access-Control-Allow-Headers`
+                                        response header.
 
                                         Support: Extended
                                       items:
@@ -8139,32 +8130,29 @@ spec:
                                         A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                         CORS-safelisted methods are always allowed, regardless of whether they
-                                        are specified in the `AllowMethods` field.
+                                        are specified in the `allowMethods` field.
 
-                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        When the `allowMethods` field is configured with one or more methods, the
                                         gateway must return the `Access-Control-Allow-Methods` response header
-                                        which value is present in the `AllowMethods` field.
+                                        which value is present in the `allowMethods` field.
 
                                         If the HTTP method of the `Access-Control-Request-Method` request header
                                         is not included in the list of methods specified by the response header
                                         `Access-Control-Allow-Methods`, it will present an error on the client
                                         side.
 
-                                        If config contains the wildcard "*" in allowMethods and the request is
-                                        not credentialed, the `Access-Control-Allow-Methods` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Method from the request.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Method` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Methods` response header. When
-                                        also the `AllowCredentials` field is true and `AllowMethods` field
-                                        specified with the `*` wildcard, the gateway must specify one HTTP method
-                                        in the value of the Access-Control-Allow-Methods response header. The
-                                        value of the header `Access-Control-Allow-Methods` is same as the
-                                        `Access-Control-Request-Method` header provided by the client. If the
-                                        header `Access-Control-Request-Method` is not included in the request,
-                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                        instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                        return a single HTTP method matching the value of the
+                                        `Access-Control-Request-Method` request header.
+                                        If the `Access-Control-Request-Method` header is not present in the request,
+                                        the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                         Support: Extended
                                       items:
@@ -8214,7 +8202,7 @@ spec:
                                         An origin value that includes _only_ the `*` character indicates requests
                                         from all `Origin`s are allowed.
 
-                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        When the `allowOrigins` field is configured with multiple origins, it
                                         means the server supports clients from multiple origins. If the request
                                         `Origin` matches the configured allowed origins, the gateway must return
                                         the given `Origin` and sets value of the header
@@ -8236,19 +8224,15 @@ spec:
                                         `Access-Control-Allow-Origin` to the same value as the `Origin`
                                         header provided by the client.
 
-                                        When config has the wildcard ("*") in allowOrigins, and the request
-                                        is not credentialed (e.g., it is a preflight request), the
-                                        `Access-Control-Allow-Origin` response header either contains the
-                                        wildcard as well or the Origin from the request.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Origin` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Origin` response header. When
-                                        also the `AllowCredentials` field is true and `AllowOrigins` field
-                                        specified with the `*` wildcard, the gateway must return a single origin
-                                        in the value of the `Access-Control-Allow-Origin` response header,
-                                        instead of specifying the `*` wildcard. The value of the header
-                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                        the client.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                        return a single origin matching the value of the `Origin` request header.
 
                                         Support: Extended
                                       items:
@@ -8287,7 +8271,7 @@ spec:
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                         The CORS-safelisted response headers are exposed to client by default.
 
-                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        When an HTTP header name is specified using the `exposeHeaders` field,
                                         this additional header will be exposed as part of the response to the
                                         client.
 
@@ -8297,12 +8281,15 @@ spec:
                                         response header are separated by a comma (",").
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
-                                        to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the request is not credentialed.
+                                        to clients.
 
-                                        When the `exposeHeaders` config field contains the "*" wildcard and
-                                        the request is credentialed, the gateway cannot use the `*` wildcard in
-                                        the `Access-Control-Expose-Headers` response header.
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                        response header can contain the wildcard `*`.
+
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                        in the `Access-Control-Expose-Headers` response header.
 
                                         Support: Extended
                                       items:
@@ -8810,6 +8797,10 @@ spec:
                                         Support: Extended for Kubernetes Service
 
                                         Support: Implementation-specific for any other resource
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
                                       properties:
                                         group:
                                           default: ""
@@ -9596,9 +9587,9 @@ spec:
                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
                                   response header are separated by a comma (",").
 
-                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  When the `allowHeaders` field is configured with one or more headers, the
                                   gateway must return the `Access-Control-Allow-Headers` response header
-                                  which value is present in the `AllowHeaders` field.
+                                  which value is present in the `allowHeaders` field.
 
                                   If any header name in the `Access-Control-Request-Headers` request header
                                   is not included in the list of header names specified by the response
@@ -9610,21 +9601,20 @@ spec:
                                   client side.
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
-                                  If config contains the wildcard "*" in allowHeaders and the request is
-                                  not credentialed, the `Access-Control-Allow-Headers` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Headers from the request.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Headers` response header. When
-                                  also the `AllowCredentials` field is true and `AllowHeaders` field
-                                  is specified with the `*` wildcard, the gateway must specify one or more
-                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                  header. The value of the header `Access-Control-Allow-Headers` is same as
-                                  the `Access-Control-Request-Headers` header provided by the client. If
-                                  the header `Access-Control-Request-Headers` is not included in the
-                                  request, the gateway will omit the `Access-Control-Allow-Headers`
-                                  response header, instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Headers` request header.
+
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                  return one or more header names matching the value of the
+                                  `Access-Control-Request-Headers` request header.
+                                  If the `Access-Control-Request-Headers` header is not present in the
+                                  request, the gateway must omit the `Access-Control-Allow-Headers`
+                                  response header.
 
                                   Support: Extended
                                 items:
@@ -9669,32 +9659,29 @@ spec:
                                   A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                   CORS-safelisted methods are always allowed, regardless of whether they
-                                  are specified in the `AllowMethods` field.
+                                  are specified in the `allowMethods` field.
 
-                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  When the `allowMethods` field is configured with one or more methods, the
                                   gateway must return the `Access-Control-Allow-Methods` response header
-                                  which value is present in the `AllowMethods` field.
+                                  which value is present in the `allowMethods` field.
 
                                   If the HTTP method of the `Access-Control-Request-Method` request header
                                   is not included in the list of methods specified by the response header
                                   `Access-Control-Allow-Methods`, it will present an error on the client
                                   side.
 
-                                  If config contains the wildcard "*" in allowMethods and the request is
-                                  not credentialed, the `Access-Control-Allow-Methods` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Method from the request.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Method` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Methods` response header. When
-                                  also the `AllowCredentials` field is true and `AllowMethods` field
-                                  specified with the `*` wildcard, the gateway must specify one HTTP method
-                                  in the value of the Access-Control-Allow-Methods response header. The
-                                  value of the header `Access-Control-Allow-Methods` is same as the
-                                  `Access-Control-Request-Method` header provided by the client. If the
-                                  header `Access-Control-Request-Method` is not included in the request,
-                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                  instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                  return a single HTTP method matching the value of the
+                                  `Access-Control-Request-Method` request header.
+                                  If the `Access-Control-Request-Method` header is not present in the request,
+                                  the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                   Support: Extended
                                 items:
@@ -9744,7 +9731,7 @@ spec:
                                   An origin value that includes _only_ the `*` character indicates requests
                                   from all `Origin`s are allowed.
 
-                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  When the `allowOrigins` field is configured with multiple origins, it
                                   means the server supports clients from multiple origins. If the request
                                   `Origin` matches the configured allowed origins, the gateway must return
                                   the given `Origin` and sets value of the header
@@ -9766,19 +9753,15 @@ spec:
                                   `Access-Control-Allow-Origin` to the same value as the `Origin`
                                   header provided by the client.
 
-                                  When config has the wildcard ("*") in allowOrigins, and the request
-                                  is not credentialed (e.g., it is a preflight request), the
-                                  `Access-Control-Allow-Origin` response header either contains the
-                                  wildcard as well or the Origin from the request.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Origin` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Origin` response header. When
-                                  also the `AllowCredentials` field is true and `AllowOrigins` field
-                                  specified with the `*` wildcard, the gateway must return a single origin
-                                  in the value of the `Access-Control-Allow-Origin` response header,
-                                  instead of specifying the `*` wildcard. The value of the header
-                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                  the client.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                  return a single origin matching the value of the `Origin` request header.
 
                                   Support: Extended
                                 items:
@@ -9817,7 +9800,7 @@ spec:
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                   The CORS-safelisted response headers are exposed to client by default.
 
-                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  When an HTTP header name is specified using the `exposeHeaders` field,
                                   this additional header will be exposed as part of the response to the
                                   client.
 
@@ -9827,12 +9810,15 @@ spec:
                                   response header are separated by a comma (",").
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
-                                  to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the request is not credentialed.
+                                  to clients.
 
-                                  When the `exposeHeaders` config field contains the "*" wildcard and
-                                  the request is credentialed, the gateway cannot use the `*` wildcard in
-                                  the `Access-Control-Expose-Headers` response header.
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                  response header can contain the wildcard `*`.
+
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                  in the `Access-Control-Expose-Headers` response header.
 
                                   Support: Extended
                                 items:
@@ -10336,6 +10322,10 @@ spec:
                                   Support: Extended for Kubernetes Service
 
                                   Support: Implementation-specific for any other resource
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
                                 properties:
                                   group:
                                     default: ""
@@ -11275,6 +11265,7 @@ spec:
                             a backend request is implementation-specific.
 
                             Support: Extended
+                          minimum: 1
                           type: integer
                         backoff:
                           description: |-
@@ -11343,7 +11334,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-
@@ -11395,15 +11386,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token
@@ -12331,9 +12313,9 @@ spec:
                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
                                         response header are separated by a comma (",").
 
-                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        When the `allowHeaders` field is configured with one or more headers, the
                                         gateway must return the `Access-Control-Allow-Headers` response header
-                                        which value is present in the `AllowHeaders` field.
+                                        which value is present in the `allowHeaders` field.
 
                                         If any header name in the `Access-Control-Request-Headers` request header
                                         is not included in the list of header names specified by the response
@@ -12345,21 +12327,20 @@ spec:
                                         client side.
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
-                                        If config contains the wildcard "*" in allowHeaders and the request is
-                                        not credentialed, the `Access-Control-Allow-Headers` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Headers from the request.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Headers` response header. When
-                                        also the `AllowCredentials` field is true and `AllowHeaders` field
-                                        is specified with the `*` wildcard, the gateway must specify one or more
-                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                        header. The value of the header `Access-Control-Allow-Headers` is same as
-                                        the `Access-Control-Request-Headers` header provided by the client. If
-                                        the header `Access-Control-Request-Headers` is not included in the
-                                        request, the gateway will omit the `Access-Control-Allow-Headers`
-                                        response header, instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Headers` request header.
+
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                        return one or more header names matching the value of the
+                                        `Access-Control-Request-Headers` request header.
+                                        If the `Access-Control-Request-Headers` header is not present in the
+                                        request, the gateway must omit the `Access-Control-Allow-Headers`
+                                        response header.
 
                                         Support: Extended
                                       items:
@@ -12404,32 +12385,29 @@ spec:
                                         A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                         CORS-safelisted methods are always allowed, regardless of whether they
-                                        are specified in the `AllowMethods` field.
+                                        are specified in the `allowMethods` field.
 
-                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        When the `allowMethods` field is configured with one or more methods, the
                                         gateway must return the `Access-Control-Allow-Methods` response header
-                                        which value is present in the `AllowMethods` field.
+                                        which value is present in the `allowMethods` field.
 
                                         If the HTTP method of the `Access-Control-Request-Method` request header
                                         is not included in the list of methods specified by the response header
                                         `Access-Control-Allow-Methods`, it will present an error on the client
                                         side.
 
-                                        If config contains the wildcard "*" in allowMethods and the request is
-                                        not credentialed, the `Access-Control-Allow-Methods` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Method from the request.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Method` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Methods` response header. When
-                                        also the `AllowCredentials` field is true and `AllowMethods` field
-                                        specified with the `*` wildcard, the gateway must specify one HTTP method
-                                        in the value of the Access-Control-Allow-Methods response header. The
-                                        value of the header `Access-Control-Allow-Methods` is same as the
-                                        `Access-Control-Request-Method` header provided by the client. If the
-                                        header `Access-Control-Request-Method` is not included in the request,
-                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                        instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                        return a single HTTP method matching the value of the
+                                        `Access-Control-Request-Method` request header.
+                                        If the `Access-Control-Request-Method` header is not present in the request,
+                                        the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                         Support: Extended
                                       items:
@@ -12479,7 +12457,7 @@ spec:
                                         An origin value that includes _only_ the `*` character indicates requests
                                         from all `Origin`s are allowed.
 
-                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        When the `allowOrigins` field is configured with multiple origins, it
                                         means the server supports clients from multiple origins. If the request
                                         `Origin` matches the configured allowed origins, the gateway must return
                                         the given `Origin` and sets value of the header
@@ -12501,19 +12479,15 @@ spec:
                                         `Access-Control-Allow-Origin` to the same value as the `Origin`
                                         header provided by the client.
 
-                                        When config has the wildcard ("*") in allowOrigins, and the request
-                                        is not credentialed (e.g., it is a preflight request), the
-                                        `Access-Control-Allow-Origin` response header either contains the
-                                        wildcard as well or the Origin from the request.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Origin` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Origin` response header. When
-                                        also the `AllowCredentials` field is true and `AllowOrigins` field
-                                        specified with the `*` wildcard, the gateway must return a single origin
-                                        in the value of the `Access-Control-Allow-Origin` response header,
-                                        instead of specifying the `*` wildcard. The value of the header
-                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                        the client.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                        return a single origin matching the value of the `Origin` request header.
 
                                         Support: Extended
                                       items:
@@ -12552,7 +12526,7 @@ spec:
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                         The CORS-safelisted response headers are exposed to client by default.
 
-                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        When an HTTP header name is specified using the `exposeHeaders` field,
                                         this additional header will be exposed as part of the response to the
                                         client.
 
@@ -12562,12 +12536,15 @@ spec:
                                         response header are separated by a comma (",").
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
-                                        to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the request is not credentialed.
+                                        to clients.
 
-                                        When the `exposeHeaders` config field contains the "*" wildcard and
-                                        the request is credentialed, the gateway cannot use the `*` wildcard in
-                                        the `Access-Control-Expose-Headers` response header.
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                        response header can contain the wildcard `*`.
+
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                        in the `Access-Control-Expose-Headers` response header.
 
                                         Support: Extended
                                       items:
@@ -13075,6 +13052,10 @@ spec:
                                         Support: Extended for Kubernetes Service
 
                                         Support: Implementation-specific for any other resource
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
                                       properties:
                                         group:
                                           default: ""
@@ -13861,9 +13842,9 @@ spec:
                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
                                   response header are separated by a comma (",").
 
-                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  When the `allowHeaders` field is configured with one or more headers, the
                                   gateway must return the `Access-Control-Allow-Headers` response header
-                                  which value is present in the `AllowHeaders` field.
+                                  which value is present in the `allowHeaders` field.
 
                                   If any header name in the `Access-Control-Request-Headers` request header
                                   is not included in the list of header names specified by the response
@@ -13875,21 +13856,20 @@ spec:
                                   client side.
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
-                                  If config contains the wildcard "*" in allowHeaders and the request is
-                                  not credentialed, the `Access-Control-Allow-Headers` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Headers from the request.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Headers` response header. When
-                                  also the `AllowCredentials` field is true and `AllowHeaders` field
-                                  is specified with the `*` wildcard, the gateway must specify one or more
-                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                  header. The value of the header `Access-Control-Allow-Headers` is same as
-                                  the `Access-Control-Request-Headers` header provided by the client. If
-                                  the header `Access-Control-Request-Headers` is not included in the
-                                  request, the gateway will omit the `Access-Control-Allow-Headers`
-                                  response header, instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Headers` request header.
+
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                  return one or more header names matching the value of the
+                                  `Access-Control-Request-Headers` request header.
+                                  If the `Access-Control-Request-Headers` header is not present in the
+                                  request, the gateway must omit the `Access-Control-Allow-Headers`
+                                  response header.
 
                                   Support: Extended
                                 items:
@@ -13934,32 +13914,29 @@ spec:
                                   A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                   CORS-safelisted methods are always allowed, regardless of whether they
-                                  are specified in the `AllowMethods` field.
+                                  are specified in the `allowMethods` field.
 
-                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  When the `allowMethods` field is configured with one or more methods, the
                                   gateway must return the `Access-Control-Allow-Methods` response header
-                                  which value is present in the `AllowMethods` field.
+                                  which value is present in the `allowMethods` field.
 
                                   If the HTTP method of the `Access-Control-Request-Method` request header
                                   is not included in the list of methods specified by the response header
                                   `Access-Control-Allow-Methods`, it will present an error on the client
                                   side.
 
-                                  If config contains the wildcard "*" in allowMethods and the request is
-                                  not credentialed, the `Access-Control-Allow-Methods` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Method from the request.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Method` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Methods` response header. When
-                                  also the `AllowCredentials` field is true and `AllowMethods` field
-                                  specified with the `*` wildcard, the gateway must specify one HTTP method
-                                  in the value of the Access-Control-Allow-Methods response header. The
-                                  value of the header `Access-Control-Allow-Methods` is same as the
-                                  `Access-Control-Request-Method` header provided by the client. If the
-                                  header `Access-Control-Request-Method` is not included in the request,
-                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                  instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                  return a single HTTP method matching the value of the
+                                  `Access-Control-Request-Method` request header.
+                                  If the `Access-Control-Request-Method` header is not present in the request,
+                                  the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                   Support: Extended
                                 items:
@@ -14009,7 +13986,7 @@ spec:
                                   An origin value that includes _only_ the `*` character indicates requests
                                   from all `Origin`s are allowed.
 
-                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  When the `allowOrigins` field is configured with multiple origins, it
                                   means the server supports clients from multiple origins. If the request
                                   `Origin` matches the configured allowed origins, the gateway must return
                                   the given `Origin` and sets value of the header
@@ -14031,19 +14008,15 @@ spec:
                                   `Access-Control-Allow-Origin` to the same value as the `Origin`
                                   header provided by the client.
 
-                                  When config has the wildcard ("*") in allowOrigins, and the request
-                                  is not credentialed (e.g., it is a preflight request), the
-                                  `Access-Control-Allow-Origin` response header either contains the
-                                  wildcard as well or the Origin from the request.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Origin` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Origin` response header. When
-                                  also the `AllowCredentials` field is true and `AllowOrigins` field
-                                  specified with the `*` wildcard, the gateway must return a single origin
-                                  in the value of the `Access-Control-Allow-Origin` response header,
-                                  instead of specifying the `*` wildcard. The value of the header
-                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                  the client.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                  return a single origin matching the value of the `Origin` request header.
 
                                   Support: Extended
                                 items:
@@ -14082,7 +14055,7 @@ spec:
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                   The CORS-safelisted response headers are exposed to client by default.
 
-                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  When an HTTP header name is specified using the `exposeHeaders` field,
                                   this additional header will be exposed as part of the response to the
                                   client.
 
@@ -14092,12 +14065,15 @@ spec:
                                   response header are separated by a comma (",").
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
-                                  to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the request is not credentialed.
+                                  to clients.
 
-                                  When the `exposeHeaders` config field contains the "*" wildcard and
-                                  the request is credentialed, the gateway cannot use the `*` wildcard in
-                                  the `Access-Control-Expose-Headers` response header.
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                  response header can contain the wildcard `*`.
+
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                  in the `Access-Control-Expose-Headers` response header.
 
                                   Support: Extended
                                 items:
@@ -14601,6 +14577,10 @@ spec:
                                   Support: Extended for Kubernetes Service
 
                                   Support: Implementation-specific for any other resource
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
                                 properties:
                                   group:
                                     default: ""
@@ -15540,6 +15520,7 @@ spec:
                             a backend request is implementation-specific.
 
                             Support: Extended
+                          minimum: 1
                           type: integer
                         backoff:
                           description: |-
@@ -15608,7 +15589,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-
@@ -15660,15 +15641,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token
@@ -16125,12 +16097,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
@@ -16140,7 +16106,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: listenersets.gateway.networking.k8s.io
 spec:
@@ -16909,12 +16875,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -16924,7 +16884,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: referencegrants.gateway.networking.k8s.io
 spec:
@@ -17099,6 +17059,8 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: false
@@ -17262,16 +17224,12 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -17281,7 +17239,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: tcproutes.gateway.networking.k8s.io
 spec:
@@ -17299,6 +17257,728 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TCPRoute provides a way to route TCP requests. When combined with a Gateway
+          listener, it can be used to forward connections on the port specified by the
+          listener to a set of backends specified by the TCPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TCP matchers and actions.
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Connection rejections must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        connections, then 80% of connections must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of TCPRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -17578,12 +18258,6 @@ spec:
                         connections, then 80% of connections must be rejected instead.
 
                         Support: Core for Kubernetes Service
-
-                        Support: Extended for Kubernetes ServiceImport
-
-                        Support: Implementation-specific for any other resource
-
-                        Support for weight: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -17706,10 +18380,8 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     name:
-                      description: |-
-                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
-
-                        Support: Extended
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -18023,15 +18695,9 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -18041,7 +18707,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: tlsroutes.gateway.networking.k8s.io
 spec:
@@ -18119,7 +18785,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
@@ -18386,6 +19052,9 @@ spec:
                         weight; if an invalid backend is requested to have 80% of requests, then
                         80% of requests must be rejected instead.
 
+                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
+                        can be used to enable re-encryption of the traffic to the backends.
+
                         Support: Core for Kubernetes Service
 
                         Support: Extended for Kubernetes ServiceImport
@@ -18393,6 +19062,8 @@ spec:
                         Support: Implementation-specific for any other resource
 
                         Support for weight: Extended
+
+                        Support for BackendTLSPolicy: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -18920,7 +19591,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 type: array
                 x-kubernetes-list-type: atomic
               parentRefs:
@@ -19175,6 +19846,9 @@ spec:
                         weight; if an invalid backend is requested to have 80% of requests, then
                         80% of requests must be rejected instead.
 
+                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
+                        can be used to enable re-encryption of the traffic to the backends.
+
                         Support: Core for Kubernetes Service
 
                         Support: Extended for Kubernetes ServiceImport
@@ -19182,6 +19856,8 @@ spec:
                         Support: Implementation-specific for any other resource
 
                         Support for weight: Extended
+
+                        Support for BackendTLSPolicy: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -19689,7 +20365,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
@@ -19956,6 +20632,9 @@ spec:
                         weight; if an invalid backend is requested to have 80% of requests, then
                         80% of requests must be rejected instead.
 
+                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
+                        can be used to enable re-encryption of the traffic to the backends.
+
                         Support: Core for Kubernetes Service
 
                         Support: Extended for Kubernetes ServiceImport
@@ -19963,6 +20642,8 @@ spec:
                         Support: Implementation-specific for any other resource
 
                         Support for weight: Extended
+
+                        Support for BackendTLSPolicy: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -20400,12 +21081,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -20415,7 +21090,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: udproutes.gateway.networking.k8s.io
 spec:
@@ -20433,6 +21108,728 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          UDPRoute provides a way to route UDP traffic. When combined with a Gateway
+          listener, it can be used to forward traffic on the port specified by the
+          listener to a set of backends specified by the UDPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of UDP matchers and actions.
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Packet drops must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        the packets, then 80% of packets must be dropped instead.
+
+                        Support: Extended for Kubernetes Service
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of UDPRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -20711,13 +22108,7 @@ spec:
                         respect weight; if an invalid backend is requested to have 80% of
                         the packets, then 80% of packets must be dropped instead.
 
-                        Support: Core for Kubernetes Service
-
-                        Support: Extended for Kubernetes ServiceImport
-
-                        Support: Implementation-specific for any other resource
-
-                        Support for weight: Extended
+                        Support: Extended for Kubernetes Service
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -20840,10 +22231,8 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     name:
-                      description: |-
-                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
-
-                        Support: Extended
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -21157,15 +22546,9 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_vap_safeupgrades.yaml
@@ -21174,7 +22557,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
   name: "safe-upgrades.gateway.networking.k8s.io"
 spec:
@@ -21193,11 +22576,13 @@ spec:
         oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
       message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."
       reason: Invalid
-    - expression: "object.spec.group != 'gateway.networking.k8s.io' ||
+    - expression: |
+        object.spec.group != 'gateway.networking.k8s.io' ||
         (has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version') &&
-        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v1.[0-4].\\\\d+') &&
-        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v0'))" #TODO Kubernetes 1.37: Migrate to kubernetes semver library
-      message: "Installing CRDs with version before v1.5.0 is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install older versions."
+        (object.metadata.annotations['gateway.networking.k8s.io/bundle-version'] == 'v0.0.0-dev' ||
+        (object.metadata.annotations['gateway.networking.k8s.io/bundle-version'].startsWith('v1.') &&
+         !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], '^v1\\.[0-4](\\.|$)'))))
+      message: "Installing CRDs with version other than v0.0.0-dev or v1.5+ is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install other versions."
       reason: Invalid
 
 ---
@@ -21206,7 +22591,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
   name: safe-upgrades.gateway.networking.k8s.io
 spec:
@@ -21220,6 +22605,678 @@ spec:
       operations:  ["CREATE", "UPDATE"]
 ---
 #
+# config/crd/experimental/gateway.networking.x-k8s.io_xbackends.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.6.1
+    gateway.networking.k8s.io/channel: experimental
+  name: xbackends.gateway.networking.x-k8s.io
+spec:
+  group: gateway.networking.x-k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: XBackend
+    listKind: XBackendList
+    plural: xbackends
+    shortNames:
+    - xbackend
+    singular: xbackend
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          XBackend is a Gateway API resource that represents a backend destination for
+          routing traffic. It serves as a Gateway-native way to define where and how a
+          Gateway should connect to a backend.
+
+          Support: Extended
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of XBackend.
+            properties:
+              externalHostname:
+                description: |-
+                  ExternalHostname specifies the configuration for an ExternalHostname
+                  backend. This field must be set when type is ExternalHostname and must
+                  be unset otherwise.
+
+                  Support: Extended
+                properties:
+                  hostname:
+                    description: |-
+                      Hostname specifies the FQDN used to reach this backend.
+                      IP addresses are not allowed in this field.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: hostname must not be an IP address or end with .cluster.local
+                      rule: '!self.endsWith(''.cluster.local'')'
+                required:
+                - hostname
+                type: object
+              port:
+                description: |-
+                  Port defines the port that the implementation should use when connecting
+                  to this backend.
+                properties:
+                  name:
+                    description: |-
+                      Name represents the name of this port. All ports in a Backend must have
+                      a unique name. Name must either be an empty string or pass DNS_LABEL
+                      validation (lowercase alphanumeric or '-', starting and ending with an
+                      alphanumeric character, at most 63 characters).
+                    maxLength: 63
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Name must be a valid DNS label
+                      rule: size(self) == 0 || format.dns1123Label().validate(self)
+                        == null
+                  port:
+                    description: Port represents the port number of the endpoint.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                required:
+                - port
+                type: object
+              protocol:
+                description: |-
+                  Protocol defines the protocol for backend communication.
+
+                  In the common case, the underlying transport protocol for the
+                  proxied traffic will already have been determined and processed
+                  by the dataplane at the routing step. Where this field is useful
+                  is either for higher level protocols or asymmetrical protocol
+                  configurations (e.g. version upgrades or h2c).
+
+                  When set, the implementation uses the specified protocol when connecting
+                  to this backend. When not set, the implementation will use the protocol
+                  determined by the route or listener configuration.
+
+                  Support: Core - HTTP, HTTP2, H2C, and HTTP11
+
+                  Support: Extended - GRPC, MCP, TCP
+                enum:
+                - TCP
+                - HTTP
+                - HTTP2
+                - HTTP11
+                - H2C
+                - MCP
+                type: string
+              tls:
+                description: |-
+                  TLS defines the TLS configuration that the implementation should use
+                  when connecting to the backend.
+
+                  ExternalHostname backends SHOULD have TLS configured; the lack of TLS
+                  for external hostnames should be considered insecure and a security risk.
+
+                  Support: Extended
+                properties:
+                  clientCertificateRef:
+                    description: |-
+                      ClientCertificateRef is a reference to a Secret containing the client
+                      TLS certificate and private key for mutual TLS. This field is required
+                      when mode is ClientAndServer and must be unset otherwise.
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  mode:
+                    description: Mode defines the TLS mode for the backend connection.
+                    enum:
+                    - None
+                    - ServerOnly
+                    - ClientAndServer
+                    type: string
+                  validation:
+                    description: Validation contains TLS validation configuration
+                      for the backend connection.
+                    properties:
+                      caCertificateRefs:
+                        description: |-
+                          CACertificateRefs contains one or more references to Kubernetes objects that
+                          contain a PEM-encoded TLS CA certificate bundle, which is used to
+                          validate a TLS handshake between the Gateway and backend Pod.
+
+                          If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                          specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                          not both. If CACertificateRefs is empty or unspecified, the configuration for
+                          WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+                          A CACertificateRef is invalid if:
+
+                          * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                            does not exist) or is misconfigured (e.g., a ConfigMap does not contain a key
+                            named `ca.crt`). In this case, the Reason must be set to `InvalidCACertificateRef`
+                            and the Message of the Condition must indicate which reference is invalid and why.
+
+                          * It refers to an unknown or unsupported kind of resource. In this case, the Reason
+                            must be set to `InvalidKind` and the Message of the Condition must explain which
+                            kind of resource is unknown or unsupported.
+
+                          * It refers to a resource in another namespace. This may change in future
+                            spec updates.
+
+                          Implementations MAY choose to perform further validation of the certificate
+                          content (e.g., checking expiry or enforcing specific formats). In such cases,
+                          an implementation-specific Reason and Message must be set for the invalid reference.
+
+                          In all cases, the implementation MUST ensure the `ResolvedRefs` Condition on
+                          the BackendTLSPolicy is set to `status: False`, with a Reason and Message
+                          that indicate the cause of the error. Connections using an invalid
+                          CACertificateRef MUST fail, and the client MUST receive an HTTP 5xx error
+                          response. If ALL CACertificateRefs are invalid, the implementation MUST also
+                          ensure the `Accepted` Condition on the BackendTLSPolicy is set to
+                          `status: False`, with a Reason `NoValidCACertificate`.
+
+                          A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                          Implementations MAY choose to support attaching multiple certificates to
+                          a backend, but this behavior is implementation-specific.
+
+                          Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                          with the CA certificate in a key named `ca.crt`.
+
+                          Support: Implementation-specific - More than one reference, other kinds
+                          of resources, or a single reference that includes multiple certificates.
+                        items:
+                          description: |-
+                            LocalObjectReference identifies an API object within the namespace of the
+                            referrer.
+                            The API object must be valid in the cluster; the Group and Kind must
+                            be registered in the cluster for this reference to be valid.
+
+                            References to objects with invalid Group and Kind are not valid, and must
+                            be rejected by the implementation, with appropriate Conditions set
+                            on the containing object.
+                          properties:
+                            group:
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              description: Kind is kind of the referent. For example
+                                "HTTPRoute" or "Service".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          - name
+                          type: object
+                        maxItems: 8
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      hostname:
+                        description: |-
+                          Hostname is used for two purposes in the connection between Gateways and
+                          backends:
+
+                          1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                          2. Hostname MUST be used for authentication and MUST match the certificate
+                             served by the matching backend, unless SubjectAltNames is specified.
+                          3. If SubjectAltNames are specified, Hostname can be used for certificate selection
+                             but MUST NOT be used for authentication. If you want to use the value
+                             of the Hostname field for authentication, you MUST add it to the SubjectAltNames list.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      subjectAltNames:
+                        description: |-
+                          SubjectAltNames contains one or more Subject Alternative Names.
+                          When specified the certificate served from the backend MUST
+                          have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
+
+                          Support: Extended
+                        items:
+                          description: SubjectAltName represents Subject Alternative
+                            Name.
+                          properties:
+                            hostname:
+                              description: |-
+                                Hostname contains Subject Alternative Name specified in DNS name format.
+                                Required when Type is set to Hostname, ignored otherwise.
+
+                                Support: Core
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            type:
+                              description: |-
+                                Type determines the format of the Subject Alternative Name. Always required.
+
+                                Support: Core
+                              enum:
+                              - Hostname
+                              - URI
+                              type: string
+                            uri:
+                              description: |-
+                                URI contains Subject Alternative Name specified in a full URI format.
+                                It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                                Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                                Required when Type is set to URI, ignored otherwise.
+
+                                Support: Core
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: SubjectAltName element must contain Hostname,
+                              if Type is set to Hostname
+                            rule: '!(self.type == "Hostname" && (!has(self.hostname)
+                              || self.hostname == ""))'
+                          - message: SubjectAltName element must not contain Hostname,
+                              if Type is not set to Hostname
+                            rule: '!(self.type != "Hostname" && has(self.hostname)
+                              && self.hostname != "")'
+                          - message: SubjectAltName element must contain URI, if Type
+                              is set to URI
+                            rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                              == ""))'
+                          - message: SubjectAltName element must not contain URI,
+                              if Type is not set to URI
+                            rule: '!(self.type != "URI" && has(self.uri) && self.uri
+                              != "")'
+                        maxItems: 5
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      wellKnownCACertificates:
+                        description: |-
+                          WellKnownCACertificates specifies whether a well-known set of CA certificates
+                          may be used in the TLS handshake between the gateway and backend pod.
+
+                          If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                          must be specified with at least one entry for a valid configuration. Only one of
+                          CACertificateRefs or WellKnownCACertificates may be specified, not both.
+                          If an implementation does not support the WellKnownCACertificates field, or
+                          the supplied value is not recognized, the implementation MUST ensure the
+                          `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with
+                          a Reason `Invalid`.
+
+                          Valid values include:
+                          * "System" - indicates that well-known system CA certificates should be used.
+
+                          Implementations MAY define their own sets of CA certificates. Such definitions
+                          MUST use an implementation-specific, prefixed name, such as
+                          `mycompany.com/my-custom-ca-certificates`.
+
+                          Support: Implementation-specific
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$
+                        type: string
+                    required:
+                    - hostname
+                    type: object
+                    x-kubernetes-validations:
+                    - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                      rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                        > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                        != "")'
+                    - message: must specify either CACertificateRefs or WellKnownCACertificates
+                      rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                        > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                        != "")
+                required:
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: clientCertificateRef must be set if and only if mode is
+                    ClientAndServer
+                  rule: 'self.mode == ''ClientAndServer'' ? has(self.clientCertificateRef)
+                    : !has(self.clientCertificateRef)'
+              type:
+                description: Type defines the backend type.
+                enum:
+                - ExternalHostname
+                type: string
+            required:
+            - port
+            - type
+            type: object
+            x-kubernetes-validations:
+            - message: externalHostname must be set when type is ExternalHostname
+                and must be unset otherwise
+              rule: 'self.type == ''ExternalHostname'' ? has(self.externalHostname)
+                : !has(self.externalHostname)'
+          status:
+            description: Status defines the current state of XBackend.
+            properties:
+              parents:
+                description: |-
+                  Ancestors is a list of parent resources associated with this Backend,
+                  and the status of the Backend with respect to each parent.
+
+                  A maximum of 32 parents will be represented in this list. An empty list
+                  indicates that the Backend is not associated with any parents.
+                items:
+                  description: |-
+                    BackendAncestorStatus describes the status of a Backend with respect to a
+                    specific parent resource (typically a Gateway).
+                  properties:
+                    conditions:
+                      description: |-
+                        For Kubernetes API conventions, see:
+                        https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                        conditions represent the current state of the Backend resource.
+                        Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                        Defined condition types include:
+                        - "Accepted": the resource has been acknowledged and accepteed by the controller
+
+                        The status of each condition is one of True, False, or Unknown.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that manages the Backend.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: AncestorRef identifies the parent resource that
+                        this status is associated with.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+#
 # config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
@@ -21227,7 +23284,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct
@@ -21429,15 +23486,6 @@ spec:
                         - Session
                         type: string
                     type: object
-                  idleTimeout:
-                    description: |-
-                      IdleTimeout defines the idle timeout of the persistent session.
-                      Once the session has been idle for more than the specified
-                      IdleTimeout duration, the session becomes invalid.
-
-                      Support: Extended
-                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                    type: string
                   sessionName:
                     description: |-
                       SessionName defines the name of the persistent session token
@@ -21824,12 +23872,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
@@ -21839,7 +23881,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: xmeshes.gateway.networking.x-k8s.io
 spec:
@@ -22076,9 +24118,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Bumps gateway api to v1.6.1
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind bump
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Kgateway now supports Gateway API v1.6.1
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
