### PR TITLE
[v2.2.x] fix: allow route-only TrafficPolicy fields without targetRefs (ExtensionRef usage)

### DIFF
--- a/api/v1alpha1/kgateway/traffic_policy_types.go
+++ b/api/v1alpha1/kgateway/traffic_policy_types.go
@@ -40,7 +40,7 @@ type TrafficPolicyList struct {
 }
 
 // TrafficPolicySpec defines the desired state of a traffic policy.
-// +kubebuilder:validation:XValidation:rule="!has(self.autoHostRewrite) || ((has(self.targetRefs) && self.targetRefs.all(r, r.kind == 'HTTPRoute')) || (has(self.targetSelectors) && self.targetSelectors.all(r, r.kind == 'HTTPRoute')))",message="autoHostRewrite can only be used when targeting HTTPRoute resources"
+// +kubebuilder:validation:XValidation:rule="!has(self.autoHostRewrite) || ((!has(self.targetRefs) || self.targetRefs.all(r, r.kind == 'HTTPRoute')) && (!has(self.targetSelectors) || self.targetSelectors.all(r, r.kind == 'HTTPRoute')))",message="autoHostRewrite can only be used when targeting HTTPRoute resources"
 // +kubebuilder:validation:XValidation:rule="has(self.retry) && has(self.timeouts) ? (has(self.retry.perTryTimeout) && has(self.timeouts.request) ? duration(self.retry.perTryTimeout) < duration(self.timeouts.request) : true) : true",message="retry.perTryTimeout must be less than timeouts.request"
 // +kubebuilder:validation:XValidation:rule="has(self.retry) && has(self.targetRefs) ? self.targetRefs.all(r, (r.kind == 'Gateway' ? has(r.sectionName) : true )) : true",message="targetRefs[].sectionName must be set when targeting Gateway resources with retry policy"
 // +kubebuilder:validation:XValidation:rule="has(self.retry) && has(self.targetSelectors) ? self.targetSelectors.all(r, (r.kind == 'Gateway' ? has(r.sectionName) : true )) : true",message="targetSelectors[].sectionName must be set when targeting Gateway resources with retry policy"

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_trafficpolicies.yaml
@@ -1817,8 +1817,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: autoHostRewrite can only be used when targeting HTTPRoute resources
-              rule: '!has(self.autoHostRewrite) || ((has(self.targetRefs) && self.targetRefs.all(r,
-                r.kind == ''HTTPRoute'')) || (has(self.targetSelectors) && self.targetSelectors.all(r,
+              rule: '!has(self.autoHostRewrite) || ((!has(self.targetRefs) || self.targetRefs.all(r,
+                r.kind == ''HTTPRoute'')) && (!has(self.targetSelectors) || self.targetSelectors.all(r,
                 r.kind == ''HTTPRoute'')))'
             - message: retry.perTryTimeout must be less than timeouts.request
               rule: 'has(self.retry) && has(self.timeouts) ? (has(self.retry.perTryTimeout)

--- a/test/e2e/tests/api_validation_test.go
+++ b/test/e2e/tests/api_validation_test.go
@@ -314,6 +314,19 @@ spec:
 			wantErrors: []string{"autoHostRewrite can only be used when targeting HTTPRoute resources"},
 		},
 		{
+			// A policy with no targetRefs/targetSelectors is attached via an HTTPRoute
+			// ExtensionRef filter, so route-only fields must be accepted.
+			name: "TrafficPolicy: policy with autoHostRewrite and no targets is valid (ExtensionRef usage)",
+			input: `---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: traffic-policy-ahr-extension-ref
+spec:
+  autoHostRewrite: true
+`,
+		},
+		{
 			name: "HTTPListenerPolicy: valid target references",
 			input: `---
 apiVersion: gateway.kgateway.dev/v1alpha1


### PR DESCRIPTION
# Description

Backport of the relevant parts of #14435 (commit 1103c362a78557f8d2635e4137804d648f1d66dd) to v2.2.x.

The CEL rule for `autoHostRewrite` requires `targetRefs` or `targetSelectors` to be **present**, which rejects valid TrafficPolicies attached via an HTTPRoute `ExtensionRef` filter (which have no targets set):

```
The TrafficPolicy "..." is invalid: spec: Invalid value: autoHostRewrite can only be used when targeting HTTPRoute resources
```

This rewrites the rule so any populated target list must contain only route kinds, but a policy with no targets at all (the ExtensionRef case) is accepted. Policies explicitly targeting Gateway/ListenerSet are still rejected.

Differences from main: the `urlRewrite` and `tracing` CEL rules fixed in #14435 do not exist on this branch, so only the `autoHostRewrite` rule is changed. Verified by evaluating this branch's old and new CRD schemas through the apiextensions-apiserver CEL validator.

# Change Type

/kind fix

# Changelog

```release-note
Fixed a bug where a TrafficPolicy using autoHostRewrite without targetRefs/targetSelectors (e.g. attached via an HTTPRoute ExtensionRef filter) was rejected by CRD validation.
```