### PR TITLE
fix(irtranslator): report PolicyConditionAccepted=False when attached policy is unsupported (#14477)

### DIFF
--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -214,7 +214,7 @@ func (h *hcmNetworkFilterTranslator) computeNetworkFilters(l ir.HttpFilterChainI
 		pols := attachedPolicies.Policies[gk]
 		pass := h.pluginPass[gk]
 		if pass == nil {
-			// TODO: report user error - they attached a non http policy
+			reportUnsupportedPolicyAcceptanceStatus(h.reporter, h.policyAncestorRef, pols...)
 			continue
 		}
 		reportPolicyAcceptanceStatus(h.reporter, h.policyAncestorRef, pols...)

--- a/pkg/kgateway/translator/irtranslator/fc_test.go
+++ b/pkg/kgateway/translator/irtranslator/fc_test.go
@@ -202,3 +202,65 @@ func TestFilterChainsInvalidIP(t *testing.T) {
 	)
 	assert.Nil(t, envoyListener, "expected nil listener for invalid IP bind address")
 }
+
+func TestFilterChains_UnsupportedAttachedPolicyStatus(t *testing.T) {
+	ctx := context.Background()
+
+	translator := irtranslator.Translator{}
+
+	unsupportedGK := schema.GroupKind{
+		Group: "unsupported.kgateway.dev",
+		Kind:  "UnsupportedPolicy",
+	}
+
+	policyRef := &ir.AttachedPolicyRef{
+		Group:     unsupportedGK.Group,
+		Kind:      unsupportedGK.Kind,
+		Namespace: "default",
+		Name:      "my-unsupported-policy",
+	}
+
+	attachedPolicies := ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{
+			unsupportedGK: {
+				{
+					PolicyRef: policyRef,
+				},
+			},
+		},
+	}
+
+	gateway := ir.GatewayIR{SourceObject: &ir.Gateway{Obj: &gwv1.Gateway{}}}
+	listener := ir.ListenerIR{
+		BindAddress:      "0.0.0.0",
+		BindPort:         8080,
+		AttachedPolicies: attachedPolicies,
+		HttpFilterChain: []ir.HttpFilterChainIR{{
+			FilterChainCommon: ir.FilterChainCommon{
+				FilterChainName: "httpchain",
+			},
+		}},
+	}
+
+	reportMap := reports.NewReportMap()
+	rpt := reports.NewReporter(&reportMap)
+
+	_, _ = translator.ComputeListener(
+		ctx,
+		irtranslator.TranslationPassPlugins{},
+		gateway,
+		listener,
+		rpt,
+	)
+
+	key := reporter.PolicyKey{
+		Group:     unsupportedGK.Group,
+		Kind:      unsupportedGK.Kind,
+		Namespace: "default",
+		Name:      "my-unsupported-policy",
+	}
+	policyStatus := reportMap.BuildPolicyStatus(ctx, key, "kgateway", gwv1.PolicyStatus{})
+	require.NotNil(t, policyStatus, "policy status should be generated")
+	require.NotEmpty(t, policyStatus.Ancestors, "policy status should have ancestor entry")
+	require.NotEmpty(t, policyStatus.Ancestors[0].Conditions, "policy status should set Condition on ancestor")
+}

--- a/pkg/kgateway/translator/irtranslator/gateway.go
+++ b/pkg/kgateway/translator/irtranslator/gateway.go
@@ -219,7 +219,7 @@ func (t *Translator) runListenerPlugins(
 		pols := attachedPolicies.Policies[gk]
 		pass := pass[gk]
 		if pass == nil {
-			// TODO: report user error - they attached a non http policy
+			reportUnsupportedPolicyAcceptanceStatus(reporter, l.PolicyAncestorRef, pols...)
 			continue
 		}
 		reportPolicyAcceptanceStatus(reporter, l.PolicyAncestorRef, pols...)

--- a/pkg/kgateway/translator/irtranslator/policy.go
+++ b/pkg/kgateway/translator/irtranslator/policy.go
@@ -57,6 +57,33 @@ func reportPolicyAcceptanceStatus(
 	}
 }
 
+func reportUnsupportedPolicyAcceptanceStatus(
+	rp reporter.Reporter,
+	ancestorRef gwv1.ParentReference,
+	policies ...ir.PolicyAtt,
+) {
+	for _, policy := range policies {
+		if policy.PolicyRef == nil {
+			continue
+		}
+
+		key := reporter.PolicyKey{
+			Group:     policy.PolicyRef.Group,
+			Kind:      policy.PolicyRef.Kind,
+			Namespace: policy.PolicyRef.Namespace,
+			Name:      policy.PolicyRef.Name,
+		}
+		r := rp.Policy(key, policy.Generation).AncestorRef(ancestorRef)
+		r.SetCondition(reporter.PolicyCondition{
+			Type:               string(shared.PolicyConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(shared.PolicyReasonInvalid),
+			Message:            "Attached policy type is not supported for this attachment target",
+			ObservedGeneration: policy.Generation,
+		})
+	}
+}
+
 func reportPolicyAttachmentStatus(
 	rp reporter.Reporter,
 	ancestorRef gwv1.ParentReference,

--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -509,7 +509,7 @@ func (h *httpRouteConfigurationTranslator) runRoutePlugins(
 		pols := attachedPolicies.Policies[gk]
 		pass := h.pluginPass[gk]
 		if pass == nil {
-			// TODO: should never happen, log error and report condition
+			reportUnsupportedPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 			continue
 		}
 		pctx := &ir.RouteContext{
@@ -578,7 +578,7 @@ func (h *httpRouteConfigurationTranslator) runBackendPolicies(in ir.HttpBackend,
 		pols := in.AttachedPolicies.Policies[gk]
 		pass := h.pluginPass[gk]
 		if pass == nil {
-			// TODO: should never happen, log error and report condition
+			reportUnsupportedPolicyAcceptanceStatus(h.reporter, h.listener.PolicyAncestorRef, pols...)
 			continue
 		}
 		reportPolicyAcceptanceStatus(h.reporter, ancestorRef, pols...)


### PR DESCRIPTION
# Description

Fixes #14477

When a policy CRD is attached to a Gateway, HTTPRoute, or HCM listener, but its `GroupKind` isn't supported by a registered plugin pass at that target (`pass == nil`), the translator was just hitting `continue` and skipping status reporting entirely:

- `pkg/kgateway/translator/irtranslator/gateway.go`
- `pkg/kgateway/translator/irtranslator/fc.go`
- `pkg/kgateway/translator/irtranslator/route.go`

Because `reportPolicyAcceptanceStatus` was never called, the policy CRD status was left blank with no status conditions when running `kubectl get <policy> -o yaml`.

This PR adds `reportUnsupportedPolicyAcceptanceStatus` in `policy.go` to mark the policy as `Accepted: False` (`Reason: Invalid`) with an error message when an unsupported policy is attached, and updates the translation loops to invoke it.

# Change Type

/kind fix

# Changelog

```release-note
fix(irtranslator): report status condition Accepted: False when an unsupported policy GroupKind is attached
```

# Additional Notes
Added TestFilterChains_UnsupportedAttachedPolicyStatus in fc_test.go to cover status reporting for unhandled policies.

Attached screenshot showing the unit tests pass after applying the fix.
<img width="1366" height="723" alt="Screenshot (932)" src="https://github.com/user-attachments/assets/78d4f8bd-6a1c-4aaf-b8d1-23243b62eb8d" />
