### PR TITLE
feat: add proxy 100-continue support to listener policy

### DIFF
--- a/api/v1alpha1/kgateway/listener_policy_types.go
+++ b/api/v1alpha1/kgateway/listener_policy_types.go
@@ -302,6 +302,12 @@ type HTTPSettings struct {
 	// +kubebuilder:validation:MinLength=1
 	DefaultHostForHttp10 *string `json:"defaultHostForHttp10,omitempty"`
 
+	// Proxy100Continue configures Envoy to proxy 100-Continue and other 1xx informational
+	// responses from the upstream, such as 103 Early Hints, instead of handling them locally.
+	// See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
+	// +optional
+	Proxy100Continue *bool `json:"proxy100Continue,omitempty"`
+
 	// EarlyRequestHeaderModifier defines header modifications to be applied early in the request processing,
 	// before route selection.
 	// For example, if you use ExternalAuthz to add a header, you may want to remove it here, to make

--- a/api/v1alpha1/kgateway/zz_generated.deepcopy.go
+++ b/api/v1alpha1/kgateway/zz_generated.deepcopy.go
@@ -2666,6 +2666,11 @@ func (in *HTTPSettings) DeepCopyInto(out *HTTPSettings) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Proxy100Continue != nil {
+		in, out := &in.Proxy100Continue, &out.Proxy100Continue
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EarlyRequestHeaderModifier != nil {
 		in, out := &in.EarlyRequestHeaderModifier, &out.EarlyRequestHeaderModifier
 		*out = new(apisv1.HTTPHeaderFilter)

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
@@ -2640,6 +2640,12 @@ spec:
                   PreserveHttp1HeaderCase determines whether to preserve the case of HTTP1 request headers.
                   See here for more information: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing
                 type: boolean
+              proxy100Continue:
+                description: |-
+                  Proxy100Continue configures Envoy to proxy 100-Continue and other 1xx informational
+                  responses from the upstream, such as 103 Early Hints, instead of handling them locally.
+                  See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
+                type: boolean
               serverHeaderTransformation:
                 description: |-
                   ServerHeaderTransformation determines how the server header is transformed.

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
@@ -2757,6 +2757,12 @@ spec:
                           PreserveHttp1HeaderCase determines whether to preserve the case of HTTP1 request headers.
                           See here for more information: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing
                         type: boolean
+                      proxy100Continue:
+                        description: |-
+                          Proxy100Continue configures Envoy to proxy 100-Continue and other 1xx informational
+                          responses from the upstream, such as 103 Early Hints, instead of handling them locally.
+                          See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
+                        type: boolean
                       serverHeaderTransformation:
                         description: |-
                           ServerHeaderTransformation determines how the server header is transformed.
@@ -6002,6 +6008,12 @@ spec:
                               description: |-
                                 PreserveHttp1HeaderCase determines whether to preserve the case of HTTP1 request headers.
                                 See here for more information: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing
+                              type: boolean
+                            proxy100Continue:
+                              description: |-
+                                Proxy100Continue configures Envoy to proxy 100-Continue and other 1xx informational
+                                responses from the upstream, such as 103 Early Hints, instead of handling them locally.
+                                See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
                               type: boolean
                             serverHeaderTransformation:
                               description: |-

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
@@ -55,6 +55,7 @@ func baseHarnessHttpListenerPolicyIr() *HttpListenerPolicyIr {
 		localReplyConfig:     &envoy_hcm.LocalReplyConfig{},
 		acceptHttp10:         new(true),
 		defaultHostForHttp10: new("example.com"),
+		proxy100Continue:     new(true),
 		earlyHeaderMutationExtensions: []*envoycorev3.TypedExtensionConfig{
 			{Name: "ext"},
 		},
@@ -172,6 +173,10 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		{
 			Field:  "defaultHostForHttp10",
 			Mutate: func(d **HttpListenerPolicyIr) { (*d).defaultHostForHttp10 = new("other.com") },
+		},
+		{
+			Field:  "proxy100Continue",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).proxy100Continue = new(false) },
 		},
 		{
 			Field: "earlyHeaderMutationExtensions",

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
@@ -65,6 +65,7 @@ type HttpListenerPolicyIr struct {
 	localReplyConfig              *envoy_hcm.LocalReplyConfig
 	acceptHttp10                  *bool
 	defaultHostForHttp10          *string
+	proxy100Continue              *bool
 	earlyHeaderMutationExtensions []*envoycorev3.TypedExtensionConfig
 	maxRequestHeadersKb           *uint32
 	maxRequestsPerConnection      *uint32
@@ -190,6 +191,10 @@ func (d *HttpListenerPolicyIr) Equals(in any) bool {
 	}
 
 	if !cmputils.PointerValsEqual(d.defaultHostForHttp10, d2.defaultHostForHttp10) {
+		return false
+	}
+
+	if !cmputils.PointerValsEqual(d.proxy100Continue, d2.proxy100Continue) {
 		return false
 	}
 
@@ -405,6 +410,7 @@ func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.Com
 		preserveHttp1HeaderCase:       h.PreserveHttp1HeaderCase,
 		acceptHttp10:                  h.AcceptHttp10,
 		defaultHostForHttp10:          h.DefaultHostForHttp10,
+		proxy100Continue:              h.Proxy100Continue,
 		earlyHeaderMutationExtensions: convertHeaderMutations(h.EarlyRequestHeaderModifier),
 		maxRequestHeadersKb:           maxRequestHeadersKb,
 		maxRequestsPerConnection:      maxRequestsPerConnection,

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
@@ -549,6 +549,10 @@ func (p *listenerPolicyPluginGwPass) ApplyHCM(
 		out.HttpProtocolOptions.DefaultHostForHttp_10 = *policy.defaultHostForHttp10
 	}
 
+	if policy.proxy100Continue != nil {
+		out.Proxy_100Continue = *policy.proxy100Continue
+	}
+
 	// translate maxRequestHeadersKb
 	if policy.maxRequestHeadersKb != nil {
 		out.MaxRequestHeadersKb = wrapperspb.UInt32(*policy.maxRequestHeadersKb)

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/merge_http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/merge_http.go
@@ -40,6 +40,7 @@ func MergeHttpPolicies(
 		mergePreserveHttp1HeaderCase,
 		mergeAcceptHttp10,
 		mergeDefaultHostForHttp10,
+		mergeProxy100Continue,
 		mergeEarlyHeaderMutation,
 		mergeMaxRequestHeadersKb,
 		mergeMaxRequestsPerConnection,
@@ -220,6 +221,22 @@ func mergeDefaultHostForHttp10(
 
 	p1.defaultHostForHttp10 = p2.defaultHostForHttp10
 	mergeOrigins.SetOne(origin+"defaultHostForHttp10", p2Ref, p2MergeOrigins)
+}
+
+func mergeProxy100Continue(
+	origin string,
+	p1, p2 *HttpListenerPolicyIr,
+	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
+	opts policy.MergeOptions,
+	mergeOrigins ir.MergeOrigins,
+) {
+	if !policy.IsMergeable(p1.proxy100Continue, p2.proxy100Continue, opts) {
+		return
+	}
+
+	p1.proxy100Continue = p2.proxy100Continue
+	mergeOrigins.SetOne(origin+"proxy100Continue", p2Ref, p2MergeOrigins)
 }
 
 func mergeXffNumTrustedHops(

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -1994,6 +1994,17 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("HTTPListenerPolicy with proxy100Continue", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"httplistenerpolicy/proxy-100-continue.yaml"},
+			outputFile: "httplistenerpolicy/proxy-100-continue.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("HTTPListenerPolicy with localReplies", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"httplistenerpolicy/local-reply-config.yaml"},
@@ -2295,6 +2306,17 @@ func TestBasic(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"listener-policy-http/default-host-for-http10-without-accept-http10.yaml"},
 			outputFile: "listener-policy-http/default-host-for-http10-without-accept-http10.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("ListenerPolicy with proxy100Continue", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-policy-http/proxy-100-continue.yaml"},
+			outputFile: "listener-policy-http/proxy-100-continue.yaml",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",

--- a/pkg/kgateway/translator/gateway/testutils/inputs/httplistenerpolicy/proxy-100-continue.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/httplistenerpolicy/proxy-100-continue.yaml
@@ -1,0 +1,47 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 80
+      targetPort: test
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: proxy-100-continue
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  proxy100Continue: true

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/proxy-100-continue.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/proxy-100-continue.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 80
+      targetPort: test
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: ListenerPolicy
+metadata:
+  name: proxy-100-continue
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  default:
+    httpSettings:
+      proxy100Continue: true

--- a/pkg/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/proxy-100-continue.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/httplistenerpolicy/proxy-100-continue.yaml
@@ -1,0 +1,156 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        proxy100Continue: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        proxy100Continue:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/proxy-100-continue
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.HTTPListenerPolicy.gateway.kgateway.dev:
+        proxy100Continue:
+        - gateway.kgateway.dev/HTTPListenerPolicy/default/proxy-100-continue
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    HTTPListenerPolicy/default/proxy-100-continue:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/proxy-100-continue.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/proxy-100-continue.yaml
@@ -1,0 +1,156 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        proxy100Continue: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.proxy100Continue:
+        - gateway.kgateway.dev/ListenerPolicy/default/proxy-100-continue
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.proxy100Continue:
+        - gateway.kgateway.dev/ListenerPolicy/default/proxy-100-continue
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    ListenerPolicy/default/proxy-100-continue:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway


### PR DESCRIPTION
# Description

**Motivation:** By default, Envoy terminates 1xx informational responses (such as `100 Continue` and `103 Early Hints`) locally at the HTTP connection manager rather than forwarding them from the upstream to the downstream client. Some upstreams and clients rely on these informational responses being proxied end-to-end. There was previously no way to enable this behavior through kgateway.

**What changed:** Adds a new optional `proxy100Continue` field to the HTTP listener policy spec. When set to `true`, it maps to the Envoy HttpConnectionManager [`proxy_100_continue`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue) field, so Envoy proxies 100-Continue and other 1xx informational responses from the upstream instead of handling them locally.

Implementation details:
- New `Proxy100Continue *bool` field on the HTTP listener policy spec (exposed via both the `HTTPListenerPolicy` and `ListenerPolicy` CRDs).
- Threaded through the listener policy plugin IR, including `Equals`/equality-harness coverage and policy merge logic.
- Applied in the translation pass onto the HttpConnectionManager proto.
- Golden translation tests added for both the `httplistenerpolicy` and `listener-policy-http` input variants.

# Change Type

/kind feature

# Changelog

```release-note
Add a `proxy100Continue` field to the HTTP listener policy that enables Envoy to proxy 100-Continue and other 1xx informational responses from the upstream instead of handling them locally.
```

# Additional Notes

- The field is optional and defaults to unset, preserving existing behavior (Envoy handles 1xx locally).
- Merge behavior follows the standard listener policy merge semantics via `mergeProxy100Continue`.
