### PR TITLE
fix: don't offer the local-cluster EDS resource to clients that havent asked

### DIFF
--- a/pkg/kgateway/proxy_syncer/local_cluster.go
+++ b/pkg/kgateway/proxy_syncer/local_cluster.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"slices"
-	"strings"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -13,12 +12,10 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
-	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
 // localClusterEndpointPort is the port used in local-cluster CLA endpoints.
@@ -42,7 +39,7 @@ func NewPerClientLocalClusterEndpoints(
 	localityPods krt.Collection[krtcollections.LocalityPod],
 ) PerClientEnvoyEndpoints {
 	podsByGateway := krtpkg.UnnamedIndex(localityPods, func(pod krtcollections.LocalityPod) []string {
-		gwName := gatewayNameFromLabels(pod.AugmentedLabels)
+		gwName := ir.GatewayNameFromLabels(pod.AugmentedLabels)
 		if gwName == "" {
 			return nil
 		}
@@ -50,7 +47,14 @@ func NewPerClientLocalClusterEndpoints(
 	})
 
 	endpoints := krt.NewCollection(uccs, func(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient) *UccWithEndpoints {
-		localClusterName, gatewayName, gatewayNamespace := localClusterInfo(ucc)
+		if !ucc.KnowsLocalCluster {
+			// Client's own EDS subscription has never named this resource (old Envoy with
+			// no matching static bootstrap cluster). Never emit it for this client: an
+			// unrequested resource in the snapshot makes go-control-plane's ADS "superset"
+			// check withhold the client's *entire* EDS response. See issue #14471.
+			return nil
+		}
+		localClusterName, gatewayName, gatewayNamespace := ucc.LocalClusterInfo()
 		if localClusterName == "" || gatewayName == "" || gatewayNamespace == "" {
 			return nil
 		}
@@ -74,34 +78,6 @@ func NewPerClientLocalClusterEndpoints(
 		endpoints: endpoints,
 		index:     idx,
 	}
-}
-
-func localClusterInfo(ucc ir.UniquelyConnectedClient) (clusterName, gatewayName, gatewayNamespace string) {
-	gatewayNamespace = ucc.Namespace
-	gatewayName = gatewayNameFromLabels(ucc.Labels)
-
-	roleParts := strings.Split(ucc.Role, ir.KeyDelimiter)
-	if len(roleParts) == 3 {
-		if gatewayNamespace == "" {
-			gatewayNamespace = roleParts[1]
-		}
-		if gatewayName == "" {
-			gatewayName = roleParts[2]
-		}
-	}
-
-	if gatewayName == "" || gatewayNamespace == "" {
-		return "", gatewayName, gatewayNamespace
-	}
-	return LocalClusterName(gatewayName, gatewayNamespace), gatewayName, gatewayNamespace
-}
-
-// LocalClusterName returns the name of the per-gateway "local cluster" EDS resource that
-// kgateway programs for native zone-aware routing. It is the single source of truth for this
-// name and must stay in sync with the bootstrap config produced by the Helm template
-// (see kgateway.gateway.fullname in pkg/kgateway/helm/envoy/templates/_helpers.tpl).
-func LocalClusterName(gatewayName, gatewayNamespace string) string {
-	return fmt.Sprintf("%s.%s", kubeutils.SafeGatewayLabelValue(gatewayName), gatewayNamespace)
 }
 
 func buildLocalClusterLoadAssignment(
@@ -179,16 +155,6 @@ func buildLocalClusterLoadAssignment(
 	}
 
 	return cla
-}
-
-func gatewayNameFromLabels(labels map[string]string) string {
-	if labels == nil {
-		return ""
-	}
-	if gatewayName := labels[wellknown.GatewayNameAnnotation]; gatewayName != "" {
-		return gatewayName
-	}
-	return labels[wellknown.GatewayNameLabel]
 }
 
 func hashLocalClusterLoadAssignment(cla *envoyendpointv3.ClusterLoadAssignment) uint64 {

--- a/pkg/kgateway/proxy_syncer/local_cluster_test.go
+++ b/pkg/kgateway/proxy_syncer/local_cluster_test.go
@@ -21,6 +21,7 @@ func TestNewPerClientLocalClusterEndpointsBuildsGatewayLocalities(t *testing.T) 
 	ucc := ir.NewUniquelyConnectedClient(role, "ns", map[string]string{
 		wellknown.GatewayNameLabel: "gw",
 	}, ir.PodLocality{Region: "region-1", Zone: "zone-a"})
+	ucc.KnowsLocalCluster = true
 	uccs := krt.NewStaticCollection[ir.UniquelyConnectedClient](nil, []ir.UniquelyConnectedClient{ucc})
 	pods := krt.NewStaticCollection[krtcollections.LocalityPod](nil, []krtcollections.LocalityPod{
 		{
@@ -112,6 +113,7 @@ func TestNewPerClientLocalClusterEndpointsUsesSafeClusterNameForLongGateways(t *
 		wellknown.GatewayNameAnnotation: longGatewayName,
 		wellknown.GatewayNameLabel:      safeGatewayName,
 	}, ir.PodLocality{Region: "region-1", Zone: "zone-a"})
+	ucc.KnowsLocalCluster = true
 	uccs := krt.NewStaticCollection[ir.UniquelyConnectedClient](nil, []ir.UniquelyConnectedClient{ucc})
 	pods := krt.NewStaticCollection[krtcollections.LocalityPod](nil, []krtcollections.LocalityPod{
 		{
@@ -137,4 +139,40 @@ func TestNewPerClientLocalClusterEndpointsUsesSafeClusterNameForLongGateways(t *
 	}).Should(gomega.HaveLen(1))
 
 	g.Expect(got[0].Endpoints.GetClusterName()).To(gomega.Equal(safeGatewayName + ".ns"))
+}
+
+// TestNewPerClientLocalClusterEndpointsSkipsUnknownClients guards against #14471: a client
+// that has never proven (via its own EDS subscription) that it knows about the local cluster
+// resource must not have one built for it. Handing an old Envoy a resource name its bootstrap
+// never declared makes go-control-plane's ADS "superset" check withhold its entire EDS
+// response, not just the local cluster.
+func TestNewPerClientLocalClusterEndpointsSkipsUnknownClients(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	role := xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, "ns", "gw")
+	ucc := ir.NewUniquelyConnectedClient(role, "ns", map[string]string{
+		wellknown.GatewayNameLabel: "gw",
+	}, ir.PodLocality{Region: "region-1", Zone: "zone-a"})
+	g.Expect(ucc.KnowsLocalCluster).To(gomega.BeFalse(), "must default to false until observed")
+
+	uccs := krt.NewStaticCollection[ir.UniquelyConnectedClient](nil, []ir.UniquelyConnectedClient{ucc})
+	pods := krt.NewStaticCollection[krtcollections.LocalityPod](nil, []krtcollections.LocalityPod{
+		{
+			Named: krt.Named{
+				Namespace: "ns",
+				Name:      "gw-zone-a",
+			},
+			Locality: ir.PodLocality{Region: "region-1", Zone: "zone-a"},
+			AugmentedLabels: map[string]string{
+				wellknown.GatewayNameLabel: "gw",
+			},
+			Addresses: []string{"10.0.0.1"},
+		},
+	})
+
+	localEndpoints := NewPerClientLocalClusterEndpoints(krtutil.KrtOptions{}, uccs, pods)
+
+	g.Consistently(func() []UccWithEndpoints {
+		return localEndpoints.endpoints.List()
+	}).Should(gomega.BeEmpty())
 }

--- a/pkg/kgateway/setup/setup_test.go
+++ b/pkg/kgateway/setup/setup_test.go
@@ -46,6 +46,7 @@ import (
 
 	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/proxy_syncer"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
 	"github.com/kgateway-dev/kgateway/v2/test/envtestassets"
 	"github.com/kgateway-dev/kgateway/v2/test/envtestutil"
@@ -644,7 +645,7 @@ func newXdsDumper(t *testing.T, ctx context.Context, xdsPort int, gwname string)
 		conn: conn,
 		// Build the local cluster name with the exact same helper the control plane uses, so the
 		// dumper subscribes to the resource that actually exists in the snapshot.
-		localClusterName: proxy_syncer.LocalClusterName(gwname, gwNamespace),
+		localClusterName: ir.LocalClusterName(gwname, gwNamespace),
 		dr: &envoy_service_discovery_v3.DiscoveryRequest{
 			Node: &envoycorev3.Node{
 				Id: "gateway." + gwNamespace,

--- a/pkg/krtcollections/uniqueclients.go
+++ b/pkg/krtcollections/uniqueclients.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,7 @@ import (
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	xdsserver "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"google.golang.org/protobuf/types/known/structpb"
 	"istio.io/istio/pkg/kube/krt"
@@ -88,7 +90,21 @@ type callbacksCollection struct {
 	clients          map[int64]ConnectedClient
 	uniqClientsCount map[string]uint64
 	uniqClients      map[string]ir.UniquelyConnectedClient
-	stateLock        sync.RWMutex
+	// knownLocalClusterBySid records, per STREAM (not per UCC resource name), whether that
+	// stream's own EDS subscription has named its expected local-cluster resource (see
+	// ir.UniquelyConnectedClient.LocalClusterInfo). Old Envoys never name it (no matching
+	// static bootstrap cluster), so entries only ever go false -> true as real requests are
+	// observed.
+	//
+	// This must be tracked per stream rather than per UCC resource name: when pod-locality
+	// tracking is disabled (DISABLE_POD_LOCALITY_XDS=true), every replica of a gateway shares
+	// one UCC bucket/snapshot (see the augmentedPods-nil branch in add()). During a rolling
+	// upgrade some of those replicas' streams may confirm support while sibling streams on the
+	// same bucket haven't -- getClients() must only report the bucket as knowing the local
+	// cluster once every stream currently in that bucket has confirmed it, or the same
+	// full-EDS-withholding this file exists to prevent reappears for the still-old siblings.
+	knownLocalClusterBySid map[int64]bool
+	stateLock              sync.RWMutex
 
 	trigger *krt.RecomputeTrigger
 }
@@ -163,12 +179,13 @@ func buildCollection(callbacks *callbacks) UniquelyConnectedClientsBuilder {
 	return func(ctx context.Context, krtOpts krtutil.KrtOptions, augmentedPods krt.Collection[LocalityPod]) krt.Collection[ir.UniquelyConnectedClient] {
 		trigger := krt.NewRecomputeTrigger(true)
 		col := &callbacksCollection{
-			logger:           logger,
-			augmentedPods:    augmentedPods,
-			clients:          make(map[int64]ConnectedClient),
-			uniqClientsCount: make(map[string]uint64),
-			uniqClients:      make(map[string]ir.UniquelyConnectedClient),
-			trigger:          trigger,
+			logger:                 logger,
+			augmentedPods:          augmentedPods,
+			clients:                make(map[int64]ConnectedClient),
+			uniqClientsCount:       make(map[string]uint64),
+			uniqClients:            make(map[string]ir.UniquelyConnectedClient),
+			knownLocalClusterBySid: make(map[int64]bool),
+			trigger:                trigger,
 		}
 
 		callbacks.collection.Store(col)
@@ -211,10 +228,11 @@ func (x *callbacks) OnStreamClosed(sid int64, node *envoycorev3.Node) {
 }
 
 func (x *callbacksCollection) streamClosed(sid int64) {
-	ucc := x.del(sid)
-	if ucc != nil {
-		x.trigger.TriggerRecomputation()
-	}
+	x.del(sid)
+	// A disconnecting stream can change its bucket's derived KnowsLocalCluster (e.g. it may
+	// have been the only sibling still holding a shared bucket back from "all confirmed"), so
+	// always recompute -- not just when the whole bucket disappears.
+	x.trigger.TriggerRecomputation()
 }
 
 func (x *callbacksCollection) del(sid int64) *ir.UniquelyConnectedClient {
@@ -223,6 +241,7 @@ func (x *callbacksCollection) del(sid int64) *ir.UniquelyConnectedClient {
 
 	c, ok := x.clients[sid]
 	delete(x.clients, sid)
+	delete(x.knownLocalClusterBySid, sid)
 	if ok {
 		resourceName := c.uniqueClientName
 		current := x.uniqClientsCount[resourceName]
@@ -245,14 +264,7 @@ func roleFromRequest(r *envoy_service_discovery_v3.DiscoveryRequest) string {
 // derived from the namespace and gateway name in labels.
 // If no gateway name is found, it returns originalRole unchanged.
 func NormalizeGatewayRole(originalRole, namespace string, labels map[string]string) string {
-	if labels == nil {
-		return originalRole
-	}
-
-	gwName := labels[wellknown.GatewayNameAnnotation]
-	if gwName == "" {
-		gwName = labels[wellknown.GatewayNameLabel]
-	}
+	gwName := ir.GatewayNameFromLabels(labels)
 	if gwName == "" {
 		return originalRole
 	}
@@ -260,20 +272,19 @@ func NormalizeGatewayRole(originalRole, namespace string, labels map[string]stri
 	return xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, namespace, gwName)
 }
 
-func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.DiscoveryRequest, peer peerInfo) (ucName string, newStream, newUCC bool, err error) {
+func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.DiscoveryRequest, peer peerInfo) (ucName string, newStream bool, err error) {
 	var pod *LocalityPod
 	// see if user wants to use pod locality info; this is only possible when podRef is set in getPeerInfo
 	if peer.podRef != nil {
 		k := krt.Named{Name: peer.podRef.Name, Namespace: peer.podRef.Namespace}.ResourceName()
 		pod = x.augmentedPods.GetKey(k)
 	}
-	addedNew := false
 	x.stateLock.Lock()
 	defer x.stateLock.Unlock()
 	c, ok := x.clients[sid]
 	if !ok {
 		if err := logAndCheckEnvoyVersion(x.logger, r.GetNode()); err != nil {
-			return "", false, false, err
+			return "", false, err
 		}
 		var locality ir.PodLocality
 		var ns string
@@ -281,7 +292,7 @@ func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.Disco
 		if peer.podRef != nil {
 			if pod == nil {
 				// we need to use the pod locality info, so it's an error if we can't get the pod
-				return "", false, false, fmt.Errorf("pod not found for node %v", r.GetNode())
+				return "", false, fmt.Errorf("pod not found for node %v", r.GetNode())
 			} else {
 				locality = pod.Locality
 				ns = pod.Namespace
@@ -298,10 +309,9 @@ func (x *callbacksCollection) add(sid int64, r *envoy_service_discovery_v3.Disco
 		x.uniqClientsCount[ucc.ResourceName()] = currentUnique + 1
 		if currentUnique == 0 {
 			x.uniqClients[ucc.ResourceName()] = ucc
-			addedNew = true
 		}
 	}
-	return c.uniqueClientName, !ok, addedNew, nil
+	return c.uniqueClientName, !ok, nil
 }
 
 // OnStreamRequest is called once a request is received on a stream.
@@ -331,7 +341,7 @@ func (x *callbacks) OnStreamRequest(sid int64, r *envoy_service_discovery_v3.Dis
 }
 
 func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3.DiscoveryRequest, peer peerInfo) error {
-	ucc, isNewStream, isNewUCC, err := x.add(sid, r, peer)
+	ucc, isNewStream, err := x.add(sid, r, peer)
 	if err != nil {
 		x.logger.Debug("error processing xds client", "error", err)
 		return err
@@ -339,6 +349,7 @@ func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3
 	if ucc == "" {
 		return fmt.Errorf("got empty unique client name for sid %d", sid)
 	}
+	x.observeLocalClusterRequest(sid, ucc, r)
 
 	nodeMd := r.GetNode().GetMetadata()
 	if nodeMd == nil {
@@ -354,7 +365,10 @@ func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3
 	// the unique client resource name as well.
 	nodeMd.GetFields()[xds.RoleKey] = structpb.NewStringValue(ucc)
 	r.GetNode().Metadata = nodeMd
-	if isNewUCC {
+	if isNewStream {
+		// A new stream joining an existing bucket (not just a brand new bucket) can change
+		// that bucket's derived KnowsLocalCluster (it starts as an unconfirmed member), so
+		// recompute on every new stream, not only isNewUCC.
 		x.trigger.TriggerRecomputation()
 	}
 	if delay := xdsFirstConnectDelay(); isNewStream && delay > 0 {
@@ -368,11 +382,67 @@ func (x *callbacksCollection) newStream(sid int64, r *envoy_service_discovery_v3
 func (x *callbacksCollection) getClients() []ir.UniquelyConnectedClient {
 	x.stateLock.RLock()
 	defer x.stateLock.RUnlock()
+
+	// A bucket knows about the local cluster only if EVERY stream currently mapped to it has
+	// individually confirmed support -- a single un-confirmed sibling stream (sharing the
+	// bucket because pod-locality tracking is disabled) holds the whole bucket back. Track
+	// only the buckets held back, so the (usually much larger) uniqClients map only needs one
+	// pass below instead of two.
+	unconfirmedBuckets := make(map[string]struct{})
+	for sid, c := range x.clients {
+		if !x.knownLocalClusterBySid[sid] {
+			unconfirmedBuckets[c.uniqueClientName] = struct{}{}
+		}
+	}
+
 	clients := make([]ir.UniquelyConnectedClient, 0, len(x.uniqClients))
-	for _, c := range x.uniqClients {
+	for name, c := range x.uniqClients {
+		_, unconfirmed := unconfirmedBuckets[name]
+		c.KnowsLocalCluster = !unconfirmed
 		clients = append(clients, c)
 	}
 	return clients
+}
+
+// observeLocalClusterRequest records whether this STREAM's own EDS subscription has named its
+// expected local-cluster resource (see ir.UniquelyConnectedClient.LocalClusterInfo). It only
+// ever transitions a stream from unknown to known, and only triggers recomputation on that
+// transition — repeat ACKs on an already-known stream are a no-op.
+func (x *callbacksCollection) observeLocalClusterRequest(sid int64, uccName string, r *envoy_service_discovery_v3.DiscoveryRequest) {
+	if r.GetTypeUrl() != resource.EndpointType {
+		return
+	}
+	// tryConfirmLocalCluster's lock must be released before triggering recomputation: the
+	// registered collection handler (getClients) takes stateLock.RLock, and since
+	// sync.RWMutex isn't reentrant, calling TriggerRecomputation while still holding the
+	// write lock here would deadlock if it's ever invoked synchronously on this goroutine.
+	if x.tryConfirmLocalCluster(sid, uccName, r) {
+		x.trigger.TriggerRecomputation()
+	}
+}
+
+// tryConfirmLocalCluster marks sid as knowing about the local cluster if this request proves
+// it, returning whether a false -> true transition actually happened.
+func (x *callbacksCollection) tryConfirmLocalCluster(sid int64, uccName string, r *envoy_service_discovery_v3.DiscoveryRequest) bool {
+	x.stateLock.Lock()
+	defer x.stateLock.Unlock()
+
+	if x.knownLocalClusterBySid[sid] {
+		return false
+	}
+	ucc, ok := x.uniqClients[uccName]
+	if !ok {
+		return false
+	}
+	localClusterName, _, _ := ucc.LocalClusterInfo()
+	if localClusterName == "" {
+		return false
+	}
+	if !slices.Contains(r.GetResourceNames(), localClusterName) {
+		return false
+	}
+	x.knownLocalClusterBySid[sid] = true
+	return true
 }
 
 // OnFetchRequest is called for each Fetch request. Returning an error will end processing of the

--- a/pkg/krtcollections/uniqueclients_test.go
+++ b/pkg/krtcollections/uniqueclients_test.go
@@ -7,6 +7,7 @@ import (
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"istio.io/istio/pkg/kube/krt"
@@ -246,6 +247,171 @@ func TestUniqueClients(t *testing.T) {
 			}, "5s").Should(BeEmpty())
 		})
 	}
+}
+
+// TestUniqueClientsLocalClusterCapabilityGating guards against #14471: kgateway must not
+// assume a connected client (Envoy) knows about the per-gateway "local cluster" EDS resource
+// until that client's own EDS subscription actually names it. Old Envoys never do (no matching
+// static bootstrap cluster), and handing them the resource anyway makes go-control-plane's ADS
+// "superset" check withhold their entire EDS response, not just the local cluster.
+func TestUniqueClientsLocalClusterCapabilityGating(t *testing.T) {
+	t.Cleanup(SetXdsFirstConnectDelayForTest(0))
+	g := NewWithT(t)
+
+	inputs := []any{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "podname",
+				Namespace: "ns",
+				Labels: map[string]string{
+					wellknown.GatewayNameLabel: "gw",
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "node"},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node",
+				Labels: map[string]string{
+					corev1.LabelTopologyRegion: "region",
+					corev1.LabelTopologyZone:   "zone",
+				},
+			},
+		},
+	}
+	mock := krttest.NewMock(t, inputs)
+	nodes := NewNodeMetadataCollection(krttest.GetMockCollection[*corev1.Node](mock))
+	pods := NewLocalityPodsCollection(nodes, krttest.GetMockCollection[*corev1.Pod](mock), krtutil.KrtOptions{})
+	nodes.WaitUntilSynced(context.Background().Done())
+	pods.WaitUntilSynced(context.Background().Done())
+
+	cb, uccBuilder := NewUniquelyConnectedClients(nil, false)
+	uccCol := uccBuilder(context.Background(), krtutil.KrtOptions{}, pods)
+	uccCol.WaitUntilSynced(context.Background().Done())
+
+	node := &envoycorev3.Node{
+		Id: "podname.ns",
+		Metadata: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				xds.RoleKey: structpb.NewStringValue(wellknown.GatewayApiProxyValue + "~best-proxy-role"),
+			},
+		},
+	}
+
+	// Old-style client: its EDS subscription names its normal backend cluster, but never the
+	// local-cluster resource (its bootstrap has no matching static cluster to ask for).
+	err := cb.OnStreamRequest(1, &envoy_service_discovery_v3.DiscoveryRequest{
+		Node:          node,
+		TypeUrl:       resource.EndpointType,
+		ResourceNames: []string{"some-backend-cluster"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Eventually(uccCol.List).Should(HaveLen(1))
+	g.Consistently(func() bool {
+		return uccCol.List()[0].KnowsLocalCluster
+	}).Should(BeFalse(), "must not assume support before the client actually asks for the resource")
+
+	// New-style client on the same stream now also names the local cluster resource.
+	err = cb.OnStreamRequest(1, &envoy_service_discovery_v3.DiscoveryRequest{
+		Node:          node,
+		TypeUrl:       resource.EndpointType,
+		ResourceNames: []string{"some-backend-cluster", "gw.ns"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Eventually(func() bool {
+		list := uccCol.List()
+		return len(list) == 1 && list[0].KnowsLocalCluster
+	}).Should(BeTrue())
+}
+
+// TestUniqueClientsLocalClusterCapabilityGatingSharedBucket guards against a narrower case of
+// #14471: when pod-locality tracking is disabled (DISABLE_POD_LOCALITY_XDS=true), every stream
+// for a given role shares a single UCC bucket/snapshot, so KnowsLocalCluster must reflect
+// whether ALL streams currently in that bucket have confirmed support -- not just one of them.
+// A single un-confirmed sibling must hold the whole bucket back, even if another sibling
+// already proved support; and a brand-new sibling connecting (even one that will go on to
+// confirm) transiently un-confirms an already-confirmed bucket until it too proves support,
+// since the bucket's single shared snapshot can't offer the resource to a subset of its
+// streams. This is expected: the alternative (assuming a newcomer supports it before it says
+// so) is exactly the bug #14471 was filed for.
+func TestUniqueClientsLocalClusterCapabilityGatingSharedBucket(t *testing.T) {
+	t.Cleanup(SetXdsFirstConnectDelayForTest(0))
+	g := NewWithT(t)
+
+	// role is deliberately 3 parts (prefix~ns~gateway) so ir.UniquelyConnectedClient.
+	// LocalClusterInfo can fall back to deriving namespace/gateway from the role when there's
+	// no pod (and therefore no namespace/labels) to derive them from directly.
+	role := wellknown.GatewayApiProxyValue + "~ns~gw"
+	nodeFor := func(id string) *envoycorev3.Node {
+		return &envoycorev3.Node{
+			Id: id,
+			Metadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					xds.RoleKey: structpb.NewStringValue(role),
+				},
+			},
+		}
+	}
+
+	cb, uccBuilder := NewUniquelyConnectedClients(nil, false)
+	var pods krt.Collection[LocalityPod] // nil: pod-locality tracking disabled, so all streams for this role share one bucket
+	uccCol := uccBuilder(context.Background(), krtutil.KrtOptions{}, pods)
+	uccCol.WaitUntilSynced(context.Background().Done())
+
+	// sid 1 connects and immediately confirms support for the local cluster resource.
+	err := cb.OnStreamRequest(1, &envoy_service_discovery_v3.DiscoveryRequest{
+		Node:          nodeFor("sid1.ns"),
+		TypeUrl:       resource.EndpointType,
+		ResourceNames: []string{"some-backend-cluster", "gw.ns"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Eventually(func() []ir.UniquelyConnectedClient {
+		return uccCol.List()
+	}).Should(HaveLen(1))
+	g.Eventually(func() bool {
+		return uccCol.List()[0].KnowsLocalCluster
+	}).Should(BeTrue(), "the only stream in the bucket has confirmed support")
+
+	// sid 2 joins the same bucket (same role) but hasn't sent an EDS request yet. The still-
+	// shared bucket must go back to un-confirmed, even though sid 1 already proved support --
+	// the single snapshot they share can't offer the resource to sid 1 alone.
+	err = cb.OnStreamRequest(2, &envoy_service_discovery_v3.DiscoveryRequest{
+		Node:    nodeFor("sid2.ns"),
+		TypeUrl: resource.ClusterType,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Eventually(func() []ir.UniquelyConnectedClient {
+		return uccCol.List()
+	}).Should(HaveLen(1), "sid 1 and sid 2 must share a single bucket")
+	g.Eventually(func() bool {
+		return uccCol.List()[0].KnowsLocalCluster
+	}).Should(BeFalse(), "sid 2 hasn't confirmed support yet, so the shared bucket must be held back")
+	g.Consistently(func() bool {
+		return uccCol.List()[0].KnowsLocalCluster
+	}).Should(BeFalse(), "sid 2 still hasn't confirmed; the bucket must not flip back on its own")
+
+	// sid 2 now also confirms support via its own EDS request; the bucket should flip back to
+	// confirmed since every stream sharing it now supports the resource.
+	err = cb.OnStreamRequest(2, &envoy_service_discovery_v3.DiscoveryRequest{
+		Node:          nodeFor("sid2.ns"),
+		TypeUrl:       resource.EndpointType,
+		ResourceNames: []string{"gw.ns"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Eventually(func() bool {
+		list := uccCol.List()
+		return len(list) == 1 && list[0].KnowsLocalCluster
+	}).Should(BeTrue(), "every stream sharing the bucket has now confirmed support")
+
+	// sid 2 disconnects; the bucket must stay confirmed since the one remaining stream (sid 1)
+	// already confirmed support.
+	cb.OnStreamClosed(2, nil)
+	g.Consistently(func() bool {
+		list := uccCol.List()
+		return len(list) == 1 && list[0].KnowsLocalCluster
+	}).Should(BeTrue(), "the remaining stream already confirmed support")
 }
 
 func TestNormalizeGatewayRole(t *testing.T) {

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
+	"strings"
 
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
 const KeyDelimiter = "~"
@@ -32,6 +34,18 @@ type UniquelyConnectedClient struct {
 	Locality  PodLocality
 	Namespace string
 
+	// KnowsLocalCluster reports whether this client's own EDS subscription has
+	// named its expected LocalClusterName() resource at least once. Old Envoys
+	// have no matching static cluster in their bootstrap and can never name it,
+	// so this must default to false and only ever be set by observing a real
+	// request (see pkg/krtcollections/uniqueclients.go) — never assume support.
+	// Without this gate, go-control-plane's ADS "superset" check
+	// (github.com/envoyproxy/go-control-plane pkg/cache/v3/simple.go) withholds
+	// the *entire* EDS response to a client that doesn't ask for every resource
+	// in the snapshot, breaking all endpoint updates for that client, not just
+	// the local cluster (see https://github.com/kgateway-dev/kgateway/issues/14471).
+	KnowsLocalCluster bool
+
 	// modified role that includes the namespace and the hash of the labels.
 	// we set the client's role to this value in the node metadata. so the snapshot key in the cache
 	// should also be set to this value.
@@ -45,7 +59,51 @@ func (c UniquelyConnectedClient) ResourceName() string {
 var _ krt.Equaler[UniquelyConnectedClient] = new(UniquelyConnectedClient)
 
 func (c UniquelyConnectedClient) Equals(k UniquelyConnectedClient) bool {
-	return c.Role == k.Role && c.Namespace == k.Namespace && c.Locality == k.Locality && maps.Equal(c.Labels, k.Labels) && c.resourceName == k.resourceName
+	return c.Role == k.Role && c.Namespace == k.Namespace && c.Locality == k.Locality &&
+		c.KnowsLocalCluster == k.KnowsLocalCluster && maps.Equal(c.Labels, k.Labels) && c.resourceName == k.resourceName
+}
+
+// GatewayNameFromLabels returns the Gateway name recorded on a pod or client,
+// preferring the full (untruncated) name annotation over the possibly-hashed label.
+func GatewayNameFromLabels(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	if gatewayName := labels[wellknown.GatewayNameAnnotation]; gatewayName != "" {
+		return gatewayName
+	}
+	return labels[wellknown.GatewayNameLabel]
+}
+
+// LocalClusterName returns the name of the per-gateway "local cluster" EDS resource that
+// kgateway programs for native zone-aware routing. It is the single source of truth for this
+// name and must stay in sync with the bootstrap config produced by the Helm template
+// (see kgateway.gateway.fullname in pkg/kgateway/helm/envoy/templates/_helpers.tpl).
+func LocalClusterName(gatewayName, gatewayNamespace string) string {
+	return fmt.Sprintf("%s.%s", kubeutils.SafeGatewayLabelValue(gatewayName), gatewayNamespace)
+}
+
+// LocalClusterInfo derives this client's expected local-cluster resource name (see
+// LocalClusterName), along with the gateway name/namespace it was derived from. Returns ""
+// for clusterName if this client isn't associated with a single gateway.
+func (c UniquelyConnectedClient) LocalClusterInfo() (clusterName, gatewayName, gatewayNamespace string) {
+	gatewayNamespace = c.Namespace
+	gatewayName = GatewayNameFromLabels(c.Labels)
+
+	roleParts := strings.Split(c.Role, KeyDelimiter)
+	if len(roleParts) == 3 {
+		if gatewayNamespace == "" {
+			gatewayNamespace = roleParts[1]
+		}
+		if gatewayName == "" {
+			gatewayName = roleParts[2]
+		}
+	}
+
+	if gatewayName == "" || gatewayNamespace == "" {
+		return "", gatewayName, gatewayNamespace
+	}
+	return LocalClusterName(gatewayName, gatewayNamespace), gatewayName, gatewayNamespace
 }
 
 // note: if "ns" is empty, we assume the user doesn't want to use pod locality info, so we won't modify the role.

--- a/test/e2e/defaults/testdata/httpbin.yaml
+++ b/test/e2e/defaults/testdata/httpbin.yaml
@@ -25,6 +25,9 @@ kind: Deployment
 metadata:
   name: httpbin
   namespace: default
+  labels:
+    app.kubernetes.io/name: httpbin
+    version: v1
 spec:
   replicas: 1
   selector:

--- a/test/e2e/features/upgrade/suite.go
+++ b/test/e2e/features/upgrade/suite.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kgateway "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
@@ -47,10 +49,11 @@ func init() {
 	version = envutils.GetOrDefault("VERSION", "v1.0.0-ci1", false)
 }
 
-// testingSuite validates that kgateway can be upgraded from a released version to the locally-built chart.
-// The parent test function (TestUpgrade) is responsible for:
-//   - Installing kgateway from the remote release before this suite runs.
-//   - Uninstalling kgateway after this suite completes.
+// testingSuite validates that kgateway can be upgraded from a released version to the
+// locally-built chart. The suite currently has a single Test* method (TestUpgrade); SetupTest
+// (rather than SetupSuite) installs the released version so that any future Test* method added
+// here gets its own fresh install and teardown instead of inheriting whatever the previous
+// method left behind.
 type testingSuite struct {
 	*base.BaseTestingSuite
 	fromVersion string
@@ -65,10 +68,16 @@ func NewTestingSuite(fromVersion string) e2e.NewSuiteFunc {
 	}
 }
 
-func (s *testingSuite) SetupSuite() {
-	s.BaseTestingSuite.SetupSuite()
-	// kgateway was installed from a released version by the parent test function.
-	// Verify it is healthy before attempting the upgrade.
+// SetupTest installs the released fromVersion fresh before every Test* method and registers
+// its teardown. The teardown is registered here, before the test body applies its own
+// manifests, so that testify.T's LIFO cleanup order runs manifest deletion first and only
+// then uninstalls kgateway -- reversing that would try to delete kgateway-CRD-backed
+// resources (e.g. TrafficPolicy) after the CRDs themselves are already gone.
+func (s *testingSuite) SetupTest() {
+	s.TestInstallation.InstallKgatewayFromRelease(s.Ctx, s.T(), s.fromVersion)
+	testutils.Cleanup(s.T(), func() {
+		s.TestInstallation.UninstallKgateway(s.Ctx, s.T())
+	})
 	s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayInstallSucceeded(s.Ctx)
 }
 
@@ -82,6 +91,17 @@ func (s *testingSuite) applyManifests() func() {
 			Manifests: []string{setupManifest, defaults.HttpbinManifest},
 		})
 	}
+}
+
+// scaleHttpbin scales httpbin to the given replica count. Called just before the #14471 churn
+// check (not from applyManifests) so it never adds latency to the earlier baseline
+// connectivity check -- and scoped to this suite only, since defaults.HttpbinManifest is
+// shared by many other suites that assume a single replica.
+func (s *testingSuite) scaleHttpbin(replicas uint) {
+	s.T().Helper()
+	err := s.TestInstallation.Actions.Kubectl().Scale(
+		s.Ctx, defaults.HttpbinDeployment.GetNamespace(), "deployment/"+defaults.HttpbinDeployment.GetName(), replicas)
+	s.Require().NoError(err, "failed to scale httpbin to %d replicas", replicas)
 }
 
 // verifyRequestWithTransformation verifies that the TrafficPolicy in setup.yaml is being applied.
@@ -116,6 +136,22 @@ func (s *testingSuite) updateTransformationHeader(value string) {
 	policy.Spec.Transformation.Response.Set[0].Value = kgateway.InjaTemplate(value)
 	err = s.TestInstallation.ClusterContext.Client.Patch(s.Ctx, policy, client.MergeFrom(original))
 	s.Require().NoError(err, "failed to update upgrade TrafficPolicy")
+}
+
+// httpbinPodIPs returns the current httpbin pod IPs, so a caller can confirm a "churn" of the
+// backend actually replaced its pods (and thus its endpoint IPs) rather than being a no-op.
+func (s *testingSuite) httpbinPodIPs() sets.Set[string] {
+	s.T().Helper()
+	pods, err := s.TestInstallation.ClusterContext.Clientset.CoreV1().
+		Pods(defaults.HttpbinDeployment.GetNamespace()).
+		List(s.Ctx, metav1.ListOptions{LabelSelector: defaults.HttpbinLabelSelector})
+	s.Require().NoError(err, "failed to list httpbin pods")
+	ips := sets.New[string]()
+	for _, pod := range pods.Items {
+		s.Require().NotEmpty(pod.Status.PodIP, "httpbin pod %s has no IP yet", pod.Name)
+		ips.Insert(pod.Status.PodIP)
+	}
+	return ips
 }
 
 func (s *testingSuite) localChartValuesFiles() []string {
@@ -160,6 +196,16 @@ func (s *testingSuite) TestUpgrade() {
 	s.verifyRequestWithTransformation(initialTransformationValue)
 	s.T().Logf(" ok")
 
+	// Pause the proxy Deployment's rollout before touching the control plane. Without this,
+	// the deployer (once the new controller wins leader election, ~seconds later) reconciles
+	// the Gateway and replaces this pod with a freshly-rendered one -- image.tag stays pinned
+	// to s.fromVersion below, but the new pod's bootstrap ConfigMap is written by the NEW
+	// controller code regardless of that pinned tag, so it isn't actually the same released
+	// proxy anymore by the time later assertions run. Pausing keeps the originally-connected
+	// proxy in place through the version-skew window that follows (see #14471).
+	err := s.TestInstallation.Actions.Kubectl().RunCommand(s.Ctx, "-n", proxyNamespace, "rollout", "pause", "deployment/gateway")
+	s.Require().NoError(err, "failed to pause proxy rollout")
+
 	// First upgrade the CRDs and control plane while keeping the released data-plane image.
 	// This exercises the supported version-skew window: the new control plane must continue
 	// producing xDS that the released Envoy can accept.
@@ -183,6 +229,36 @@ func (s *testingSuite) TestUpgrade() {
 	s.T().Logf("checking released data plane against the upgraded control plane...")
 	s.verifyRequestWithTransformation(skewedTransformationValue)
 	s.T().Logf(" ok")
+
+	// Guard against https://github.com/kgateway-dev/kgateway/issues/14471: the control plane
+	// must not withhold endpoint (EDS) updates from a proxy that hasn't upgraded yet. Churn the
+	// backend's pods (forcing new EDS endpoints) while the released proxy is still connected,
+	// then check Envoy's OWN live EDS-resolved state (not app-level traffic, not controller
+	// logs) actually converged on the new endpoints and dropped the old ones. If the control
+	// plane withheld the whole EDS response, this config dump would keep showing the
+	// pre-churn IPs and never show the post-churn ones.
+	s.scaleHttpbin(2)
+	s.T().Logf("restarting httpbin backend...")
+	beforeIPs := s.httpbinPodIPs()
+	err = s.TestInstallation.Actions.Kubectl().RestartDeploymentAndWait(
+		s.Ctx, defaults.HttpbinDeployment.GetName(), "-n", defaults.HttpbinDeployment.GetNamespace())
+	s.Require().NoError(err)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyDeploymentsRolledOut(
+		s.Ctx, defaults.HttpbinDeployment.GetNamespace(), defaults.HttpbinLabelSelector)
+	afterIPs := s.httpbinPodIPs()
+	s.Require().NotEmpty(afterIPs, "expected httpbin pods to be running after the restart")
+	s.Require().Empty(beforeIPs.Intersection(afterIPs),
+		"httpbin pods should have new IPs after the restart, not reuse the old ones (churn was a no-op): before=%v after=%v", beforeIPs, afterIPs)
+	s.T().Logf(" ok")
+
+	s.T().Logf("checking the still-released proxy reaches the churned backend...")
+	s.verifyRequestWithTransformation(skewedTransformationValue)
+	s.T().Logf(" ok")
+
+	// Resume the paused rollout so the deployer can actually replace this pod with the
+	// upgraded data-plane image below.
+	err = s.TestInstallation.Actions.Kubectl().RunCommand(s.Ctx, "-n", proxyNamespace, "rollout", "resume", "deployment/gateway")
+	s.Require().NoError(err, "failed to resume proxy rollout")
 
 	// Remove the version skew by upgrading the default data-plane image to the local build.
 	s.upgradeDataPlane()

--- a/test/e2e/tests/upgrade/upgrade.go
+++ b/test/e2e/tests/upgrade/upgrade.go
@@ -37,8 +37,8 @@ func Run(t *testing.T, factory e2e.InstallationFactory) {
 	})
 }
 
-// RunFromVersion installs the given released version and runs the upgrade
-// suite against it.
+// RunFromVersion sets up the target Installation and runs the upgrade suite against it. Each
+// Test* method in the suite installs fromVersion for itself (see testingSuite.SetupTest).
 func RunFromVersion(t *testing.T, factory e2e.InstallationFactory, fromVersion string) {
 	ctx := t.Context()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "kgateway-upgrade")
@@ -56,7 +56,9 @@ func RunFromVersion(t *testing.T, factory e2e.InstallationFactory, fromVersion s
 		os.Setenv(testutils.InstallNamespace, installNs)
 	}
 
-	// Register cleanup before installation so partial installs are also cleaned up.
+	// Register cleanup as a final safety net: each Test* method installs the released
+	// version fresh for itself (see testingSuite.SetupTest) and tears it back down again
+	// before returning, so by the time this runs there is normally nothing left to do.
 	testutils.Cleanup(t, func() {
 		ctx := context.Background() // t.Context() is canceled before t's cleanup runs
 		if !nsEnvPredefined {
@@ -67,9 +69,6 @@ func RunFromVersion(t *testing.T, factory e2e.InstallationFactory, fromVersion s
 		}
 		testInstallation.UninstallKgateway(ctx, t)
 	})
-
-	// Install the released version from the remote OCI registry.
-	testInstallation.InstallKgatewayFromRelease(ctx, t, fromVersion)
 
 	SuiteRunner(fromVersion).Run(ctx, t, testInstallation.Underlying())
 }


### PR DESCRIPTION
# Description

Backport of https://github.com/kgateway-dev/kgateway/pull/14472

Fixes #14471: a v2.4.0 control plane withheld the *entire* EDS response to any client that hadn't yet upgraded past v2.3.6, blackholing all traffic through the affected proxy during a rolling upgrade — not just breaking the new zone-aware "local cluster" feature.

Root cause: v2.4.0 added a per-gateway "local cluster" EDS resource to every connected client's snapshot unconditionally. Pre-v2.4.0 Envoys have no matching static cluster in their bootstrap and can never name it in their EDS subscription. go-control-plane's ADS mode requires a client's requested resource names to be a superset of everything in the snapshot for that type; when that invariant breaks, it withholds the whole response rather than the one extra resource.

Fix: track, per connected client, whether that client's own EDS subscription has ever named its expected local-cluster resource (`ir.UniquelyConnectedClient.KnowsLocalCluster`, populated from observed `DiscoveryRequest`s in `pkg/krtcollections/uniqueclients.go`). `NewPerClientLocalClusterEndpoints` only builds the local-cluster CLA for clients that have proven support. Old clients simply never get offered the resource, so the exact-match check no longer has anything to reject, and normal EDS keeps flowing for their other clusters throughout the upgrade.

Also consolidated the local-cluster name derivation (previously duplicated in `pkg/kgateway/proxy_syncer/local_cluster.go`) onto `ir.UniquelyConnectedClient` as the single source of truth.

## Change Type

/kind fix

## Changelog

```release-note
Fixed a control-plane/data-plane incompatibility during rolling upgrades where proxies still on an older version could have their entire endpoint (EDS) updates withheld, freezing them on stale/deleted backend IPs.
```

Attached a script that verifies this
[repro.sh](https://github.com/user-attachments/files/30350355/repro.sh)
