### PR TITLE
refactor(endpoints): make the AttachedPolicies stand-in hash structur…

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
@@ -540,7 +540,7 @@ func (p *backendConfigEndpointPlugin) processEndpoints(
 	ucc ir.UniquelyConnectedClient,
 	out *endpoints.EndpointsInputs,
 ) uint64 {
-	pol, bcpIR := selectZoneAwareBackendConfigPolicy(out.EndpointsForBackend.AttachedPolicies)
+	pol, bcpIR := selectZoneAwareBackendConfigPolicy(out.EndpointsForBackend.AttachedPolicies())
 	if bcpIR == nil {
 		return 0
 	}

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
@@ -740,11 +740,11 @@ func TestProcessEndpointsZoneAwarePolicy(t *testing.T) {
 		Name:      "httpbin-policy",
 	}
 	withPolicies := func(inputs *endpoints.EndpointsInputs, policies ...ir.PolicyAtt) *endpoints.EndpointsInputs {
-		inputs.EndpointsForBackend.AttachedPolicies = ir.AttachedPolicies{
+		inputs.EndpointsForBackend.SetAttachedPolicies(ir.AttachedPolicies{
 			Policies: map[schema.GroupKind][]ir.PolicyAtt{
 				wellknown.BackendConfigPolicyGVK.GroupKind(): policies,
 			},
-		}
+		})
 		return inputs
 	}
 

--- a/pkg/kgateway/proxy_syncer/cla.go
+++ b/pkg/kgateway/proxy_syncer/cla.go
@@ -52,7 +52,7 @@ func NewPerClientEnvoyEndpoints(
 			u := UccWithEndpoints{
 				Client:        ucc,
 				Endpoints:     cla,
-				EndpointsHash: ep.LbEpsEqualityHash ^ additionalHash,
+				EndpointsHash: ep.LbEpsEqualityHash() ^ additionalHash,
 				endpointsName: ep.ResourceName(),
 			}
 			uccWithEndpointsRet = append(uccWithEndpointsRet, u)

--- a/pkg/kgateway/proxy_syncer/effective_endpoints.go
+++ b/pkg/kgateway/proxy_syncer/effective_endpoints.go
@@ -1,15 +1,8 @@
 package proxy_syncer
 
 import (
-	"cmp"
-	"hash/fnv"
-	"slices"
-	"strconv"
-
 	"istio.io/istio/pkg/kube/krt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	krtutil "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 )
@@ -28,7 +21,11 @@ func newFinalBackendEndpoints(
 		}
 
 		final := raw.EmptyCopy()
-		final.AttachedPolicies = backend.AttachedPolicies
+		// A same-named EDS cluster can still re-warm when policy changes CDS, so
+		// the endpoint version has to move with policy content. Setting the
+		// policy view is enough: LbEpsEqualityHash derives from it, and the
+		// ordering against Add no longer matters.
+		final.SetAttachedPolicies(backend.AttachedPolicies)
 		final.ClusterName = backend.ClusterName()
 		final.UpstreamResourceName = backend.ResourceName()
 		for locality, endpoints := range raw.LbEps {
@@ -36,60 +33,6 @@ func newFinalBackendEndpoints(
 				final.Add(locality, endpoint)
 			}
 		}
-		// A same-named EDS cluster can still re-warm when policy changes CDS.
-		// Bump only the endpoint version so Envoy receives a fresh CLA response.
-		if policyHash := backendEndpointVersionHash(backend); policyHash != 0 {
-			final.LbEpsEqualityHash = combineEndpointHashes(final.LbEpsEqualityHash, policyHash)
-		}
 		return &final
 	}, krtopts.ToOptions("FinalBackendEndpoints")...)
-}
-
-func backendEndpointVersionHash(backend *ir.BackendObjectIR) uint64 {
-	if backend == nil || len(backend.AttachedPolicies.Policies) == 0 {
-		return 0
-	}
-
-	hasher := fnv.New64a()
-	groupKinds := make([]schema.GroupKind, 0, len(backend.AttachedPolicies.Policies))
-	for groupKind := range backend.AttachedPolicies.Policies {
-		groupKinds = append(groupKinds, groupKind)
-	}
-	slices.SortFunc(groupKinds, func(a, b schema.GroupKind) int {
-		if a.Group != b.Group {
-			return cmp.Compare(a.Group, b.Group)
-		}
-		return cmp.Compare(a.Kind, b.Kind)
-	})
-
-	for _, groupKind := range groupKinds {
-		utils.HashStringField(hasher, groupKind.Group)
-		utils.HashStringField(hasher, groupKind.Kind)
-		for _, policy := range backend.AttachedPolicies.Policies[groupKind] {
-			utils.HashStringField(hasher, ir.PolicyRefString(policy.PolicyRef))
-			utils.HashStringField(hasher, strconv.FormatInt(policy.Generation, 10))
-			for _, err := range policy.Errors {
-				if err != nil {
-					utils.HashStringField(hasher, err.Error())
-				}
-			}
-			if policy.PolicyIr == nil {
-				continue
-			}
-			if hashable, ok := policy.PolicyIr.(ir.PolicyHashIR); ok {
-				utils.HashUint64(hasher, hashable.PolicyHash())
-				continue
-			}
-			utils.HashStringField(hasher, strconv.FormatInt(policy.PolicyIr.CreationTime().UnixNano(), 10))
-		}
-	}
-
-	return hasher.Sum64()
-}
-
-func combineEndpointHashes(endpointHash, policyHash uint64) uint64 {
-	hasher := fnv.New64a()
-	utils.HashUint64(hasher, endpointHash)
-	utils.HashUint64(hasher, policyHash)
-	return hasher.Sum64()
 }

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -146,7 +146,7 @@ func (t *BackendTranslator) runPolicies(
 		endpointInputs = &endpoints.EndpointsInputs{
 			EndpointsForBackend: *inlineEps,
 		}
-		endpointInputs.EndpointsForBackend.AttachedPolicies = backend.AttachedPolicies
+		endpointInputs.EndpointsForBackend.SetAttachedPolicies(backend.AttachedPolicies)
 	}
 
 	var errs []error

--- a/pkg/krtcollections/endpoints_test.go
+++ b/pkg/krtcollections/endpoints_test.go
@@ -293,8 +293,8 @@ func TestEndpointsForUpstreamWithDifferentNameButSameEndpoints(t *testing.T) {
 		Zone:   "zone",
 	}, emd2)
 
-	h1 := result1.LbEpsEqualityHash ^ result2.LbEpsEqualityHash
-	h2 := result3.LbEpsEqualityHash ^ result4.LbEpsEqualityHash
+	h1 := result1.LbEpsEqualityHash() ^ result2.LbEpsEqualityHash()
+	h2 := result3.LbEpsEqualityHash() ^ result4.LbEpsEqualityHash()
 
 	g.Expect(h1).NotTo(Equal(h2), "not expected %v, got %v", h1, h2)
 }
@@ -374,7 +374,7 @@ func TestEndpointsForUpstreamWithDifferentTrafficDistributionButSameEndpoints(t 
 	}, emd)
 
 	// Verify that the hashes are different due to different traffic distribution
-	g.Expect(result1.LbEpsEqualityHash).NotTo(Equal(result2.LbEpsEqualityHash),
+	g.Expect(result1.LbEpsEqualityHash()).NotTo(Equal(result2.LbEpsEqualityHash()),
 		"Hash should be different when traffic distribution changes")
 
 	// Test with more traffic distribution values
@@ -398,10 +398,10 @@ func TestEndpointsForUpstreamWithDifferentTrafficDistributionButSameEndpoints(t 
 
 	// All hashes should be different
 	hashes := []uint64{
-		result1.LbEpsEqualityHash,
-		result2.LbEpsEqualityHash,
-		result3.LbEpsEqualityHash,
-		result4.LbEpsEqualityHash,
+		result1.LbEpsEqualityHash(),
+		result2.LbEpsEqualityHash(),
+		result3.LbEpsEqualityHash(),
+		result4.LbEpsEqualityHash(),
 	}
 
 	// Check that all hashes are unique
@@ -522,7 +522,7 @@ func TestEndpointsForGatewayScopedBackendsWithSameEndpointsHaveDifferentHashes(t
 
 	g.Expect(backend1.ResourceName()).NotTo(Equal(backend2.ResourceName()))
 	g.Expect(backend1.ClusterName()).NotTo(Equal(backend2.ClusterName()))
-	g.Expect(result1.LbEpsEqualityHash).NotTo(Equal(result2.LbEpsEqualityHash),
+	g.Expect(result1.LbEpsEqualityHash()).NotTo(Equal(result2.LbEpsEqualityHash()),
 		"Gateway-scoped backends with the same endpoints must still hash differently")
 }
 

--- a/pkg/pluginsdk/ir/endpoints_policy_hash_test.go
+++ b/pkg/pluginsdk/ir/endpoints_policy_hash_test.go
@@ -1,0 +1,301 @@
+package ir
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// This file pins the invariant that policyHash really stands in for
+// attachedPolicies on EndpointsForBackend, which is what lets the field carry a
+// +noKrtEquals marker. Every semantic difference AttachedPolicies.Equals can see
+// must also move VersionHash, and the derived LbEpsEqualityHash must not depend
+// on the order in which endpoints and policies are supplied.
+
+type hashTestPolicyIR struct {
+	val string
+	// ct only backs CreationTime; like the real policy IRs it is not part of
+	// equality.
+	// +noKrtEquals
+	ct time.Time
+}
+
+func (f *hashTestPolicyIR) CreationTime() time.Time { return f.ct }
+func (f *hashTestPolicyIR) Equals(in any) bool {
+	other, ok := in.(*hashTestPolicyIR)
+	return ok && f.val == other.val
+}
+
+// hashTestHashablePolicyIR additionally implements PolicyHashIR, the path used
+// by policies (such as BackendTLSPolicy) whose content can change without the
+// CR generation moving.
+type hashTestHashablePolicyIR struct {
+	hashTestPolicyIR
+	h uint64
+}
+
+func (f *hashTestHashablePolicyIR) PolicyHash() uint64 { return f.h }
+
+var _ PolicyHashIR = &hashTestHashablePolicyIR{}
+
+func policyHashTestGK() schema.GroupKind {
+	return schema.GroupKind{Group: "example.com", Kind: "MyPolicy"}
+}
+
+func basePolicyAttForHash() PolicyAtt {
+	return PolicyAtt{
+		GroupKind:  policyHashTestGK(),
+		Generation: 1,
+		PolicyIr:   &hashTestPolicyIR{val: "base"},
+		PolicyRef: &AttachedPolicyRef{
+			Group:     "example.com",
+			Kind:      "MyPolicy",
+			Name:      "my-policy",
+			Namespace: "default",
+		},
+		Errors: []error{errors.New("base error")},
+	}
+}
+
+func baseAttachedPoliciesForHash() AttachedPolicies {
+	return AttachedPolicies{
+		Policies: map[schema.GroupKind][]PolicyAtt{
+			policyHashTestGK(): {basePolicyAttForHash()},
+		},
+	}
+}
+
+// TestAttachedPoliciesVersionHashStandsInForEquals is the "B really stands in
+// for A" check: for every mutation that makes Equals report a difference,
+// VersionHash must differ too. A hash that missed one of these would let a
+// policy change reach CDS without moving the EDS version.
+func TestAttachedPoliciesVersionHashStandsInForEquals(t *testing.T) {
+	cases := []struct {
+		field  string
+		mutate func(*AttachedPolicies)
+	}{
+		{
+			field: "Policies/added GroupKind",
+			mutate: func(a *AttachedPolicies) {
+				a.Policies[schema.GroupKind{Group: "other.io", Kind: "OtherPolicy"}] = []PolicyAtt{basePolicyAttForHash()}
+			},
+		},
+		{
+			field: "Policies/removed GroupKind",
+			mutate: func(a *AttachedPolicies) {
+				delete(a.Policies, policyHashTestGK())
+			},
+		},
+		{
+			field: "Policies/added second policy under same GroupKind",
+			mutate: func(a *AttachedPolicies) {
+				a.Policies[policyHashTestGK()] = append(a.Policies[policyHashTestGK()], basePolicyAttForHash())
+			},
+		},
+		{
+			field: "PolicyAtt.Generation",
+			mutate: func(a *AttachedPolicies) {
+				p := basePolicyAttForHash()
+				p.Generation = 99
+				a.Policies[policyHashTestGK()] = []PolicyAtt{p}
+			},
+		},
+		{
+			field: "PolicyAtt.PolicyRef",
+			mutate: func(a *AttachedPolicies) {
+				p := basePolicyAttForHash()
+				p.PolicyRef = &AttachedPolicyRef{
+					Group: "example.com", Kind: "MyPolicy", Name: "other-policy", Namespace: "default",
+				}
+				a.Policies[policyHashTestGK()] = []PolicyAtt{p}
+			},
+		},
+		{
+			field: "PolicyAtt.Errors",
+			mutate: func(a *AttachedPolicies) {
+				p := basePolicyAttForHash()
+				p.Errors = []error{errors.New("a different error")}
+				a.Policies[policyHashTestGK()] = []PolicyAtt{p}
+			},
+		},
+		{
+			field: "PolicyAtt.PolicyIr via PolicyHashIR",
+			mutate: func(a *AttachedPolicies) {
+				p := basePolicyAttForHash()
+				p.PolicyIr = &hashTestHashablePolicyIR{h: 12345}
+				a.Policies[policyHashTestGK()] = []PolicyAtt{p}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			base := baseAttachedPoliciesForHash()
+			mutated := baseAttachedPoliciesForHash()
+			tc.mutate(&mutated)
+
+			if base.Equals(mutated) {
+				t.Fatalf("test bug: mutation of %q did not make AttachedPolicies.Equals report a difference", tc.field)
+			}
+			if base.VersionHash() == mutated.VersionHash() {
+				t.Errorf("VersionHash collided after mutating %s; the hash must move whenever Equals reports a difference", tc.field)
+			}
+		})
+	}
+}
+
+// TestAttachedPoliciesVersionHashStable guards the two directions that must NOT
+// change the hash: recomputation, and Go's randomized map iteration order.
+func TestAttachedPoliciesVersionHashStable(t *testing.T) {
+	t.Run("empty is zero", func(t *testing.T) {
+		var empty AttachedPolicies
+		if got := empty.VersionHash(); got != 0 {
+			t.Errorf("VersionHash of empty AttachedPolicies = %d, want 0 so it contributes nothing downstream", got)
+		}
+	})
+
+	t.Run("stable across map iteration order", func(t *testing.T) {
+		build := func() AttachedPolicies {
+			a := AttachedPolicies{Policies: map[schema.GroupKind][]PolicyAtt{}}
+			for _, gk := range []schema.GroupKind{
+				{Group: "a.io", Kind: "A"}, {Group: "b.io", Kind: "B"},
+				{Group: "c.io", Kind: "C"}, {Group: "d.io", Kind: "D"},
+			} {
+				p := basePolicyAttForHash()
+				p.GroupKind = gk
+				a.Policies[gk] = []PolicyAtt{p}
+			}
+			return a
+		}
+		want := build().VersionHash()
+		// Rebuild repeatedly: each map gets a fresh randomized iteration order.
+		for i := range 50 {
+			if got := build().VersionHash(); got != want {
+				t.Fatalf("VersionHash is not stable across map iteration order (iteration %d): got %d, want %d", i, got, want)
+			}
+		}
+	})
+}
+
+func backendForHashTest(t *testing.T) BackendObjectIR {
+	t.Helper()
+	b := NewBackendObjectIR(ObjectSource{
+		Kind: "Service", Namespace: "default", Name: "my-service",
+	}, 8080, "", "")
+	b.Obj = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-service", Namespace: "default", ResourceVersion: "1"},
+	}
+	return b
+}
+
+func endpointForHashTest() EndpointWithMd {
+	return EndpointWithMd{EndpointMd: EndpointMetadata{Labels: map[string]string{"zone": "a"}}}
+}
+
+// TestLbEpsEqualityHashIsOrderIndependent is the regression this refactor buys.
+// LbEpsEqualityHash is derived on read, so a policy contribution can no longer
+// be clobbered by a later Add, regardless of the order the two mutators run in.
+func TestLbEpsEqualityHashIsOrderIndependent(t *testing.T) {
+	loc := PodLocality{Region: "region", Zone: "zone"}
+	policies := baseAttachedPoliciesForHash()
+
+	// Policies first, then endpoints.
+	a := NewEndpointsForBackend(backendForHashTest(t))
+	a.SetAttachedPolicies(policies)
+	a.Add(loc, endpointForHashTest())
+
+	// Endpoints first, then policies.
+	b := NewEndpointsForBackend(backendForHashTest(t))
+	b.Add(loc, endpointForHashTest())
+	b.SetAttachedPolicies(policies)
+
+	if a.LbEpsEqualityHash() != b.LbEpsEqualityHash() {
+		t.Errorf("LbEpsEqualityHash depends on mutator order: policies-then-endpoints = %d, endpoints-then-policies = %d",
+			a.LbEpsEqualityHash(), b.LbEpsEqualityHash())
+	}
+	if !a.Equals(*b) {
+		t.Error("Equals depends on mutator order; the two builds must be indistinguishable")
+	}
+}
+
+// TestLbEpsEqualityHashTracksPolicies checks that policy content reaches the EDS
+// version at all, and that EmptyCopy carries the pair forward.
+func TestLbEpsEqualityHashTracksPolicies(t *testing.T) {
+	loc := PodLocality{Region: "region", Zone: "zone"}
+
+	withoutPolicies := NewEndpointsForBackend(backendForHashTest(t))
+	withoutPolicies.Add(loc, endpointForHashTest())
+
+	withPolicies := NewEndpointsForBackend(backendForHashTest(t))
+	withPolicies.Add(loc, endpointForHashTest())
+	withPolicies.SetAttachedPolicies(baseAttachedPoliciesForHash())
+
+	if withoutPolicies.LbEpsEqualityHash() == withPolicies.LbEpsEqualityHash() {
+		t.Error("attaching a policy did not move LbEpsEqualityHash; Envoy would not receive a fresh CLA")
+	}
+	if withoutPolicies.Equals(*withPolicies) {
+		t.Error("Equals did not detect the attached policy; the KRT event would be suppressed")
+	}
+
+	t.Run("changing policy content moves the hash", func(t *testing.T) {
+		changed := NewEndpointsForBackend(backendForHashTest(t))
+		changed.Add(loc, endpointForHashTest())
+		bumped := baseAttachedPoliciesForHash()
+		bumped.Policies[policyHashTestGK()][0].Generation = 2
+		changed.SetAttachedPolicies(bumped)
+
+		if changed.LbEpsEqualityHash() == withPolicies.LbEpsEqualityHash() {
+			t.Error("bumping the policy generation did not move LbEpsEqualityHash")
+		}
+	})
+
+	t.Run("EmptyCopy carries the policy pair", func(t *testing.T) {
+		cp := withPolicies.EmptyCopy()
+		if !cp.AttachedPolicies().Equals(withPolicies.AttachedPolicies()) {
+			t.Error("EmptyCopy dropped attachedPolicies")
+		}
+		// No endpoints on the copy, so the endpoint contribution is absent, but
+		// the policy contribution must survive.
+		bare := NewEndpointsForBackend(backendForHashTest(t))
+		if cp.LbEpsEqualityHash() == bare.LbEpsEqualityHash() {
+			t.Error("EmptyCopy dropped the policy contribution to LbEpsEqualityHash")
+		}
+	})
+}
+
+// TestLbEpsEqualityHashMatchesLegacyComposition pins the derived value to the
+// composition the stored field used to produce, so this refactor does not churn
+// every EDS version on rollout.
+func TestLbEpsEqualityHashMatchesLegacyComposition(t *testing.T) {
+	loc := PodLocality{Region: "region", Zone: "zone"}
+
+	t.Run("no endpoints, no policies", func(t *testing.T) {
+		e := NewEndpointsForBackend(backendForHashTest(t))
+		if got, want := e.LbEpsEqualityHash(), e.upstreamHash; got != want {
+			t.Errorf("bare backend hash = %d, want upstreamHash %d", got, want)
+		}
+	})
+
+	t.Run("endpoints, no policies", func(t *testing.T) {
+		e := NewEndpointsForBackend(backendForHashTest(t))
+		e.Add(loc, endpointForHashTest())
+		if got, want := e.LbEpsEqualityHash(), hash(e.epsEqualityHash, e.upstreamHash); got != want {
+			t.Errorf("hash = %d, want hash(epsEqualityHash, upstreamHash) = %d", got, want)
+		}
+	})
+
+	t.Run("endpoints and policies", func(t *testing.T) {
+		e := NewEndpointsForBackend(backendForHashTest(t))
+		e.Add(loc, endpointForHashTest())
+		e.SetAttachedPolicies(baseAttachedPoliciesForHash())
+		want := hash(hash(e.epsEqualityHash, e.upstreamHash), baseAttachedPoliciesForHash().VersionHash())
+		if got := e.LbEpsEqualityHash(); got != want {
+			t.Errorf("hash = %d, want combine(hash(eps, upstream), policyHash) = %d", got, want)
+		}
+	})
+}

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -1,10 +1,13 @@
 package ir
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
+	"hash/fnv"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"unique"
 
@@ -13,6 +16,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 )
 
 const delimiter = "/"
@@ -262,6 +266,60 @@ func (a *AttachedPolicies) Prepend(hierarchicalPriority int, l ...AttachedPolici
 			a.Policies[k] = append(cp, a.Policies[k]...)
 		}
 	}
+}
+
+// VersionHash returns a hash that changes whenever the attached policy content
+// changes. It is the canonical stand-in for AttachedPolicies in the equality of
+// derived IR that carries a policy view but does not compare it field by field
+// (see EndpointsForBackend).
+//
+// The hash covers the same ground as Equals: the set of GroupKinds, and per
+// policy the ref, generation, errors, and IR content. Policy IRs that implement
+// PolicyHashIR contribute their own content hash; the rest fall back to
+// creation time, with Generation carrying spec changes.
+//
+// Iteration is over sorted GroupKinds so the result does not depend on Go's map
+// ordering.
+func (a AttachedPolicies) VersionHash() uint64 {
+	if len(a.Policies) == 0 {
+		return 0
+	}
+
+	hasher := fnv.New64a()
+	groupKinds := make([]schema.GroupKind, 0, len(a.Policies))
+	for groupKind := range a.Policies {
+		groupKinds = append(groupKinds, groupKind)
+	}
+	slices.SortFunc(groupKinds, func(a, b schema.GroupKind) int {
+		if a.Group != b.Group {
+			return cmp.Compare(a.Group, b.Group)
+		}
+		return cmp.Compare(a.Kind, b.Kind)
+	})
+
+	for _, groupKind := range groupKinds {
+		utils.HashStringField(hasher, groupKind.Group)
+		utils.HashStringField(hasher, groupKind.Kind)
+		for _, policy := range a.Policies[groupKind] {
+			utils.HashStringField(hasher, PolicyRefString(policy.PolicyRef))
+			utils.HashStringField(hasher, strconv.FormatInt(policy.Generation, 10))
+			for _, err := range policy.Errors {
+				if err != nil {
+					utils.HashStringField(hasher, err.Error())
+				}
+			}
+			if policy.PolicyIr == nil {
+				continue
+			}
+			if hashable, ok := policy.PolicyIr.(PolicyHashIR); ok {
+				utils.HashUint64(hasher, hashable.PolicyHash())
+				continue
+			}
+			utils.HashStringField(hasher, strconv.FormatInt(policy.PolicyIr.CreationTime().UnixNano(), 10))
+		}
+	}
+
+	return hasher.Sum64()
 }
 
 func (l AttachedPolicies) MarshalJSON() ([]byte, error) {

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -153,11 +153,15 @@ type EndpointsForBackend struct {
 	// +krtEqualsTodo include backend labels in equality or confirm omission
 	BackendLabels map[string]string
 
-	// AttachedPolicies carries the policy attachment view already resolved for
-	// the backend. LbEpsEqualityHash includes backend policy versioning, so this
-	// field does not need to participate in equality directly.
-	// +noKrtEquals
-	AttachedPolicies AttachedPolicies
+	// attachedPolicies carries the policy attachment view already resolved for
+	// the backend. It is private so it cannot be assigned without recomputing
+	// policyHash; use AttachedPolicies() and SetAttachedPolicies().
+	// +noKrtEquals policyHash stands in for it in Equals, and SetAttachedPolicies is the only writer of the pair
+	attachedPolicies AttachedPolicies
+
+	// policyHash is attachedPolicies.VersionHash(). Written only by
+	// SetAttachedPolicies, so it can never drift from attachedPolicies.
+	policyHash uint64
 
 	// +krtEqualsTodo compare load-balanced endpoint map
 	LbEps                LocalityLbMap
@@ -168,9 +172,44 @@ type EndpointsForBackend struct {
 	// Inherited from the backend object
 	TrafficDistribution wellknown.TrafficDistribution
 
-	LbEpsEqualityHash uint64
-	upstreamHash      uint64
-	epsEqualityHash   uint64
+	upstreamHash    uint64
+	epsEqualityHash uint64
+}
+
+// AttachedPolicies returns the policy attachment view resolved for the backend.
+func (e EndpointsForBackend) AttachedPolicies() AttachedPolicies {
+	return e.attachedPolicies
+}
+
+// SetAttachedPolicies replaces the policy view and recomputes the hash that
+// stands in for it in Equals. This is the only way to change either half of the
+// pair, which is what keeps LbEpsEqualityHash honest about policy content.
+func (e *EndpointsForBackend) SetAttachedPolicies(policies AttachedPolicies) {
+	e.attachedPolicies = policies
+	e.policyHash = policies.VersionHash()
+}
+
+// LbEpsEqualityHash is the EDS version for this backend: it changes whenever
+// the backend identity, its endpoints, or its attached policy content changes.
+//
+// It is derived on read rather than stored, so no mutator can clobber a
+// contribution added by another one. Endpoints reach it through Add and
+// policies through SetAttachedPolicies, in any order.
+func (e EndpointsForBackend) LbEpsEqualityHash() uint64 {
+	h := e.upstreamHash
+	// Endpoints are folded in only once Add has run. We can't xor the endpoint
+	// hash with the upstream hash, because upstreams with different names and
+	// similar endpoints will cancel out, so endpoint changes won't result in
+	// different equality hashes.
+	if len(e.LbEps) > 0 {
+		h = hash(e.epsEqualityHash, e.upstreamHash)
+	}
+	// A same-named EDS cluster can still re-warm when policy changes CDS, so
+	// policy content has to move the endpoint version too.
+	if e.policyHash != 0 {
+		h = hash(h, e.policyHash)
+	}
+	return h
 }
 
 func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
@@ -207,18 +246,18 @@ func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
 	h.Write([]byte{byte(us.TrafficDistribution)})
 	upstreamHash := h.Sum64()
 
-	return &EndpointsForBackend{
+	ret := &EndpointsForBackend{
 		BackendLabels:        labels,
-		AttachedPolicies:     us.AttachedPolicies,
 		LbEps:                make(map[PodLocality][]EndpointWithMd),
 		ClusterName:          us.ClusterName(),
 		UpstreamResourceName: us.ResourceName(),
 		Port:                 uint32(us.GetPort()), //nolint:gosec // G115: upstream port is always valid port range
 		Hostname:             us.CanonicalHostname,
-		LbEpsEqualityHash:    upstreamHash,
 		upstreamHash:         upstreamHash,
 		TrafficDistribution:  us.TrafficDistribution,
 	}
+	ret.SetAttachedPolicies(us.AttachedPolicies)
+	return ret
 }
 
 // EmptyCopy creates a fresh EndpointsForBackend with no endpoints
@@ -226,13 +265,13 @@ func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
 func (e EndpointsForBackend) EmptyCopy() EndpointsForBackend {
 	return EndpointsForBackend{
 		BackendLabels:        e.BackendLabels,
-		AttachedPolicies:     e.AttachedPolicies,
+		attachedPolicies:     e.attachedPolicies,
+		policyHash:           e.policyHash,
 		LbEps:                make(map[PodLocality][]EndpointWithMd),
 		ClusterName:          e.ClusterName,
 		UpstreamResourceName: e.UpstreamResourceName,
 		Port:                 e.Port,
 		Hostname:             e.Hostname,
-		LbEpsEqualityHash:    e.upstreamHash,
 		upstreamHash:         e.upstreamHash,
 		TrafficDistribution:  e.TrafficDistribution,
 	}
@@ -262,10 +301,6 @@ func (e *EndpointsForBackend) Add(l PodLocality, emd EndpointWithMd) {
 	// xor it as we dont care about order - if we have the same endpoints in the same locality
 	// we are good.
 	e.epsEqualityHash ^= hashEndpoints(l, emd)
-	// we can't xor the endpoint hash with the upstream hash, because upstreams with
-	// different names and similar endpoints will cancel out, so endpoint changes
-	// won't result in different equality hashes.
-	e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
 	e.LbEps[l] = append(e.LbEps[l], emd)
 }
 
@@ -273,6 +308,16 @@ func (c EndpointsForBackend) ResourceName() string {
 	return c.UpstreamResourceName
 }
 
+// Equals compares the hash components rather than the combined
+// LbEpsEqualityHash: the combined value is a pure function of them, and
+// comparing the parts avoids collisions introduced by folding them together.
 func (c EndpointsForBackend) Equals(in EndpointsForBackend) bool {
-	return c.UpstreamResourceName == in.UpstreamResourceName && c.ClusterName == in.ClusterName && c.Port == in.Port && c.LbEpsEqualityHash == in.LbEpsEqualityHash && c.Hostname == in.Hostname && c.TrafficDistribution == in.TrafficDistribution && c.upstreamHash == in.upstreamHash && c.epsEqualityHash == in.epsEqualityHash
+	return c.UpstreamResourceName == in.UpstreamResourceName &&
+		c.ClusterName == in.ClusterName &&
+		c.Port == in.Port &&
+		c.Hostname == in.Hostname &&
+		c.TrafficDistribution == in.TrafficDistribution &&
+		c.upstreamHash == in.upstreamHash &&
+		c.epsEqualityHash == in.epsEqualityHash &&
+		c.policyHash == in.policyHash
 }


### PR DESCRIPTION
…ally unable to drift

# Description

## Motivation

`EndpointsForBackend.AttachedPolicies` carried a `+noKrtEquals` marker justified by *"LbEpsEqualityHash includes backend policy versioning."* That was not true where the marker sat. `NewEndpointsForBackend` derives `upstreamHash` from backend identity, labels and traffic distribution only — no policy input — so in the raw endpoints collection the hash gated by `Equals` contained zero policy content. Policy content was mixed in one collection later, in `newFinalBackendEndpoints`.

The field was nonetheless safe, but for an unstated and non-local reason: the raw collection has a single consumer, which overwrites `AttachedPolicies` from the authoritative `BackendObjectIR` before anything reads it. That is a liveness property no marker, comment, linter, or test enforces.

On top of that, `LbEpsEqualityHash` was a stored field with three writers that did not compose:

- `Add` recomputed `hash(epsEqualityHash, upstreamHash)`, clobbering any policy contribution
- `EmptyCopy` reset it to `upstreamHash`, dropping it
- `newFinalBackendEndpoints` mixed the policy hash in last

The ordering was correct, but only by convention. Any future `Add` after the mix-in would have silently erased policy versioning from the EDS version, and nothing would have caught it.

## What changed

- **`AttachedPolicies.VersionHash()`** — `backendEndpointVersionHash` moves out of `proxy_syncer` onto the type it hashes, so the value owns its own hash function rather than having one supplied per call site.
- **`EndpointsForBackend.attachedPolicies` + `policyHash` are private**, written only by `SetAttachedPolicies`. The two halves cannot drift because there is no other writer.
- **`LbEpsEqualityHash` becomes a derived method rather than a stored field.** Endpoints contribute through `Add`, policies through `SetAttachedPolicies`, and the composition happens on read — so no mutator can clobber another's contribution, in any order.
- **`Equals` compares the three hash components** (`upstreamHash`, `epsEqualityHash`, `policyHash`) instead of the folded value. Strictly more precise, since folding can only add collisions.
- `effective_endpoints.go` drops `backendEndpointVersionHash` and `combineEndpointHashes` and shrinks from 95 to 39 lines; the order-sensitive `if policyHash != 0 { ... }` block becomes one `SetAttachedPolicies` call.

The `+noKrtEquals` marker on `attachedPolicies` remains, because the analyzer is syntactic and `Equals` names `policyHash` rather than the field. What changed is that its justification is now structurally true and test-pinned instead of false.

## Behavior

No functional change intended, and EDS versions are byte-identical. `hash(a, b)` writes 16 little-endian bytes into FNV-1a in one call; the removed `combineEndpointHashes` wrote the same 16 bytes as two 8-byte writes. FNV-1a is streaming, so the results are equal — there is no version churn on rollout. All three compositions (bare, endpoints, endpoints plus policies) are pinned against the previous formulas in `TestLbEpsEqualityHashMatchesLegacyComposition`.

This does not fix a known live bug. It removes a latent ordering hazard and corrects a justification comment that did not describe the code.

## Testing

New `pkg/pluginsdk/ir/endpoints_policy_hash_test.go`:

- **B stands in for A** — seven mutations that make `AttachedPolicies.Equals` report a difference must each move `VersionHash`. Every case asserts the `Equals` difference first, so the test fails loudly if a case stops being a real mutation.
- **Hash stability** — empty is zero; 50 rebuilds confirm the sorted-GroupKind iteration is immune to Go's randomized map ordering.
- **Order independence** — policies-then-endpoints and endpoints-then-policies produce the same hash and compare equal.
- **`EmptyCopy` carries the pair.**

These were mutation-tested rather than assumed: dropping the policy term from `LbEpsEqualityHash`, and making `SetAttachedPolicies` skip the recompute, are each caught by four subtests.

`./pkg/...` passes. The krtequals analyzer built with this repo's config (`deepEqual: false`, `checkUnexported: true`) reports zero findings across `./pkg/...` and `./internal/...`.

# Change Type

/kind cleanup
/kind breaking_change

# Changelog

```release-note
The `pkg/pluginsdk` type `ir.EndpointsForBackend` no longer exposes `AttachedPolicies` and `LbEpsEqualityHash` as fields. Use the `AttachedPolicies()` accessor, the `SetAttachedPolicies()` setter, and the `LbEpsEqualityHash()` method instead. Setting the policy view now updates the endpoint equality hash automatically, so out-of-tree plugins no longer need to combine the two by hand.
```

# Additional Notes

The breaking change is limited to out-of-tree plugins that reference those two exported fields; all in-tree consumers, including `examples/plugin`, are updated in this PR.

Worth a reviewer's attention: `LbEpsEqualityHash()` uses `len(LbEps) > 0` to decide whether to fold in the endpoint hash. This reproduces the old stored-field values exactly, including the case where `epsEqualityHash` XORs back to zero, because `Add` always appends to `LbEps`. It does assume nothing populates `LbEps` directly — true today, where every write goes through `Add`.

