### PR TITLE
perf(endpoints): reuse precomputed endpoint hashes on derived collections

### DIFF
--- a/pkg/kgateway/proxy_syncer/effective_endpoints.go
+++ b/pkg/kgateway/proxy_syncer/effective_endpoints.go
@@ -31,11 +31,10 @@ func newFinalBackendEndpoints(
 		final.AttachedPolicies = backend.AttachedPolicies
 		final.ClusterName = backend.ClusterName()
 		final.UpstreamResourceName = backend.ResourceName()
-		for locality, endpoints := range raw.LbEps {
-			for _, endpoint := range endpoints {
-				final.Add(locality, endpoint)
-			}
-		}
+		// Reuse the endpoint protos AND their precomputed equality hash instead
+		// of re-Adding every endpoint: Add re-marshals each LbEndpoint proto
+		// (HashProtoWithHasher), which is a major allocation source at scale.
+		final.ReuseEndpointsFrom(raw)
 		// A same-named EDS cluster can still re-warm when policy changes CDS.
 		// Bump only the endpoint version so Envoy receives a fresh CLA response.
 		if policyHash := backendEndpointVersionHash(backend); policyHash != 0 {

--- a/pkg/kgateway/proxy_syncer/gateway_backend_variants.go
+++ b/pkg/kgateway/proxy_syncer/gateway_backend_variants.go
@@ -93,11 +93,10 @@ func newGatewayBackendVariantEndpoints(
 		}
 
 		clone := ir.NewEndpointsForBackend(*variant.backend)
-		for locality, endpoints := range base.LbEps {
-			for _, endpoint := range endpoints {
-				clone.Add(locality, endpoint)
-			}
-		}
+		// The endpoint protos are shared with the base backend; reuse the
+		// precomputed equality hash as well to avoid re-marshaling every
+		// LbEndpoint proto (HashProtoWithHasher) on each recompute.
+		clone.ReuseEndpointsFrom(base)
 
 		return clone
 	}, krtopts.ToOptions("GatewayBackendClientCertificateVariantEndpoints")...)

--- a/pkg/krtcollections/endpoints_reuse_bench_test.go
+++ b/pkg/krtcollections/endpoints_reuse_bench_test.go
@@ -1,0 +1,75 @@
+package krtcollections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+func reuseBenchBackend(name string) ir.BackendObjectIR {
+	return ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      name,
+	}, 80, "", "")
+}
+
+// reuseBenchBuildEndpoints simulates transformK8sEndpoints for a backend with
+// `endpoints` ready endpoints spread across `localities` zones.
+func reuseBenchBuildEndpoints(name string, endpoints, localities int) *ir.EndpointsForBackend {
+	ret := ir.NewEndpointsForBackend(reuseBenchBackend(name))
+	labels := map[string]string{
+		"app":                         "demo",
+		"security.istio.io/tlsMode":   "istio",
+		"topology.kubernetes.io/zone": "us-east-1a",
+	}
+	for i := range endpoints {
+		loc := ir.PodLocality{
+			Region: "us-east-1",
+			Zone:   fmt.Sprintf("us-east-1%c", 'a'+i%localities),
+		}
+		ep := CreateLBEndpoint(fmt.Sprintf("10.0.%d.%d", i/256, i%256), 8080, labels, false)
+		ret.Add(loc, ir.EndpointWithMd{
+			LbEndpoint: ep,
+			EndpointMd: ir.EndpointMetadata{Labels: labels},
+		})
+	}
+	return ret
+}
+
+// BenchmarkCopyEndpointsForBackend compares copying an EndpointsForBackend to a
+// variant/final copy by re-hashing every endpoint (old effective_endpoints /
+// gateway_backend_variants behavior) vs reusing the precomputed hashes.
+func BenchmarkCopyEndpointsForBackend(b *testing.B) {
+	for _, endpoints := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("endpoints=%d", endpoints), func(b *testing.B) {
+			base := reuseBenchBuildEndpoints("svc", endpoints, 3)
+			b.Run("rehash_add", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					clone := base.EmptyCopy()
+					for locality, eps := range base.LbEps {
+						for _, ep := range eps {
+							clone.Add(locality, ep)
+						}
+					}
+					if clone.LbEpsEqualityHash != base.LbEpsEqualityHash {
+						b.Fatal("hash mismatch")
+					}
+				}
+			})
+			b.Run("reuse_hashes", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					clone := base.EmptyCopy()
+					clone.ReuseEndpointsFrom(base)
+					if clone.LbEpsEqualityHash != base.LbEpsEqualityHash {
+						b.Fatal("hash mismatch")
+					}
+				}
+			})
+		})
+	}
+}

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
+	"slices"
 	"strings"
 
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -267,6 +268,35 @@ func (e *EndpointsForBackend) Add(l PodLocality, emd EndpointWithMd) {
 	// won't result in different equality hashes.
 	e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
 	e.LbEps[l] = append(e.LbEps[l], emd)
+}
+
+// ReuseEndpointsFrom copies the endpoint entries and their precomputed
+// equality hash from base, avoiding a per-endpoint proto re-hash (which
+// marshals every LbEndpoint). The equality hashes are identical to what a full
+// re-Add of every endpoint would produce: epsEqualityHash only depends on the
+// endpoint set (shared with base), and the final hash mixes in this copy's own
+// upstreamHash for backend identity.
+// The per-locality slices are cloned to avoid append aliasing with base. The
+// endpoint map is rebuilt from scratch, so any stale localities previously
+// present in e are dropped.
+func (e *EndpointsForBackend) ReuseEndpointsFrom(base *EndpointsForBackend) {
+	e.epsEqualityHash = base.epsEqualityHash
+	e.LbEpsEqualityHash = e.upstreamHash
+	// Mirror what Add() computes. Distinguish the empty set by endpoint count,
+	// not by hash value: a non-empty set can xor to a zero epsEqualityHash
+	// (e.g. duplicate endpoints across localities), and Add() would still
+	// produce hash(0, upstreamHash) in that case.
+	nonEmpty := false
+	e.LbEps = make(LocalityLbMap, len(base.LbEps))
+	for l, eps := range base.LbEps {
+		if len(eps) > 0 {
+			nonEmpty = true
+		}
+		e.LbEps[l] = slices.Clone(eps)
+	}
+	if nonEmpty {
+		e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
+	}
 }
 
 func (c EndpointsForBackend) ResourceName() string {

--- a/pkg/pluginsdk/ir/model_endpoints_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_test.go
@@ -1,0 +1,134 @@
+package ir
+
+import (
+	"fmt"
+	"testing"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+)
+
+func epsBackend(name string) BackendObjectIR {
+	return NewBackendObjectIR(ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      name,
+	}, 80, "", "")
+}
+
+// testLbEndpoint builds a minimal non-nil LbEndpoint so hashEndpoints exercises
+// the proto-marshaling path (HashProtoWithHasher) used in production.
+func testLbEndpoint(addr string, port uint32) *envoyendpointv3.LbEndpoint {
+	return &envoyendpointv3.LbEndpoint{
+		HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
+			Endpoint: &envoyendpointv3.Endpoint{
+				Address: &envoycorev3.Address{
+					Address: &envoycorev3.Address_SocketAddress{
+						SocketAddress: &envoycorev3.SocketAddress{
+							Address: addr,
+							PortSpecifier: &envoycorev3.SocketAddress_PortValue{
+								PortValue: port,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testEndpointWithMd(i int) EndpointWithMd {
+	return EndpointWithMd{
+		LbEndpoint: testLbEndpoint(fmt.Sprintf("10.0.%d.%d", i/256, i%256), 8080),
+		EndpointMd: EndpointMetadata{Labels: map[string]string{"i": fmt.Sprint(i)}},
+	}
+}
+
+func TestReuseEndpointsFromMatchesReAdd(t *testing.T) {
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	for i := range 50 {
+		loc := PodLocality{Region: "us-east-1", Zone: fmt.Sprintf("zone-%d", i%3)}
+		base.Add(loc, testEndpointWithMd(i))
+	}
+
+	// reference: rebuild by re-Adding every endpoint
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	for loc, eps := range base.LbEps {
+		for _, ep := range eps {
+			readded.Add(loc, ep)
+		}
+	}
+
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.ReuseEndpointsFrom(base)
+
+	if clone.LbEpsEqualityHash != readded.LbEpsEqualityHash {
+		t.Fatalf("LbEpsEqualityHash mismatch: reuse=%d readd=%d", clone.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+	if clone.LbEpsEqualityHash == base.LbEpsEqualityHash {
+		t.Fatal("variant hash should differ from base due to different upstream identity")
+	}
+	if len(clone.LbEps) != len(base.LbEps) {
+		t.Fatalf("locality count mismatch: got %d want %d", len(clone.LbEps), len(base.LbEps))
+	}
+	for loc, eps := range base.LbEps {
+		got := clone.LbEps[loc]
+		if len(got) != len(eps) {
+			t.Fatalf("endpoint count mismatch in %v: got %d want %d", loc, len(got), len(eps))
+		}
+		// verify slice was cloned (no aliasing of backing arrays)
+		if len(got) > 0 && &got[0] == &eps[0] {
+			t.Fatalf("endpoint slice for %v aliases base backing array", loc)
+		}
+	}
+}
+
+func TestReuseEndpointsFromDropsStaleLocalities(t *testing.T) {
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	base.Add(PodLocality{Region: "r1", Zone: "z1"}, testEndpointWithMd(0))
+
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.Add(PodLocality{Region: "r9", Zone: "z9"}, testEndpointWithMd(1))
+	clone.ReuseEndpointsFrom(base)
+
+	if _, ok := clone.LbEps[PodLocality{Region: "r9", Zone: "z9"}]; ok {
+		t.Fatal("stale locality r9/z9 should have been dropped")
+	}
+	if len(clone.LbEps) != 1 {
+		t.Fatalf("expected 1 locality, got %d", len(clone.LbEps))
+	}
+}
+
+func TestReuseEndpointsFromNonEmptyZeroHash(t *testing.T) {
+	// two identical (locality, endpoint) entries xor to a zero epsEqualityHash;
+	// a re-Add still produces hash(0, upstreamHash), so reuse must too.
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	loc := PodLocality{Region: "us-east-1", Zone: "zone-a"}
+	emd := testEndpointWithMd(1)
+	base.Add(loc, emd)
+	base.Add(loc, emd)
+	if base.epsEqualityHash != 0 {
+		t.Fatalf("expected xor of identical endpoints to be 0, got %d", base.epsEqualityHash)
+	}
+
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	readded.Add(loc, emd)
+	readded.Add(loc, emd)
+
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.ReuseEndpointsFrom(base)
+	if clone.LbEpsEqualityHash != readded.LbEpsEqualityHash {
+		t.Fatalf("zero-hash non-empty reuse mismatch: reuse=%d readd=%d", clone.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+}
+
+func TestReuseEndpointsFromEmpty(t *testing.T) {
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.ReuseEndpointsFrom(base)
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	if clone.LbEpsEqualityHash != readded.LbEpsEqualityHash {
+		t.Fatalf("empty reuse hash mismatch: reuse=%d readd=%d", clone.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+}


### PR DESCRIPTION
# Description

Heap profiles of large deployments show ~4% of in-use heap in fnv hashing, set operations, and proto marshaling on the endpoint path. `FinalBackendEndpoints` and `GatewayBackendClientCertificateVariantEndpoints` cloned `EndpointsForBackend` by re-`Add`ing every endpoint, which re-ran `hashEndpoints` -> `HashProtoWithHasher` (a full proto marshal) per endpoint per copy per recompute.

This PR adds `EndpointsForBackend.ReuseEndpointsFrom`, which copies the endpoint entries (cloned slices, no append aliasing) and reuses the precomputed `epsEqualityHash`, mixing in the copy's own `upstreamHash` for backend identity. The resulting equality hashes are byte-identical to the re-Add path, including the empty endpoint set (`upstreamHash`) and a non-empty set whose xor'd hash is zero (`hash(0, upstreamHash)`); emptiness is determined by endpoint count, not hash value. Both call sites are switched over.

Benchmark (included in this PR): ~1088 B/endpoint copied -> ~16 B/endpoint, ~300x faster at 10k endpoints. No wire-format change.

Part 2 of 3 independent PRs split from #14487 (fully parallel — can merge in any order): #14488 (metadata allocation), #14490 (weight wrapper).


# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

New unit tests cover hash-equivalence with the re-Add path, slice non-aliasing, the empty set, and the non-empty zero-xor collision case (two identical endpoints).
