### PR TITLE
Run Buffer before Rustformation to honor request-size limits

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
@@ -3,10 +3,15 @@ package trafficpolicy
 import (
 	"testing"
 
+	bufferv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/buffer/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/filters"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
 func TestBufferIREquals(t *testing.T) {
@@ -58,4 +63,34 @@ func TestBufferIREquals(t *testing.T) {
 			a.Equal(tt.want, aOut.buffer.Equals(bOut.buffer))
 		})
 	}
+}
+
+func TestBufferFilterRunsImmediatelyBeforeRustformation(t *testing.T) {
+	const filterChainName = "test-filter-chain"
+
+	plugin := &trafficPolicyPluginGwPass{
+		setTransformationInChain: map[string]bool{
+			filterChainName: true,
+		},
+		bufferInChain: map[string]*bufferv3.Buffer{
+			filterChainName: {
+				MaxRequestBytes: &wrapperspb.UInt32Value{Value: 1024},
+			},
+		},
+	}
+
+	httpFilters, err := plugin.HttpFilters(
+		ir.HttpFiltersContext{},
+		ir.FilterChainCommon{FilterChainName: filterChainName},
+	)
+	require.NoError(t, err)
+	require.Len(t, httpFilters, 2)
+
+	sortedFilters := filters.StagedHttpFilterList(httpFilters)
+	sortedFilters.Sort()
+
+	assert.Equal(t, bufferFilterName, sortedFilters[0].Filter.GetName())
+	assert.Equal(t, filters.RelativeToStage(filters.AcceptedStage, -2), sortedFilters[0].Stage)
+	assert.Equal(t, rustformationFilterNamePrefix, sortedFilters[1].Filter.GetName())
+	assert.Equal(t, filters.BeforeStage(filters.AcceptedStage), sortedFilters[1].Stage)
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -678,10 +678,14 @@ func (p *trafficPolicyPluginGwPass) HttpFilters(_ ir.HttpFiltersContext, fcc ir.
 		stagedFilters = append(stagedFilters, filter)
 	}
 
-	// Add Buffer filter to enable buffer for the listener.
-	// Requires the buffer policy to be set as typed_per_filter_config.
+	// Register Buffer immediately before Rustformation so its per-route request
+	// limit is established before a body-parsing transformation buffers data.
 	if f := p.bufferInChain[fcc.FilterChainName]; f != nil {
-		filter := filters.MustNewStagedFilter(bufferFilterName, f, filters.DuringStage(filters.RouteStage))
+		filter := filters.MustNewStagedFilter(
+			bufferFilterName,
+			f,
+			filters.RelativeToStage(filters.AcceptedStage, -2),
+		)
 		filter.Filter.Disabled = true
 		stagedFilters = append(stagedFilters, filter)
 	}


### PR DESCRIPTION
# Description

Fixes #13630.

When a route enables both request buffering and a body-parsing transformation,
Rustformation currently runs before Envoy's Buffer filter. Rustformation then
buffers the request using Envoy's default per-stream limit, so requests above
roughly 16 MiB can receive a 413 even when `buffer.maxRequestSize` is larger.

Stage Buffer immediately before Rustformation so the route's configured request
limit is established before the transformation reads the body. Buffer remains
disabled by default and is still enabled only through its per-route
configuration.

Unlike #13635, this leaves Rustformation at its existing stage and therefore
does not change its ordering relative to authentication, authorization, or rate
limiting filters.

The regression test sorts the generated filter chain and verifies that Buffer
is immediately before Rustformation.

This change is intentionally limited to honoring an explicitly configured Buffer
policy. Having Rustformation configure its own bounded buffering would be a
separate design and could eventually supersede this ordering for transformed
requests.

Validation:

- `make test TEST_PKG=./pkg/kgateway/extensions2/plugins/trafficpolicy`
- repository-specific golangci-lint for
  `./pkg/kgateway/extensions2/plugins/trafficpolicy/...`

# Change Type

/kind fix

# Changelog

```release-note
Honor configured request buffer limits when body transformations are enabled.
```
