### PR TITLE
fix: propagate commonLabels to kgateway controller pod template

### DIFF
--- a/install/helm/kgateway/templates/deployment.yaml
+++ b/install/helm/kgateway/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
       labels:
         {{- include "kgateway.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/test/helm/testdata/kgateway/additional-labels.golden
+++ b/test/helm/testdata/kgateway/additional-labels.golden
@@ -331,6 +331,8 @@ spec:
         app.kubernetes.io/name: kgateway
         app.kubernetes.io/instance: test-release
         app.kubernetes.io/component: controller
+        another-label: "true"
+        extra-label-key: extra-label-value
     spec:
       serviceAccountName: test-release-kgateway
       containers:


### PR DESCRIPTION
# Description

The Helm chart's `commonLabels` value is documented as applying to "all resources created by the Helm chart," and it is already merged into every resource's own `metadata.labels` via the `kgateway.labels` helper (Deployment, Service, ServiceAccount, PodDisruptionBudget, etc.). However, the controller Deployment's **pod template** labels (`spec.template.metadata.labels`) were built only from `kgateway.selectorLabels` plus a hardcoded `app.kubernetes.io/component: controller`, so `commonLabels` never reached the running controller pods.

This change adds `commonLabels` to the pod template labels, keeping it separate from `selectorLabels` (which also backs the immutable `spec.selector.matchLabels`, so it must stay stable across upgrades).

Fixes #14503

# Change type

/kind fix

# Changelog

```release-note
Custom labels set via the Helm chart's `commonLabels` value now propagate to the kgateway controller's pod template, in addition to the Deployment's own metadata.
```

## Additional notes

- Regenerated the `additional-labels` golden test in `test/helm/testdata/kgateway/` (`REFRESH_GOLDEN=true go test -run TestHelmChartTemplate ./test/helm/...`); it was the only golden file affected.
- Verified with `helm lint install/helm/kgateway` and the full `go test ./test/helm/...` suite.