### PR TITLE
fix: pin pre-v1 TCPRoute watch GVR to v1alpha2

### DIFF
--- a/pkg/pluginsdk/collections/tcproute_version.go
+++ b/pkg/pluginsdk/collections/tcproute_version.go
@@ -3,7 +3,6 @@ package collections
 import (
 	"context"
 
-	"istio.io/istio/pkg/config/schema/gvr"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,7 +35,7 @@ func preV1TCPRouteWatchGVRs(versions servedTCPRouteVersions) []schema.GroupVersi
 	if !versions.PreV1 || (versions.Authoritative && versions.Promoted) {
 		return nil
 	}
-	return []schema.GroupVersionResource{gvr.TCPRoute}
+	return []schema.GroupVersionResource{wellknown.TCPRouteGVR}
 }
 
 // getServedTCPRouteVersions resolves which TCPRoute API versions are currently

--- a/pkg/pluginsdk/collections/tcproute_version_test.go
+++ b/pkg/pluginsdk/collections/tcproute_version_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"istio.io/istio/pkg/config/schema/gvr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,14 +99,14 @@ func TestPreV1TCPRouteWatchGVRs(t *testing.T) {
 	})
 
 	t.Run("returns the pre-v1 watch when promoted v1 is not served", func(t *testing.T) {
-		require.Equal(t, []schema.GroupVersionResource{gvr.TCPRoute}, preV1TCPRouteWatchGVRs(servedTCPRouteVersions{
+		require.Equal(t, []schema.GroupVersionResource{wellknown.TCPRouteGVR}, preV1TCPRouteWatchGVRs(servedTCPRouteVersions{
 			PreV1:         true,
 			Authoritative: true,
 		}))
 	})
 
 	t.Run("returns the pre-v1 fallback when discovery is non-authoritative", func(t *testing.T) {
-		require.Equal(t, []schema.GroupVersionResource{gvr.TCPRoute}, preV1TCPRouteWatchGVRs(servedTCPRouteVersions{
+		require.Equal(t, []schema.GroupVersionResource{wellknown.TCPRouteGVR}, preV1TCPRouteWatchGVRs(servedTCPRouteVersions{
 			Promoted: true,
 			PreV1:    true,
 		}))


### PR DESCRIPTION
# Description

`preV1TCPRouteWatchGVRs` returned istio's `gvr.TCPRoute` as the pre-v1 TCPRoute watch GVR. That constant's version tracks whatever istio pins upstream and is not guaranteed to stay `v1alpha2`. The function's job is to gate the experimental *pre-v1* (v1alpha2) TCPRoute informer, so tying it to a version-unstable istio constant means a future istio bump could silently point the pre-v1 CRD-discovery gate at the wrong version (e.g. v1) — watching the promoted version twice or missing the actual pre-v1 CRD.

This returns `wellknown.TCPRouteGVR` instead, which is explicitly pinned to `gwv1a2.GroupVersion.Version` (v1alpha2) and cannot drift. This mirrors `tlsroute_version.go`, which already builds its own version-pinned GVRs rather than relying on istio's `gvr.TLSRoute` for the same reason.

With the currently-pinned istio, `gvr.TCPRoute` is still `v1alpha2`, so this was latent rather than actively broken — the change removes the dependency on that assumption regardless of what istio does.

The test was updated to assert against `wellknown.TCPRouteGVR`.


# Change Type

/kind fix

# Changelog

```release-note
NONE
```
