### PR TITLE
test(endpoints): guard ReuseEndpointsFrom against struct changes

### DIFF
--- a/pkg/pluginsdk/ir/model_endpoints_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_test.go
@@ -2,10 +2,15 @@ package ir
 
 import (
 	"fmt"
+	"reflect"
+	"slices"
 	"testing"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func epsBackend(name string) BackendObjectIR {
@@ -130,5 +135,114 @@ func TestReuseEndpointsFromEmpty(t *testing.T) {
 	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
 	if clone.LbEpsEqualityHash != readded.LbEpsEqualityHash {
 		t.Fatalf("empty reuse hash mismatch: reuse=%d readd=%d", clone.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+}
+
+// reuseCmpOpts compares two EndpointsForBackend in full, including the unexported
+// equality hashes.
+//
+// AttachedPolicies is ignored rather than compared: it is +noKrtEquals,
+// ReuseEndpointsFrom does not touch it, and cmp cannot traverse it — PolicyAtt
+// holds a PolicyIR interface whose concrete plugin types have unexported fields,
+// so cmp panics ("cannot handle unexported field") as soon as a fixture attaches
+// a real policy. There is no finite set of types to pass to AllowUnexported.
+var reuseCmpOpts = []cmp.Option{
+	cmp.AllowUnexported(EndpointsForBackend{}),
+	cmpopts.IgnoreFields(EndpointsForBackend{}, "AttachedPolicies"),
+	protocmp.Transform(),
+}
+
+// TestReuseEndpointsFromCopiesEveryDerivedField compares the whole struct against
+// one built by re-Adding every endpoint. Unlike an assertion on the hashes alone,
+// this fails when a future field is maintained incrementally by Add() and
+// ReuseEndpointsFrom forgets to reproduce it, and when ReuseEndpointsFrom starts
+// copying a backend-identity field it should have left to the caller.
+func TestReuseEndpointsFromCopiesEveryDerivedField(t *testing.T) {
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	for i := range 10 {
+		base.Add(
+			PodLocality{
+				Region: "us-east-1",
+				Zone:   fmt.Sprintf("zone-%d", i%3),
+			},
+			testEndpointWithMd(i),
+		)
+	}
+
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	for locality, endpoints := range base.LbEps {
+		for _, endpoint := range endpoints {
+			readded.Add(locality, endpoint)
+		}
+	}
+
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	clone.ReuseEndpointsFrom(base)
+
+	if diff := cmp.Diff(readded, clone, reuseCmpOpts...); diff != "" {
+		t.Fatalf("ReuseEndpointsFrom differs from re-Add (-want +got):\n%s", diff)
+	}
+
+	// Equal contents do not prove that each locality has its own backing slice,
+	// so assert non-aliasing separately.
+	for locality, baseEndpoints := range base.LbEps {
+		clonedEndpoints := clone.LbEps[locality]
+		if len(baseEndpoints) > 0 && len(clonedEndpoints) > 0 && &baseEndpoints[0] == &clonedEndpoints[0] {
+			t.Errorf("endpoint slice for %v aliases the base backing array", locality)
+		}
+	}
+}
+
+// TestReuseEndpointsFromCopiesEmptyLocality covers the len(eps) > 0 == false
+// branch, which needs a locality key with no endpoints.
+//
+// Such a locality is unreachable in production: Add is the only writer of LbEps
+// anywhere in the tree, and it always appends an endpoint. It is also the one
+// input where reuse and re-Add disagree on state — the re-Add loop never calls
+// Add for a zero-length slice, so it drops the key, while reuse preserves it. The
+// equality hash agrees either way, and the hash is what Equals compares, so this
+// documents the divergence rather than asserting equivalence.
+func TestReuseEndpointsFromCopiesEmptyLocality(t *testing.T) {
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	emptyLocality := PodLocality{Region: "empty-region"}
+	base.LbEps[emptyLocality] = nil
+
+	clone := NewEndpointsForBackend(epsBackend("svc-variant"))
+	initialHash := clone.LbEpsEqualityHash
+	clone.ReuseEndpointsFrom(base)
+
+	if _, ok := clone.LbEps[emptyLocality]; !ok {
+		t.Error("empty locality was not copied")
+	}
+	if clone.LbEpsEqualityHash != initialHash {
+		t.Errorf(
+			"empty endpoint set changed hash: got %d want %d",
+			clone.LbEpsEqualityHash,
+			initialHash,
+		)
+	}
+}
+
+// TestEndpointHashInputsUnchanged is a canary on the structs hashEndpoints reads.
+// EndpointsForBackend.Equals compares equality hashes instead of endpoints, so a
+// new field on any of these is invisible to KRT until hashEndpoints folds it in.
+// This cannot prove an existing field is actually hashed; it forces a conscious
+// decision when one of these structs grows.
+func TestEndpointHashInputsUnchanged(t *testing.T) {
+	for ty, want := range map[reflect.Type][]string{
+		reflect.TypeFor[PodLocality]():      {"Region", "Zone", "Subzone"},
+		reflect.TypeFor[EndpointWithMd]():   {"LbEndpoint", "EndpointMd"},
+		reflect.TypeFor[EndpointMetadata](): {"Labels"},
+	} {
+		var got []string
+		for field := range ty.Fields() {
+			got = append(got, field.Name)
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf(
+				"%s fields changed: got %v want %v; update hashEndpoints or explicitly document the exclusion",
+				ty.Name(), got, want,
+			)
+		}
 	}
 }


### PR DESCRIPTION
# Description

Follow-up to #14489, which added `EndpointsForBackend.ReuseEndpointsFrom` and switched `FinalBackendEndpoints` and `GatewayBackendClientCertificateVariantEndpoints` onto it. The change is correct; its tests assert the equality hashes and the `LbEps` shape, which leaves two ways for a later change to break the derived collections with everything still green.

**A field maintained incrementally by `Add()` would silently not be reproduced.** Adding a `TotalEndpoints int` to `EndpointsForBackend` and incrementing it in `Add` leaves the two derived collections diverging from the re-Add path they replaced, and every existing test still passes. This PR compares the whole struct — unexported hashes included — against a re-Add reference. It also catches the opposite mistake: injecting `e.ClusterName = base.ClusterName` into `ReuseEndpointsFrom` (a plausible "copy a bit more" edit that would corrupt a variant's cluster identity) now produces a diff.

**`EndpointsForBackend.Equals` compares hashes rather than endpoints,** so a new field on `PodLocality`, `EndpointWithMd`, or `EndpointMetadata` is invisible to KRT until `hashEndpoints` folds it in. `hashEndpoints` reads `Region`, `Zone`, and `Subzone` individually, so a fourth `PodLocality` field would go unhashed. The canary forces a conscious decision when one of those structs grows. It cannot prove an existing field is actually hashed — a mutation table per hash input would, and is a reasonable follow-up.

**The `len(eps) > 0 == false` branch** had no coverage; it needs a locality key with no endpoints. Removing that guard from `ReuseEndpointsFrom` passed the existing suite.

Each of the four regressions above was injected against this branch and fails exactly one test.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Test-only; no production code touched.

Two things worth a reviewer's attention:

- **`AttachedPolicies` is ignored, not compared.** It is `+noKrtEquals`, `ReuseEndpointsFrom` does not touch it, and cmp cannot traverse it: `PolicyAtt` holds a `PolicyIR` interface whose concrete plugin types have unexported fields, so `cmp.Diff` panics with `cannot handle unexported field ... PolicyIr.(*ir.probeIR).v` as soon as a fixture attaches a real policy, and there is no finite set of types to pass to `AllowUnexported`. Ignoring it keeps the test from becoming a trap for whoever enriches the fixture.
- **An empty locality is the one input where reuse and re-Add disagree on state.** The re-Add loop never calls `Add` for a zero-length slice, so it drops the key; reuse preserves it. The equality hash agrees either way, and the hash is what `Equals` compares, so nothing breaks. It is also unreachable today — `Add` is the only writer of `LbEps` in the tree. The new test documents the divergence rather than asserting equivalence. If we would rather have unconditional equivalence, `ReuseEndpointsFrom` could skip zero-length slices and the test would assert the key is absent.

`TestReuseEndpointsFromMatchesReAdd` from #14489 is left in place; the new full-struct test largely subsumes it, but it carries a base-vs-variant hash assertion the new one does not. Happy to fold them together if reviewers prefer.
