### PR TITLE
perf(endpoints): drop the per-endpoint load-balancing-weight wrapper

### DIFF
--- a/pkg/kgateway/endpoints/prioritize.go
+++ b/pkg/kgateway/endpoints/prioritize.go
@@ -156,6 +156,15 @@ func prioritizeWithLbInfo(logger *slog.Logger, ep ir.EndpointsForBackend, lbInfo
 	return cla
 }
 
+// lbWeight returns the per-endpoint load balancing weight, treating an unset
+// weight as 1, matching Envoy's default (LbEndpoint.load_balancing_weight).
+func lbWeight(ep *envoyendpointv3.LbEndpoint) uint32 {
+	if w := ep.GetLoadBalancingWeight(); w != nil {
+		return w.GetValue()
+	}
+	return 1
+}
+
 // ensure we don't send invalid endpoints to envoy and cause NACKs
 func filterInvalidEps(eps []ir.EndpointWithMd) []ir.EndpointWithMd {
 	return istioslices.Filter(eps, func(ewm ir.EndpointWithMd) bool {
@@ -178,7 +187,7 @@ func getEndpoints(eps []ir.EndpointWithMd, lbinfo LoadBalancingInfo) []*envoyend
 	var weight uint32
 	for _, ep := range eps {
 		epsOut[0].LbEndpoints = append(epsOut[0].GetLbEndpoints(), ep.LbEndpoint)
-		weight += ep.LbEndpoint.GetLoadBalancingWeight().GetValue()
+		weight += lbWeight(ep.LbEndpoint)
 	}
 	// reset weight
 	if weight > 0 {
@@ -214,7 +223,7 @@ func applyFailoverPriorityPerLocality(
 		var weight uint32
 		for _, index := range priorityMap[priority] {
 			out[i].LbEndpoints = append(out[i].GetLbEndpoints(), eps[index].LbEndpoint)
-			weight += eps[index].GetLoadBalancingWeight().GetValue()
+			weight += lbWeight(eps[index].LbEndpoint)
 		}
 		// reset weight
 		if weight > 0 {

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/authz-serviceentry.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 5000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-a_se-a.example.com_5000
   type: STATIC
@@ -23,7 +22,6 @@ Clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-b_se-b.example.com_9000
   type: STATIC

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se-hostname.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 5000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-a_se-a.example.com_5000
   type: STATIC
@@ -23,7 +22,6 @@ Clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-b_se-b.example.com_9000
   type: STATIC

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/httproute-se.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 5000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-a_se-a.example.com_5000
   type: STATIC
@@ -23,7 +22,6 @@ Clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-b_se-b.example.com_9000
   type: STATIC

--- a/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
+++ b/pkg/kgateway/extensions2/plugins/waypoint/testdata/output/ns-use-waypoint.yaml
@@ -9,7 +9,6 @@ Clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 9000
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_infra_se-c_se-c.infra.svc.cluster.local_9000
   type: STATIC

--- a/pkg/kgateway/setup/testdata/experimental/cors-hr-and-tp-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-hr-and-tp-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-httproute-backend-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-httproute-backend-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-httproute-rule-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-httproute-rule-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-gw-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-gw-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/experimental/cors-trafficpolicy-route-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-diffns-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-diffns-out.yaml
@@ -39,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -51,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -64,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -77,7 +74,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-default-out.yaml
@@ -39,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -51,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -64,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -77,7 +74,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-key-val-labels-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-label-keys-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-label-keys-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_destination_rule/failover-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_destination_rule/failover-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -50,7 +49,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -63,7 +61,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -76,7 +73,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-mtls-disabled-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-mtls-disabled-out.yaml
@@ -143,7 +143,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_httpbin_9000
 listeners:

--- a/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-out.yaml
+++ b/pkg/kgateway/setup/testdata/istio_mtls/istio-svc-out.yaml
@@ -161,7 +161,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_httpbin_9000
 listeners:

--- a/pkg/kgateway/setup/testdata/listenerbind/v4/happypath-out.yaml
+++ b/pkg/kgateway/setup/testdata/listenerbind/v4/happypath-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/listenerbind/v6/happypath-out.yaml
+++ b/pkg/kgateway/setup/testdata/listenerbind/v6/happypath-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/backendconfigpolicy-alias-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/backendconfigpolicy-alias-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_gwtest_httpbin-se_se.example.com_80
   type: STATIC

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-backendref-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-backendref-out.yaml
@@ -32,7 +32,6 @@ endpoints:
           socketAddress:
             address: 255.0.0.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     priority: 3
   - lbEndpoints:
@@ -41,7 +40,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -79,7 +75,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-dns-endpoints-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-dns-endpoints-out.yaml
@@ -17,7 +17,6 @@ clusters:
             socketAddress:
               address: foo.external.com
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -30,7 +29,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-multiport-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 18443
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -21,7 +20,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 18443
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -33,7 +31,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 18443
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -51,7 +48,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 18080
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -63,7 +59,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 18080
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -75,7 +70,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 18080
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-out.yaml
@@ -12,7 +12,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -25,7 +24,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -38,7 +36,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-polattach-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-hostname-ref-polattach-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
   name: istio-se_gwtest_example-se_se.example.com_80
   transportSocket:

--- a/pkg/kgateway/setup/testdata/serviceentry/dr/se-inline-eps-out.yaml
+++ b/pkg/kgateway/setup/testdata/serviceentry/dr/se-inline-eps-out.yaml
@@ -12,7 +12,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -25,7 +24,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -38,7 +36,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2

--- a/pkg/kgateway/setup/testdata/standard/accesslog-filtercel-httplisteneropt-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/accesslog-filtercel-httplisteneropt-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/accesslog-filterhttp-httplisteneropt-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/accesslog-filterhttp-httplisteneropt-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 50051
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/accesslog-httplisteneropt-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/accesslog-httplisteneropt-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/auto-host-plus-host-rewrite-out.yaml
@@ -47,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-label-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-label-out.yaml
@@ -46,7 +46,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-out.yaml
@@ -46,7 +46,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-tls-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendconfigpolicy-tls-out.yaml
@@ -119,7 +119,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/backendtlspolicy-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/backendtlspolicy-out.yaml
@@ -60,7 +60,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/csrf-gw-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/csrf-gw-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/csrf-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/csrf-route-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/csrf-route-shadowed-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-disable-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-gw-and-route-out.yaml
@@ -58,7 +58,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.16
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_ext-authz_9000
   endpoints:
@@ -68,7 +67,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -78,7 +76,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-gw-only-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extauth-route-only-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.15
             portValue: 9000
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extproc-backend-extref-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extproc-backend-extref-out.yaml
@@ -53,7 +53,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 9091
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_ratings_8080
 - clusterName: kube_gwtest_reviews_8080
@@ -64,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
   - lbEndpoints:
     - endpoint:
@@ -72,7 +70,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extproc-routerule-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extproc-routerule-out.yaml
@@ -53,7 +53,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 9091
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_ratings_8080
 - clusterName: kube_gwtest_reviews_8080
@@ -64,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
   - lbEndpoints:
     - endpoint:
@@ -72,7 +70,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/extproc-targetref-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/extproc-targetref-out.yaml
@@ -43,7 +43,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 9091
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -53,7 +52,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
   - lbEndpoints:
     - endpoint:
@@ -61,7 +59,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/happypath-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/happypath-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-extref-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-extref-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews-v2_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-disabled-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-disabled-out.yaml
@@ -38,7 +38,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.12
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 - clusterName: kube_gwtest_reviews_8080
   endpoints:
@@ -48,7 +47,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-gw-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-gw-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/local-rate-limit-route-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/routeoptions-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-and-route-disable-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-gw-only-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transform-route-only-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1

--- a/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
+++ b/pkg/kgateway/setup/testdata/standard/transformation-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
 listeners:
 - address:

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-any-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-any-out.yaml
@@ -9,7 +9,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -21,7 +20,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -33,7 +31,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -69,7 +66,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -81,7 +77,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -93,7 +88,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-network-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-network-out.yaml
@@ -11,7 +11,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -23,7 +22,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -36,7 +34,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -73,7 +70,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -85,7 +81,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -98,7 +93,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-node-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-node-out.yaml
@@ -11,7 +11,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -24,7 +23,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -37,7 +35,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -74,7 +71,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -87,7 +83,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -100,7 +95,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-zone-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/se-prefer-same-zone-out.yaml
@@ -11,7 +11,6 @@ clusters:
             socketAddress:
               address: 1.1.1.1
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -24,7 +23,6 @@ clusters:
             socketAddress:
               address: 2.2.2.2
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r1
@@ -37,7 +35,6 @@ clusters:
             socketAddress:
               address: 3.3.3.3
               portValue: 80
-        loadBalancingWeight: 1
       loadBalancingWeight: 1
       locality:
         region: r2
@@ -74,7 +71,6 @@ endpoints:
           socketAddress:
             address: 1.1.1.1
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -87,7 +83,6 @@ endpoints:
           socketAddress:
             address: 2.2.2.2
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -100,7 +95,6 @@ endpoints:
           socketAddress:
             address: 3.3.3.3
             portValue: 80
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-any-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-any-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -52,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -64,7 +61,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-close-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-close-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -52,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -65,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-network-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-network-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -52,7 +50,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -65,7 +62,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-node-out.yaml
+++ b/pkg/kgateway/setup/testdata/traffic_distribution/svc-prefer-same-node-out.yaml
@@ -28,7 +28,6 @@ endpoints:
           socketAddress:
             address: 10.244.1.11
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -40,7 +39,6 @@ endpoints:
           socketAddress:
             address: 10.244.2.14
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -53,7 +51,6 @@ endpoints:
           socketAddress:
             address: 10.244.3.3
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r1
@@ -66,7 +63,6 @@ endpoints:
           socketAddress:
             address: 10.244.4.4
             portValue: 8080
-      loadBalancingWeight: 1
     loadBalancingWeight: 1
     locality:
       region: r2

--- a/pkg/krtcollections/endpoints.go
+++ b/pkg/krtcollections/endpoints.go
@@ -6,7 +6,6 @@ import (
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -226,8 +225,11 @@ func CreateLBEndpoint(address string, port uint32, podLabels map[string]string, 
 	metadata := istioAutomtlsMetadata(podLabels, enableAutoMtls)
 
 	return &envoyendpointv3.LbEndpoint{
-		Metadata:            metadata,
-		LoadBalancingWeight: wrapperspb.UInt32(1),
+		Metadata: metadata,
+		// LoadBalancingWeight is left unset: Envoy treats an unset per-endpoint
+		// weight as 1, so omitting the wrapper avoids one protobuf wrapper
+		// allocation per endpoint. Readers must treat nil as weight 1
+		// (see kgateway/endpoints.lbWeight).
 		HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 			Endpoint: &envoyendpointv3.Endpoint{
 				Address: &envoycorev3.Address{

--- a/pkg/krtcollections/endpoints_bench_test.go
+++ b/pkg/krtcollections/endpoints_bench_test.go
@@ -1,0 +1,79 @@
+package krtcollections
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+func benchBackend(name string) ir.BackendObjectIR {
+	return ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "",
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      name,
+	}, 80, "", "")
+}
+
+// buildEndpointsForBackend simulates transformK8sEndpoints for a backend with
+// `endpoints` ready endpoints spread across `localities` zones.
+func buildEndpointsForBackend(name string, endpoints, localities int, autoMtls bool) *ir.EndpointsForBackend {
+	ret := ir.NewEndpointsForBackend(benchBackend(name))
+	labels := map[string]string{
+		"app":                         "demo",
+		"security.istio.io/tlsMode":   "istio",
+		"topology.kubernetes.io/zone": "us-east-1a",
+	}
+	for i := range endpoints {
+		loc := ir.PodLocality{
+			Region: "us-east-1",
+			Zone:   fmt.Sprintf("us-east-1%c", 'a'+i%localities),
+		}
+		ep := CreateLBEndpoint(fmt.Sprintf("10.0.%d.%d", i/256, i%256), 8080, labels, autoMtls)
+		ret.Add(loc, ir.EndpointWithMd{
+			LbEndpoint: ep,
+			EndpointMd: ir.EndpointMetadata{Labels: labels},
+		})
+	}
+	return ret
+}
+
+// BenchmarkBuildEndpointsForBackend measures the per-backend endpoint IR build
+// (the CreateLBEndpoint + hashing hot path dominating the heap profiles).
+func BenchmarkBuildEndpointsForBackend(b *testing.B) {
+	for _, endpoints := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("endpoints=%d", endpoints), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out := buildEndpointsForBackend(fmt.Sprintf("svc-%d", i), endpoints, 3, false)
+				if len(out.LbEps) == 0 {
+					b.Fatal("empty")
+				}
+			}
+		})
+	}
+}
+
+// TestBenchHeapDelta reports heap allocated by building N backends' endpoints,
+// for manual before/after comparison with runtime.ReadMemStats.
+func TestBenchHeapDelta(t *testing.T) {
+	const backends = 200
+	const endpoints = 1000
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	refs := make([]*ir.EndpointsForBackend, 0, backends)
+	for i := range backends {
+		refs = append(refs, buildEndpointsForBackend(fmt.Sprintf("svc-%d", i), endpoints, 3, false))
+	}
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	t.Logf("backends=%d endpoints/backend=%d total_eps=%d heap_alloc_delta=%d bytes (%.1f bytes/endpoint)",
+		backends, endpoints, backends*endpoints,
+		after.HeapAlloc-before.HeapAlloc,
+		float64(after.HeapAlloc-before.HeapAlloc)/float64(backends*endpoints))
+	runtime.KeepAlive(refs)
+}

--- a/pkg/krtcollections/endpoints_test.go
+++ b/pkg/krtcollections/endpoints_test.go
@@ -6,7 +6,6 @@ import (
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	corev1 "k8s.io/api/core/v1"
@@ -619,7 +618,6 @@ func TestEndpoints(t *testing.T) {
 				// output
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -872,7 +870,6 @@ func TestEndpoints(t *testing.T) {
 					Zone:   "zone",
 				}, ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -901,7 +898,6 @@ func TestEndpoints(t *testing.T) {
 					Zone:   "zone2",
 				}, ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1018,7 +1014,6 @@ func TestEndpoints(t *testing.T) {
 				// output
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1168,7 +1163,6 @@ func TestEndpoints(t *testing.T) {
 				// Only one endpoint should be present after deduplication
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1398,7 +1392,6 @@ func TestEndpoints(t *testing.T) {
 				// output
 				emd := ir.EndpointWithMd{
 					LbEndpoint: &envoyendpointv3.LbEndpoint{
-						LoadBalancingWeight: wrapperspb.UInt32(1),
 						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
 							Endpoint: &envoyendpointv3.Endpoint{
 								Address: &envoycorev3.Address{
@@ -1494,5 +1487,19 @@ func TestCreateLBEndpointAutoMtls(t *testing.T) {
 	}
 	if got := tsm.GetFields()[wellknown.TLSModeLabelShortname].GetStringValue(); got != wellknown.IstioMutualTLSModeLabel {
 		t.Fatalf("unexpected tlsMode: %q", got)
+	}
+}
+
+func TestCreateLBEndpointNoWeightWrapper(t *testing.T) {
+	ep := CreateLBEndpoint("10.0.0.1", 8080, nil, false)
+	if ep.GetLoadBalancingWeight() != nil {
+		t.Fatal("expected no LoadBalancingWeight wrapper; unset weight defaults to 1 in Envoy")
+	}
+	if ep.GetMetadata() != nil {
+		t.Fatal("expected nil Metadata when automtls disabled")
+	}
+	sock := ep.GetEndpoint().GetAddress().GetSocketAddress()
+	if sock.GetAddress() != "10.0.0.1" || sock.GetPortValue() != 8080 {
+		t.Fatalf("unexpected socket address: %v:%d", sock.GetAddress(), sock.GetPortValue())
 	}
 }


### PR DESCRIPTION
# Description

Heap profiles of large production deployments show ~60-67% of in-use control-plane heap in `pkg/krtcollections.CreateLBEndpoint` (per-endpoint translation IR, one proto set per endpoint per Service x port backend) and ~8% in `wrapperspb.UInt32`: an explicit load-balancing-weight wrapper of value 1 allocated for every endpoint.

Envoy treats an unset per-endpoint `load_balancing_weight` as 1 (in all versions), so this PR drops the wrapper. Locality-level `LocalityLbEndpoints` weights are computed exactly as before, treating an unset endpoint weight as 1 via a new `lbWeight()` helper. Plugins that set explicit endpoint weights (ServiceEntry, local cluster) are unaffected.

Benchmarks (included, `pkg/krtcollections/endpoints_bench_test.go`): build path -9.5% B/op, -21% allocs/op at 100/1k/10k endpoints; retained heap ~462 B/endpoint.

Part 3 of 3 independent PRs split from #14487 (fully parallel — can merge in any order): #14488 (metadata allocation), #14489 (hash reuse).

# Change Type

/kind fix
/kind cleanup

# Changelog

```release-note
Reduced control-plane memory and GC pressure for endpoint translation at scale by omitting the per-endpoint load-balancing-weight wrapper (Envoy defaults an unset weight to 1) and eliminating dead metadata and re-marshaling allocations on endpoint recomputation.
```

# Additional Notes

- **Wire compatibility:** `LbEndpoint.load_balancing_weight` is now omitted instead of explicitly "1"; behavior-identical for any Envoy version. Golden diffs are only removal of per-endpoint `loadBalancingWeight: 1` lines (zero insertions); locality weights are unchanged.
- **Rollout/rollback:** endpoint equality hashes change once, so every EDS resource receives one re-push to connected envoys at upgrade (and again on rollback). No CRDs or persisted state changed; rollback is clean.
- Golden outputs regenerated via `REFRESH_GOLDEN=true` (setup + waypoint plugin tests).
