### PR TITLE
test: share one envtest environment across setup package tests

### DIFF
--- a/pkg/kgateway/setup/main_test.go
+++ b/pkg/kgateway/setup/main_test.go
@@ -1,8 +1,15 @@
 package setup_test
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/kgateway-dev/kgateway/v2/test/envtestassets"
 )
 
 func TestMain(m *testing.M) {
@@ -19,5 +26,32 @@ func TestMain(m *testing.M) {
 	if os.Getenv("KGW_XDS_FIRST_CONNECT_DELAY") == "" {
 		os.Setenv("KGW_XDS_FIRST_CONNECT_DELAY", "0")
 	}
-	os.Exit(m.Run())
+
+	// Start a single envtest environment (etcd + kube-apiserver) shared by all
+	// tests in this package; booting one per test dominates the suite runtime.
+	assetsDir, err := envtestassets.GetEnvTestAssetsDir()
+	if err != nil {
+		fmt.Printf("failed to get assets dir: %v\n", err)
+		os.Exit(1)
+	}
+	sharedTestEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "crds"),
+			filepath.Join("..", "..", "..", "install", "helm", "kgateway-crds", "templates"),
+			filepath.Join("testdata", "istio_crds_setup"),
+		},
+		ErrorIfCRDPathMissing: true,
+		// set assets dir so we can run without the makefile
+		BinaryAssetsDirectory: assetsDir,
+		// This often hangs (for unknown reasons); we don't need cleanup so just kill it almost instantly
+		ControlPlaneStopTimeout: time.Millisecond,
+		// web hook to add cluster ips to services
+	}
+	if _, err := sharedTestEnv.Start(); err != nil {
+		fmt.Printf("failed to start envtest: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	sharedTestEnv.Stop()
+	os.Exit(code)
 }

--- a/pkg/kgateway/setup/setup_test.go
+++ b/pkg/kgateway/setup/setup_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/proxy_syncer"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/envutils"
-	"github.com/kgateway-dev/kgateway/v2/test/envtestassets"
 	"github.com/kgateway-dev/kgateway/v2/test/envtestutil"
 )
 
@@ -115,6 +114,11 @@ func init() {
 		grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(writer, writer, writer, 100))
 	}
 }
+
+// sharedTestEnv is started once in TestMain and reused across all tests in this
+// package; each test still starts its own kgateway controller against it (settings
+// differ per test), so only the expensive etcd+apiserver boot is shared.
+var sharedTestEnv *envtest.Environment
 
 func TestServiceEntry(t *testing.T) {
 	st, err := envtestutil.BuildSettings()
@@ -202,6 +206,26 @@ func TestWithAutoDns(t *testing.T) {
 	runScenario(t, "testdata/autodns", st)
 }
 
+// applyYAMLContents writes yamls to a temp file, applies them, and registers a
+// cleanup that deletes them. Deletion matters because the envtest apiserver is
+// shared across tests in this package: leftovers would pollute later tests (and
+// repeated runs via `go test -count=N`).
+func applyYAMLContents(t *testing.T, client istiokube.CLIClient, ns string, yamls ...string) {
+	t.Helper()
+	yamlfile := filepath.Join(t.TempDir(), "test.yaml")
+	if err := os.WriteFile(yamlfile, []byte(strings.Join(yamls, "\n---\n")), 0o600); err != nil {
+		t.Fatalf("failed to write yaml: %v", err)
+	}
+	if err := client.ApplyYAMLFiles(ns, yamlfile); err != nil {
+		t.Fatalf("failed to apply yaml: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.DeleteYAMLFiles(ns, yamlfile); err != nil {
+			t.Logf("failed to delete yaml: %v", err)
+		}
+	})
+}
+
 func TestPolicyUpdate(t *testing.T) {
 	st, err := envtestutil.BuildSettings()
 	if err != nil {
@@ -210,7 +234,7 @@ func TestPolicyUpdate(t *testing.T) {
 	setupEnvTestAndRun(t, st, func(t *testing.T, ctx context.Context, kdbg *krt.DebugHandler, client istiokube.CLIClient, xdsPort int) {
 		client.Kube().CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "gwtest"}}, metav1.CreateOptions{})
 
-		err = client.ApplyYAMLContents("gwtest", `kind: Gateway
+		applyYAMLContents(t, client, "gwtest", `kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: http-gw
@@ -308,7 +332,7 @@ func TestServiceAppProtocolUpdate(t *testing.T) {
 	setupEnvTestAndRun(t, st, func(t *testing.T, ctx context.Context, kdbg *krt.DebugHandler, client istiokube.CLIClient, xdsPort int) {
 		client.Kube().CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "gwtest"}}, metav1.CreateOptions{})
 
-		err = client.ApplyYAMLContents("gwtest", `kind: Gateway
+		applyYAMLContents(t, client, "gwtest", `kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: http-gw
@@ -351,9 +375,6 @@ spec:
       port: 8080
       targetPort: 8080
 `)
-		if err != nil {
-			t.Fatalf("failed to apply initial resources: %v", err)
-		}
 
 		time.Sleep(time.Second * 2)
 		t.Cleanup(func() {
@@ -459,28 +480,10 @@ func setupEnvTestAndRun(t *testing.T, globalSettings *apisettings.Settings, run 
 		writer.set(nil)
 	})
 
-	assetsDir, err := envtestassets.GetEnvTestAssetsDir()
-	if err != nil {
-		t.Fatalf("failed to get assets dir: %v", err)
-	}
-
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "crds"),
-			filepath.Join("..", "..", "..", "install", "helm", "kgateway-crds", "templates"),
-			filepath.Join("testdata", "istio_crds_setup"),
-		},
-		ErrorIfCRDPathMissing: true,
-		// set assets dir so we can run without the makefile
-		BinaryAssetsDirectory: assetsDir,
-		// This often hangs (for unknown reasons); we don't need cleanup so just kill it almost instantly
-		ControlPlaneStopTimeout: time.Millisecond,
-		// web hook to add cluster ips to services
-	}
 	envtestutil.RunController(
 		t,
 		globalSettings,
-		testEnv,
+		sharedTestEnv,
 		nil,
 		[][]string{
 			{"default", "testdata/setup_yaml/setup.yaml"},

--- a/test/envtestutil/util.go
+++ b/test/envtestutil/util.go
@@ -129,16 +129,24 @@ func RunController(
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	cfg, err := testEnv.Start()
-	if err != nil {
-		t.Fatalf("failed to get assets dir: %v", err)
+	cfg := testEnv.Config
+	if cfg == nil {
+		// Environment not started yet; start it and stop it when this test ends.
+		// When the environment is shared across tests (started once in TestMain),
+		// Config is already set and we must not re-start or stop it here.
+		var startErr error
+		cfg, startErr = testEnv.Start()
+		if startErr != nil {
+			t.Fatalf("failed to start envtest environment: %v", startErr)
+		}
+		t.Cleanup(func() { testEnv.Stop() })
 	}
-	t.Cleanup(func() { testEnv.Stop() })
 
 	kubeconfig := GenerateKubeConfiguration(t, cfg)
 	t.Log("kubeconfig:", kubeconfig)
 
 	var apiClient apiclient.Client
+	var err error
 	if newAPIClientFn != nil {
 		apiClient, err = newAPIClientFn(cfg)
 		if err != nil {


### PR DESCRIPTION
# Description

**Motivation:** `pkg/kgateway/setup` is one of the slowest unit test packages (~105s locally) because every test boots its own envtest environment (etcd + kube-apiserver, 5-7s each, ~12x, serially).

**What changed:**
- `TestMain` in `pkg/kgateway/setup` now boots a single envtest environment shared by all tests in the package. Each test still starts its own kgateway controller with its own settings (e.g. `EnableIstioIntegration`), so what the tests verify is unchanged.
- `envtestutil.RunController` skips `Start()`/`Stop()` when handed an already-started environment (detected via `testEnv.Config != nil`), staying backward-compatible for standalone per-test use.
- `TestPolicyUpdate`/`TestServiceAppProtocolUpdate` now delete the yamls they apply (new `applyYAMLContents` helper that applies from a temp file and deletes in cleanup), matching what the scenario subtests already do.

Result: package runtime drops from ~105s to ~14s locally.

Builds on prior work here: #11807 ("make envtest fast", complementary speedups) and #14008 (introduced the `SharedEnv` pattern for the deployer/helm tests).

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes

- **Cleanup fix found via `go test -count=3`:** with a shared apiserver, resources left behind by `TestPolicyUpdate` (gateway `http-gw` + `ws-route` + policy in `gwtest`) polluted `TestServiceAppProtocolUpdate` and repeated runs (`Routes[0]` ordering changed, causing "expected 1 filter config, got 0" failures). Deleting applied yamls in cleanup fixes this and makes the suite robust to repeated in-process runs. `go test -count=3 ./pkg/kgateway/setup/` passes in ~36s.
- Debugging-only caveat: `DEBUG_APISERVER=true` api server log/audit-log configuration in `RunController` only takes effect when `RunController` starts the environment itself; with the shared env it is a no-op after `TestMain`'s start.
- CI runs `-count=1` per package, so behavior there changes only in the time taken.
