### PR TITLE
fix: Set initial_fetch_timeout to resuce startup time in envoy

### DIFF
--- a/pkg/kgateway/helm/envoy/templates/configmap.yaml
+++ b/pkg/kgateway/helm/envoy/templates/configmap.yaml
@@ -204,6 +204,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/base-gateway-out.yaml
+++ b/test/deployer/testdata/base-gateway-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/base-gateway-tls-out.yaml
+++ b/test/deployer/testdata/base-gateway-tls-out.yaml
@@ -154,6 +154,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-envoy-extra-args-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
+++ b/test/deployer/testdata/both-gwc-and-gw-have-params-reversed-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-all-autoscalers-out.yaml
+++ b/test/deployer/testdata/envoy-all-autoscalers-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-both-gwc-and-gw-have-overlays-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
+++ b/test/deployer/testdata/envoy-configs-and-overlays-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-dns-resolver-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
+++ b/test/deployer/testdata/envoy-dns-resolver-zero-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-hpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-hpa-overlay-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
+++ b/test/deployer/testdata/envoy-image-digest-erases-tag-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-infrastructure-out.yaml
+++ b/test/deployer/testdata/envoy-infrastructure-out.yaml
@@ -138,6 +138,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-log-json-out.yaml
+++ b/test/deployer/testdata/envoy-log-json-out.yaml
@@ -139,6 +139,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-log-text-out.yaml
+++ b/test/deployer/testdata/envoy-log-text-out.yaml
@@ -135,6 +135,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-overlay-ordering-out.yaml
+++ b/test/deployer/testdata/envoy-overlay-ordering-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-pdb-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-pdb-overlay-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
+++ b/test/deployer/testdata/envoy-readiness-listener-proxy-protocol-out.yaml
@@ -137,6 +137,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
+++ b/test/deployer/testdata/envoy-strategic-merge-patch-out.yaml
@@ -135,6 +135,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/envoy-vpa-overlay-out.yaml
+++ b/test/deployer/testdata/envoy-vpa-overlay-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/gwc-with-replicas-null-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-null-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/gwc-with-replicas-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
+++ b/test/deployer/testdata/gwc-with-replicas-zero-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/loadbalancer-class-out.yaml
+++ b/test/deployer/testdata/loadbalancer-class-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-api-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
+++ b/test/deployer/testdata/loadbalancer-source-ranges-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/loadbalancer-static-ip-out.yaml
+++ b/test/deployer/testdata/loadbalancer-static-ip-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-exactly-63-chars-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
+++ b/test/deployer/testdata/long-gateway-name-over-63-chars-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/omit-default-security-context-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
+++ b/test/deployer/testdata/omit-default-security-context-via-gw-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/openshift-two-params-security-context-out.yaml
+++ b/test/deployer/testdata/openshift-two-params-security-context-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/priority-class-name-out.yaml
+++ b/test/deployer/testdata/priority-class-name-out.yaml
@@ -132,6 +132,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/stats-matcher-exclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-exclusion-out.yaml
@@ -140,6 +140,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/deployer/testdata/stats-matcher-inclusion-out.yaml
+++ b/test/deployer/testdata/stats-matcher-inclusion-out.yaml
@@ -144,6 +144,12 @@ data:
             eds_config:
               ads: {}
               resource_api_version: V3
+              # The control plane cannot answer this EDS request before the first CDS
+              # response (go-control-plane ADS mode only responds once the request names
+              # cover every CLA in the snapshot), so cluster-manager init always waits
+              # the full initial_fetch_timeout. Keep it short to avoid delaying startup
+              # by the 15s default; the endpoints arrive right after CDS regardless.
+              initial_fetch_timeout: 1s
         - name: xds_cluster
           alt_stat_name: xds_cluster
           connect_timeout: 5.000s

--- a/test/e2e/features/backendconfigpolicy/suite.go
+++ b/test/e2e/features/backendconfigpolicy/suite.go
@@ -202,7 +202,7 @@ func (s *testingSuite) TestBackendConfigPolicyDNS() {
 			g.Expect(dnsCluster.GetDnsJitter().AsDuration()).To(gomega.Equal(15 * time.Second))
 		}).
 			WithContext(ctx).
-			WithTimeout(10 * time.Second).
+			WithTimeout(30 * time.Second).
 			WithPolling(200 * time.Millisecond).
 			Should(gomega.Succeed())
 	})


### PR DESCRIPTION
# Description

Since #13978, every fresh gateway pod stalls ~15s before receiving its initial xDS config. The zone-aware routing local cluster in the bootstrap fetches endpoints via EDS over ADS, but Envoy requests it before subscribing to CDS, and go-control-plane's ADS mode refuses to answer EDS requests that don't cover every CLA in the snapshot. The request can therefore never be answered pre-CDS, and Envoy blocks cluster-manager init for the full `initial_fetch_timeout` (15s default) on every startup.

This made sub-15s e2e assertion windows flaky whenever a gateway pod was freshly created (e.g. [this run](https://github.com/kgateway-dev/kgateway/actions/runs/29449135138/job/87468184041), where the first CDS response landed 2s after `TestBackendConfigPolicyDNS` gave up).

# Change Type

/kind fix


# Changelog

```release-note
Fixed a ~15 second delay before freshly started gateway proxies receive their initial xDS configuration.
```