### PR TITLE
[2.4] fix: Report proper parent and section name for policy attachment

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
@@ -29,6 +29,27 @@ type TrafficPolicyMergeOpts struct {
 	ACL string `json:"acl,omitempty"`
 }
 
+// Merge shallow-merges other into o: o's already-set fields win, other only
+// fills fields o left empty.
+func (o TrafficPolicyMergeOpts) Merge(other TrafficPolicyMergeOpts) TrafficPolicyMergeOpts {
+	merged := o
+
+	if merged.ExtAuth == "" {
+		merged.ExtAuth = other.ExtAuth
+	}
+	if merged.ExtProc == "" {
+		merged.ExtProc = other.ExtProc
+	}
+	if merged.Transformation == "" {
+		merged.Transformation = other.Transformation
+	}
+	if merged.ACL == "" {
+		merged.ACL = other.ACL
+	}
+
+	return merged
+}
+
 // MergeTrafficPolicies merges two TrafficPolicy IRs, returning a map that contains information
 // about the origin policy reference for each merged field.
 func MergeTrafficPolicies(
@@ -180,7 +201,7 @@ func mergeRustFormationActionListJson(action string, obj1, obj2 map[string]any) 
 }
 
 func mergeRustFormationActionBody(obj1, obj2 map[string]any) {
-	body2, ok := obj2["body"].(any)
+	body2, ok := obj2["body"]
 	if ok {
 		obj1["body"] = body2
 	}

--- a/pkg/kgateway/query/route.go
+++ b/pkg/kgateway/query/route.go
@@ -107,9 +107,18 @@ func (r *gatewayQueries) GetRouteChain(
 ) *RouteInfo {
 	var children BackendMap[[]*RouteInfo]
 
+	// parentRef comes straight from route's own spec.parentRefs, so Group, Kind,
+	// and Namespace may be nil/empty when the user relied on Gateway API's implicit
+	// defaults (Group=gateway.networking.k8s.io, Kind=Gateway, Namespace=route's own
+	// namespace). Apply those defaults here, once, at the top of the chain, so
+	// descendant delegated routes -- which inherit this same parentRef unchanged --
+	// report status against the correct ancestor instead of re-deriving (and
+	// potentially misresolving) it from their own, different, namespace later.
+	defaultedParentRef := defaultParentRef(parentRef, route.GetNamespace())
+
 	switch typedRoute := route.(type) {
 	case *ir.HttpRouteIR:
-		children = r.getDelegatedChildren(kctx, parentRef, typedRoute, sets.New[types.NamespacedName]())
+		children = r.getDelegatedChildren(kctx, defaultedParentRef, typedRoute, sets.New[types.NamespacedName]())
 	case *ir.TcpRouteIR:
 		// TODO (danehans): Should TCPRoute delegation support be added in the future?
 	case *ir.TlsRouteIR:
@@ -121,9 +130,28 @@ func (r *gatewayQueries) GetRouteChain(
 		Object:            route,
 		HostnameOverrides: hostnames,
 		ParentRef:         parentRef,
-		ListenerParentRef: parentRef,
+		ListenerParentRef: defaultedParentRef,
 		Children:          children,
 	}
+}
+
+// defaultParentRef fills in a ParentReference's Group, Kind, and Namespace with
+// Gateway API's implicit defaults (Group=gateway.networking.k8s.io, Kind=Gateway,
+// Namespace=routeNamespace) wherever the route left them unset.
+func defaultParentRef(ref gwv1.ParentReference, routeNamespace string) gwv1.ParentReference {
+	if ref.Group == nil {
+		group := gwv1.Group(wellknown.GatewayGroup)
+		ref.Group = &group
+	}
+	if ref.Kind == nil {
+		kind := gwv1.Kind(wellknown.GatewayKind)
+		ref.Kind = &kind
+	}
+	if ref.Namespace == nil && routeNamespace != "" {
+		ns := gwv1.Namespace(routeNamespace)
+		ref.Namespace = &ns
+	}
+	return ref
 }
 
 func (r *gatewayQueries) allowedRoutes(resource client.Object, l *gwv1.Listener) (func(krt.HandlerContext, string) bool, []metav1.GroupKind, error) {

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -3019,6 +3019,39 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("listener policy isolation across ListenerSets sharing a port", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-sets/shared-port-policy-isolation.yaml"},
+			outputFile: "listener-sets/shared-port-policy-isolation.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("route-attached policy ancestor across ListenerSets sharing a port", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-sets/shared-port-route-policy-ancestor.yaml"},
+			outputFile: "listener-sets/shared-port-route-policy-ancestor.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("listener policy isolation across listeners on the same Gateway sharing a port", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"traffic-policy/shared-port-policy-isolation-same-parent.yaml"},
+			outputFile: "traffic-policy/shared-port-policy-isolation-same-parent.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("TrafficPolicy RateLimit Full Config", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"traffic-policy/rate-limit-full-config.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/shared-port-policy-isolation.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/shared-port-policy-isolation.yaml
@@ -1,0 +1,132 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: kgateway
+  listeners: []
+  allowedListeners:
+    namespaces:
+      from: All
+---
+# Team A's ListenerSet: a wildcard listener meant to catch any subdomain
+# they haven't explicitly delegated. No policy attached here.
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: wildcard-listenerset
+spec:
+  parentRef:
+    name: example-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: http-9090
+    protocol: HTTP
+    port: 9090
+    hostname: "*.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# Team B's ListenerSet: independently authored, picks the same port by
+# coincidence, and scopes a listener-level TrafficPolicy to its own
+# specific hostname, expecting isolation from anything else on the Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: specific-listenerset
+spec:
+  parentRef:
+    name: example-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: http-9090
+    protocol: HTTP
+    port: 9090
+    hostname: "specific.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# Team A's route, served through their wildcard listener, but it happens to
+# claim the exact same hostname that Team B's listener uses.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wildcard-route
+spec:
+  parentRefs:
+  - name: wildcard-listenerset
+    group: gateway.networking.k8s.io
+    kind: ListenerSet
+  hostnames:
+  - "specific.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: wildcard-svc
+      port: 8080
+---
+# Team B's route, served through their own specific listener.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: specific-route
+spec:
+  parentRefs:
+  - name: specific-listenerset
+    group: gateway.networking.k8s.io
+    kind: ListenerSet
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: specific-svc
+      port: 8080
+---
+# Team B's listener-scoped TrafficPolicy. Intended to apply only to
+# Team B's own routes on specific-listenerset.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: specific-listener-policy
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: specific-listenerset
+    sectionName: http-9090
+  cors:
+    allowOrigins:
+    - "https://team-b-only.example.com"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wildcard-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 8080
+      targetPort: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: specific-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 8080
+      targetPort: test

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/shared-port-route-policy-ancestor.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/shared-port-route-policy-ancestor.yaml
@@ -1,0 +1,127 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: kgateway
+  listeners: []
+  allowedListeners:
+    namespaces:
+      from: All
+---
+# Two independently-authored ListenerSets sharing a port by coincidence.
+# Neither has a listener-level policy -- only a-listenerset's route is
+# targeted by a TrafficPolicy. If route-level policy status ancestor
+# reporting is fixed to "whichever ListenerSet built the merged listener
+# first", the policy's status will show the WRONG ListenerSet as ancestor.
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: a-listenerset
+spec:
+  parentRef:
+    name: example-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: http-9090
+    protocol: HTTP
+    port: 9090
+    hostname: "a.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: b-listenerset
+spec:
+  parentRef:
+    name: example-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: http-9090
+    protocol: HTTP
+    port: 9090
+    hostname: "b.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: a-route
+spec:
+  parentRefs:
+  - name: a-listenerset
+    group: gateway.networking.k8s.io
+    kind: ListenerSet
+  hostnames:
+  - "a.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: a-svc
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: b-route
+spec:
+  parentRefs:
+  - name: b-listenerset
+    group: gateway.networking.k8s.io
+    kind: ListenerSet
+  hostnames:
+  - "b.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: b-svc
+      port: 8080
+---
+# Route-attached (not listener-attached) TrafficPolicy, targeting only b-route.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: b-route-policy
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: b-route
+  statPrefix: "b-route-policy"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: a-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 8080
+      targetPort: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: b-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 8080
+      targetPort: test

--- a/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/shared-port-policy-isolation-same-parent.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/traffic-policy/shared-port-policy-isolation-same-parent.yaml
@@ -1,0 +1,92 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  # Two listeners on the SAME Gateway, sharing a port, with different
+  # hostnames -- the classic multi-tenant-single-Gateway pattern.
+  - name: wildcard-listener
+    protocol: HTTP
+    port: 9090
+    hostname: "*.example.com"
+  - name: specific-listener
+    protocol: HTTP
+    port: 9090
+    hostname: "specific.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wildcard-route
+spec:
+  parentRefs:
+  - name: example-gateway
+    sectionName: wildcard-listener
+  hostnames:
+  - "specific.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: wildcard-svc
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: specific-route
+spec:
+  parentRefs:
+  - name: example-gateway
+    sectionName: specific-listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: specific-svc
+      port: 8080
+---
+# Listener-scoped TrafficPolicy, targeting only specific-listener via sectionName.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: specific-listener-policy
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+    sectionName: specific-listener
+  cors:
+    allowOrigins:
+    - "https://team-b-only.example.com"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wildcard-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 8080
+      targetPort: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: specific-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 8080
+      targetPort: test

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/shared-port-policy-isolation.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/shared-port-policy-isolation.yaml
@@ -1,0 +1,249 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_specific-svc_8080
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_wildcard-svc_8080
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 9090
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - disabled: true
+          name: envoy.filters.http.cors
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~9090
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~9090
+  name: listener~9090
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~9090
+  virtualHosts:
+  - domains:
+    - specific.example.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          cors:
+          - gateway.kgateway.dev/TrafficPolicy/default/specific-listener-policy
+    name: listener~9090~specific_example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~9090~specific_example_com-route-0-httproute-specific-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_specific-svc_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    typedPerFilterConfig:
+      envoy.filters.http.cors:
+        '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+        allowOriginStringMatch:
+        - exact: https://team-b-only.example.com
+        forwardNotMatchingPreflights: false
+        maxAge: "5"
+Statuses:
+  gateways:
+    default/example-gateway:
+      attachedListenerSets: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+  httpRoutes:
+    default/specific-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: specific-listenerset
+    default/wildcard-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: wildcard-listenerset
+  listenerSets:
+    default/specific-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted ListenerSet
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed ListenerSet
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-9090
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    default/wildcard-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted ListenerSet
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed ListenerSet
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-9090
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  policies:
+    TrafficPolicy/default/specific-listener-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: specific-listenerset
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/shared-port-route-policy-ancestor.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/shared-port-route-policy-ancestor.yaml
@@ -1,0 +1,249 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_a-svc_8080
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_b-svc_8080
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 9090
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~9090
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~9090
+  name: listener~9090
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~9090
+  virtualHosts:
+  - domains:
+    - a.example.com
+    name: listener~9090~a_example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~9090~a_example_com-route-0-httproute-a-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_a-svc_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+  - domains:
+    - b.example.com
+    name: listener~9090~b_example_com
+    routes:
+    - match:
+        prefix: /
+      metadata:
+        filterMetadata:
+          merge.TrafficPolicy.gateway.kgateway.dev:
+            statPrefix:
+            - gateway.kgateway.dev/TrafficPolicy/default/b-route-policy
+      name: listener~9090~b_example_com-route-0-httproute-b-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_b-svc_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+      statPrefix: b-route-policy
+Statuses:
+  gateways:
+    default/example-gateway:
+      attachedListenerSets: 2
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+  httpRoutes:
+    default/a-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: a-listenerset
+    default/b-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: b-listenerset
+  listenerSets:
+    default/a-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted ListenerSet
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed ListenerSet
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-9090
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    default/b-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted ListenerSet
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed ListenerSet
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-9090
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  policies:
+    TrafficPolicy/default/b-route-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: ListenerSet
+          name: b-listenerset
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-cross-namespace.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/extauth-cross-namespace.yaml
@@ -496,6 +496,7 @@ Statuses:
           kind: Gateway
           name: example-gateway
           namespace: default
+          sectionName: http
         conditions:
         - lastTransitionTime: null
           message: Policy accepted
@@ -515,6 +516,7 @@ Statuses:
           kind: Gateway
           name: example-gateway
           namespace: default
+          sectionName: http
         conditions:
         - lastTransitionTime: null
           message: 'extauth: failed to resolve ExtAuth gRPC backend: missing reference

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/shared-port-policy-isolation-same-parent.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/shared-port-policy-isolation-same-parent.yaml
@@ -1,0 +1,224 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_specific-svc_8080
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_wildcard-svc_8080
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 9090
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - disabled: true
+          name: envoy.filters.http.cors
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~9090
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~9090
+  name: listener~9090
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~9090
+  virtualHosts:
+  - domains:
+    - specific.example.com
+    metadata:
+      filterMetadata:
+        merge.TrafficPolicy.gateway.kgateway.dev:
+          cors:
+          - gateway.kgateway.dev/TrafficPolicy/default/specific-listener-policy
+    name: listener~9090~specific_example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~9090~specific_example_com-route-0-httproute-specific-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_specific-svc_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    typedPerFilterConfig:
+      envoy.filters.http.cors:
+        '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+        allowOriginStringMatch:
+        - exact: https://team-b-only.example.com
+        forwardNotMatchingPreflights: false
+        maxAge: "5"
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: wildcard-listener
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: specific-listener
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/specific-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+          sectionName: specific-listener
+    default/wildcard-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+          sectionName: wildcard-listener
+  policies:
+    TrafficPolicy/default/specific-listener-policy:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -438,6 +438,13 @@ func (h *httpRouteConfigurationTranslator) runVhostPlugins(
 	// this is the isolation boundary: failures here replace only this vhost with
 	// a 500 direct response (preserving Name and Domains). Policies that require
 	// HCM/global knobs must be handled at RouteConfiguration scope instead.
+	//
+	// Use virtualHost.ParentRef.PolicyAncestorRef, not h.listener.PolicyAncestorRef:
+	// on a shared HTTP port, h.listener represents the whole merged filter chain and
+	// its PolicyAncestorRef is fixed to whichever Gateway/ListenerSet happened to be
+	// first in the merge, which misattributes status for every other parent sharing
+	// the port. virtualHost.ParentRef is the listener that actually won this vhost.
+	ancestorRef := virtualHost.ParentRef.PolicyAncestorRef
 	var errs []error
 	for _, gk := range virtualHost.AttachedPolicies.ApplyOrderedGroupKinds() {
 		pols := virtualHost.AttachedPolicies.Policies[gk]
@@ -445,7 +452,7 @@ func (h *httpRouteConfigurationTranslator) runVhostPlugins(
 		if pass == nil {
 			continue
 		}
-		reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
+		reportPolicyAcceptanceStatus(h.reporter, ancestorRef, pols...)
 		policies, mergeOrigins := mergePolicies(pass, pols)
 		for _, pol := range policies {
 			if len(pol.Errors) > 0 {
@@ -461,7 +468,7 @@ func (h *httpRouteConfigurationTranslator) runVhostPlugins(
 			pass.ApplyVhostPlugin(pctx, out)
 		}
 		out.Metadata = addMergeOriginsToFilterMetadata(gk, mergeOrigins, out.GetMetadata())
-		reportPolicyAttachmentStatus(h.reporter, h.listener.PolicyAncestorRef, mergeOrigins, pols...)
+		reportPolicyAttachmentStatus(h.reporter, ancestorRef, mergeOrigins, pols...)
 	}
 	return errors.Join(errs...)
 }
@@ -513,7 +520,8 @@ func (h *httpRouteConfigurationTranslator) runRoutePlugins(
 			ListenerPort:      h.listener.BindPort,
 			ListenerHasTLS:    h.fc.TLS != nil,
 		}
-		reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
+		ancestorRef := routeAncestorRef(in, h.listener.PolicyAncestorRef)
+		reportPolicyAcceptanceStatus(h.reporter, ancestorRef, pols...)
 		policies, mergeOrigins := mergePolicies(pass, pols)
 		for _, pol := range policies {
 			// Builtin policies use InheritedPolicyPriority
@@ -533,10 +541,25 @@ func (h *httpRouteConfigurationTranslator) runRoutePlugins(
 			}
 		}
 		out.Metadata = addMergeOriginsToFilterMetadata(gk, mergeOrigins, out.GetMetadata())
-		reportPolicyAttachmentStatus(h.reporter, h.listener.PolicyAncestorRef, mergeOrigins, pols...)
+		reportPolicyAttachmentStatus(h.reporter, ancestorRef, mergeOrigins, pols...)
 	}
 
 	return errors.Join(errs...)
+}
+
+// routeAncestorRef returns the ancestor to report route-attached policy status
+// against: the route's own ListenerParentRef (the Gateway/ListenerSet it actually
+// attaches to, taken from its own spec.parentRefs and already defaulted at the
+// query layer -- see query.defaultParentRef), not fallbackRef
+// (h.listener.PolicyAncestorRef), which is fixed to whichever Gateway/ListenerSet
+// happened to build the merged HTTP filter chain first and misattributes status
+// for every other parent sharing the port. Falls back when ListenerParentRef is
+// unset, e.g. for synthetic routes that have no source HTTPRoute.
+func routeAncestorRef(in ir.HttpRouteRuleMatchIR, fallbackRef gwv1.ParentReference) gwv1.ParentReference {
+	if in.ListenerParentRef.Name == "" {
+		return fallbackRef
+	}
+	return in.ListenerParentRef
 }
 
 func mergePolicies(pass *TranslationPass, policies []ir.PolicyAtt) ([]ir.PolicyAtt, ir.MergeOrigins) {
@@ -549,7 +572,7 @@ func mergePolicies(pass *TranslationPass, policies []ir.PolicyAtt) ([]ir.PolicyA
 	return policies, nil
 }
 
-func (h *httpRouteConfigurationTranslator) runBackendPolicies(in ir.HttpBackend, pCtx *ir.RouteBackendContext) error {
+func (h *httpRouteConfigurationTranslator) runBackendPolicies(in ir.HttpBackend, ancestorRef gwv1.ParentReference, pCtx *ir.RouteBackendContext) error {
 	var errs []error
 	for _, gk := range in.AttachedPolicies.ApplyOrderedGroupKinds() {
 		pols := in.AttachedPolicies.Policies[gk]
@@ -558,7 +581,7 @@ func (h *httpRouteConfigurationTranslator) runBackendPolicies(in ir.HttpBackend,
 			// TODO: should never happen, log error and report condition
 			continue
 		}
-		reportPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
+		reportPolicyAcceptanceStatus(h.reporter, ancestorRef, pols...)
 		policies, _ := mergePolicies(pass, pols)
 		for _, pol := range policies {
 			// Policy on extension ref
@@ -614,7 +637,8 @@ func (h *httpRouteConfigurationTranslator) translateRouteAction(
 			TypedFilterConfig: backendConfigCtx.typedPerFilterConfigRoute,
 		}
 
-		reportBackendObjectPolicyStatus(h.reporter, h.listener.PolicyAncestorRef, h.pluginPass, backend.Backend.BackendObject)
+		ancestorRef := routeAncestorRef(in, h.listener.PolicyAncestorRef)
+		reportBackendObjectPolicyStatus(h.reporter, ancestorRef, h.pluginPass, backend.Backend.BackendObject)
 
 		// non attached policy translation
 		err := h.runBackend(
@@ -628,6 +652,7 @@ func (h *httpRouteConfigurationTranslator) translateRouteAction(
 		}
 		err = h.runBackendPolicies(
 			backend,
+			ancestorRef,
 			&pCtx,
 		)
 		if err != nil {


### PR DESCRIPTION
# Description

Backport of https://github.com/kgateway-dev/kgateway/pull/14448

Fixes policy attachment status reporting the wrong Gateway/ListenerSet ancestor when two listeners from different parents share the same port — `PolicyAncestorRef` was pinned to whichever parent built the merged HTTP listener first, so `TrafficPolicy`/`ListenerPolicy` status could show an unrelated ListenerSet as attached. 
Vhost-scoped policies now use `virtualHost.ParentRef.PolicyAncestorRef`; route-attached policies use the route's own `ListenerParentRef`, defaulted once at the root of the delegation chain (`query.defaultParentRef`) so descendants inherit the correct ancestor instead of misresolving it from their own namespace.

# Change Type

/kind fix

# Changelog

```release-note
Fixed TrafficPolicy (and other route/listener-attached policy) status incorrectly reporting the wrong Gateway or ListenerSet as ancestor when multiple Gateways/ListenerSets share the same port.
```