### PR TITLE
2.2.x - CVE fixes - bump serde_with to 3.21.0 and mark containerd unreachable

### DIFF
--- a/internal/envoyinit/Cargo.lock
+++ b/internal/envoyinit/Cargo.lock
@@ -62,6 +62,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -109,11 +118,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -123,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -191,12 +199,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fragile"
@@ -631,11 +633,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093cd8c01b25262b84927e0f7151692158fab02d961e04c979d3903eba7ecc5"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "schemars",
@@ -647,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e6c180db0816026a61afa1cff5344fb7ebded7e4d3062772179f2501481c27"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -737,6 +740,21 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "transformations"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -44,3 +44,46 @@ reason = "False positive: istio.io/istio pseudo-version v0.0.0-20251218162427-60
 [[IgnoredVulns]]
 id = "CVE-2026-35206"
 reason = "Not exploitable: kgateway uses helm as a library to render its own bundled charts; it never invokes `helm pull --untar` or extracts attacker-controlled chart archives. Cannot bump to 3.20.2 because that forces k8s.io/client-go v0.35+, which is incompatible with the pinned istio fake client used in unit tests."
+
+# The following three advisories are flagged against github.com/containerd/containerd
+# v1.7.33, pulled in only transitively via helm's OCI registry client
+# (helm.sh/helm/v3/pkg/registry -> containerd/remotes -> containerd/content).
+#
+# All three live in containerd's CRI (Container Runtime Interface) checkpoint/restore
+# subsystem (github.com/containerd/containerd/.../cri). kgateway compiles in only
+# containerd's OCI content/registry packages (content, remotes, images,
+# archive/compression, labels, filters, errdefs, pkg/randutil) -- verified via
+# `go list -deps` over ./cmd/kgateway and ./cmd/sds; no CRI package is present in any
+# kgateway binary. The vulnerable checkpoint/restore code is therefore never built or
+# reachable.
+#
+# There is also no upstream fix on the containerd v1.x line -- the CVEs are only
+# resolved by dropping containerd, which for kgateway requires bumping helm. That bump
+# triggers a coordinated dependency chain that is out of scope for this LTS branch:
+#
+#   1. helm.sh/helm/v3 3.19.5 -> 3.21.x drops the containerd dependency entirely, but
+#      helm 3.21.x requires k8s.io 0.36, so MVS raises k8s.io 0.34 -> 0.36.
+#   2. k8s.io 0.36 adds a HasSyncedChecker method to client-go's
+#      cache.ResourceEventHandlerRegistration interface. The istio (1.28-alpha) and
+#      sigs.k8s.io/controller-runtime (0.22.x) versions pinned on this branch do not
+#      implement it, so the build fails until istio and controller-runtime are bumped.
+#   3. The istio versions that support k8s.io 0.36 in turn require
+#      sigs.k8s.io/gateway-api 1.5.1 -- i.e. the k8s bump forces an istio bump, and the
+#      istio bump forces a Gateway API conformance-contract bump (1.4 -> 1.5).
+#
+# So clearing these unreachable CVEs would drag k8s.io, istio, controller-runtime, and
+# gateway-api forward together -- the coordinated uplift that shipped as v2.3.x, not a
+# security patch. This branch stays on gateway-api 1.4, so they are ignored here as not
+# exploitable instead.
+
+[[IgnoredVulns]]
+id = "GO-2026-5622"
+reason = "Not exploitable (CVE-2026-53489 / GHSA-rgh6-rfwx-v388): arbitrary host CRI log file read via symlink following in containerd's CRI checkpoint restore. containerd is pulled only via helm's OCI registry client; kgateway builds none of containerd's CRI packages (verified via `go list -deps`), so the checkpoint-restore path is unreachable. No fix on the containerd v1.x line."
+
+[[IgnoredVulns]]
+id = "GO-2026-5338"
+reason = "Not exploitable (CVE-2026-50195 / GHSA-cvxm-645q-p574): local image tag poisoning via containerd's CRI checkpoint import. containerd is pulled only via helm's OCI registry client; kgateway builds none of containerd's CRI packages (verified via `go list -deps`), so the checkpoint-import path is unreachable. No fix on the containerd v1.x line."
+
+[[IgnoredVulns]]
+id = "GO-2026-5064"
+reason = "Not exploitable (CVE-2026-53492 / GHSA-33vj-92qq-66hc): CDI annotation smuggling via containerd's CRI checkpoint restore. containerd is pulled only via helm's OCI registry client; kgateway builds none of containerd's CRI packages (verified via `go list -deps`), so the checkpoint-restore path is unreachable. No fix on the containerd v1.x line."


### PR DESCRIPTION


# Description
Similar to CVE fixes applied in https://github.com/kgateway-dev/kgateway/pull/14440

- **`serde_with` 3.15.0 -> 3.21.0** in `internal/envoyinit/Cargo.lock`, clearing GHSA-7gcf-g7xr-8hxj (a panic when serializing an empty `KeyValueMap` entry).
- **containerd CRI advisories** (GO-2026-5622 / GO-2026-5338 / GO-2026-5064) marked as **not exploitable** in `osv-scanner.toml`. containerd is pulled only transitively via helm's OCI registry client (`helm.sh/helm/v3/pkg/registry` -> `containerd/remotes` + `containerd/content`), and all three CVEs live in containerd's CRI checkpoint/restore subsystem, which is not compiled into any kgateway binary (verified with `go list -deps` over `cmd/kgateway` and `cmd/sds` -- only the OCI content/registry packages are present). There is **no fix on the containerd v1 line**, and dropping containerd via helm 3.21 would force k8s.io 0.36 -> a newer istio -> gateway-api 1.5, a coordinated uplift out of scope for this LTS branch. The full chain is documented in `osv-scanner.toml`.

Verification: `cargo check` on the `transformations` crate and a local `make osv-scan`-equivalent `osv-scanner` (v2.3.5) re-scan both pass; the scan confirms serde_with is cleared and the containerd advisories are suppressed.

## CVEs resolved

| CVE | module | how |
| --- | --- | --- |
| GHSA-7gcf-g7xr-8hxj | serde_with | bumped to 3.21.0 |
| CVE-2026-53489 / GO-2026-5622 | containerd | not exploitable (CRI code not built) |
| CVE-2026-50195 / GO-2026-5338 | containerd | not exploitable (CRI code not built) |
| CVE-2026-53492 / GO-2026-5064 | containerd | not exploitable (CRI code not built) |

## Not addressed here
- `CVE-2026-41413` / `CVE-2026-39350` (`istio.io/istio`) - the fix requires an istio bump that transitively pulls `sigs.k8s.io/gateway-api` 1.5.1. These paths are reachable (the waypoint plugin translates `AuthorizationPolicy` via `pilot/pkg/security/authz/builder`), so they are not added to `osv-scanner.toml`.
- `GO-2026-5932` (`golang.org/x/crypto` openpgp) - no upstream fix exists; the subpackage is unmaintained.
- `envoy-wrapper` base-image CVEs -- handled in main branch by switching the base image to chainguard, but that is not a trivial backport. Will address separately if needed.

# Change Type

```
/kind fix
```


# Changelog


```release-note
NONE
```

# Additional Notes
Performed with the cve-bump skill.
