### PR TITLE
2.4.x - Build SDS with chainguard distroless

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,7 +101,7 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--build-arg=GOARCH=arm64"
-      - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
+      - "--build-arg=BASE_IMAGE={{ .Env.DISTROLESS_BASE_IMAGE }}"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:arm64,mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'
@@ -115,7 +115,7 @@ dockers:
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=GOARCH=amd64"
-      - "--build-arg=BASE_IMAGE={{ .Env.ALPINE_BASE_IMAGE }}"
+      - "--build-arg=BASE_IMAGE={{ .Env.DISTROLESS_BASE_IMAGE }}"
       - "--cache-from=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64"
       - "--cache-to=type=registry,ref={{ .Env.IMAGE_REGISTRY }}/sds-cache:amd64,mode=max,ignore-error=true"
       - '{{ if isEnvSet "DOCKER_NO_CACHE" }}--pull{{ else }}--progress=auto{{ end }}'

--- a/Makefile
+++ b/Makefile
@@ -283,10 +283,7 @@ osv-scan: ## Run OSV-Scanner locally; set OSV_SCAN_IMAGES="image-ref ..." to als
 			image_arch="$${image_platform#*/}"; \
 			image_arch="$${image_arch%%/*}"; \
 			rm -f "$$host_image_archive"; \
-			if docker image inspect "$$image" > /dev/null 2>&1; then \
-				echo "Image $$image found in local Docker daemon, using docker save"; \
-				docker save "$$image" -o "$$host_image_archive"; \
-			elif command -v skopeo > /dev/null 2>&1; then \
+			if command -v skopeo > /dev/null 2>&1; then \
 				if skopeo copy \
 					--override-os "$$image_os" \
 					--override-arch "$$image_arch" \
@@ -366,10 +363,6 @@ osv-scan: ## Run OSV-Scanner locally; set OSV_SCAN_IMAGES="image-ref ..." to als
 .PHONY: osv-scan-latest-main-images
 osv-scan-latest-main-images:
 	$(MAKE) osv-scan OSV_SCAN_IMAGES="ghcr.io/kgateway-dev/kgateway:$(ROLLING_MAIN_VERSION) ghcr.io/kgateway-dev/sds:$(ROLLING_MAIN_VERSION) ghcr.io/kgateway-dev/envoy-wrapper:$(ROLLING_MAIN_VERSION)"
-
-.PHONY: osv-scan-local-images
-osv-scan-local-images: kgateway-docker sds-docker envoy-wrapper-docker ## Build images from the current branch and run OSV-Scanner against them
-	$(MAKE) osv-scan OSV_SCAN_IMAGES="$(IMAGE_REGISTRY)/$(CONTROLLER_IMAGE_REPO):$(VERSION) $(IMAGE_REGISTRY)/$(SDS_IMAGE_REPO):$(VERSION) $(IMAGE_REGISTRY)/$(ENVOYINIT_IMAGE_REPO):$(VERSION)"
 
 #----------------------------------------------------------------------------------
 # Ginkgo Tests

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ $(BUG_REPORT_DIR):
 # Base Alpine image used for the dummy-idp container. Exported for use in goreleaser.yaml.
 export ALPINE_BASE_IMAGE ?= alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-# Distroless glibc base used for the kgateway controller and SDS containers. Exported for use in goreleaser.yaml.
+# Distroless glibc base used for the kgateway controller, SDS, and envoy-wrapper containers. Exported for use in goreleaser.yaml.
 # Tracked as :latest (unpinned) on purpose: this distroless image has no package manager, so the only way
 # to receive Chainguard's CVE fixes is to pull a newer build. A pinned digest would freeze CVEs in place and
 # may be garbage-collected on the free tier. Release builds set DOCKER_NO_CACHE=1, which adds --pull so each

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,10 @@ BUG_REPORT_DIR := $(TEST_ASSET_DIR)/bug_report
 $(BUG_REPORT_DIR):
 	mkdir -p $(BUG_REPORT_DIR)
 
-# Base Alpine image used for SDS and dummy-idp containers. Exported for use in goreleaser.yaml.
+# Base Alpine image used for the dummy-idp container. Exported for use in goreleaser.yaml.
 export ALPINE_BASE_IMAGE ?= alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-# Distroless glibc base used for the kgateway controller container. Exported for use in goreleaser.yaml.
+# Distroless glibc base used for the kgateway controller and SDS containers. Exported for use in goreleaser.yaml.
 # Tracked as :latest (unpinned) on purpose: this distroless image has no package manager, so the only way
 # to receive Chainguard's CVE fixes is to pull a newer build. A pinned digest would freeze CVEs in place and
 # may be garbage-collected on the free tier. Release builds set DOCKER_NO_CACHE=1, which adds --pull so each
@@ -283,7 +283,10 @@ osv-scan: ## Run OSV-Scanner locally; set OSV_SCAN_IMAGES="image-ref ..." to als
 			image_arch="$${image_platform#*/}"; \
 			image_arch="$${image_arch%%/*}"; \
 			rm -f "$$host_image_archive"; \
-			if command -v skopeo > /dev/null 2>&1; then \
+			if docker image inspect "$$image" > /dev/null 2>&1; then \
+				echo "Image $$image found in local Docker daemon, using docker save"; \
+				docker save "$$image" -o "$$host_image_archive"; \
+			elif command -v skopeo > /dev/null 2>&1; then \
 				if skopeo copy \
 					--override-os "$$image_os" \
 					--override-arch "$$image_arch" \
@@ -363,6 +366,10 @@ osv-scan: ## Run OSV-Scanner locally; set OSV_SCAN_IMAGES="image-ref ..." to als
 .PHONY: osv-scan-latest-main-images
 osv-scan-latest-main-images:
 	$(MAKE) osv-scan OSV_SCAN_IMAGES="ghcr.io/kgateway-dev/kgateway:$(ROLLING_MAIN_VERSION) ghcr.io/kgateway-dev/sds:$(ROLLING_MAIN_VERSION) ghcr.io/kgateway-dev/envoy-wrapper:$(ROLLING_MAIN_VERSION)"
+
+.PHONY: osv-scan-local-images
+osv-scan-local-images: kgateway-docker sds-docker envoy-wrapper-docker ## Build images from the current branch and run OSV-Scanner against them
+	$(MAKE) osv-scan OSV_SCAN_IMAGES="$(IMAGE_REGISTRY)/$(CONTROLLER_IMAGE_REPO):$(VERSION) $(IMAGE_REGISTRY)/$(SDS_IMAGE_REPO):$(VERSION) $(IMAGE_REGISTRY)/$(ENVOYINIT_IMAGE_REPO):$(VERSION)"
 
 #----------------------------------------------------------------------------------
 # Ginkgo Tests
@@ -808,7 +815,7 @@ $(SDS_OUTPUT_DIR)/Dockerfile.sds: cmd/sds/Dockerfile
 $(SDS_OUTPUT_DIR)/.docker-stamp-$(VERSION)-$(GOARCH): $(SDS_OUTPUT_DIR)/sds-linux-$(GOARCH) $(SDS_OUTPUT_DIR)/Dockerfile.sds
 	$(BUILDX_BUILD) --load $(PLATFORM) $(SDS_OUTPUT_DIR) -f $(SDS_OUTPUT_DIR)/Dockerfile.sds \
 		--build-arg GOARCH=$(GOARCH) \
-		--build-arg BASE_IMAGE=$(ALPINE_BASE_IMAGE) \
+		--build-arg BASE_IMAGE=$(DISTROLESS_BASE_IMAGE) \
 		$(SDS_CACHE_FROM) \
 		-t $(IMAGE_REGISTRY)/$(SDS_IMAGE_REPO):$(VERSION)
 	@touch $@

--- a/cmd/sds/Dockerfile
+++ b/cmd/sds/Dockerfile
@@ -1,10 +1,8 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=cgr.dev/chainguard/glibc-dynamic:latest
 
 FROM $BASE_IMAGE
 
 ARG GOARCH=amd64
-
-RUN apk -U upgrade
 
 COPY sds-linux-$GOARCH /usr/local/bin/sds
 

--- a/test/container-structure/sds.yaml
+++ b/test/container-structure/sds.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.0.0
 
 # Container structure tests for the sds (Secret Discovery Service) image
-# Built on Alpine base
+# Built on Chainguard distroless base
 
 # UID 10101 must match the helm chart's securityContext.runAsUser
 # (see pkg/deployer/gateway_parameters.go)
@@ -21,8 +21,3 @@ commandTests:
     command: "/usr/local/bin/sds"
     exitCode: 1
     expectedError: ["invalid config"]
-
-  - name: "running as non-root user"
-    command: "id"
-    args: ["-u"]
-    expectedOutput: ["10101"]


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

Switches the SDS image from Alpine to `cgr.dev/chainguard/glibc-dynamic:latest`, eliminating 15 OpenSSL CVEs that Alpine 3.23 currently carries. This mirrors the approach taken for the kgateway controller (#14432) and envoy-wrapper (#14446) images.

The SDS binary is built with `CGO_ENABLED=0` (fully static Go), makes no outbound TLS connections, and calls no shell utilities — the only runtime dependency is the `/etc/istio-certs/` volume mount injected by the pod spec. No utilities need to be copied into the image.

Dropped "running as non-root user" test is covered by the checking the user in the metadata test

# Change Type


Select one or more of the following by including the corresponding slash-command:
```
/kind bump
```


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
