### PR TITLE
fix: validate listener TLS signature algorithms

### DIFF
--- a/pkg/kgateway/translator/sslutils/ssl_utils.go
+++ b/pkg/kgateway/translator/sslutils/ssl_utils.go
@@ -25,6 +25,21 @@ const (
 	ListenerReasonNoValidCACertificate     gwv1.ListenerConditionReason = "NoValidCACertificate"
 )
 
+var supportedSignatureAlgorithms = map[string]bool{
+	"rsa_pkcs1_sha256":       true,
+	"rsa_pkcs1_sha384":       true,
+	"rsa_pkcs1_sha512":       true,
+	"ecdsa_secp256r1_sha256": true,
+	"ecdsa_secp384r1_sha384": true,
+	"ecdsa_secp521r1_sha512": true,
+	"rsa_pss_rsae_sha256":    true,
+	"rsa_pss_rsae_sha384":    true,
+	"rsa_pss_rsae_sha512":    true,
+	"ed25519":                true,
+	"rsa_pkcs1_sha1":         true,
+	"ecdsa_sha1":             true,
+}
+
 var (
 	ErrInvalidTlsSecret = errors.New("invalid TLS secret")
 
@@ -173,9 +188,21 @@ func ApplyEcdhCurves(in string, out *ir.TLSConfig) error {
 
 func ApplySignatureAlgorithms(in string, out *ir.TLSConfig) error {
 	signatureAlgorithms := strings.Split(in, ",")
-	for i, suite := range signatureAlgorithms {
-		signatureAlgorithms[i] = strings.TrimSpace(suite)
+
+	for i, algorithm := range signatureAlgorithms {
+		algorithm = strings.TrimSpace(algorithm)
+
+		if algorithm == "" {
+			return errors.New("signature algorithms must not contain empty values")
+		}
+
+		if !supportedSignatureAlgorithms[algorithm] {
+			return fmt.Errorf("unsupported TLS signature algorithm: %s", algorithm)
+		}
+
+		signatureAlgorithms[i] = algorithm
 	}
+
 	out.SignatureAlgorithms = signatureAlgorithms
 	return nil
 }

--- a/pkg/kgateway/translator/sslutils/ssl_utils_test.go
+++ b/pkg/kgateway/translator/sslutils/ssl_utils_test.go
@@ -73,6 +73,26 @@ func TestApplyTLSExtensionOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "signature_algorithms_with_unsupported_algorithm",
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "rsa_pss_rsae_sha256,rsa_pss_rsae_sha255",
+			},
+			out: &ir.TLSConfig{},
+			errors: []string{
+				"unsupported TLS signature algorithm: rsa_pss_rsae_sha255",
+			},
+		},
+		{
+			name: "signature_algorithms_with_trailing_comma",
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "rsa_pss_rsae_sha256,",
+			},
+			out: &ir.TLSConfig{},
+			errors: []string{
+				"signature algorithms must not contain empty values",
+			},
+		},
+		{
 			name: "subject_alt_names",
 			out: &ir.TLSConfig{
 				VerifySubjectAltNames: []string{"foo", "bar"},


### PR DESCRIPTION
# Description

Fixes #14453 

Validate `kgateway.dev/signature-algorithms` while translating Gateway listener TLS options.

Previously, kgateway split the comma-separated option and forwarded every entry to Envoy without validation. A misspelled algorithm or an empty entry from a trailing comma was therefore accepted by the control plane, but rejected by Envoy as an LDS NACK. This could leave the listener reported as `Programmed=True` even though Envoy did not apply the configuration.

This change rejects empty and unsupported signature-algorithm values during listener translation, preventing invalid listener TLS configuration from reaching Envoy.

# Change Type

/kind fix

# Changelog

```release-note
Reject invalid `kgateway.dev/signature-algorithms` listener TLS option values during translation.
```