### PR TITLE
Support local-origin outlier detection

### DIFF
--- a/api/v1alpha1/kgateway/backend_config_policy_types.go
+++ b/api/v1alpha1/kgateway/backend_config_policy_types.go
@@ -733,6 +733,38 @@ type OutlierDetection struct {
 	// +kubebuilder:validation:Minimum=0
 	Consecutive5xx *int32 `json:"consecutive5xx,omitempty"`
 
+	// The percentage chance that a host is ejected when an outlier status is
+	// detected through consecutive 5xx responses. This setting can be used to
+	// disable ejection or to ramp it up slowly. Defaults to 100.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	EnforcingConsecutive5xx *int32 `json:"enforcingConsecutive5xx,omitempty"`
+
+	// Determines whether to distinguish locally originated failures from
+	// externally generated errors. When true, consecutiveLocalOriginFailure and
+	// enforcingConsecutiveLocalOriginFailure are used for locally originated
+	// failures. Defaults to false.
+	// +optional
+	SplitExternalLocalOriginErrors *bool `json:"splitExternalLocalOriginErrors,omitempty"`
+
+	// The number of consecutive locally originated failures before an ejection
+	// occurs. Defaults to 5. This setting takes effect only when
+	// splitExternalLocalOriginErrors is true. If this is zero, consecutive local
+	// origin failure ejection is disabled.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ConsecutiveLocalOriginFailure *int32 `json:"consecutiveLocalOriginFailure,omitempty"`
+
+	// The percentage chance that a host is ejected when an outlier status is
+	// detected through consecutive locally originated failures. This setting can
+	// be used to disable ejection or to ramp it up slowly. Defaults to 100 and
+	// takes effect only when splitExternalLocalOriginErrors is true.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	EnforcingConsecutiveLocalOriginFailure *int32 `json:"enforcingConsecutiveLocalOriginFailure,omitempty"`
+
 	// The time interval between ejection analysis sweeps. This can result in
 	// both new ejections as well as hosts being returned to service. Defaults
 	// to 10s.

--- a/api/v1alpha1/kgateway/zz_generated.deepcopy.go
+++ b/api/v1alpha1/kgateway/zz_generated.deepcopy.go
@@ -4446,6 +4446,26 @@ func (in *OutlierDetection) DeepCopyInto(out *OutlierDetection) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnforcingConsecutive5xx != nil {
+		in, out := &in.EnforcingConsecutive5xx, &out.EnforcingConsecutive5xx
+		*out = new(int32)
+		**out = **in
+	}
+	if in.SplitExternalLocalOriginErrors != nil {
+		in, out := &in.SplitExternalLocalOriginErrors, &out.SplitExternalLocalOriginErrors
+		*out = new(bool)
+		**out = **in
+	}
+	if in.ConsecutiveLocalOriginFailure != nil {
+		in, out := &in.ConsecutiveLocalOriginFailure, &out.ConsecutiveLocalOriginFailure
+		*out = new(int32)
+		**out = **in
+	}
+	if in.EnforcingConsecutiveLocalOriginFailure != nil {
+		in, out := &in.EnforcingConsecutiveLocalOriginFailure, &out.EnforcingConsecutiveLocalOriginFailure
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Interval != nil {
 		in, out := &in.Interval, &out.Interval
 		*out = new(v1.Duration)

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
@@ -824,6 +824,34 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  consecutiveLocalOriginFailure:
+                    description: |-
+                      The number of consecutive locally originated failures before an ejection
+                      occurs. Defaults to 5. This setting takes effect only when
+                      splitExternalLocalOriginErrors is true. If this is zero, consecutive local
+                      origin failure ejection is disabled.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  enforcingConsecutive5xx:
+                    description: |-
+                      The percentage chance that a host is ejected when an outlier status is
+                      detected through consecutive 5xx responses. This setting can be used to
+                      disable ejection or to ramp it up slowly. Defaults to 100.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  enforcingConsecutiveLocalOriginFailure:
+                    description: |-
+                      The percentage chance that a host is ejected when an outlier status is
+                      detected through consecutive locally originated failures. This setting can
+                      be used to disable ejection or to ramp it up slowly. Defaults to 100 and
+                      takes effect only when splitExternalLocalOriginErrors is true.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
                   interval:
                     default: 10s
                     description: |-
@@ -845,6 +873,13 @@ spec:
                     maximum: 100
                     minimum: 0
                     type: integer
+                  splitExternalLocalOriginErrors:
+                    description: |-
+                      Determines whether to distinguish locally originated failures from
+                      externally generated errors. When true, consecutiveLocalOriginFailure and
+                      enforcingConsecutiveLocalOriginFailure are used for locally originated
+                      failures. Defaults to false.
+                    type: boolean
                 type: object
               perConnectionBufferLimitBytes:
                 description: |-

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/outlierdetection.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/outlierdetection.go
@@ -18,6 +18,18 @@ func translateOutlierDetection(od *kgateway.OutlierDetection) *envoyclusterv3.Ou
 	if od.Consecutive5xx != nil {
 		outlierDetection.Consecutive_5Xx = &wrapperspb.UInt32Value{Value: uint32(*od.Consecutive5xx)} // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
 	}
+	if od.EnforcingConsecutive5xx != nil {
+		outlierDetection.EnforcingConsecutive_5Xx = &wrapperspb.UInt32Value{Value: uint32(*od.EnforcingConsecutive5xx)} // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	}
+	if od.SplitExternalLocalOriginErrors != nil {
+		outlierDetection.SplitExternalLocalOriginErrors = *od.SplitExternalLocalOriginErrors
+	}
+	if od.ConsecutiveLocalOriginFailure != nil {
+		outlierDetection.ConsecutiveLocalOriginFailure = &wrapperspb.UInt32Value{Value: uint32(*od.ConsecutiveLocalOriginFailure)} // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	}
+	if od.EnforcingConsecutiveLocalOriginFailure != nil {
+		outlierDetection.EnforcingConsecutiveLocalOriginFailure = &wrapperspb.UInt32Value{Value: uint32(*od.EnforcingConsecutiveLocalOriginFailure)} // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	}
 	if od.Interval != nil {
 		outlierDetection.Interval = durationpb.New(od.Interval.Duration)
 	}

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/outlierdetection_test.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/outlierdetection_test.go
@@ -39,6 +39,21 @@ func TestTranslateOutlierDetection(t *testing.T) {
 			},
 		},
 		{
+			name: "enforce local origin failures and disable external 5xx ejections",
+			config: &kgateway.OutlierDetection{
+				SplitExternalLocalOriginErrors:         new(true),
+				ConsecutiveLocalOriginFailure:          new(int32(10)),
+				EnforcingConsecutiveLocalOriginFailure: new(int32(100)),
+				EnforcingConsecutive5xx:                new(int32(0)),
+			},
+			expected: &envoyclusterv3.OutlierDetection{
+				SplitExternalLocalOriginErrors:         true,
+				ConsecutiveLocalOriginFailure:          &wrapperspb.UInt32Value{Value: 10},
+				EnforcingConsecutiveLocalOriginFailure: &wrapperspb.UInt32Value{Value: 100},
+				EnforcingConsecutive_5Xx:               &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
 			name: "full outlier detection config",
 			config: &kgateway.OutlierDetection{
 				Consecutive5xx:     new(int32(2)),

--- a/pkg/kgateway/translator/gateway/testutils/inputs/backendconfigpolicy/outlierdetection.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/backendconfigpolicy/outlierdetection.yaml
@@ -68,3 +68,7 @@ spec:
       kind: Service
   outlierDetection:
     maxEjectionPercent: 95
+    splitExternalLocalOriginErrors: true
+    consecutiveLocalOriginFailure: 10
+    enforcingConsecutiveLocalOriginFailure: 100
+    enforcingConsecutive5xx: 0

--- a/pkg/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/backendconfigpolicy/outlierdetection.yaml
@@ -11,8 +11,12 @@ Clusters:
   outlierDetection:
     baseEjectionTime: 30s
     consecutive5xx: 5
+    consecutiveLocalOriginFailure: 10
+    enforcingConsecutive5xx: 0
+    enforcingConsecutiveLocalOriginFailure: 100
     interval: 10s
     maxEjectionPercent: 95
+    splitExternalLocalOriginErrors: true
   type: EDS
 - commonLbConfig:
     localityWeightedLbConfig: {}


### PR DESCRIPTION
# Description

Extends `BackendConfigPolicy` outlier detection with Envoy’s local/external error separation.

This allows users to eject endpoints for locally originated failures while disabling ejection for externally generated HTTP 5xx responses. This is particularly useful for gRPC backends, where legitimate application statuses such as `UNAVAILABLE` map to HTTP 5xx for Envoy outlier detection.

Added support for:

- `splitExternalLocalOriginErrors`
- `consecutiveLocalOriginFailure`
- `enforcingConsecutiveLocalOriginFailure`
- `enforcingConsecutive5xx`

The fields are translated to their corresponding Envoy cluster `OutlierDetection` fields. Enforcement percentages are validated to be between 0 and 100. Generated CRDs, deep-copy code, API documentation, and translation tests have also been updated.

# Change Type

/kind feature

# Changelog

```release-note
Add BackendConfigPolicy support for separating local-origin outlier detection failures from externally generated errors.
```

# Additional Notes

Translation coverage verifies that users can enforce local-origin failure ejections while disabling externally generated 5xx ejections:

```yaml
splitExternalLocalOriginErrors: true
consecutiveLocalOriginFailure: 10
enforcingConsecutiveLocalOriginFailure: 100
enforcingConsecutive5xx: 0
```
