### PR TITLE
feat(listenerpolicy): add proxy100Continue setting to HTTPSettings

### DIFF
--- a/api/v1alpha1/kgateway/listener_policy_types.go
+++ b/api/v1alpha1/kgateway/listener_policy_types.go
@@ -216,6 +216,7 @@ type HTTPSettings struct {
 	// Proxy100Continue determines whether Envoy forwards requests with an
 	// Expect: 100-continue header upstream and proxies upstream 100 Continue
 	// responses downstream. When unset or false, Envoy handles the response locally.
+	// +optional
 	Proxy100Continue *bool `json:"proxy100Continue,omitempty"`
 
 	// XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.

--- a/api/v1alpha1/kgateway/listener_policy_types.go
+++ b/api/v1alpha1/kgateway/listener_policy_types.go
@@ -213,6 +213,10 @@ type HTTPSettings struct {
 	// See here for more information https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-generate-request-id
 	// +optional
 	GenerateRequestId *bool `json:"generateRequestId,omitempty"`
+	// Proxy100Continue determines whether Envoy forwards requests with an
+	// Expect: 100-continue header upstream and proxies upstream 100 Continue
+	// responses downstream. When unset or false, Envoy handles the response locally.
+	Proxy100Continue *bool `json:"proxy100Continue,omitempty"`
 
 	// XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.
 	// This is mutually exclusive with XffTrustedCIDRs.

--- a/api/v1alpha1/kgateway/zz_generated.deepcopy.go
+++ b/api/v1alpha1/kgateway/zz_generated.deepcopy.go
@@ -2596,6 +2596,11 @@ func (in *HTTPSettings) DeepCopyInto(out *HTTPSettings) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Proxy100Continue != nil {
+		in, out := &in.Proxy100Continue, &out.Proxy100Continue
+		*out = new(bool)
+		**out = **in
+	}
 	if in.XffNumTrustedHops != nil {
 		in, out := &in.XffNumTrustedHops, &out.XffNumTrustedHops
 		*out = new(int32)

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
@@ -2640,6 +2640,14 @@ spec:
                   PreserveHttp1HeaderCase determines whether to preserve the case of HTTP1 request headers.
                   See here for more information: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing
                 type: boolean
+              proxy100Continue:
+                description: |-
+                  Proxy100Continue determines whether Envoy forwards requests with an
+                  Expect: 100-continue header upstream and proxies upstream 100 Continue
+                  responses downstream. When unset or false, Envoy handles the response locally.
+
+                  See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
+                type: boolean
               serverHeaderTransformation:
                 description: |-
                   ServerHeaderTransformation determines how the server header is transformed.

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
@@ -2645,8 +2645,6 @@ spec:
                   Proxy100Continue determines whether Envoy forwards requests with an
                   Expect: 100-continue header upstream and proxies upstream 100 Continue
                   responses downstream. When unset or false, Envoy handles the response locally.
-
-                  See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
                 type: boolean
               serverHeaderTransformation:
                 description: |-

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
@@ -2762,8 +2762,6 @@ spec:
                           Proxy100Continue determines whether Envoy forwards requests with an
                           Expect: 100-continue header upstream and proxies upstream 100 Continue
                           responses downstream. When unset or false, Envoy handles the response locally.
-
-                          See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
                         type: boolean
                       serverHeaderTransformation:
                         description: |-
@@ -6016,8 +6014,6 @@ spec:
                                 Proxy100Continue determines whether Envoy forwards requests with an
                                 Expect: 100-continue header upstream and proxies upstream 100 Continue
                                 responses downstream. When unset or false, Envoy handles the response locally.
-
-                                See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
                               type: boolean
                             serverHeaderTransformation:
                               description: |-

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
@@ -2757,6 +2757,14 @@ spec:
                           PreserveHttp1HeaderCase determines whether to preserve the case of HTTP1 request headers.
                           See here for more information: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing
                         type: boolean
+                      proxy100Continue:
+                        description: |-
+                          Proxy100Continue determines whether Envoy forwards requests with an
+                          Expect: 100-continue header upstream and proxies upstream 100 Continue
+                          responses downstream. When unset or false, Envoy handles the response locally.
+
+                          See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
+                        type: boolean
                       serverHeaderTransformation:
                         description: |-
                           ServerHeaderTransformation determines how the server header is transformed.
@@ -6002,6 +6010,14 @@ spec:
                               description: |-
                                 PreserveHttp1HeaderCase determines whether to preserve the case of HTTP1 request headers.
                                 See here for more information: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing
+                              type: boolean
+                            proxy100Continue:
+                              description: |-
+                                Proxy100Continue determines whether Envoy forwards requests with an
+                                Expect: 100-continue header upstream and proxies upstream 100 Continue
+                                responses downstream. When unset or false, Envoy handles the response locally.
+
+                                See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-proxy-100-continue
                               type: boolean
                             serverHeaderTransformation:
                               description: |-

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
@@ -46,6 +46,7 @@ func baseHarnessHttpListenerPolicyIr() *HttpListenerPolicyIr {
 		preserveHttp1HeaderCase:   new(true),
 		preserveExternalRequestId: new(true),
 		generateRequestId:         new(true),
+		proxy100Continue:          new(true),
 		accessLogConfig:           []proto.Message{wrapperspb.String("access-log")},
 		accessLogPolicies: []kgateway.AccessLog{
 			{FileSink: &kgateway.FileSink{Path: "/dev/stdout"}},
@@ -136,6 +137,12 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		{
 			Field:  "generateRequestId",
 			Mutate: func(d **HttpListenerPolicyIr) { (*d).generateRequestId = new(false) },
+		},
+		{
+			Field: "proxy100Continue",
+			Mutate: func(d **HttpListenerPolicyIr) {
+				(*d).proxy100Continue = new(false)
+			},
 		},
 		{
 			Field: "accessLogConfig",

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
@@ -50,6 +50,7 @@ type HttpListenerPolicyIr struct {
 	preserveHttp1HeaderCase    *bool
 	preserveExternalRequestId  *bool
 	generateRequestId          *bool
+	proxy100Continue           *bool
 	// For a better UX, we set the default serviceName for access logs to the envoy cluster name (`<gateway-name>.<gateway-namespace>`).
 	// Since the gateway name can only be determined during translation, the access log configs and policies
 	// are stored so that during translation, the default serviceName is set if not already provided
@@ -128,6 +129,10 @@ func (d *HttpListenerPolicyIr) Equals(in any) bool {
 
 	// Check xffNumTrustedHops
 	if !cmputils.PointerValsEqual(d.xffNumTrustedHops, d2.xffNumTrustedHops) {
+		return false
+	}
+
+	if !cmputils.PointerValsEqual(d.proxy100Continue, d2.proxy100Continue) {
 		return false
 	}
 
@@ -393,6 +398,7 @@ func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.Com
 		useRemoteAddress:              h.UseRemoteAddress,
 		preserveExternalRequestId:     h.PreserveExternalRequestId,
 		generateRequestId:             h.GenerateRequestId,
+		proxy100Continue:              h.Proxy100Continue,
 		xffNumTrustedHops:             xffNumTrustedHops,
 		xffConfig:                     xffConfig,
 		skipXffAppend:                 h.SkipXffAppend,

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
@@ -445,6 +445,9 @@ func (p *listenerPolicyPluginGwPass) ApplyHCM(
 	if policy.generateRequestId != nil {
 		out.GenerateRequestId = wrapperspb.Bool(*policy.generateRequestId)
 	}
+	if policy.proxy100Continue != nil {
+		out.Proxy_100Continue = *policy.proxy100Continue
+	}
 
 	// translate xffNumTrustedHops
 	if policy.xffNumTrustedHops != nil {

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/merge_http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/merge_http.go
@@ -28,6 +28,7 @@ func MergeHttpPolicies(
 		mergeUseRemoteAddress,
 		mergePreserveExternalRequestId,
 		mergeGenerateRequestId,
+		mergeProxy100Continue,
 		mergeXffNumTrustedHops,
 		mergeXffConfig,
 		mergeSkipXffAppend,
@@ -172,6 +173,22 @@ func mergeGenerateRequestId(
 
 	p1.generateRequestId = p2.generateRequestId
 	mergeOrigins.SetOne(origin+"generateRequestId", p2Ref, p2MergeOrigins)
+}
+
+func mergeProxy100Continue(
+	origin string,
+	p1, p2 *HttpListenerPolicyIr,
+	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
+	opts policy.MergeOptions,
+	mergeOrigins ir.MergeOrigins,
+) {
+	if !policy.IsMergeable(p1.proxy100Continue, p2.proxy100Continue, opts) {
+		return
+	}
+
+	p1.proxy100Continue = p2.proxy100Continue
+	mergeOrigins.SetOne(origin+"proxy100Continue", p2Ref, p2MergeOrigins)
 }
 
 func mergePreserveHttp1HeaderCase(

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -2445,6 +2445,17 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("ListenerPolicy_proxy100Continue", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-policy-http/proxy-100-continue.yaml"},
+			outputFile: "listener-policy-http/proxy-100-continue.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("ListenerPolicy with stripHostPortMode MatchingPort", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"listener-policy-http/strip-host-port-matching-port.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/proxy-100-continue.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/proxy-100-continue.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 80
+      targetPort: test
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: ListenerPolicy
+metadata:
+  name: proxy-100-continue
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  default:
+    httpSettings:
+      proxy100Continue: true

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/proxy-100-continue.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/proxy-100-continue.yaml
@@ -1,0 +1,156 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        proxy100Continue: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.proxy100Continue:
+        - gateway.kgateway.dev/ListenerPolicy/default/proxy-100-continue
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.proxy100Continue:
+        - gateway.kgateway.dev/ListenerPolicy/default/proxy-100-continue
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    ListenerPolicy/default/proxy-100-continue:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway


### PR DESCRIPTION
# Description

Adds a `proxy100Continue` boolean field to `HTTPSettings` in the `ListenerPolicy` CRD. This maps directly to Envoy's `HttpConnectionManager.proxy_100_continue` field to allow users to opt into end-to-end proxying of 1xx informational responses (e.g. `100 Continue` and `103 Early Hints`).

Fixes #14480

/kind feature

## Changelog

```release-note
Added a `proxy100Continue` field to `HTTPSettings` on the `ListenerPolicy` CRD to enable end-to-end proxying of HTTP 1xx informational responses.
```

