### PR TITLE
fix: remove deprecated google_re2 field from RegexMatcher

### DIFF
--- a/pkg/utils/regexutils/regex.go
+++ b/pkg/utils/regexutils/regex.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // CheckRegexString to make sure the string is a valid RE2 expression
@@ -19,18 +18,10 @@ func CheckRegexString(candidateRegex string) error {
 // NewRegexWithProgramSize creates a new regex matcher with the given program size.
 // This means its tightly coupled to envoy's implementation of regex.
 // NOTE: Call this after having checked regex with CheckRegexString.
-func NewRegexWithProgramSize(candidateRegex string, programsize *uint32) *envoy_type_matcher_v3.RegexMatcher {
-	var maxProgramSize *wrappers.UInt32Value
-	if programsize != nil {
-		maxProgramSize = &wrappers.UInt32Value{
-			Value: *programsize,
-		}
-	}
-
+// Deprecated programsize: The MaxProgramSize field inside GoogleRE2 is deprecated and ignored by Envoy.
+// The programsize parameter is kept for API compatibility but has no effect.
+func NewRegexWithProgramSize(candidateRegex string, _ *uint32) *envoy_type_matcher_v3.RegexMatcher {
 	return &envoy_type_matcher_v3.RegexMatcher{
-		EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-			GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{MaxProgramSize: maxProgramSize},
-		},
 		Regex: candidateRegex,
 	}
 }

--- a/pkg/utils/regexutils/regex_test.go
+++ b/pkg/utils/regexutils/regex_test.go
@@ -11,17 +11,16 @@ var _ = Describe("Regex", func() {
 	It("should create regex with default program size", func() {
 		regex := NewRegexWithProgramSize("foo", nil)
 		Expect(regex.GetRegex()).To(Equal("foo"))
-		Expect(regex.GetGoogleRe2().GetMaxProgramSize()).To(BeNil()) //nolint:staticcheck // GetGoogleRe2 and GetMaxProgramSize are deprecated
-
-		// regex = NewRegex(nil, "foo")
-		// Expect(regex.GetRegex()).To(Equal("foo"))
-		// Expect(regex.GetGoogleRe2().GetMaxProgramSize()).To(BeNil())
+		// GoogleRe2 is no longer set; Envoy defaults to RE2 engine
+		Expect(regex.GetEngineType()).To(BeNil())
 	})
 	It("should create regex with a specific program size", func() {
 		var number uint32
 		number = 123
+		// programsize is accepted for API compatibility but ignored (MaxProgramSize is deprecated by Envoy)
 		regex := NewRegexWithProgramSize("foo", &number)
 		Expect(regex.GetRegex()).To(Equal("foo"))
-		Expect(regex.GetGoogleRe2().GetMaxProgramSize().GetValue()).To(Equal(number)) //nolint:staticcheck // GetGoogleRe2 and GetMaxProgramSize are deprecated
+		// GoogleRe2 is no longer set; Envoy defaults to RE2 engine
+		Expect(regex.GetEngineType()).To(BeNil())
 	})
 })


### PR DESCRIPTION
# Description
Envoy deprecated the google_re2 field inside safe_regex in recent versions. kgateway was still emitting it when translating RegularExpression path and header matchers from HTTPRoute.

RE2 is the default regex engine in Envoy so the field is redundant. Removing it eliminates the deprecation warning without any functional change.

The programsize parameter in NewRegexWithProgramSize is kept for API compatibility but is now ignored since MaxProgramSize was part of the removed GoogleRE2 struct.

# Change Type
```
/kind fix
```
# Changelog

```
Fixed Envoy deprecation warning for `RegexMatcher.google_re2` on HTTPRoutes using RegularExpression matchers.
```
Fixes #14442

```release-note
NONE
```



