### PR TITLE
[2.3] chore: strict validation performance part two

### DIFF
--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -137,6 +137,7 @@ func (h *httpRouteConfigurationTranslator) computeVirtualHost(
 	sanitizedName := utils.SanitizeForEnvoy(ctx, virtualHost.Name, "virtual host")
 
 	var envoyRoutes []*envoyroutev3.Route
+	var computedRoutes []computedHTTPRoute
 	for i, route := range virtualHost.Rules {
 		var routeReport reportssdk.ParentRefReporter = &reports.ParentRefReport{}
 		if route.Parent != nil {
@@ -146,9 +147,14 @@ func (h *httpRouteConfigurationTranslator) computeVirtualHost(
 			routeReport = h.reporter.Route(route.Parent.SourceObject).ParentRef(&route.ParentRef)
 		}
 		generatedName := fmt.Sprintf("%s-route-%d", virtualHost.Name, i)
-		computedRoute := h.envoyRoutes(ctx, routeReport, route, generatedName)
+		computedRoute := h.envoyRoutes(routeReport, route, generatedName)
 		if computedRoute != nil {
 			envoyRoutes = append(envoyRoutes, computedRoute)
+			computedRoutes = append(computedRoutes, computedHTTPRoute{
+				in:          route,
+				routeReport: routeReport,
+				route:       computedRoute,
+			})
 		}
 	}
 	domains := []string{virtualHost.Hostname}
@@ -184,6 +190,7 @@ func (h *httpRouteConfigurationTranslator) computeVirtualHost(
 	}
 	out.TypedPerFilterConfig = typedPerFilterConfigRoute.ToAnyMap()
 
+	out = h.validateStrictRouteBatch(ctx, virtualHost, out, computedRoutes)
 	return out
 }
 
@@ -221,8 +228,13 @@ type backendConfigContext struct {
 	ResponseHeadersToRemove   []string
 }
 
+type computedHTTPRoute struct {
+	in          ir.HttpRouteRuleMatchIR
+	routeReport reportssdk.ParentRefReporter
+	route       *envoyroutev3.Route
+}
+
 func (h *httpRouteConfigurationTranslator) envoyRoutes(
-	ctx context.Context,
 	routeReport reportssdk.ParentRefReporter,
 	in ir.HttpRouteRuleMatchIR,
 	generatedName string,
@@ -271,10 +283,19 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 		// If there are no errors, validate the route will not be rejected by the xDS server.
 		// Skip delegating routes as they have no action and are not propagated to envoy
 		if routeProcessingErr == nil {
-			routeProcessingErr = validateRoute(ctx, out, h.validator, h.validationLevel)
+			routeProcessingErr = validateRoutePreEnvoy(out, h.validationLevel)
 		}
 	}
 
+	return h.finalizeRoute(routeReport, in, out, routeProcessingErr)
+}
+
+func (h *httpRouteConfigurationTranslator) finalizeRoute(
+	routeReport reportssdk.ParentRefReporter,
+	in ir.HttpRouteRuleMatchIR,
+	out *envoyroutev3.Route,
+	routeProcessingErr error,
+) *envoyroutev3.Route {
 	// routeAcceptanceErr is used to set the Accepted=false,Reason=RouteRuleDropped condition on the route
 	routeAcceptanceErr := errors.Join(routeProcessingErr, in.RouteAcceptanceError)
 
@@ -337,6 +358,57 @@ func (h *httpRouteConfigurationTranslator) envoyRoutes(
 		}
 	}
 
+	return out
+}
+
+func (h *httpRouteConfigurationTranslator) validateStrictRouteBatch(
+	ctx context.Context,
+	virtualHost *ir.VirtualHost,
+	out *envoyroutev3.VirtualHost,
+	computedRoutes []computedHTTPRoute,
+) *envoyroutev3.VirtualHost {
+	if h.validationLevel != apisettings.ValidationStrict || len(out.GetRoutes()) == 0 {
+		return out
+	}
+	if err := validateFullRoutes(ctx, out.GetRoutes(), h.validator); err == nil {
+		return out
+	} else {
+		h.logger.Debug("strict route batch validation failed; isolating invalid routes", "vhost", out.GetName(), "error", err)
+	}
+
+	isolatedRoutes := make([]*envoyroutev3.Route, 0, len(out.GetRoutes()))
+	for _, computedRoute := range computedRoutes {
+		routeValidationErr := validateRoute(ctx, computedRoute.route, h.validator, h.validationLevel)
+		if routeValidationErr != nil {
+			route := h.finalizeRoute(computedRoute.routeReport, computedRoute.in, computedRoute.route, routeValidationErr)
+			if route != nil {
+				isolatedRoutes = append(isolatedRoutes, route)
+			}
+			continue
+		}
+		isolatedRoutes = append(isolatedRoutes, computedRoute.route)
+	}
+	out.Routes = isolatedRoutes
+	if len(out.GetRoutes()) == 0 {
+		return out
+	}
+	if err := validateFullRoutes(ctx, out.GetRoutes(), h.validator); err != nil {
+		h.logger.Error("strict route batch validation failed after invalid route isolation", "vhost", out.GetName(), "error", err)
+		if h.reporter != nil && virtualHost.ParentRef.Parent != nil {
+			reporter := virtualHost.ParentRef.GetParentReporter(h.reporter)
+			reporter.Listener(&virtualHost.ParentRef.Listener).SetCondition(reportssdk.ListenerCondition{
+				Type:    gwv1.ListenerConditionAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  reportssdk.ListenerReplacedReason,
+				Message: err.Error(),
+			})
+		}
+		domain := "*"
+		if len(out.GetDomains()) > 0 {
+			domain = out.GetDomains()[0]
+		}
+		return setFallBackConfig(out.GetName(), domain)
+	}
 	return out
 }
 

--- a/pkg/kgateway/translator/irtranslator/route_test.go
+++ b/pkg/kgateway/translator/irtranslator/route_test.go
@@ -1,16 +1,36 @@
 package irtranslator
 
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"testing"
 
+	envoybootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 )
+
+type routeMockValidator struct {
+	validateFunc func(context.Context, *envoybootstrapv3.Bootstrap) error
+}
+
+var _ validator.Validator = &routeMockValidator{}
+
+func (m *routeMockValidator) Validate(ctx context.Context, config *envoybootstrapv3.Bootstrap) error {
+	if m.validateFunc != nil {
+		return m.validateFunc(ctx, config)
+	}
+	return nil
+}
 
 func TestValidateWeightedClusters(t *testing.T) {
 	tests := []struct {
@@ -148,6 +168,197 @@ func TestSetEnvoyPathMatcher_PathPrefix(t *testing.T) {
 	}
 }
 
+func TestValidateRouteStrictSkipsMatcherOnlyEnvoyValidationForCommonMatchers(t *testing.T) {
+	pathPrefix := gwv1.PathMatchPathPrefix
+	pathExact := gwv1.PathMatchExact
+
+	tests := []struct {
+		name  string
+		match gwv1.HTTPRouteMatch
+	}{
+		{
+			name: "prefix",
+			match: gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &pathPrefix,
+					Value: new("/"),
+				},
+			},
+		},
+		{
+			name: "exact",
+			match: gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &pathExact,
+					Value: new("/exact"),
+				},
+			},
+		},
+		{
+			name: "path separated prefix",
+			match: gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &pathPrefix,
+					Value: new("/separated"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			v := &routeMockValidator{validateFunc: func(context.Context, *envoybootstrapv3.Bootstrap) error {
+				calls++
+				return nil
+			}}
+
+			err := validateRoute(context.Background(), testRouteWithMatch(translateMatcher(tt.match)), v, apisettings.ValidationStrict)
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, calls, "strict validation should only run full-route Envoy validation")
+		})
+	}
+}
+
+func TestValidateRouteStrictInvalidGeneratedRegexMatcher(t *testing.T) {
+	pathRegex := gwv1.PathMatchRegularExpression
+	headerRegex := gwv1.HeaderMatchRegularExpression
+	queryRegex := gwv1.QueryParamMatchRegularExpression
+
+	tests := []struct {
+		name  string
+		match gwv1.HTTPRouteMatch
+	}{
+		{
+			name: "path regex",
+			match: gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &pathRegex,
+					Value: new("[[invalid"),
+				},
+			},
+		},
+		{
+			name: "header regex",
+			match: gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &pathPrefixPtr,
+					Value: new("/"),
+				},
+				Headers: []gwv1.HTTPHeaderMatch{{
+					Type:  &headerRegex,
+					Name:  "x-test",
+					Value: "[[invalid",
+				}},
+			},
+		},
+		{
+			name: "query regex",
+			match: gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &pathPrefixPtr,
+					Value: new("/"),
+				},
+				QueryParams: []gwv1.HTTPQueryParamMatch{{
+					Type:  &queryRegex,
+					Name:  "q",
+					Value: "[[invalid",
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			v := &routeMockValidator{validateFunc: func(context.Context, *envoybootstrapv3.Bootstrap) error {
+				calls++
+				return nil
+			}}
+
+			err := validateRoute(context.Background(), testRouteWithMatch(translateMatcher(tt.match)), v, apisettings.ValidationStrict)
+
+			require.ErrorIs(t, err, ErrInvalidMatcher)
+			assert.Equal(t, 0, calls, "invalid generated matcher should be rejected before Envoy validation")
+		})
+	}
+}
+
+func TestComputeVirtualHostStrictBatchesFullRouteValidation(t *testing.T) {
+	calls := 0
+	var routeCounts []int
+	v := &routeMockValidator{validateFunc: func(_ context.Context, config *envoybootstrapv3.Bootstrap) error {
+		calls++
+		routeCounts = append(routeCounts, len(routesFromValidationBootstrap(t, config)))
+		return nil
+	}}
+	h := testHTTPRouteTranslator(v, apisettings.ValidationStrict)
+
+	out := h.computeVirtualHost(context.Background(), &ir.VirtualHost{
+		Name:     "test-vhost",
+		Hostname: "example.com",
+		Rules: []ir.HttpRouteRuleMatchIR{
+			testRouteIR(0, "/one", "cluster-one"),
+			testRouteIR(1, "/two", "cluster-two"),
+		},
+	})
+
+	require.Len(t, out.GetRoutes(), 2)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, []int{2}, routeCounts)
+}
+
+func TestComputeVirtualHostStrictIsolatesInvalidRouteAfterBatchFailure(t *testing.T) {
+	calls := 0
+	var routeCounts []int
+	v := &routeMockValidator{validateFunc: func(_ context.Context, config *envoybootstrapv3.Bootstrap) error {
+		calls++
+		routes := routesFromValidationBootstrap(t, config)
+		routeCounts = append(routeCounts, len(routes))
+		switch calls {
+		case 1:
+			require.Len(t, routes, 2)
+			return errors.New("batch failed")
+		case 2:
+			require.Len(t, routes, 1)
+			assert.Contains(t, routes[0].GetName(), "route-0")
+			return nil
+		case 3:
+			require.Len(t, routes, 1)
+			assert.Contains(t, routes[0].GetName(), "route-1")
+			return errors.New("bad route")
+		case 4:
+			require.Len(t, routes, 1)
+			assert.Contains(t, routes[0].GetName(), "route-1")
+			return nil
+		case 5:
+			require.Len(t, routes, 2)
+			return nil
+		default:
+			t.Fatalf("unexpected validation call %d", calls)
+			return nil
+		}
+	}}
+	h := testHTTPRouteTranslator(v, apisettings.ValidationStrict)
+
+	out := h.computeVirtualHost(context.Background(), &ir.VirtualHost{
+		Name:     "test-vhost",
+		Hostname: "example.com",
+		Rules: []ir.HttpRouteRuleMatchIR{
+			testRouteIR(0, "/one", "cluster-one"),
+			testRouteIR(1, "/two", "cluster-two"),
+		},
+	})
+
+	require.Len(t, out.GetRoutes(), 2)
+	_, ok := out.GetRoutes()[0].GetAction().(*envoyroutev3.Route_Route)
+	assert.True(t, ok)
+	_, ok = out.GetRoutes()[1].GetAction().(*envoyroutev3.Route_DirectResponse)
+	assert.True(t, ok)
+	assert.Equal(t, []int{2, 1, 1, 1, 2}, routeCounts)
+}
+
 func refFor(name string) *ir.AttachedPolicyRef {
 	return &ir.AttachedPolicyRef{
 		Group:     "gateway.kgateway.dev",
@@ -155,6 +366,69 @@ func refFor(name string) *ir.AttachedPolicyRef {
 		Namespace: "ns",
 		Name:      name,
 	}
+}
+
+func testRouteWithMatch(match *envoyroutev3.RouteMatch) *envoyroutev3.Route {
+	return &envoyroutev3.Route{
+		Name:  "test-route",
+		Match: match,
+		Action: &envoyroutev3.Route_Route{
+			Route: &envoyroutev3.RouteAction{
+				ClusterSpecifier: &envoyroutev3.RouteAction_Cluster{
+					Cluster: "test-cluster",
+				},
+			},
+		},
+	}
+}
+
+var pathPrefixPtr = gwv1.PathMatchPathPrefix
+
+func testHTTPRouteTranslator(v validator.Validator, mode apisettings.ValidationMode) *httpRouteConfigurationTranslator {
+	return &httpRouteConfigurationTranslator{
+		gw: ir.GatewayIR{
+			SourceObject: &ir.Gateway{Obj: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{GatewayClassName: "test-class"},
+			}},
+		},
+		pluginPass:      TranslationPassPlugins{},
+		logger:          slog.Default(),
+		validator:       v,
+		validationLevel: mode,
+	}
+}
+
+func testRouteIR(matchIndex int, path string, clusterName string) ir.HttpRouteRuleMatchIR {
+	return ir.HttpRouteRuleMatchIR{
+		MatchIndex: matchIndex,
+		Match: gwv1.HTTPRouteMatch{
+			Path: &gwv1.HTTPPathMatch{
+				Type:  &pathPrefixPtr,
+				Value: new(path),
+			},
+		},
+		Backends: []ir.HttpBackend{{
+			Backend: ir.BackendRefIR{
+				ClusterName: clusterName,
+				Weight:      1,
+			},
+		}},
+	}
+}
+
+func routesFromValidationBootstrap(t *testing.T, config *envoybootstrapv3.Bootstrap) []*envoyroutev3.Route {
+	t.Helper()
+	listeners := config.GetStaticResources().GetListeners()
+	require.Len(t, listeners, 1)
+	filterChains := listeners[0].GetFilterChains()
+	require.Len(t, filterChains, 1)
+	filters := filterChains[0].GetFilters()
+	require.NotEmpty(t, filters)
+	hcm := &envoy_hcm.HttpConnectionManager{}
+	require.NoError(t, filters[0].GetTypedConfig().UnmarshalTo(hcm))
+	vhosts := hcm.GetRouteConfig().GetVirtualHosts()
+	require.Len(t, vhosts, 1)
+	return vhosts[0].GetRoutes()
 }
 
 func TestSummarizeRuleErrors_NilReturnsEmpty(t *testing.T) {

--- a/pkg/kgateway/translator/irtranslator/validate.go
+++ b/pkg/kgateway/translator/irtranslator/validate.go
@@ -10,8 +10,10 @@ import (
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 
 	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/regexutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
 	"github.com/kgateway-dev/kgateway/v2/pkg/xds/bootstrap"
 )
@@ -42,24 +44,34 @@ var (
 	ErrInvalidRoute = errors.New("invalid route configuration")
 )
 
-// validateRoute performs RDS validation against the given route that's been translated from the IR.
+// validateRoute performs RDS validation against a single route that's been translated from the IR.
 // It provides validation checks that prevent invalid routes from being sent to the xDS server.
 //
 // The validation pipeline runs lightweight checks regardless of route replacement mode.
 // These include basic Envoy route property validation such as paths, prefixes, and weighted clusters,
 // along with quick checks for common issues that could cause problems.
 //
-// In strict mode, the full route is validated against envoy in a single invocation. If that
-// invocation fails, a second matcher-only invocation disambiguates whether the failure
-// originates in the route's match block (drop the route) or in its action (replace with a
-// direct response). Valid routes — the common case — pay only one envoy invocation; invalid
-// routes pay two.
+// In strict mode, generated Gateway API matchers are checked in-process where possible. The full route
+// is then validated against Envoy in a single invocation. If that invocation fails, matcher validation
+// disambiguates whether the failure originates in the route's match block (drop the route) or in its
+// action (replace with a direct response). Matcher shapes this code cannot prove safe fall back to Envoy
+// matcher-only validation.
 func validateRoute(
 	ctx context.Context,
 	route *envoyroutev3.Route,
 	v validator.Validator,
 	mode apisettings.ValidationMode,
 ) error {
+	if err := validateRoutePreEnvoy(route, mode); err != nil {
+		return err
+	}
+	if mode != apisettings.ValidationStrict {
+		return nil
+	}
+	return validateRouteWithEnvoy(ctx, route, v)
+}
+
+func validateRoutePreEnvoy(route *envoyroutev3.Route, mode apisettings.ValidationMode) error {
 	if route == nil {
 		return fmt.Errorf("route cannot be nil for RDS validation")
 	}
@@ -69,13 +81,27 @@ func validateRoute(
 	if mode != apisettings.ValidationStrict {
 		return nil
 	}
-	fullErr := validateFullRoute(ctx, route, v)
+	if handled, err := validateGeneratedMatcher(route.GetMatch()); handled && err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidMatcher, err)
+	}
+	return nil
+}
+
+func validateRouteWithEnvoy(
+	ctx context.Context,
+	route *envoyroutev3.Route,
+	v validator.Validator,
+) error {
+	if route == nil {
+		return fmt.Errorf("route cannot be nil for RDS validation")
+	}
+	fullErr := validateFullRoutes(ctx, []*envoyroutev3.Route{route}, v)
 	if fullErr == nil {
 		return nil
 	}
 	// Only run the matcher-only validation when the full route already failed,
 	// purely to attribute the failure to ErrInvalidMatcher vs ErrInvalidRoute.
-	if matcherErr := validateMatcherOnly(ctx, route, v); matcherErr != nil {
+	if matcherErr := validateMatcherOnlyEnvoy(ctx, route, v); matcherErr != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidMatcher, matcherErr)
 	}
 	return fmt.Errorf("%w: %w", ErrInvalidRoute, fullErr)
@@ -181,8 +207,8 @@ func runValidation(
 	return nil
 }
 
-// validateMatcherOnly validates just the matcher using a dummy route.
-func validateMatcherOnly(ctx context.Context, route *envoyroutev3.Route, v validator.Validator) error {
+// validateMatcherOnlyEnvoy validates just the matcher using a dummy route.
+func validateMatcherOnlyEnvoy(ctx context.Context, route *envoyroutev3.Route, v validator.Validator) error {
 	clusterName := "dummy-cluster"
 	builder := bootstrap.New()
 	builder.AddRoute(&envoyroutev3.Route{
@@ -202,16 +228,140 @@ func validateMatcherOnly(ctx context.Context, route *envoyroutev3.Route, v valid
 	return runValidation(ctx, v, builder)
 }
 
-// validateFullRoute validates the complete route configuration.
-func validateFullRoute(ctx context.Context, route *envoyroutev3.Route, v validator.Validator) error {
+// validateFullRoutes validates a set of complete route configurations in one Envoy invocation.
+func validateFullRoutes(ctx context.Context, routes []*envoyroutev3.Route, v validator.Validator) error {
 	builder := bootstrap.New()
-	builder.AddRoute(route)
-	stubClusters := createStubClusters(extractClusterNames(route))
+	clusterNames := make([]string, 0)
+	// A batched route bootstrap can reference the same backend cluster from many routes.
+	// Track names here so validation adds only one stub Cluster per unique Envoy cluster name.
+	seenClusterNames := make(map[string]struct{})
+	for _, route := range routes {
+		builder.AddRoute(route)
+		clusterNames = appendClusterNames(clusterNames, seenClusterNames, route)
+	}
+	stubClusters := createStubClusters(clusterNames)
 	for _, cluster := range stubClusters {
 		builder.AddCluster(cluster)
 	}
 
 	return runValidation(ctx, v, builder)
+}
+
+func validateGeneratedMatcher(match *envoyroutev3.RouteMatch) (bool, error) {
+	if match == nil {
+		return false, nil
+	}
+	if match.GetRuntimeFraction() != nil || match.GetGrpc() != nil || match.GetTlsContext() != nil || match.GetDynamicMetadata() != nil {
+		return false, nil
+	}
+
+	if handled, err := validateGeneratedPathMatcher(match); !handled || err != nil {
+		return handled, err
+	}
+	for _, header := range match.GetHeaders() {
+		if handled, err := validateGeneratedHeaderMatcher(header); !handled || err != nil {
+			return handled, err
+		}
+	}
+	for _, query := range match.GetQueryParameters() {
+		if handled, err := validateGeneratedQueryMatcher(query); !handled || err != nil {
+			return handled, err
+		}
+	}
+
+	return true, nil
+}
+
+func validateGeneratedPathMatcher(match *envoyroutev3.RouteMatch) (bool, error) {
+	switch path := match.GetPathSpecifier().(type) {
+	case *envoyroutev3.RouteMatch_Path:
+		return true, nil
+	case *envoyroutev3.RouteMatch_Prefix:
+		return true, nil
+	case *envoyroutev3.RouteMatch_PathSeparatedPrefix:
+		if !isValidPathSeparated(path.PathSeparatedPrefix) {
+			return true, fmt.Errorf("path separated prefix %q is invalid", path.PathSeparatedPrefix)
+		}
+		return true, nil
+	case *envoyroutev3.RouteMatch_SafeRegex:
+		return true, validateRegexMatcher(path.SafeRegex, "path regex")
+	default:
+		return false, nil
+	}
+}
+
+func validateGeneratedHeaderMatcher(header *envoyroutev3.HeaderMatcher) (bool, error) {
+	if header == nil {
+		return false, nil
+	}
+	switch matcher := header.GetHeaderMatchSpecifier().(type) {
+	case *envoyroutev3.HeaderMatcher_PresentMatch:
+		return true, nil
+	case *envoyroutev3.HeaderMatcher_StringMatch:
+		return validateGeneratedStringMatcher(matcher.StringMatch, fmt.Sprintf("header %q", header.GetName()))
+	default:
+		return false, nil
+	}
+}
+
+func validateGeneratedQueryMatcher(query *envoyroutev3.QueryParameterMatcher) (bool, error) {
+	if query == nil {
+		return false, nil
+	}
+	switch matcher := query.GetQueryParameterMatchSpecifier().(type) {
+	case *envoyroutev3.QueryParameterMatcher_PresentMatch:
+		return true, nil
+	case *envoyroutev3.QueryParameterMatcher_StringMatch:
+		return validateGeneratedStringMatcher(matcher.StringMatch, fmt.Sprintf("query parameter %q", query.GetName()))
+	default:
+		return false, nil
+	}
+}
+
+func validateGeneratedStringMatcher(matcher *envoy_type_matcher_v3.StringMatcher, field string) (bool, error) {
+	if matcher == nil {
+		return false, nil
+	}
+	switch pattern := matcher.GetMatchPattern().(type) {
+	case *envoy_type_matcher_v3.StringMatcher_Exact:
+		return true, nil
+	case *envoy_type_matcher_v3.StringMatcher_SafeRegex:
+		return true, validateRegexMatcher(pattern.SafeRegex, field+" regex")
+	default:
+		return false, nil
+	}
+}
+
+// validateRegexMatcher checks RE2 syntax only. Envoy's RE2 max_program_size
+// (default 100) is the compiled-instruction count, which Go's regexp cannot
+// reproduce, so an oversized-but-syntactically-valid regex passes here and is
+// caught by the authoritative Envoy validation in validateFullRoutes.
+func validateRegexMatcher(matcher *envoy_type_matcher_v3.RegexMatcher, field string) error {
+	if matcher == nil {
+		return fmt.Errorf("%s is missing", field)
+	}
+	if err := regexutils.CheckRegexString(matcher.GetRegex()); err != nil {
+		return fmt.Errorf(
+			"validation failed: %w: error initializing configuration '/dev/fd/0': %s",
+			validator.ErrInvalidXDS,
+			envoyRegexError(matcher.GetRegex(), err),
+		)
+	}
+	return nil
+}
+
+func envoyRegexError(pattern string, err error) string {
+	errText := err.Error()
+	if strings.Contains(errText, "missing closing ]") {
+		if bracket := strings.Index(pattern, "["); bracket >= 0 {
+			pattern = pattern[bracket:]
+		}
+		return "missing ]: " + pattern
+	}
+	if strings.Contains(errText, "invalid named capture") {
+		return "invalid named capture group: " + pattern
+	}
+	return errText
 }
 
 // createStubClusters creates minimal cluster definitions for validation purposes.
@@ -228,36 +378,34 @@ func createStubClusters(clusterNames []string) []*envoyclusterv3.Cluster {
 	return clusters
 }
 
-// extractClusterNames extracts all cluster names referenced by a route,
-// handling both single cluster routes and weighted cluster routes.
-// Returns a slice of unique cluster names to prevent redundant stub cluster creation.
-func extractClusterNames(route *envoyroutev3.Route) []string {
-	clusterNameSet := make(map[string]struct{})
+func appendClusterNames(clusterNames []string, seen map[string]struct{}, route *envoyroutev3.Route) []string {
 	if route == nil {
-		return []string{}
+		return clusterNames
+	}
+	appendClusterName := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		clusterNames = append(clusterNames, name)
 	}
 	switch action := route.GetAction().(type) {
 	case *envoyroutev3.Route_Route:
 		if action.Route != nil {
 			switch clusterSpec := action.Route.GetClusterSpecifier().(type) {
 			case *envoyroutev3.RouteAction_Cluster:
-				if clusterSpec.Cluster != "" {
-					clusterNameSet[clusterSpec.Cluster] = struct{}{}
-				}
+				appendClusterName(clusterSpec.Cluster)
 			case *envoyroutev3.RouteAction_WeightedClusters:
 				if clusterSpec.WeightedClusters != nil {
 					for _, weightedCluster := range clusterSpec.WeightedClusters.GetClusters() {
-						if weightedCluster.GetName() != "" {
-							clusterNameSet[weightedCluster.GetName()] = struct{}{}
-						}
+						appendClusterName(weightedCluster.GetName())
 					}
 				}
 			}
 		}
-	}
-	clusterNames := make([]string, 0, len(clusterNameSet))
-	for name := range clusterNameSet {
-		clusterNames = append(clusterNames, name)
 	}
 	return clusterNames
 }

--- a/pkg/kgateway/translator/irtranslator/validate_test.go
+++ b/pkg/kgateway/translator/irtranslator/validate_test.go
@@ -74,7 +74,7 @@ func TestValidateRoute_StrictValidSinglecall(t *testing.T) {
 }
 
 func TestValidateRoute_StrictRouteActionFailure(t *testing.T) {
-	// First call (validateFullRoute) fails; second call (validateMatcherOnly) succeeds
+	// First call (validateFullRoutes) fails; second call (validateMatcherOnlyEnvoy) succeeds
 	// -> classify as ErrInvalidRoute.
 	v := &countingValidator{
 		failureFunc: func(call int) error {
@@ -92,7 +92,7 @@ func TestValidateRoute_StrictRouteActionFailure(t *testing.T) {
 }
 
 func TestValidateRoute_StrictMatcherFailure(t *testing.T) {
-	// Both calls fail (matcher-only also fails) -> classify as ErrInvalidMatcher.
+	// Both calls fail (matcher-only Envoy validation also fails) -> classify as ErrInvalidMatcher.
 	v := &countingValidator{
 		failureFunc: func(call int) error {
 			return errors.New("matcher rejected")

--- a/test/e2e/features/loadtesting/attachedroutes_suite.go
+++ b/test/e2e/features/loadtesting/attachedroutes_suite.go
@@ -236,7 +236,8 @@ func (s *AttachedRoutesSuite) measureIncrementalRoutePerformance(config *Attache
 	s.Require().NotNil(incrementalRoute, "Should create incremental route")
 
 	s.T().Log("Phase 10: Probing gateway until incremental route returns 200")
-	routeReadyTime := s.curlGatewayUntilReady(config.Gateways[0], config.Routes)
+	routeReadyTime, err := s.curlGatewayUntilReady(config.Gateways[0], config.Routes)
+	s.Require().NoError(err, "Incremental route should become ready")
 
 	stopwatchEnd := time.Now()
 	userTime := stopwatchEnd.Sub(stopwatchStart)
@@ -248,10 +249,12 @@ func (s *AttachedRoutesSuite) measureIncrementalRoutePerformance(config *Attache
 	// Measure teardown
 	s.T().Log("Phase 12: Measuring teardown time for incremental route")
 	teardownStart := time.Now()
-	err := s.deleteIncrementalRoute(incrementalRoute)
+	err = s.deleteIncrementalRoute(incrementalRoute)
 	s.Require().NoError(err, "Should delete incremental route")
 
-	results.TeardownTime = s.waitForRouteTeardown(config.Gateways, config.Routes, teardownStart)
+	teardownTime, err := s.waitForRouteTeardown(config.Gateways, config.Routes, teardownStart)
+	s.Require().NoError(err, "Incremental route should detach")
+	results.TeardownTime = teardownTime
 	s.T().Logf("=== TEARDOWN COMPLETE === Teardown Time: %v", results.TeardownTime)
 }
 
@@ -417,7 +420,7 @@ func (s *AttachedRoutesSuite) createSingleIncrementalRoute(gatewayName string) *
 				BackendRefs: []gwv1.HTTPBackendRef{{
 					BackendRef: gwv1.BackendRef{
 						BackendObjectReference: gwv1.BackendObjectReference{
-							Name: gwv1.ObjectName("simulated-service-1"),
+							Name: gwv1.ObjectName("loadtest-backend"),
 							Port: &[]gwv1.PortNumber{80}[0],
 						},
 					},
@@ -433,27 +436,35 @@ func (s *AttachedRoutesSuite) createSingleIncrementalRoute(gatewayName string) *
 	return route
 }
 
-func (s *AttachedRoutesSuite) curlGatewayUntilReady(gatewayName string, baselineRoutes int) time.Duration {
+func (s *AttachedRoutesSuite) curlGatewayUntilReady(gatewayName string, baselineRoutes int) (time.Duration, error) {
 	s.T().Log("Probing gateway until incremental route returns 200")
 	return s.waitForGatewayCondition(gatewayName, baselineRoutes+1, "ready")
 }
 
-func (s *AttachedRoutesSuite) waitForRouteTeardown(gateways []string, expectedCount int, teardownStart time.Time) time.Duration {
+func (s *AttachedRoutesSuite) waitForRouteTeardown(gateways []string, expectedCount int, teardownStart time.Time) (time.Duration, error) {
 	s.T().Log("Waiting for incremental route teardown")
 	return s.waitForAllGatewaysCondition(gateways, expectedCount, teardownStart, "teardown")
 }
 
-func (s *AttachedRoutesSuite) waitForGatewayCondition(gatewayName string, expectedCount int, conditionType string) time.Duration {
+func (s *AttachedRoutesSuite) waitForGatewayCondition(gatewayName string, expectedCount int, conditionType string) (time.Duration, error) {
 	probeStart := time.Now()
 	timeout := time.After(routeConditionTimeout)
 	ticker := time.NewTicker(gatewayPollingInterval)
 	defer ticker.Stop()
+	lastAttachedRoutes := -1
 
 	for {
 		select {
 		case <-timeout:
+			elapsed := time.Since(probeStart)
 			s.T().Logf("Timeout waiting for gateway %s condition", conditionType)
-			return time.Since(probeStart)
+			return elapsed, fmt.Errorf(
+				"timeout waiting for gateway %s condition after %v: expected AttachedRoutes >= %d, last observed %d",
+				conditionType,
+				elapsed,
+				expectedCount,
+				lastAttachedRoutes,
+			)
 		case <-ticker.C:
 			namespacedName := types.NamespacedName{
 				Name:      gatewayName,
@@ -470,27 +481,36 @@ func (s *AttachedRoutesSuite) waitForGatewayCondition(gatewayName string, expect
 			}
 
 			attachedRoutes := int(gateway.Status.Listeners[0].AttachedRoutes)
+			lastAttachedRoutes = attachedRoutes
 			s.T().Logf("Probing: AttachedRoutes=%d (expecting %d)", attachedRoutes, expectedCount)
 
 			if attachedRoutes >= expectedCount {
 				readyTime := time.Since(probeStart)
 				s.T().Logf("Gateway condition %s met! Time: %v", conditionType, readyTime)
-				return readyTime
+				return readyTime, nil
 			}
 		}
 	}
 }
 
-func (s *AttachedRoutesSuite) waitForAllGatewaysCondition(gateways []string, expectedCount int, startTime time.Time, conditionType string) time.Duration {
+func (s *AttachedRoutesSuite) waitForAllGatewaysCondition(gateways []string, expectedCount int, startTime time.Time, conditionType string) (time.Duration, error) {
 	timeout := time.After(routeConditionTimeout)
 	ticker := time.NewTicker(teardownPollingInterval)
 	defer ticker.Stop()
+	lastObserved := "none"
 
 	for {
 		select {
 		case <-timeout:
+			elapsed := time.Since(startTime)
 			s.T().Logf("Timeout waiting for %s condition", conditionType)
-			return time.Since(startTime)
+			return elapsed, fmt.Errorf(
+				"timeout waiting for %s condition after %v: expected every gateway AttachedRoutes <= %d, last observed %s",
+				conditionType,
+				elapsed,
+				expectedCount,
+				lastObserved,
+			)
 		case <-ticker.C:
 			allReady := true
 
@@ -502,16 +522,19 @@ func (s *AttachedRoutesSuite) waitForAllGatewaysCondition(gateways []string, exp
 
 				gateway := &gwv1.Gateway{}
 				if err := s.testInstallation.ClusterContext.Client.Get(s.ctx, namespacedName, gateway); err != nil {
+					lastObserved = fmt.Sprintf("%s: get failed: %v", gatewayName, err)
 					allReady = false
 					break
 				}
 
 				if len(gateway.Status.Listeners) == 0 {
+					lastObserved = fmt.Sprintf("%s: no listeners", gatewayName)
 					allReady = false
 					break
 				}
 
 				attachedRoutes := int(gateway.Status.Listeners[0].AttachedRoutes)
+				lastObserved = fmt.Sprintf("%s: AttachedRoutes=%d", gatewayName, attachedRoutes)
 				if attachedRoutes > expectedCount {
 					allReady = false
 					break
@@ -521,7 +544,7 @@ func (s *AttachedRoutesSuite) waitForAllGatewaysCondition(gateways []string, exp
 			if allReady {
 				conditionTime := time.Since(startTime)
 				s.T().Logf("%s condition complete: %v", conditionType, conditionTime)
-				return conditionTime
+				return conditionTime, nil
 			}
 		}
 	}

--- a/test/e2e/tests/kgateway_test.go
+++ b/test/e2e/tests/kgateway_test.go
@@ -21,17 +21,18 @@ import (
 func TestKgateway(t *testing.T) {
 	ctx := context.Background()
 	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "kgateway-test")
-	testInstallation := e2e.CreateTestInstallation(
-		t,
-		&install.Context{
-			InstallNamespace:          installNs,
-			ProfileValuesManifestFile: e2e.CommonRecommendationManifest,
-			ValuesManifestFile:        e2e.EmptyValuesManifestPath,
-			ExtraHelmArgs: []string{
-				"--set", "controller.extraEnv.KGW_GLOBAL_POLICY_NAMESPACE=" + installNs,
-			},
+	installContext := &install.Context{
+		InstallNamespace:          installNs,
+		ProfileValuesManifestFile: e2e.CommonRecommendationManifest,
+		ValuesManifestFile:        e2e.EmptyValuesManifestPath,
+		ExtraHelmArgs: []string{
+			"--set", "controller.extraEnv.KGW_GLOBAL_POLICY_NAMESPACE=" + installNs,
 		},
-	)
+	}
+	if validationMode := os.Getenv("VALIDATION_MODE"); validationMode != "" {
+		installContext.ExtraHelmArgs = append(installContext.ExtraHelmArgs, "--set", "validation.level="+validationMode)
+	}
+	testInstallation := e2e.CreateTestInstallation(t, installContext)
 
 	// Set the env to the install namespace if it is not already set
 	if !nsEnvPredefined {


### PR DESCRIPTION
# Description
Backports #14269

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->


<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix
/kind cleanup
<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Improved strict HTTPRoute validation performance by batching full-route Envoy validation per virtual host.
```

# Additional Notes

Not a cherry pick because of the load test, which didn't have all the same toys to play with.
<!--
Any extra context or edge cases for reviewers.
-->
