### PR TITLE
fix: fix spurious OSV scan failures from absent scan targets and apt flakes

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -25,6 +25,11 @@ permissions:
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   OSV_SCANNER_IMAGE: ghcr.io/google/osv-scanner-action:v2.3.5
+  # Severity used to report a scan target that this repository does not have.
+  # Forks routinely track a subset of the release branches and do not publish
+  # release images, so a gap there is expected; on the repository that cuts
+  # releases it is worth flagging.
+  ANNOTATION_LEVEL: ${{ github.event.repository.fork && 'warning' || 'error' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -40,33 +45,67 @@ jobs:
       - name: Determine branch matrix
         id: determine
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          BRANCH_SELECTION: ${{ inputs.branches }}
         run: |
           set -euo pipefail
 
+          # Branch allowlist, and the single source of truth for which branches
+          # get scanned: hack/osvtool parses this assignment out of this file, so
+          # keep it a one-line JSON array literal in single quotes.
           branches='["main","v2.2.x","v2.3.x","v2.4.x"]'
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            case "${{ inputs.branches }}" in
-              all)
-                ;;
-              main)
-                branches='["main"]'
-                ;;
-              v2.2.x)
-                branches='["v2.2.x"]'
-                ;;
-              v2.3.x)
-                branches='["v2.3.x"]'
-                ;;
-              v2.4.x)
-                branches='["v2.4.x"]'
-                ;;
-              *)
-                echo "::error::Unsupported branch selection: ${{ inputs.branches }}"
-                exit 1
-                ;;
-            esac
+          candidates=()
+          while IFS= read -r branch; do
+            candidates+=("${branch}")
+          done < <(jq -r '.[]' <<<"${branches}")
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && "${BRANCH_SELECTION}" != "all" ]]; then
+            matched=false
+            for branch in "${candidates[@]}"; do
+              if [[ "${branch}" == "${BRANCH_SELECTION}" ]]; then
+                matched=true
+                break
+              fi
+            done
+            if [[ "${matched}" != "true" ]]; then
+              echo "::error::Unsupported branch selection: ${BRANCH_SELECTION}"
+              exit 1
+            fi
+            candidates=("${BRANCH_SELECTION}")
           fi
+
+          # Not every repository carries every release branch. Scan the ones that
+          # are present instead of failing the checkout of the ones that are not.
+          selected=()
+          missing=()
+          for branch in "${candidates[@]}"; do
+            if gh api "repos/${REPO}/branches/${branch}" >/dev/null 2>&1; then
+              selected+=("${branch}")
+            else
+              missing+=("${branch}")
+              echo "::${ANNOTATION_LEVEL}::Skipping ${branch}: no such branch in ${REPO}."
+            fi
+          done
+
+          if [[ "${#selected[@]}" -eq 0 ]]; then
+            echo "::error::None of the requested branches exist in ${REPO}: ${candidates[*]}"
+            exit 1
+          fi
+
+          branches="$(printf '%s\n' "${selected[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+
+          {
+            echo "### OSV scan targets"
+            echo
+            echo "- Scanning: \`${selected[*]}\`"
+            if [[ "${#missing[@]}" -gt 0 ]]; then
+              echo "- Skipped, no such branch in \`${REPO}\`: \`${missing[*]}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
           {
             echo "branches=${branches}"
@@ -181,8 +220,19 @@ jobs:
       - name: Resolve image scan target
         id: image-target
         shell: bash
+        env:
+          OSV_DOCKER_PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
+
+          image_os="${OSV_DOCKER_PLATFORM%%/*}"
+          image_arch="${OSV_DOCKER_PLATFORM#*/}"
+          image_arch="${image_arch%%/*}"
+
+          {
+            echo "image_os=${image_os}"
+            echo "image_arch=${image_arch}"
+          } >> "$GITHUB_OUTPUT"
 
           branch="${{ matrix.branch }}"
           case "${branch}" in
@@ -200,8 +250,12 @@ jobs:
                   | tail -n 1 || true
               )"
               if [[ -z "${image_version}" ]]; then
-                echo "::error::No stable patch release tag found for ${branch}"
-                exit 1
+                # A release branch carries no image until it is tagged, which is
+                # the normal state for a freshly cut branch.
+                echo "::${ANNOTATION_LEVEL}::Skipping image scan for ${branch}: no stable patch release tag found."
+                echo "- Skipped \`${{ matrix.image }}\` on \`${branch}\`: no stable patch release tag." >> "$GITHUB_STEP_SUMMARY"
+                echo "found=false" >> "$GITHUB_OUTPUT"
+                exit 0
               fi
               ;;
             *)
@@ -211,6 +265,7 @@ jobs:
           esac
 
           {
+            echo "found=true"
             echo "image_version=${image_version}"
             echo "image=${IMAGE_REGISTRY}/${{ matrix.image }}:${image_version}"
           } >> "$GITHUB_OUTPUT"
@@ -218,23 +273,64 @@ jobs:
           echo "Resolved image for ${branch}: ${IMAGE_REGISTRY}/${{ matrix.image }}:${image_version}"
 
       - name: Log in to GHCR for image scans
+        if: ${{ steps.image-target.outputs.found == 'true' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Install skopeo
+      - name: Verify skopeo is available
+        if: ${{ steps.image-target.outputs.found == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y skopeo
+
+          # skopeo ships with the GitHub-hosted Ubuntu images (1.4.1 on 22.04,
+          # 1.13.3 on 24.04), so there is nothing to install. Deliberately no
+          # `apt-get update`: it exits non-zero when any third-party repository
+          # preinstalled on the runner serves a stale index, which has failed
+          # this job for reasons that have nothing to do with the scan.
+          if ! command -v skopeo >/dev/null 2>&1; then
+            echo "::error::skopeo is not available on this runner image; cannot scan ${{ matrix.image }}."
+            exit 1
+          fi
+
+          skopeo --version
+
+      - name: Check image is published
+        id: image-probe
+        if: ${{ steps.image-target.outputs.found == 'true' }}
+        shell: bash
+        env:
+          OSV_DOCKER_IMAGE: ${{ steps.image-target.outputs.image }}
+          OSV_DOCKER_IMAGE_OS: ${{ steps.image-target.outputs.image_os }}
+          OSV_DOCKER_IMAGE_ARCH: ${{ steps.image-target.outputs.image_arch }}
+          OSV_DOCKER_PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+
+          # Release images only exist in the registry of the repository that cut
+          # the release, so the scanned registry may hold a subset of them.
+          if skopeo inspect \
+            --override-os "${OSV_DOCKER_IMAGE_OS}" \
+            --override-arch "${OSV_DOCKER_IMAGE_ARCH}" \
+            "docker://${OSV_DOCKER_IMAGE}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "::${ANNOTATION_LEVEL}::Skipping image scan: ${OSV_DOCKER_IMAGE} (${OSV_DOCKER_PLATFORM}) is not published."
+          echo "- Skipped \`${OSV_DOCKER_IMAGE}\` (\`${OSV_DOCKER_PLATFORM}\`): image not published." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run image scanner
+        if: ${{ steps.image-probe.outputs.exists == 'true' }}
         shell: bash
         env:
           OSV_DOCKER_IMAGE: ${{ steps.image-target.outputs.image }}
           OSV_DOCKER_IMAGE_NAME: ${{ matrix.image }}
+          OSV_DOCKER_IMAGE_OS: ${{ steps.image-target.outputs.image_os }}
+          OSV_DOCKER_IMAGE_ARCH: ${{ steps.image-target.outputs.image_arch }}
           OSV_DOCKER_PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
@@ -251,14 +347,10 @@ jobs:
           result_json="image-result.json"
           result_sarif="image-result.sarif"
 
-          image_platform="${OSV_DOCKER_PLATFORM}"
-          image_os="${image_platform%%/*}"
-          image_arch="${image_platform#*/}"
-          image_arch="${image_arch%%/*}"
           rm -f "${image_archive}"
           skopeo copy \
-            --override-os "${image_os}" \
-            --override-arch "${image_arch}" \
+            --override-os "${OSV_DOCKER_IMAGE_OS}" \
+            --override-arch "${OSV_DOCKER_IMAGE_ARCH}" \
             "docker://${image}" \
             "docker-archive:${image_archive}:${image}"
 

--- a/devel/contributing/releasing.md
+++ b/devel/contributing/releasing.md
@@ -53,6 +53,8 @@ If the release branch **does not** exist, create one:
 - Update the OSV security scan workflow branch allowlist in [.github/workflows/osv-scanner.yaml](../../.github/workflows/osv-scanner.yaml) to include the new release branch, and drop any branch that is no longer LTS.
   This workflow only scans an explicit set of branches, so each newly cut release branch must be added to both the scheduled scan matrix and the `workflow_dispatch` branch options.
   This allowlist is the single source of truth for which branches get scanned: tooling such as [`hack/osvtool`](../../hack/osvtool) and the `cve-bump` skill reads it rather than hardcoding the branch list, so keeping it current is all that is needed.
+  An allowlisted branch that does not exist in the repository being scanned, and a release image that has not been published to its registry, are reported as annotations and skipped rather than failing the run.
+  That keeps the scan green on forks, which carry only a subset of the release branches and publish no release images; on `kgateway-dev/kgateway` the same gaps are annotated at error level, so a newly cut branch that is missing a scan target is still visible in the run summary.
 
 ### OSV scan and CVE triage
 


### PR DESCRIPTION
# Description

The scheduled OSV scan has two independent failure modes that turn the run red without a vulnerability being involved.

**1. A third-party apt repo can fail the image scan.** The `Install skopeo` step ran `sudo apt-get update`, which exits `100` if *any* configured source fails — including the Google Chrome repo that is preinstalled on the runner image and has nothing to do with this workflow. In [run 30289924079](https://github.com/kgateway-dev/kgateway/actions/runs/30289924079) that repo served a stale index (`File has unexpected size (1425 != 1423). Mirror sync in progress?`) and took down `Scan image (v2.2.x, envoy-wrapper, linux/arm64)`. Every Ubuntu index had fetched fine.

The step was a no-op regardless: skopeo ships with the GitHub-hosted Ubuntu images (1.4.1 on 22.04, 1.13.3 on 24.04), and the sibling jobs' logs say `skopeo is already the newest version`. It is now a presence check that touches no network, and fails with a clear message if a runner image ever drops skopeo. This was the only `apt-get` left under `.github/`, so the apt-flake surface is gone from CI rather than patched at one site.

**2. A scan target the repository does not have fails hard.** Three variants, all of which abort a job instead of reporting a gap:

- a branch in the allowlist that does not exist in the repository being scanned — `actions/checkout` fails on the missing ref;
- a release image that is not published to the registry being scanned — `skopeo copy` fails with `manifest unknown`;
- a release branch that has not been tagged yet — the resolve step raised `No stable patch release tag found`, which is the normal state of a freshly cut branch and would fail all six of its image jobs until the first release.

Each is now reported as an annotation plus a run-summary line and skipped. Severity is `warning` on forks and `error` on this repository, so a genuine gap here stays visible without blocking the branches that can be scanned. Concretely, the branch matrix is filtered to branches that exist, and a new `Check image is published` step probes the exact `(image, platform)` the scan will pull.

The allowlist stays a one-line JSON array literal, because `hack/osvtool` scrapes that assignment out of this file with `sed` and the `cve-bump` skill depends on it — the candidate list is parsed out of it with `jq` rather than replacing it.

# Change Type

/kind fix
/kind flake

# Changelog

```release-note
NONE
```

# Additional Notes

For existing targets on this repository nothing changes: the matrix still resolves to all four allowlisted branches and every published image is still scanned. The one intentional behavior change is that an untagged release branch now annotates and skips instead of failing.

Verification:

- `actionlint` clean; `make fmt-yaml` a no-op.
- Branch-matrix logic dry-run with a stubbed `gh`: full allowlist when all branches exist; filtered plus warnings when only a subset does; `exit 1` for an unsupported `workflow_dispatch` choice, and for an explicit choice that does not exist in the repository.
- The image probe was checked against skopeo **1.4.1**, the version on `ubuntu-22.04` runners, not just a current build: a published image exits 0, a missing tag is non-zero, and a published tag with the wrong arch is non-zero — so it verifies the platform variant, not merely the tag.
- `hack/osvtool --table --target source --state open` still discovers all four branches from the edited workflow.
- `shellcheck` clean on the two rewritten `run:` scripts.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note

```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
