### PR TITLE
test(equalstest): report broken mutators instead of blaming Equals

### DIFF
--- a/test/testutils/equalstest/equalstest.go
+++ b/test/testutils/equalstest/equalstest.go
@@ -37,7 +37,10 @@ type Case[T any] struct {
 // Run builds two fresh instances via base() for each case, applies
 // Mutate to one, and asserts:
 //  1. base().Equals(base()) is true (reflexivity on identical values)
-//  2. after mutation, Equals is false in both directions (detection + symmetry)
+//  2. Mutate actually changed the value, so a broken mutator is reported as such
+//     instead of being blamed on Equals
+//  3. after mutation, Equals is false, and agrees in both directions (detection +
+//     symmetry)
 //
 // It then reflects over T's exported fields (flattening embedded structs one
 // level) and fails if any field name is neither covered by a Case nor listed
@@ -71,12 +74,29 @@ func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []C
 			mutated := base()
 			c.Mutate(&mutated)
 
-			if equals(orig, mutated) {
-				t.Errorf("Equals returned true after mutating field %q; Equals must detect this change", c.Field)
+			// Precondition: Mutate must actually have changed something, otherwise
+			// the case below would blame Equals for a broken mutator. DeepEqual is
+			// used only to detect "nothing changed at all": over-reporting a
+			// difference (as it may for independently built protos) is harmless
+			// here, and it never reports two genuinely different values as equal.
+			if !mutationChanged(orig, mutated) {
+				t.Fatalf(
+					"Mutate for field %q left the value unchanged, so this case tests nothing; "+
+						"fix the mutator (or the base() factory, if it now returns the mutated value)",
+					c.Field,
+				)
 			}
-			// Symmetry: a.Equals(b) must equal b.Equals(a)
-			if equals(mutated, orig) {
-				t.Errorf("Equals is not symmetric: Equals(orig, mutated)=false but Equals(mutated, orig)=true for field %q", c.Field)
+
+			fwd := equals(orig, mutated)
+			rev := equals(mutated, orig)
+			if fwd != rev {
+				t.Errorf(
+					"Equals is not symmetric for field %q: Equals(orig, mutated)=%v but Equals(mutated, orig)=%v",
+					c.Field, fwd, rev,
+				)
+			}
+			if fwd {
+				t.Errorf("Equals returned true after mutating field %q; Equals must detect this change", c.Field)
 			}
 		})
 	}
@@ -107,6 +127,15 @@ func Run[T any](t *testing.T, base func() T, equals func(a, b T) bool, cases []C
 			missing,
 		)
 	}
+}
+
+// mutationChanged reports whether Mutate actually altered the value. DeepEqual is
+// used only as a "nothing changed at all" detector: for types holding
+// independently built protos it may report a difference that proto.Equal would
+// call equal, which is harmless here, and it never reports two genuinely
+// different values as identical.
+func mutationChanged(orig, mutated any) bool {
+	return !reflect.DeepEqual(orig, mutated)
 }
 
 // uncoveredFields returns the exported field names of typ that are not present

--- a/test/testutils/equalstest/equalstest_internal_test.go
+++ b/test/testutils/equalstest/equalstest_internal_test.go
@@ -109,3 +109,29 @@ func TestUncoveredFields_UnexportedIncludedWhenRequested(t *testing.T) {
 		}
 	}
 }
+
+func TestMutationChanged(t *testing.T) {
+	type withProto struct {
+		Msg  *EmbeddedBase // stands in for a pointer-typed field
+		Name string
+	}
+	cases := []struct {
+		name       string
+		orig, mut  any
+		wantChange bool
+	}{
+		{"noop scalar", internalFixture{Plain: "a"}, internalFixture{Plain: "a"}, false},
+		{"changed scalar", internalFixture{Plain: "a"}, internalFixture{Plain: "b"}, true},
+		{"noop embedded", internalFixture{EmbeddedBase: EmbeddedBase{Embedded: "x"}}, internalFixture{EmbeddedBase: EmbeddedBase{Embedded: "x"}}, false},
+		{"changed embedded", internalFixture{EmbeddedBase: EmbeddedBase{Embedded: "x"}}, internalFixture{EmbeddedBase: EmbeddedBase{Embedded: "y"}}, true},
+		{"distinct pointers, equal pointees", withProto{Msg: &EmbeddedBase{Embedded: "x"}}, withProto{Msg: &EmbeddedBase{Embedded: "x"}}, false},
+		{"nil to non-nil pointer", withProto{}, withProto{Msg: &EmbeddedBase{}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mutationChanged(c.orig, c.mut); got != c.wantChange {
+				t.Errorf("mutationChanged() = %v, want %v", got, c.wantChange)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

`test/testutils/equalstest` applies each `Case`'s `Mutate` and asserts `Equals` goes false, but never checks that `Mutate` changed anything. A mutator that silently becomes a no-op — most easily when a `base()` factory is updated to return the value the mutator sets, since factories and case lists sit far apart — is reported as a broken `Equals`:

```
Equals returned true after mutating field "PerConnectionBufferLimitBytes"; Equals must detect this change
Equals is not symmetric: Equals(orig, mutated)=false but Equals(mutated, orig)=true for field "PerConnectionBufferLimitBytes"
```

Both lines point at `Gateway.Equals`, which is correct; the bug is in the test data. This PR adds a precondition so the same slip reports:

```
Mutate for field "PerConnectionBufferLimitBytes" left the value unchanged, so this case tests nothing;
fix the mutator (or the base() factory, if it now returns the mutated value)
```

`reflect.DeepEqual` is used only as a "nothing changed at all" detector. Some harnessed types are proto-heavy (`listenerpolicy.HttpListenerPolicyIr` is 14 fields of `*envoy_hcm.*` / `*envoyxffv3.XffConfig` / `*healthcheckv3.HealthCheck`), and DeepEqual on independently built protos can over-report a difference. In this direction that is harmless: over-reporting means the precondition passes and the real assertion runs. The only dangerous verdict — two genuinely different values reported as identical — is not one DeepEqual produces. It is deliberately not used as an equality oracle.

This also fixes the symmetry check, which tested `equals(mutated, orig)` on its own instead of comparing the two directions. It therefore always fired alongside a detection failure, with an inverted claim: in the example above it printed `Equals(orig, mutated)=false` when both directions had returned `true`.

The precondition is extracted as `mutationChanged` and tested directly in the existing white-box `equalstest_internal_test.go`, including the distinct-pointers-with-equal-pointees case that pins the behavior relied on above.

No behavior change for the 12 existing `Run` call sites (`pkg/pluginsdk/ir`, `directresponse`, `listenerpolicy`) — all still pass, which also confirms no current mutator is secretly a no-op.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Test-only; no production code touched. Noticed while reviewing #14489, but independent of it.
