### PR TITLE
fix: validate CEL expressions at translation time to reject unsupported functions

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/rbac.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/rbac.go
@@ -151,8 +151,9 @@ func createCELMatcher(celExprs []sharedv1alpha1.CELExpression, action sharedv1al
 		TypedConfig: celMatchInput,
 	}
 
-	// Create parsed expression
-	env, err := cel.NewEnv()
+	// Validate against the Envoy HTTP CEL attributes exposed by the matcher.
+	// Keep these attributes dynamic because their exact runtime shape is owned by Envoy.
+	env, err := newRBACCELValidationEnv()
 	if err != nil {
 		logger.Error("failed to create CEL environment", "err", err.Error())
 		return nil, err
@@ -163,7 +164,7 @@ func createCELMatcher(celExprs []sharedv1alpha1.CELExpression, action sharedv1al
 		// Single expression - use SinglePredicate
 		celDevParsed, err := parseCELExpression(env, celExprs[0])
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse CEL expression: %w", err)
+			return nil, fmt.Errorf("failed to validate CEL expression: %w", err)
 		}
 
 		matcher := &cncfmatcherv3.CelMatcher{
@@ -197,7 +198,7 @@ func createCELMatcher(celExprs []sharedv1alpha1.CELExpression, action sharedv1al
 		for _, celExpr := range celExprs {
 			celDevParsed, err := parseCELExpression(env, celExpr)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse CEL expression: %w", err)
+				return nil, fmt.Errorf("failed to validate CEL expression: %w", err)
 			}
 
 			matcher := &cncfmatcherv3.CelMatcher{
@@ -250,6 +251,16 @@ func createCELMatcher(celExprs []sharedv1alpha1.CELExpression, action sharedv1al
 		Predicate: predicate,
 		OnMatch:   onMatchAction,
 	}, nil
+}
+
+func newRBACCELValidationEnv() (*cel.Env, error) {
+	return cel.NewEnv(
+		cel.Variable("request", cel.DynType),
+		cel.Variable("source", cel.DynType),
+		cel.Variable("destination", cel.DynType),
+		cel.Variable("connection", cel.DynType),
+		cel.Variable("metadata", cel.DynType),
+	)
 }
 
 func createMatchAction(action envoyrbacv3.RBAC_Action) *cncfmatcherv3.Matcher_OnMatch {
@@ -305,10 +316,10 @@ func parseCELExpression(env *cel.Env, celExpr sharedv1alpha1.CELExpression) (*ex
 		return nil, fmt.Errorf("CEL environment is nil")
 	}
 
-	ast, iss := env.Parse(string(celExpr))
+	ast, iss := env.Compile(string(celExpr))
 	if iss.Err() != nil {
-		logger.Error("parse error", "err", iss.Err())
-		return nil, iss.Err()
+		logger.Error("invalid RBAC CEL expression", "err", iss.Err())
+		return nil, fmt.Errorf("invalid RBAC CEL expression %q: %w", celExpr, iss.Err())
 	}
 
 	parsedExpr, err := cel.AstToParsedExpr(ast)

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/rbac_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/rbac_test.go
@@ -7,7 +7,6 @@ import (
 	cncfmatcherv3 "github.com/cncf/xds/go/xds/type/matcher/v3"
 	envoyrbacv3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	envoyauthz "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
-	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -129,7 +128,7 @@ func TestTranslateRBAC(t *testing.T) {
 				require.NotNil(t, got.Rbac.Matcher, "Expected Matcher field in actual result")
 
 				// Create CEL environment for validation
-				env, err := cel.NewEnv()
+				env, err := newRBACCELValidationEnv()
 				require.NoError(t, err, "Failed to create CEL environment")
 
 				// Validate CEL expressions for all expected rules
@@ -144,6 +143,51 @@ func TestTranslateRBAC(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestParseCELExpression(t *testing.T) {
+	env, err := newRBACCELValidationEnv()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		expr    shared.CELExpression
+		wantErr string
+	}{
+		{
+			name: "accepts request header expression",
+			expr: "request.headers['x-foo'] == 'bar'",
+		},
+		{
+			name: "accepts JWT metadata expression",
+			expr: "metadata.filter_metadata['envoy.filters.http.jwt_authn']['payload']['email'] == 'dev2@kgateway.io'",
+		},
+		{
+			name: "accepts standard string function",
+			expr: "source.address.startsWith('10.')",
+		},
+		{
+			name:    "rejects unsupported split function",
+			expr:    "'admin' in metadata.filter_metadata['envoy.filters.http.jwt_authn']['payload']['scope'].split(' ')",
+			wantErr: "undeclared reference to 'split'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := parseCELExpression(env, tt.expr)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Nil(t, parsed)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, parsed)
 		})
 	}
 }


### PR DESCRIPTION
# Description

This PR fixes an issue where invalid CEL expressions in RBAC `matchExpressions` (such as those using the unsupported `.split()` function) were accepted at admission time but later failed during Envoy xDS config load.

Previously, `kgateway` only parsed the CEL expressions using `env.Parse()`, which checks syntax but not function or variable declarations. By switching to `env.Compile()` and supplying an explicit `cel.Env` populated with the Envoy HTTP CEL attributes (`request`, `source`, `destination`, `connection`, `metadata`), we now validate the expressions at translation time. This correctly catches undeclared references (like `.split(' ')`) and reports an error in the `TrafficPolicy` status, preventing bad config from reaching Envoy.

Fixes #14447

## Change Type
/kind fix

## Changelog

```release-note
Fix: Validate RBAC CEL match expressions against supported Envoy attributes during translation, rejecting unsupported functions like `.split()` before they reach Envoy.
```