### PR TITLE
perf(endpoints): reduce per-endpoint heap and re-hash churn at scale

### DIFF
--- a/pkg/kgateway/endpoints/prioritize.go
+++ b/pkg/kgateway/endpoints/prioritize.go
@@ -156,6 +156,15 @@ func prioritizeWithLbInfo(logger *slog.Logger, ep ir.EndpointsForBackend, lbInfo
 	return cla
 }
 
+// lbWeight returns the per-endpoint load balancing weight, treating an unset
+// weight as 1, matching Envoy's default (LbEndpoint.load_balancing_weight).
+func lbWeight(ep *envoyendpointv3.LbEndpoint) uint32 {
+	if w := ep.GetLoadBalancingWeight(); w != nil {
+		return w.GetValue()
+	}
+	return 1
+}
+
 // ensure we don't send invalid endpoints to envoy and cause NACKs
 func filterInvalidEps(eps []ir.EndpointWithMd) []ir.EndpointWithMd {
 	return istioslices.Filter(eps, func(ewm ir.EndpointWithMd) bool {
@@ -178,7 +187,7 @@ func getEndpoints(eps []ir.EndpointWithMd, lbinfo LoadBalancingInfo) []*envoyend
 	var weight uint32
 	for _, ep := range eps {
 		epsOut[0].LbEndpoints = append(epsOut[0].GetLbEndpoints(), ep.LbEndpoint)
-		weight += ep.LbEndpoint.GetLoadBalancingWeight().GetValue()
+		weight += lbWeight(ep.LbEndpoint)
 	}
 	// reset weight
 	if weight > 0 {
@@ -214,7 +223,7 @@ func applyFailoverPriorityPerLocality(
 		var weight uint32
 		for _, index := range priorityMap[priority] {
 			out[i].LbEndpoints = append(out[i].GetLbEndpoints(), eps[index].LbEndpoint)
-			weight += eps[index].GetLoadBalancingWeight().GetValue()
+			weight += lbWeight(eps[index].LbEndpoint)
 		}
 		// reset weight
 		if weight > 0 {

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 5000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-a_se-a.example.com_5000
   type: STATIC
@@ -23,7 +22,6 @@ Clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-b_se-b.example.com_9000
   type: STATIC

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 5000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-a_se-a.example.com_5000
   type: STATIC
@@ -23,7 +22,6 @@ Clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-b_se-b.example.com_9000
   type: STATIC

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 5000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-a_se-a.example.com_5000
   type: STATIC
@@ -23,7 +22,6 @@ Clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-b_se-b.example.com_9000
   type: STATIC

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-c_se-c.infra.svc.cluster.local_9000
   type: STATIC

--- a/pkg/kgateway/proxy_syncer/effective_endpoints.go
+++ b/pkg/kgateway/proxy_syncer/effective_endpoints.go
@@ -31,11 +31,10 @@ func newFinalBackendEndpoints(
 		final.AttachedPolicies = backend.AttachedPolicies
 		final.ClusterName = backend.ClusterName()
 		final.UpstreamResourceName = backend.ResourceName()
-		for locality, endpoints := range raw.LbEps {
-			for _, endpoint := range endpoints {
-				final.Add(locality, endpoint)
-			}
-		}
+		// Reuse the endpoint protos AND their precomputed equality hash instead
+		// of re-Adding every endpoint: Add re-marshals each LbEndpoint proto
+		// (HashProtoWithHasher), which is a major allocation source at scale.
+		final.ReuseEndpointsFrom(raw)
 		// A same-named EDS cluster can still re-warm when policy changes CDS.
 		// Bump only the endpoint version so Envoy receives a fresh CLA response.
 		if policyHash := backendEndpointVersionHash(backend); policyHash != 0 {

--- a/pkg/kgateway/proxy_syncer/gateway_backend_variants.go
+++ b/pkg/kgateway/proxy_syncer/gateway_backend_variants.go
@@ -93,11 +93,10 @@ func newGatewayBackendVariantEndpoints(
 		}
 
 		clone := ir.NewEndpointsForBackend(*variant.backend)
-		for locality, endpoints := range base.LbEps {
-			for _, endpoint := range endpoints {
-				clone.Add(locality, endpoint)
-			}
-		}
+		// The endpoint protos are shared with the base backend; reuse the
+		// precomputed equality hash as well to avoid re-marshaling every
+		// LbEndpoint proto (HashProtoWithHasher) on each recompute.
+		clone.ReuseEndpointsFrom(base)
 
 		return clone
 	}, krtopts.ToOptions("GatewayBackendClientCertificateVariantEndpoints")...)

--- a/pkg/kgateway/setup/testdata/experimental/cors-hr-and-tp-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-hr-and-tp-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-httproute-backend-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-httproute-backend-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-httproute-rule-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-httproute-rule-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-gw-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-gw-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-route-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-diffns-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-diffns-out.yaml
@@ -39,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -51,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -64,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -77,7 +74,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-out.yaml
@@ -39,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -51,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -64,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -77,7 +74,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-label-keys-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-label-keys-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -50,7 +49,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -63,7 +61,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -76,7 +73,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-mtls-disabled-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-mtls-disabled-out.yaml
@@ -143,7 +143,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_httpbin_9000
 listeners:

--- a/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-out.yaml
@@ -161,7 +161,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_httpbin_9000
 listeners:

--- a/pkg/kgateway/setup/testdata/listenerbind/v4/happypath-out.yaml
+++ b/pkg/kgateway/setup/testdata/listenerbind/v4/happypath-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/listenerbind/v6/happypath-out.yaml
+++ b/pkg/kgateway/setup/testdata/listenerbind/v6/happypath-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/backendconfigpolicy-alias-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/backendconfigpolicy-alias-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_gwtest_httpbin-se_se.example.com_80
   type: STATIC

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-backendref-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-backendref-out.yaml
@@ -32,7 +32,6 @@ endpoints:
           socketAddress:
             address: 255.0.0.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     priority: 3
   - lbEndpoints:
@@ -41,7 +40,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -79,7 +75,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-dns-endpoints-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-dns-endpoints-out.yaml
@@ -17,7 +17,6 @@ clusters:
             socketAddress:
               address: foo.external.com
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -30,7 +29,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 18443
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -21,7 +20,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 18443
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -33,7 +31,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 18443
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -51,7 +48,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 18080
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -63,7 +59,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 18080
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -75,7 +70,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 18080
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-out.yaml
@@ -12,7 +12,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -25,7 +24,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -38,7 +36,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-polattach-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-polattach-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_gwtest_example-se_se.example.com_80
   transportSocket:

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-inline-eps-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-inline-eps-out.yaml
@@ -12,7 +12,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -25,7 +24,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -38,7 +36,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/standard/accesslog-filtercel-httplisteneropt-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/accesslog-filtercel-httplisteneropt-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/accesslog-filterhttp-httplisteneropt-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/accesslog-filterhttp-httplisteneropt-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 50051
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/accesslog-httplisteneropt-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/accesslog-httplisteneropt-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
@@ -47,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-label-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-label-out.yaml
@@ -46,7 +46,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-out.yaml
@@ -46,7 +46,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-tls-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-tls-out.yaml
@@ -119,7 +119,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendtlspolicy-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendtlspolicy-out.yaml
@@ -60,7 +60,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/csrf-gw-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/csrf-gw-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/csrf-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/csrf-route-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
@@ -58,7 +58,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.16
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_ext-authz_9000
   endpoints:
@@ -68,7 +67,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -78,7 +76,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extproc-backend-extref-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extproc-backend-extref-out.yaml
@@ -53,7 +53,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 9091
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_ratings_8080
 - clusterName: kube_gwtest_reviews_8080
@@ -64,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
   - lbEndpoints:
     - endpoint:
@@ -72,7 +70,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extproc-routerule-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extproc-routerule-out.yaml
@@ -53,7 +53,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 9091
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_ratings_8080
 - clusterName: kube_gwtest_reviews_8080
@@ -64,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
   - lbEndpoints:
     - endpoint:
@@ -72,7 +70,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extproc-targetref-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extproc-targetref-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 9091
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
   - lbEndpoints:
     - endpoint:
@@ -61,7 +59,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/happypath-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/happypath-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-extref-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-extref-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews-v2_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-disabled-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-disabled-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-gw-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-gw-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-any-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-any-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -21,7 +20,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -33,7 +31,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -69,7 +66,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -81,7 +77,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -93,7 +88,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-network-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-network-out.yaml
@@ -11,7 +11,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -23,7 +22,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -36,7 +34,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -73,7 +70,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -85,7 +81,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -98,7 +93,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-node-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-node-out.yaml
@@ -11,7 +11,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -24,7 +23,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -37,7 +35,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -74,7 +71,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -87,7 +83,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -100,7 +95,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-zone-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-zone-out.yaml
@@ -11,7 +11,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -24,7 +23,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -37,7 +35,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -74,7 +71,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -87,7 +83,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -100,7 +95,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-any-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-any-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -52,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -64,7 +61,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-close-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-close-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -52,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -65,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-network-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-network-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -52,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -65,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-node-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-node-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/krtcollections/endpoints.go
+++ b/pkg/krtcollections/endpoints.go
@@ -6,7 +6,6 @@ import (
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -217,21 +216,20 @@ func transformK8sEndpoints(inputs EndpointsInputs,
 func CreateLBEndpoint(address string, port uint32, podLabels map[string]string, enableAutoMtls bool) *envoyendpointv3.LbEndpoint {
 	// Don't get the metadata labels and filter metadata for the envoy load balancer based on the backend, as this is not used
 	// metadata := getLbMetadata(upstream, labels, "")
-	// Get the metadata labels for the transport socket match if Istio auto mtls is enabled
-	metadata := &envoycorev3.Metadata{
-		FilterMetadata: map[string]*structpb.Struct{},
-	}
-	metadata = addIstioAutomtlsMetadata(metadata, podLabels, enableAutoMtls)
+	// Get the metadata labels for the transport socket match if Istio auto mtls is enabled.
+	// Only allocate the Metadata proto when it will actually be populated: this
+	// function runs once per endpoint per backend and dominates control-plane
+	// heap in large clusters.
 	// Don't add the annotations to the metadata - it's not documented so it's not coming
 	// metadata = addAnnotations(metadata, addr.GetMetadata().GetAnnotations())
-
-	if len(metadata.GetFilterMetadata()) == 0 {
-		metadata = nil
-	}
+	metadata := istioAutomtlsMetadata(podLabels, enableAutoMtls)
 
 	return &envoyendpointv3.LbEndpoint{
-		Metadata:            metadata,
-		LoadBalancingWeight: wrapperspb.UInt32(1),
+		Metadata: metadata,
+		// LoadBalancingWeight is left unset: Envoy treats an unset per-endpoint
+		// weight as 1, so omitting the wrapper avoids one protobuf wrapper
+		// allocation per endpoint. Readers must treat nil as weight 1
+		// (see kgateway/endpoints.lbWeight).
 		HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 			Endpoint: &envoyendpointv3.Endpoint{
 				Address: &envoycorev3.Address{
@@ -250,11 +248,21 @@ func CreateLBEndpoint(address string, port uint32, podLabels map[string]string, 
 	}
 }
 
-func addIstioAutomtlsMetadata(metadata *envoycorev3.Metadata, labels map[string]string, enableAutoMtls bool) *envoycorev3.Metadata {
+// istioAutomtlsMetadata returns the filter metadata enabling the Istio
+// transport socket match for the endpoint, or nil when auto-mTLS is disabled
+// or the pod is not Istio-managed. Returning nil avoids allocating an empty
+// Metadata proto (and its FilterMetadata map) for every endpoint.
+func istioAutomtlsMetadata(labels map[string]string, enableAutoMtls bool) *envoycorev3.Metadata {
 	const EnvoyTransportSocketMatch = "envoy.transport_socket_match"
-	if enableAutoMtls {
-		if _, ok := labels[wellknown.IstioTlsModeLabel]; ok {
-			metadata.GetFilterMetadata()[EnvoyTransportSocketMatch] = &structpb.Struct{
+	if !enableAutoMtls {
+		return nil
+	}
+	if _, ok := labels[wellknown.IstioTlsModeLabel]; !ok {
+		return nil
+	}
+	return &envoycorev3.Metadata{
+		FilterMetadata: map[string]*structpb.Struct{
+			EnvoyTransportSocketMatch: {
 				Fields: map[string]*structpb.Value{
 					wellknown.TLSModeLabelShortname: {
 						Kind: &structpb.Value_StringValue{
@@ -262,10 +270,9 @@ func addIstioAutomtlsMetadata(metadata *envoycorev3.Metadata, labels map[string]
 						},
 					},
 				},
-			}
-		}
+			},
+		},
 	}
-	return metadata
 }
 
 func findPortForService(svc *corev1.Service, svcPort uint32) (*corev1.ServicePort, bool) {

--- a/pkg/krtcollections/endpoints_bench_test.go
+++ b/pkg/krtcollections/endpoints_bench_test.go
@@ -1,0 +1,114 @@
+package krtcollections
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+func testBackend(name string) ir.BackendObjectIR {
+	return ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      name,
+	}, 80, "", "")
+}
+
+// buildEndpointsForBackend simulates transformK8sEndpoints for a backend with
+// `endpoints` ready endpoints spread across `localities` zones.
+func buildEndpointsForBackend(name string, endpoints, localities int, autoMtls bool) *ir.EndpointsForBackend {
+	ret := ir.NewEndpointsForBackend(testBackend(name))
+	labels := map[string]string{
+		"app":                         "demo",
+		"security.istio.io/tlsMode":   "istio",
+		"topology.kubernetes.io/zone": "us-east-1a",
+	}
+	for i := 0; i < endpoints; i++ {
+		loc := ir.PodLocality{
+			Region: "us-east-1",
+			Zone:   fmt.Sprintf("us-east-1%c", 'a'+i%localities),
+		}
+		ep := CreateLBEndpoint(fmt.Sprintf("10.0.%d.%d", i/256, i%256), 8080, labels, autoMtls)
+		ret.Add(loc, ir.EndpointWithMd{
+			LbEndpoint: ep,
+			EndpointMd: ir.EndpointMetadata{Labels: labels},
+		})
+	}
+	return ret
+}
+
+// BenchmarkBuildEndpointsForBackend measures the per-backend endpoint IR build
+// (the CreateLBEndpoint + hashing hot path dominating the heap profiles).
+func BenchmarkBuildEndpointsForBackend(b *testing.B) {
+	for _, endpoints := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("endpoints=%d", endpoints), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out := buildEndpointsForBackend(fmt.Sprintf("svc-%d", i), endpoints, 3, false)
+				if len(out.LbEps) == 0 {
+					b.Fatal("empty")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCopyEndpointsForBackend compares copying an EndpointsForBackend to a
+// variant/final copy by re-hashing every endpoint (old effective_endpoints /
+// gateway_backend_variants behavior) vs reusing the precomputed hashes.
+func BenchmarkCopyEndpointsForBackend(b *testing.B) {
+	for _, endpoints := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("endpoints=%d", endpoints), func(b *testing.B) {
+			base := buildEndpointsForBackend("svc", endpoints, 3, false)
+			b.Run("rehash_add", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					clone := base.EmptyCopy()
+					for locality, eps := range base.LbEps {
+						for _, ep := range eps {
+							clone.Add(locality, ep)
+						}
+					}
+					if clone.LbEpsEqualityHash != base.LbEpsEqualityHash {
+						b.Fatal("hash mismatch")
+					}
+				}
+			})
+			b.Run("reuse_hashes", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					clone := base.EmptyCopy()
+					clone.ReuseEndpointsFrom(base)
+					if clone.LbEpsEqualityHash != base.LbEpsEqualityHash {
+						b.Fatal("hash mismatch")
+					}
+				}
+			})
+		})
+	}
+}
+
+// TestBenchHeapDelta reports heap allocated by building N backends' endpoints,
+// for manual before/after comparison with runtime.ReadMemStats.
+func TestBenchHeapDelta(t *testing.T) {
+	const backends = 200
+	const endpoints = 1000
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	refs := make([]*ir.EndpointsForBackend, 0, backends)
+	for i := 0; i < backends; i++ {
+		refs = append(refs, buildEndpointsForBackend(fmt.Sprintf("svc-%d", i), endpoints, 3, false))
+	}
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	t.Logf("backends=%d endpoints/backend=%d total_eps=%d heap_alloc_delta=%d bytes (%.1f bytes/endpoint)",
+		backends, endpoints, backends*endpoints,
+		after.HeapAlloc-before.HeapAlloc,
+		float64(after.HeapAlloc-before.HeapAlloc)/float64(backends*endpoints))
+	runtime.KeepAlive(refs)
+}

--- a/pkg/krtcollections/endpoints_test.go
+++ b/pkg/krtcollections/endpoints_test.go
@@ -6,7 +6,6 @@ import (
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	corev1 "k8s.io/api/core/v1"
@@ -619,7 +618,6 @@ func TestEndpoints(t *testing.T) {
 				// output
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -872,7 +870,6 @@ func TestEndpoints(t *testing.T) {
 					Zone:   "zone",
 				}, ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -901,7 +898,6 @@ func TestEndpoints(t *testing.T) {
 					Zone:   "zone2",
 				}, ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1018,7 +1014,6 @@ func TestEndpoints(t *testing.T) {
 				// output
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1168,7 +1163,6 @@ func TestEndpoints(t *testing.T) {
 				// Only one endpoint should be present after deduplication
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1398,7 +1392,6 @@ func TestEndpoints(t *testing.T) {
 				// output
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1471,5 +1464,42 @@ func TestEndpoints(t *testing.T) {
 			res := tc.result(tc.upstream)
 			g.Expect(eps.Equals(*res)).To(BeTrue(), "expected %v, got %v", res, eps)
 		})
+	}
+}
+
+func TestCreateLBEndpointNoWeightWrapper(t *testing.T) {
+	ep := CreateLBEndpoint("10.0.0.1", 8080, nil, false)
+	if ep.GetLoadBalancingWeight() != nil {
+		t.Fatal("expected no LoadBalancingWeight wrapper; unset weight defaults to 1 in Envoy")
+	}
+	if ep.GetMetadata() != nil {
+		t.Fatal("expected nil Metadata when automtls disabled")
+	}
+	sock := ep.GetEndpoint().GetAddress().GetSocketAddress()
+	if sock.GetAddress() != "10.0.0.1" || sock.GetPortValue() != 8080 {
+		t.Fatalf("unexpected socket address: %v:%d", sock.GetAddress(), sock.GetPortValue())
+	}
+}
+
+func TestCreateLBEndpointAutoMtls(t *testing.T) {
+	labels := map[string]string{wellknown.IstioTlsModeLabel: "istio"}
+
+	// automtls disabled -> no metadata even for istio pods
+	if ep := CreateLBEndpoint("10.0.0.1", 8080, labels, false); ep.GetMetadata() != nil {
+		t.Fatal("expected nil Metadata when automtls disabled")
+	}
+	// automtls enabled but pod not istio-managed -> no metadata
+	if ep := CreateLBEndpoint("10.0.0.1", 8080, map[string]string{"app": "x"}, true); ep.GetMetadata() != nil {
+		t.Fatal("expected nil Metadata for non-istio pod")
+	}
+	// automtls enabled + istio pod -> transport socket match metadata
+	ep := CreateLBEndpoint("10.0.0.1", 8080, labels, true)
+	fm := ep.GetMetadata().GetFilterMetadata()
+	tsm, ok := fm["envoy.transport_socket_match"]
+	if !ok {
+		t.Fatalf("expected transport_socket_match metadata, got %v", fm)
+	}
+	if got := tsm.GetFields()[wellknown.TLSModeLabelShortname].GetStringValue(); got != wellknown.IstioMutualTLSModeLabel {
+		t.Fatalf("unexpected tlsMode: %q", got)
 	}
 }

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
+	"slices"
 	"strings"
 
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -267,6 +268,32 @@ func (e *EndpointsForBackend) Add(l PodLocality, emd EndpointWithMd) {
 	// won't result in different equality hashes.
 	e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
 	e.LbEps[l] = append(e.LbEps[l], emd)
+}
+
+// ReuseEndpointsFrom copies the endpoint entries and their precomputed
+// equality hash from base, avoiding a per-endpoint proto re-hash (which
+// marshals every LbEndpoint). The equality hashes are identical to what a full
+// re-Add of every endpoint would produce: epsEqualityHash only depends on the
+// endpoint set (shared with base), and the final hash mixes in this copy's own
+// upstreamHash for backend identity.
+// The per-locality slices are cloned to avoid append aliasing with base.
+func (e *EndpointsForBackend) ReuseEndpointsFrom(base *EndpointsForBackend) {
+	e.epsEqualityHash = base.epsEqualityHash
+	e.LbEpsEqualityHash = e.upstreamHash
+	// Mirror what Add() computes. Distinguish the empty set by endpoint count,
+	// not by hash value: a non-empty set can xor to a zero epsEqualityHash
+	// (e.g. duplicate endpoints across localities), and Add() would still
+	// produce hash(0, upstreamHash) in that case.
+	nonEmpty := false
+	for l, eps := range base.LbEps {
+		if len(eps) > 0 {
+			nonEmpty = true
+		}
+		e.LbEps[l] = slices.Clone(eps)
+	}
+	if nonEmpty {
+		e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
+	}
 }
 
 func (c EndpointsForBackend) ResourceName() string {

--- a/pkg/pluginsdk/ir/model_endpoints_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_test.go
@@ -1,0 +1,89 @@
+package ir
+
+import (
+	"fmt"
+	"testing"
+)
+
+func epsBackend(name string) BackendObjectIR {
+	return NewBackendObjectIR(ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      name,
+	}, 80, "", "")
+}
+
+func TestReuseEndpointsFromMatchesReAdd(t *testing.T) {
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	for i := 0; i < 50; i++ {
+		loc := PodLocality{Region: "us-east-1", Zone: fmt.Sprintf("zone-%d", i%3)}
+		base.Add(loc, EndpointWithMd{
+			EndpointMd: EndpointMetadata{Labels: map[string]string{"i": fmt.Sprint(i)}},
+		})
+	}
+
+	// reference: rebuild by re-Adding every endpoint
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	for loc, eps := range base.LbEps {
+		for _, ep := range eps {
+			readded.Add(loc, ep)
+		}
+	}
+
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.ReuseEndpointsFrom(base)
+
+	if clone.LbEpsEqualityHash != readded.LbEpsEqualityHash {
+		t.Fatalf("LbEpsEqualityHash mismatch: reuse=%d readd=%d", clone.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+	if clone.LbEpsEqualityHash == base.LbEpsEqualityHash {
+		t.Fatal("variant hash should differ from base due to different upstream identity")
+	}
+	if len(clone.LbEps) != len(base.LbEps) {
+		t.Fatalf("locality count mismatch: got %d want %d", len(clone.LbEps), len(base.LbEps))
+	}
+	for loc, eps := range base.LbEps {
+		got := clone.LbEps[loc]
+		if len(got) != len(eps) {
+			t.Fatalf("endpoint count mismatch in %v: got %d want %d", loc, len(got), len(eps))
+		}
+		// verify slice was cloned (no aliasing of backing arrays)
+		if len(got) > 0 && &got[0] == &eps[0] {
+			t.Fatalf("endpoint slice for %v aliases base backing array", loc)
+		}
+	}
+}
+
+func TestReuseEndpointsFromNonEmptyZeroHash(t *testing.T) {
+	// two identical (locality, endpoint) entries xor to a zero epsEqualityHash;
+	// a re-Add still produces hash(0, upstreamHash), so reuse must too.
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	loc := PodLocality{Region: "us-east-1", Zone: "zone-a"}
+	emd := EndpointWithMd{EndpointMd: EndpointMetadata{Labels: map[string]string{"i": "1"}}}
+	base.Add(loc, emd)
+	base.Add(loc, emd)
+	if base.epsEqualityHash != 0 {
+		t.Fatalf("expected xor of identical endpoints to be 0, got %d", base.epsEqualityHash)
+	}
+
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	readded.Add(loc, emd)
+	readded.Add(loc, emd)
+
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.ReuseEndpointsFrom(base)
+	if clone.LbEpsEqualityHash != readded.LbEpsEqualityHash {
+		t.Fatalf("zero-hash non-empty reuse mismatch: reuse=%d readd=%d", clone.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+}
+
+func TestReuseEndpointsFromEmpty(t *testing.T) {
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.ReuseEndpointsFrom(base)
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	if clone.LbEpsEqualityHash != readded.LbEpsEqualityHash {
+		t.Fatalf("empty reuse hash mismatch: reuse=%d readd=%d", clone.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> This is fully vibed & I haven't done a self-review yet. I'll mark this is as ready for review once I have.

--- 

## Description

Motivation: Heap profiles of large production deployments show that endpoint translation IR dominates control-plane memory: ~60–67% of in-use heap in pkg/krtcollections.CreateLBEndpoint (per-endpoint protos built once per endpoint per Service×port backend), ~8% in wrapperspb.UInt32 (a weight wrapper of value 1 allocated per endpoint), and ~4% in fnv hashing/proto marshaling from re-hashing every LbEndpoint proto whenever derived endpoint collections are recomputed.

## What changed:

- CreateLBEndpoint no longer sets LoadBalancingWeight: wrapperspb.UInt32(1). Envoy treats an unset per-endpoint weight as 1 (true for all Envoy versions), so the wrapper was a heap allocation per endpoint with no behavioral effect. Locality-level weights are unchanged; readers treat nil as 1 via a new lbWeight() helper.
- The endpoint Metadata proto (and its FilterMetadata map) is now only allocated when Istio auto-mTLS is enabled and the pod is Istio-managed, instead of allocating and discarding it for every endpoint.
- Derived EndpointsForBackend copies (FinalBackendEndpoints, GatewayBackendClientCertificateVariantEndpoints) reuse precomputed endpoint equality hashes via a new ReuseEndpointsFrom method instead of re-Adding every endpoint — which previously re-marshaled every LbEndpoint proto per copy per recompute. Resulting hashes are byte-identical, including the empty-set and non-empty-zero-xor edge cases.

Measured (benchstat, 100/1k/10k endpoints): build path −9.5% B/op, −21% allocs/op; copy path ~1088 B/endpoint → ~16 B/endpoint (~98% fewer allocations, ~300x faster at 10k endpoints).

## Change Type

/kind fix
/kind cleanup

## Changelog

```release-note
Reduced control-plane memory and CPU for endpoint translation at scale: dropped the per-endpoint load-balancing-weight wrapper (Envoy defaults unset weight to 1) and unnecessary metadata allocations, and eliminated re-marshaling of endpoint protos when deriving per-backend endpoint collections.
```

## Additional Notes

- Wire compatibility: LbEndpoint.load_balancing_weight is now omitted instead of explicitly "1"; Envoy defaults unset weight to 1 in all versions, so any data-plane version is compatible. Locality-level LocalityLbEndpoints weights are computed exactly as before (goldens diff is only removal of per-endpoint loadBalancingWeight: 1 lines, zero insertions).
- Rollout/rollback: endpoint equality hashes change once, so every EDS resource gets a single new version and one full re-push to connected envoys at upgrade (and again on rollback). No CRDs or persisted state changed; rollback is clean.
- ReuseEndpointsFrom distinguishes empty endpoint sets by count, not hash value, so a non-empty set whose xor'd hash is zero (e.g. duplicate endpoints) still produces hash(0, upstreamHash) exactly as the previous Add loop did — covered by a dedicated unit test.
- New unit tests cover the no-weight-wrapper and metadata behavior, hash-equivalence of ReuseEndpointsFrom vs re-Add (incl. slice-aliasing and zero-hash cases); new benchmarks in pkg/krtcollections/endpoints_bench_test.go quantify the allocation reductions.
- Golden outputs regenerated via REFRESH_GOLDEN=true (setup + waypoint plugin tests).