### PR TITLE
chore: v2.2.x branch is no longer LTS, and v2.4.x is tested nightly

### DIFF
--- a/.claude/skills/cve-bump/scripts/detect_base.sh
+++ b/.claude/skills/cve-bump/scripts/detect_base.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 # Read the scan workflow's branch allowlist. The scheduled matrix is a
-# single-quoted JSON array, e.g. branches='["main","v2.2.x","v2.3.x"]'.
+# single-quoted JSON array, e.g. branches='["main","v2.3.x","v2.4.x"]'.
 candidates_from_workflow() {
     local workflow="$1"
     local line

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -49,8 +49,8 @@ jobs:
           if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
             refs='[
               {"checkout_ref":"main","display_ref":"main"},
-              {"checkout_ref":"v2.2.x","display_ref":"v2.2.x"},
-              {"checkout_ref":"v2.3.x","display_ref":"v2.3.x"}
+              {"checkout_ref":"v2.3.x","display_ref":"v2.3.x"},
+              {"checkout_ref":"v2.4.x","display_ref":"v2.4.x"}
             ]'
           else
             checkout_ref="${INPUT_TARGET_REF:-}"
@@ -174,11 +174,9 @@ jobs:
         with:
           path: ${{ matrix.env-versions.file }}
           log-variables: true
-      # v2.2.x is built against Gateway API 1.4 and refuses to start on 1.5+ (#13872), so the
-      # v2.2.x x v1.5+ lanes need special handling: skip the standard channel entirely, and run
-      # the experimental channel with the version check bypassed to keep forward-compat signal.
-      # This is done with step guards rather than a matrix `exclude:` because every dimension
-      # here is object-valued and object-valued excludes are unreliable (actions/runner#1512).
+      # Incompatible lanes are dropped with a step guard rather than a matrix `exclude:`
+      # because every dimension here is object-valued and object-valued excludes are
+      # unreliable (actions/runner#1512).
       - name: Determine run plan
         id: guard
         env:
@@ -187,41 +185,16 @@ jobs:
           GW_API_CHANNEL: ${{ matrix.gateway-api-version.channel }}
           VERSIONS_LABEL: ${{ matrix.env-versions.label }}
           KUBE_VERSION: ${{ steps.dotenv.outputs.kubectl_version }}
-          BASE_REGEX: ${{ matrix.controllers.regex }}
         shell: bash
         run: |
           run=true
-          bypass_version_check=false
-          run_regex="${BASE_REGEX}"
-          if [[ "${REF}" == "v2.2.x" && "${GW_API_VERSION}" == "v1.6.1" ]]; then
-            case "${GW_API_CHANNEL}" in
-              standard)     run=false ;;
-              experimental) bypass_version_check=true ;;
-            esac
-          fi
-          if [[ "${REF}" == "v2.2.x" && "${GW_API_VERSION}" == "v1.5.1" ]]; then
-            case "${GW_API_CHANNEL}" in
-              standard)     run=false ;;
-              experimental) bypass_version_check=true ;;
-            esac
-          fi
-          # v2.2.x's chart predates ListenerSet support, so TestListenerSet fails at apply time
-          # ("the server could not find the requested resource") even with the version check
-          # bypassed. Drop it from the regex on v2.2.x while keeping the rest of the
-          # forward-compat signal. (ListenerSet only runs on the experimental channel; the
-          # standard v2.2.x lanes are skipped above.)
-          if [[ "${REF}" == "v2.2.x" ]]; then
-            run_regex="${run_regex//^TestListenerSet|/}"
-          fi
           # The Gateway API experimental-channel CRDs rely on CEL library functions that
           # Kubernetes only ships starting at specific minor versions: the 1.5+ CRDs use
           # isIP() (added in k8s 1.31), and the 1.6+ CRDs additionally use the `format`
           # library, e.g. format.dns1123Label() (only reliably available from k8s 1.33).
           # Skip experimental-channel lanes whose Kubernetes version predates what the CRDs
           # need, based on the actual version pin rather than a hardcoded ref/label -- a
-          # hardcoded list silently goes stale as per-ref version pins drift (this is what
-          # let the v2.2.x min lane start failing once its pin moved under a 1.6.1 CRD without
-          # anyone updating this guard).
+          # hardcoded list silently goes stale as per-ref version pins drift.
           if [[ "${GW_API_CHANNEL}" == "experimental" ]]; then
             gwapi_minor="${GW_API_VERSION#v}"
             gwapi_minor="${gwapi_minor#*.}"
@@ -235,22 +208,8 @@ jobs:
               run=false
             fi
           fi
-          {
-            echo "run=${run}"
-            echo "bypass_version_check=${bypass_version_check}"
-            echo "run_regex=${run_regex}"
-          } >> "${GITHUB_OUTPUT}"
-          echo "ref=${REF} gw-api=${GW_API_VERSION}-${GW_API_CHANNEL} versions=${VERSIONS_LABEL} k8s=${KUBE_VERSION} -> run=${run} bypass_version_check=${bypass_version_check} run_regex=${run_regex}"
-      # Bake KGW_SKIP_GATEWAY_API_VERSION_CHECK into the chart before setup-kind-cluster
-      # packages it (hack/kind/setup-kind.sh runs `make package-kgateway-charts` from source),
-      # so the controller starts despite the unsupported Gateway API version.
-      - name: Bypass Gateway API version check
-        if: ${{ steps.guard.outputs.bypass_version_check == 'true' }}
-        shell: bash
-        run: |
-          yq -i '.controller.extraEnv.KGW_SKIP_GATEWAY_API_VERSION_CHECK = "true"' \
-            install/helm/kgateway/values.yaml
-          echo "Set controller.extraEnv.KGW_SKIP_GATEWAY_API_VERSION_CHECK=true in install/helm/kgateway/values.yaml"
+          echo "run=${run}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${REF} gw-api=${GW_API_VERSION}-${GW_API_CHANNEL} versions=${VERSIONS_LABEL} k8s=${KUBE_VERSION} -> run=${run}"
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Setup KinD Cluster
@@ -289,7 +248,7 @@ jobs:
           cluster-name: "kgw-api-e2e-${{ matrix.env-versions.label }}-${{ matrix.gateway-api-version.version }}-${{ matrix.gateway-api-version.channel }}"
           cluster-type: ${{ steps.dotenv.outputs.cluster_type || 'kind' }}
           test-args: '-timeout=120m'
-          run-regex: ${{ steps.guard.outputs.run_regex }}
+          run-regex: ${{ matrix.controllers.regex }}
           istio-version: ${{ steps.dotenv.outputs.istio_version }}
           matrix-label: "nightly-kgw-api-${{ matrix.env-versions.label }}-${{ matrix.gateway-api-version.version }}-${{ matrix.gateway-api-version.channel }}"
           envtest-k8s-version: ${{ steps.dotenv.outputs.envtest_k8s_version }}

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -12,7 +12,6 @@ on:
         options:
           - all
           - main
-          - v2.2.x
           - v2.3.x
           - v2.4.x
 
@@ -43,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          branches='["main","v2.2.x","v2.3.x","v2.4.x"]'
+          branches='["main","v2.3.x","v2.4.x"]'
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             case "${{ inputs.branches }}" in
@@ -51,9 +50,6 @@ jobs:
                 ;;
               main)
                 branches='["main"]'
-                ;;
-              v2.2.x)
-                branches='["v2.2.x"]'
                 ;;
               v2.3.x)
                 branches='["v2.3.x"]'

--- a/devel/contributing/releasing.md
+++ b/devel/contributing/releasing.md
@@ -50,9 +50,23 @@ If the release branch **does not** exist, create one:
 - On `main`, bump `ROLLING_MAIN_VERSION` in the [Makefile](../../Makefile) to the next minor's rolling tag via a PR (for example, after cutting `v2.3.x`, set it to `v2.4.0-main`), since `main` now tracks the next minor.
 - On `main`, bump `gateway-api-version` in the [e2e test workflow](https://github.com/kgateway-dev/kgateway/blob/96403169afb6b0f4becb864b42d22fcf000033f7/.github/workflows/e2e.yaml#L129) to 1 version lower than what is used in go.mod (since this is an upgrade test)
 
-- Update the OSV security scan workflow branch allowlist in [.github/workflows/osv-scanner.yaml](../../.github/workflows/osv-scanner.yaml) to include the new release branch, and drop any branch that is no longer LTS.
-  This workflow only scans an explicit set of branches, so each newly cut release branch must be added to both the scheduled scan matrix and the `workflow_dispatch` branch options.
-  This allowlist is the single source of truth for which branches get scanned: tooling such as [`hack/osvtool`](../../hack/osvtool) and the `cve-bump` skill reads it rather than hardcoding the branch list, so keeping it current is all that is needed.
+- Add the new release branch to both CI workflows that hardcode a branch list. Neither discovers branches automatically, so a newly cut branch gets no coverage until it is listed:
+  - [.github/workflows/osv-scanner.yaml](../../.github/workflows/osv-scanner.yaml): add it to the scheduled scan matrix (the `branches='[...]'` array) *and* the `workflow_dispatch` branch options.
+    This allowlist is the single source of truth for which branches get scanned: tooling such as [`hack/osvtool`](../../hack/osvtool) and the `cve-bump` skill reads it rather than hardcoding the branch list, so keeping it current is all that is needed.
+  - [.github/workflows/nightly-tests.yaml](../../.github/workflows/nightly-tests.yaml): add it to the scheduled `refs` array in the `determine_refs` job, which drives the nightly conformance, load, and e2e matrices.
+
+### Retiring an LTS branch
+
+When a release branch reaches end of life, remove it from the same two workflows it was added to when it was cut:
+
+- [.github/workflows/osv-scanner.yaml](../../.github/workflows/osv-scanner.yaml): drop it from the scheduled `branches='[...]'` array, the `workflow_dispatch` options, and the dispatch `case` arm.
+- [.github/workflows/nightly-tests.yaml](../../.github/workflows/nightly-tests.yaml): drop it from the scheduled `refs` array.
+
+Both edits land on `main` only. Scheduled runs always use the workflow definition from the default branch even though they check out each ref, so removing a ref from `main`'s matrix retires it everywhere -- there is no corresponding change to make on the release branch itself.
+
+Also delete any branch-specific workarounds that existed solely to keep the retired branch green.
+
+Once a branch is retired it stops being scanned, so it no longer appears in `hack/osvtool` output and no longer needs CVE triage before a release.
 
 ### OSV scan and CVE triage
 
@@ -101,7 +115,7 @@ relying on the scan results for that branch.
 
 ### Patch Release
 
-A patch release is generated from an existing release branch, e.g. [v2.2.x](https://github.com/kgateway-dev/kgateway/commits/v2.2.x/).
+A patch release is generated from an existing release branch, e.g. [v2.3.x](https://github.com/kgateway-dev/kgateway/commits/v2.3.x/).
 After all the necessary backport pull requests have merged, you can proceed to the next section.
 
 ## Publish the Release
@@ -112,7 +126,7 @@ Use the "Run workflow" drop-down in the right corner of the page to dispatch a r
 
 - Select the branch to release from
   - Minor release: Select the `main` branch.
-  - Patch release: Select the release branch, e.g. `v2.2.x`, that will be patched.
+  - Patch release: Select the release branch, e.g. `v2.3.x`, that will be patched.
 - Enter the version for the release to create, e.g. `v2.0.3`. This will trigger
   the release process and result in a new GitHub release, [v2.0.3](https://github.com/kgateway-dev/kgateway/releases/tag/v2.0.3)
   for example.


### PR DESCRIPTION
# Description

`v2.2.x` has reached end of life, so this removes it from the two workflows that hardcode the supported branch list, and cleans up the workarounds that existed only to keep its lanes green.

**OSV scanner** (`.github/workflows/osv-scanner.yaml`) — dropped from the scheduled allowlist, the `workflow_dispatch` options, and the dispatch `case`. Mirrors #14085, which retired `v2.1.x`.

**Nightly tests** (`.github/workflows/nightly-tests.yaml`) — dropped from the scheduled ref matrix. This also lets a fair amount of dead machinery go:

- both `REF == v2.2.x` guard blocks handling Gateway API 1.5/1.6 (#13872)
- the `TestListenerSet` regex surgery, needed because v2.2.x's chart predated ListenerSet
- the entire `KGW_SKIP_GATEWAY_API_VERSION_CHECK` bypass step. That env var only exists in v2.2.x's Go source (`pkg/kgateway/gatewayapiversion/version.go`); it is unread on v2.3.x, v2.4.x, and `main`, so the step could not have done anything once v2.2.x left the matrix.

With `bypass_version_check` and `run_regex` both gone, `run-regex` now reads `matrix.controllers.regex` directly.

The ref-agnostic CEL guard stays, and is still load-bearing: it skips the Gateway API 1.6.1-experimental lanes on the min pin, where k8s 1.32 predates the 1.33 that `format.dns1123Label()` needs.

**`v2.4.x` added to nightly.** It was never added when cut — #14444 updated only the OSV allowlist — so nightly was covering just one of the two remaining LTS branches. End state is `main + v2.3.x + v2.4.x`, matching the OSV allowlist and the cron comment.

**`devel/contributing/releasing.md`** — the cut-a-branch checklist mentioned the OSV allowlist but not the nightly matrix, which is how `v2.4.x` slipped through, and there was no retirement procedure at all. Both are now documented, including the non-obvious detail that scheduled runs always use `main`'s workflow definition, so these lists are only ever edited on `main`.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Verified with `make lint-actions` (actionlint clean) and `make fmt-yaml` (no further changes). I simulated the guard across the full 3 refs x 2 env-pins x 4 Gateway API versions x 2 channels matrix to confirm the only skipped lanes are the three 1.6.1-experimental-on-min ones, one per ref. `detect_base.sh` parses the allowlist rather than hardcoding it and reads back the new list correctly; its example comment was stale so it is updated too.

Left alone deliberately: `docs/guides/transformation.md` and `pkg/kgateway/proxy_syncer/status_syncer.go` mention v2.2.x as historical behavior notes, not support declarations.
