### PR TITLE
test: add a status scale benchmark harness for control plane A/B runs

### DIFF
--- a/hack/perf/run-one-scale.sh
+++ b/hack/perf/run-one-scale.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run a single scale measurement in a named tree, with absolute paths. Verifies the
+# result file exists before reporting success, so a skipped or misdirected run can't
+# look like a pass.
+#
+# Assumes it has the machine to itself: a concurrent build or another measurement
+# will contend for CPU and invalidate the numbers.
+#
+# Usage: hack/perf/run-one-scale.sh <label> <tree> <routes> <rep> <out-root>
+set -euo pipefail
+
+LABEL="$1"; TREE="$2"; ROUTES="$3"; REP="$4"; OUT_ROOT="$5"
+
+TREE="$(cd "$TREE" && pwd)"
+OUT="$(cd "$(dirname "$OUT_ROOT")" && pwd)/$(basename "$OUT_ROOT")/scale-$ROUTES/$LABEL/rep$REP"
+mkdir -p "$OUT"
+
+(
+    cd "$TREE"
+    env \
+        GOMAXPROCS="${GOMAXPROCS:-4}" GOGC="${GOGC:-100}" \
+        SCALEPERF=1 SCALEPERF_LABEL="$LABEL" \
+        SCALEPERF_GATEWAYS="${GATEWAYS:-10}" SCALEPERF_ROUTES="$ROUTES" \
+        SCALEPERF_SERVICES="${SERVICES:-20}" \
+        SCALEPERF_CHURN_ROUNDS="${CHURN_ROUNDS:-3}" SCALEPERF_CHURN_ROUTES="${CHURN_ROUTES:-100}" \
+        SCALEPERF_QUIET="${QUIET:-5s}" SCALEPERF_TIMEOUT="${TIMEOUT:-30m}" \
+		SCALEPERF_WRITE_LATENCY="${WRITE_LATENCY:-0s}" \
+        SCALEPERF_OUT="$OUT" \
+        SCALEPERF_MEMPROFILERATE="${SCALEPERF_MEMPROFILERATE:-0}" \
+        go test -tags e2e -count=1 -timeout 90m -run TestScaleFootprint ./test/perf/statusscale/ \
+        >"$OUT/test.log" 2>&1
+)
+
+if [[ ! -f "$OUT/result-$LABEL.json" ]]; then
+    echo "FAIL $LABEL routes=$ROUTES rep=$REP: no result file (skipped or misdirected) - $OUT/test.log" >&2
+    exit 1
+fi
+echo "ok $LABEL routes=$ROUTES rep=$REP -> $OUT/result-$LABEL.json"

--- a/hack/perf/status-scale-compare.sh
+++ b/hack/perf/status-scale-compare.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# A/B the control plane's scale footprint between the current worktree and a base
+# ref, using test/perf/statusscale. Reps alternate A/B then B/A so machine drift
+# affects both sides equally, and the identical harness file is copied into the base
+# worktree so both sides run the same measurement code.
+#
+# Usage:
+#   hack/perf/status-scale-compare.sh [--base main] [--reps 3] [--routes 1000] ...
+#   hack/perf/status-scale-compare.sh --control   # base vs base: the noise floor
+set -euo pipefail
+
+BASE_REF="main"
+CANDIDATE_REF=""
+CANDIDATE_TREE_IN=""
+REPS=3
+GATEWAYS=10
+ROUTES=1000
+SERVICES=20
+CHURN_ROUNDS=3
+CHURN_ROUTES=100
+OUT=""
+CONTROL=0
+GOMAXPROCS_VAL="${GOMAXPROCS:-4}"
+GOGC_VAL="${GOGC:-100}"
+QUIET="5s"
+TIMEOUT="10m"
+
+usage() {
+    sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
+    cat <<'EOF'
+
+Options:
+  --base <ref>          baseline git ref (default: main)
+  --candidate-ref <ref> measure this ref instead of the current worktree
+  --candidate-tree <d>  measure this existing directory as-is (uncommitted work
+                        included); the harness is copied into it
+  --reps <n>            measurement reps per side (default: 3)
+  --gateways <n>        Gateways to create (default: 10)
+  --routes <n>          HTTPRoutes to create (default: 1000)
+  --services <n>        Services to create (default: 20)
+  --churn-rounds <n>    churn rounds per churn phase (default: 3)
+  --churn-routes <n>    routes patched per churn round (default: 100)
+  --quiet <dur>         idle period that counts as converged (default: 5s)
+  --timeout <dur>       per-phase timeout (default: 10m)
+  --out <dir>           output dir (default: _output/scaleperf)
+  --control             run base vs base to measure the noise floor
+  -h, --help            show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base) BASE_REF="$2"; shift 2 ;;
+        --candidate-ref) CANDIDATE_REF="$2"; shift 2 ;;
+        --candidate-tree) CANDIDATE_TREE_IN="$2"; shift 2 ;;
+        --reps) REPS="$2"; shift 2 ;;
+        --gateways) GATEWAYS="$2"; shift 2 ;;
+        --routes) ROUTES="$2"; shift 2 ;;
+        --services) SERVICES="$2"; shift 2 ;;
+        --churn-rounds) CHURN_ROUNDS="$2"; shift 2 ;;
+        --churn-routes) CHURN_ROUTES="$2"; shift 2 ;;
+        --quiet) QUIET="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+        --out) OUT="$2"; shift 2 ;;
+        --control) CONTROL=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+OUT="${OUT:-$ROOT/_output/scaleperf}"
+mkdir -p "$OUT"
+# Measured runs cd into a worktree, so a relative --out would resolve there.
+OUT="$(cd "$OUT" && pwd)"
+# Worktrees live outside OUT so repeated comparisons reuse them (and their build
+# caches) instead of recreating one per output directory.
+TREES="$ROOT/_output/scaleperf-trees"
+mkdir -p "$TREES"
+
+CANDIDATE_SHA="$(git rev-parse --short HEAD)"
+CANDIDATE_NAME="$(git rev-parse --abbrev-ref HEAD)"
+BASE_SHA="$(git rev-parse --short "$BASE_REF")"
+
+if [[ -n "$(git status --porcelain -- ':!_output' 2>/dev/null)" ]]; then
+    echo "note: working tree is dirty; the candidate side measures the working tree as-is" >&2
+fi
+
+# Base runs in a detached worktree so the current checkout is untouched.
+BASE_TREE="$TREES/base-$BASE_SHA"
+if [[ ! -d "$BASE_TREE" ]]; then
+    echo "==> creating base worktree at $BASE_TREE ($BASE_REF @ $BASE_SHA)"
+    git worktree add --detach "$BASE_TREE" "$BASE_REF" >/dev/null
+fi
+# The harness must be byte-identical on both sides.
+mkdir -p "$BASE_TREE/test/perf/statusscale"
+cp "$ROOT/test/perf/statusscale/"*.go "$BASE_TREE/test/perf/statusscale/"
+
+# An explicit directory: measured exactly as it sits, uncommitted work included.
+if [[ -n "$CANDIDATE_TREE_IN" ]]; then
+    CANDIDATE_TREE="$(cd "$CANDIDATE_TREE_IN" && pwd)"
+    CANDIDATE_LABEL="candidate"
+    mkdir -p "$CANDIDATE_TREE/test/perf/statusscale"
+    cp "$ROOT/test/perf/statusscale/"*.go "$CANDIDATE_TREE/test/perf/statusscale/"
+    CANDIDATE_DESC="$(cd "$CANDIDATE_TREE" && git rev-parse --short HEAD) tree $CANDIDATE_TREE"
+# A worktree candidate: either the control (base vs base) or an explicit ref. Both
+# get the harness copied in, since it is untracked on the measured ref.
+elif [[ "$CONTROL" == "1" || -n "$CANDIDATE_REF" ]]; then
+    if [[ "$CONTROL" == "1" ]]; then
+        CANDIDATE_REF="$BASE_REF"
+        CANDIDATE_LABEL="control"
+    else
+        CANDIDATE_LABEL="candidate"
+    fi
+    CAND_SHA="$(git rev-parse --short "$CANDIDATE_REF")"
+    CANDIDATE_TREE="$TREES/cand-$CANDIDATE_LABEL-$CAND_SHA"
+    if [[ ! -d "$CANDIDATE_TREE" ]]; then
+        echo "==> creating candidate worktree at $CANDIDATE_TREE ($CANDIDATE_REF @ $CAND_SHA)"
+        git worktree add --detach "$CANDIDATE_TREE" "$CANDIDATE_REF" >/dev/null
+    fi
+    mkdir -p "$CANDIDATE_TREE/test/perf/statusscale"
+    cp "$ROOT/test/perf/statusscale/"*.go "$CANDIDATE_TREE/test/perf/statusscale/"
+    CANDIDATE_DESC="$CANDIDATE_REF @ $CAND_SHA"
+    [[ "$CONTROL" == "1" ]] && CANDIDATE_DESC="$CANDIDATE_DESC (control)"
+else
+    CANDIDATE_TREE="$ROOT"
+    CANDIDATE_LABEL="candidate"
+    CANDIDATE_DESC="$CANDIDATE_NAME @ $CANDIDATE_SHA"
+fi
+
+echo "==> candidate: $CANDIDATE_DESC"
+echo "==> base:      $BASE_REF @ $BASE_SHA"
+echo "==> scale:     ${GATEWAYS} gateways, ${ROUTES} routes, ${SERVICES} services"
+echo "==> churn:     ${CHURN_ROUNDS} rounds x ${CHURN_ROUTES} routes (neutral + status)"
+echo "==> reps:      $REPS per side, alternating A/B order; GOMAXPROCS=$GOMAXPROCS_VAL GOGC=$GOGC_VAL"
+echo "==> out:       $OUT"
+
+# Warm both build caches first so compile time never lands inside a measured run.
+for tree in "$CANDIDATE_TREE" "$BASE_TREE"; do
+    (cd "$tree" && go test -tags e2e -count=1 -run XXX_NONE ./test/perf/statusscale/ >/dev/null)
+done
+
+run_one() {
+    local tree="$1" side="$2" rep="$3"
+    local rep_out="$OUT/$side/rep$rep"
+    mkdir -p "$rep_out"
+    echo "--> $side rep $rep"
+    (
+        cd "$tree"
+        env \
+            GOMAXPROCS="$GOMAXPROCS_VAL" \
+            GOGC="$GOGC_VAL" \
+            SCALEPERF=1 \
+            SCALEPERF_LABEL="$side" \
+            SCALEPERF_GATEWAYS="$GATEWAYS" \
+            SCALEPERF_ROUTES="$ROUTES" \
+            SCALEPERF_SERVICES="$SERVICES" \
+            SCALEPERF_CHURN_ROUNDS="$CHURN_ROUNDS" \
+            SCALEPERF_CHURN_ROUTES="$CHURN_ROUTES" \
+            SCALEPERF_QUIET="$QUIET" \
+            SCALEPERF_TIMEOUT="$TIMEOUT" \
+            SCALEPERF_OUT="$rep_out" \
+            SCALEPERF_MEMPROFILERATE="${SCALEPERF_MEMPROFILERATE:-0}" \
+            go test -tags e2e -count=1 -timeout 60m -run TestScaleFootprint ./test/perf/statusscale/ \
+            >"$rep_out/test.log" 2>&1
+    ) || { echo "    FAILED - see $rep_out/test.log" >&2; tail -20 "$rep_out/test.log" >&2; exit 1; }
+}
+
+for rep in $(seq 1 "$REPS"); do
+    # Alternate A/B then B/A so a consistent thermal or background-load drift
+    # cannot systematically favor the side that always runs first.
+    if (( rep % 2 == 1 )); then
+        run_one "$CANDIDATE_TREE" "$CANDIDATE_LABEL" "$rep"
+        run_one "$BASE_TREE" "base" "$rep"
+    else
+        run_one "$BASE_TREE" "base" "$rep"
+        run_one "$CANDIDATE_TREE" "$CANDIDATE_LABEL" "$rep"
+    fi
+done
+
+echo
+python3 "$ROOT/hack/perf/status_scale_report.py" \
+    --out "$OUT" \
+    --candidate "$CANDIDATE_LABEL" \
+    --candidate-desc "$CANDIDATE_DESC" \
+    --base-desc "$BASE_REF @ $BASE_SHA"

--- a/hack/perf/status-scale-sweep.sh
+++ b/hack/perf/status-scale-sweep.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Sweep the scale footprint across several route counts and several trees, to test
+# whether a cost grows with route count or stays flat.
+#
+# Churn stays constant (same rounds x routes patched) while total routes grow, so
+# churn cost rising with scale means per-change work is O(all routes).
+#
+# Usage:
+#   hack/perf/status-scale-sweep.sh \
+#     --tree main=/path/to/main-worktree \
+#     --tree fragments=/path/to/other-worktree \
+#     --scales 1000,5000,10000 --reps 2 --out _output/scaleperf/sweep
+set -euo pipefail
+
+SCALES="1000,5000,10000"
+REPS=2
+GATEWAYS=10
+SERVICES=20
+CHURN_ROUNDS=3
+CHURN_ROUTES=100
+OUT=""
+QUIET="5s"
+TIMEOUT="30m"
+WRITE_LATENCY="${WRITE_LATENCY:-0s}"
+GOMAXPROCS_VAL="${GOMAXPROCS:-4}"
+GOGC_VAL="${GOGC:-100}"
+declare -a TREE_SPECS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tree) TREE_SPECS+=("$2"); shift 2 ;;
+        --scales) SCALES="$2"; shift 2 ;;
+        --reps) REPS="$2"; shift 2 ;;
+        --gateways) GATEWAYS="$2"; shift 2 ;;
+        --services) SERVICES="$2"; shift 2 ;;
+        --churn-rounds) CHURN_ROUNDS="$2"; shift 2 ;;
+        --churn-routes) CHURN_ROUTES="$2"; shift 2 ;;
+        --quiet) QUIET="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+		--write-latency) WRITE_LATENCY="$2"; shift 2 ;;
+        --out) OUT="$2"; shift 2 ;;
+        *) echo "unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ ${#TREE_SPECS[@]} -lt 2 ]]; then
+    echo "need at least two --tree name=path arguments" >&2
+    exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+OUT="${OUT:-$ROOT/_output/scaleperf/sweep}"
+mkdir -p "$OUT"
+OUT="$(cd "$OUT" && pwd)"
+
+# The harness must be byte-identical everywhere, and it is untracked on the
+# measured refs, so copy it into each tree up front.
+for spec in "${TREE_SPECS[@]}"; do
+    tree="${spec#*=}"
+    mkdir -p "$tree/test/perf/statusscale"
+    cp "$ROOT/test/perf/statusscale/"*.go "$tree/test/perf/statusscale/"
+    echo "==> $(echo "$spec" | cut -d= -f1): $tree ($(cd "$tree" && git rev-parse --short HEAD))"
+    (cd "$tree" && go test -tags e2e -count=1 -run XXX_NONE ./test/perf/statusscale/ >/dev/null)
+done
+echo "==> scales: $SCALES; reps: $REPS; churn held constant at ${CHURN_ROUNDS}x${CHURN_ROUTES}"
+echo "==> out: $OUT"
+
+run_one() {
+    local side="$1" tree="$2" routes="$3" rep="$4"
+    local rep_out="$OUT/scale-$routes/$side/rep$rep"
+    mkdir -p "$rep_out"
+    local started
+    started="$(date +%s)"
+    if (
+        cd "$tree"
+        env \
+            GOMAXPROCS="$GOMAXPROCS_VAL" GOGC="$GOGC_VAL" \
+            SCALEPERF=1 SCALEPERF_LABEL="$side" \
+            SCALEPERF_GATEWAYS="$GATEWAYS" SCALEPERF_ROUTES="$routes" \
+            SCALEPERF_SERVICES="$SERVICES" \
+            SCALEPERF_CHURN_ROUNDS="$CHURN_ROUNDS" SCALEPERF_CHURN_ROUTES="$CHURN_ROUTES" \
+            SCALEPERF_QUIET="$QUIET" SCALEPERF_TIMEOUT="$TIMEOUT" \
+			SCALEPERF_WRITE_LATENCY="$WRITE_LATENCY" \
+            SCALEPERF_OUT="$rep_out" \
+            go test -tags e2e -count=1 -timeout 90m -run TestScaleFootprint ./test/perf/statusscale/ \
+            >"$rep_out/test.log" 2>&1
+    ); then
+        echo "    ok   $side routes=$routes rep=$rep ($(( $(date +%s) - started ))s)"
+    else
+        # Keep going: a failure at a large scale should not discard smaller scales.
+        echo "    FAIL $side routes=$routes rep=$rep - $rep_out/test.log" >&2
+        tail -5 "$rep_out/test.log" >&2 || true
+    fi
+}
+
+IFS=',' read -ra SCALE_LIST <<< "$SCALES"
+for routes in "${SCALE_LIST[@]}"; do
+    echo "--> scale $routes"
+    for rep in $(seq 1 "$REPS"); do
+        # Reverse the tree order on even reps so machine drift cannot
+        # systematically favor the first tree.
+        if (( rep % 2 == 1 )); then
+            for spec in "${TREE_SPECS[@]}"; do
+                run_one "${spec%%=*}" "${spec#*=}" "$routes" "$rep"
+            done
+        else
+            for ((i=${#TREE_SPECS[@]}-1; i>=0; i--)); do
+                spec="${TREE_SPECS[$i]}"
+                run_one "${spec%%=*}" "${spec#*=}" "$routes" "$rep"
+            done
+        fi
+    done
+done
+
+echo
+python3 "$ROOT/hack/perf/status_scale_sweep_report.py" --out "$OUT"

--- a/hack/perf/status_scale_report.py
+++ b/hack/perf/status_scale_report.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Aggregate test/perf/statusscale result JSON files into an A/B comparison.
+
+Reports the median of each metric per side plus the per-rep spread, so a small
+median delta can be judged against the run-to-run noise instead of being read as
+a result on its own.
+"""
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+
+# (label, json path, unit, lower_is_better). None marks an informational metric
+# for which the report must not infer better/worse.
+METRICS = [
+    ("live heap (HeapAlloc)", ("steadyHeap", "heapAllocBytes"), "bytes", True),
+    ("live heap growth (steady-baseline)", ("__live_growth",), "bytes", True),
+    ("steady heap objects", ("steadyHeap", "heapObjects"), "count", True),
+    ("heap span inuse (secondary)", ("steadyHeap", "heapInuseBytes"), "bytes", None),
+    ("heap span growth (secondary)", ("__inuse_growth",), "bytes", None),
+    ("goroutines", ("steadyHeap", "goroutines"), "count", True),
+    ("peak rss (secondary)", ("maxRSSBytes",), "bytes", None),
+    ("total alloc (whole run)", ("totalAllocBytes",), "bytes", True),
+    # Work crosses the create/settle boundary because controllers process objects
+    # while the fixture is still being submitted. The sums are the stable load signal.
+    ("load alloc (create+settle)", ("__load_alloc",), "bytes", True),
+    ("load cpu (create+settle)", ("__load_cpu",), "seconds", True),
+    ("convergence alloc (+post-write idle)", ("__convergence_alloc",), "bytes", True),
+    ("convergence cpu (+post-write idle)", ("__convergence_cpu",), "seconds", True),
+    ("settle alloc", ("settle", "allocBytes"), "bytes", True),
+    ("idle alloc after writes stop", ("idle", "allocBytes"), "bytes", True),
+    ("neutral churn alloc", ("churnNeutral", "allocBytes"), "bytes", True),
+    ("status churn alloc", ("churnStatus", "allocBytes"), "bytes", True),
+    ("settle cpu", ("settle", "cpuSeconds"), "seconds", True),
+    ("idle cpu after writes stop", ("idle", "cpuSeconds"), "seconds", True),
+    # Writes must be summed over create+settle: a faster build lands more of them
+    # while objects are still being created, so a per-phase count alone is an
+    # attribution artifact rather than a real difference.
+    ("load route status writes (create+settle)", ("__load_route_writes",), "count", True),
+    ("route status writes per route", ("__writes_per_route",), "ratio", True),
+    ("load gw writes (batching-sensitive)", ("__load_gw_writes",), "count", None),
+    ("settle route writes (phase-sensitive)", ("settle", "routeStatusWrites"), "count", None),
+    ("neutral churn cpu", ("churnNeutral", "cpuSeconds"), "seconds", True),
+    ("neutral churn route writes (1/patch expected)", ("churnNeutral", "routeStatusWrites"), "count", True),
+    ("neutral churn gw writes (0 expected)", ("churnNeutral", "gatewayStatusWrites"), "count", True),
+    ("status churn cpu", ("churnStatus", "cpuSeconds"), "seconds", True),
+    ("status churn route writes", ("churnStatus", "routeStatusWrites"), "count", True),
+]
+
+
+def dig(obj, path):
+    if path == ("__live_growth",):
+        return obj["steadyHeap"]["heapAllocBytes"] - obj["baselineHeap"]["heapAllocBytes"]
+    if path == ("__inuse_growth",):
+        return obj["steadyHeap"]["heapInuseBytes"] - obj["baselineHeap"]["heapInuseBytes"]
+    if path == ("__load_alloc",):
+        return obj["create"]["allocBytes"] + obj["settle"]["allocBytes"]
+    if path == ("__load_cpu",):
+        return obj["create"]["cpuSeconds"] + obj["settle"]["cpuSeconds"]
+    if path == ("__convergence_alloc",):
+        return dig(obj, ("__load_alloc",)) + obj["idle"]["allocBytes"]
+    if path == ("__convergence_cpu",):
+        return dig(obj, ("__load_cpu",)) + obj["idle"]["cpuSeconds"]
+    if path == ("__load_route_writes",):
+        return obj["create"]["routeStatusWrites"] + obj["settle"]["routeStatusWrites"]
+    if path == ("__load_gw_writes",):
+        return obj["create"]["gatewayStatusWrites"] + obj["settle"]["gatewayStatusWrites"]
+    if path == ("__writes_per_route",):
+        return dig(obj, ("__load_route_writes",)) / obj["config"]["routes"]
+    for key in path:
+        obj = obj[key]
+    return obj
+
+
+def load_side(out_dir, side):
+    runs = []
+    for path in sorted(glob.glob(os.path.join(out_dir, side, "rep*", "result-*.json"))):
+        with open(path) as f:
+            data = json.load(f)
+        data["__path"] = path
+        runs.append(data)
+    return runs
+
+
+def fmt(value, unit):
+    if unit == "bytes":
+        v = float(value)
+        sign = "-" if v < 0 else ""
+        v = abs(v)
+        for suffix, scale in (("GiB", 1 << 30), ("MiB", 1 << 20), ("KiB", 1 << 10)):
+            if v >= scale:
+                return f"{sign}{v / scale:.2f}{suffix}"
+        return f"{sign}{v:.0f}B"
+    if unit == "seconds":
+        return f"{float(value):.2f}s"
+    if unit == "ratio":
+        return f"{float(value):.2f}x"
+    return f"{value:g}" if isinstance(value, float) else str(value)
+
+
+def spread(values, unit):
+    if len(values) < 2:
+        return ""
+    lo, hi = min(values), max(values)
+    med = statistics.median(values)
+    pct = (hi - lo) / med * 100 if med else 0.0
+    return f"[{fmt(lo, unit)}..{fmt(hi, unit)}] {pct:.1f}%"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--candidate", default="candidate")
+    ap.add_argument("--candidate-desc", default="candidate")
+    ap.add_argument("--base-desc", default="base")
+    args = ap.parse_args()
+
+    base = load_side(args.out, "base")
+    cand = load_side(args.out, args.candidate)
+    if not base or not cand:
+        print(f"no results found under {args.out} (base: {len(base)}, {args.candidate}: {len(cand)})",
+              file=sys.stderr)
+        return 1
+
+    cfg = cand[0]["config"]
+    print("=" * 150)
+    print(f"control plane scale footprint: {args.candidate_desc}  vs  {args.base_desc}")
+    print(f"scale: {cfg['gateways']} gateways, {cfg['routes']} routes, {cfg['services']} services; "
+          f"churn {cfg['churnRounds']} rounds x {cfg['churnRoutes']} routes")
+    print(f"reps: {len(cand)} candidate, {len(base)} base; "
+          f"GOMAXPROCS={cand[0]['gomaxprocs']} GOGC={cand[0]['gogc']} "
+          f"{cand[0]['goos']}/{cand[0]['goarch']}")
+    print("=" * 150)
+
+    header = (f"{'metric':43} {'base':>12} {'candidate':>12} {'delta':>12} {'delta %':>9}  "
+              f"{'base spread':>24}  {'candidate spread':>24}")
+    print(header)
+    print("-" * len(header))
+
+    for label, path, unit, lower_better in METRICS:
+        try:
+            b_vals = [dig(r, path) for r in base]
+            c_vals = [dig(r, path) for r in cand]
+        except (KeyError, TypeError):
+            continue
+        b_med = statistics.median(b_vals)
+        c_med = statistics.median(c_vals)
+        delta = c_med - b_med
+        pct = (delta / b_med * 100) if b_med else float("nan")
+        marker = ""
+        if lower_better is not None and b_med and abs(pct) >= 5:
+            improved = delta < 0 if lower_better else delta > 0
+            marker = "  <-- better" if improved else "  <-- WORSE"
+        print(f"{label:43} {fmt(b_med, unit):>12} {fmt(c_med, unit):>12} "
+              f"{fmt(delta, unit):>12} {pct:>8.1f}%  {spread(b_vals, unit):>24}  "
+              f"{spread(c_vals, unit):>24}{marker}")
+
+    print()
+    print("per-rep live heap (HeapAlloc):")
+    for side, runs in (("base", base), (args.candidate, cand)):
+        vals = ", ".join(fmt(dig(r, ("steadyHeap", "heapAllocBytes")), "bytes") for r in runs)
+        print(f"  {side:>10}: {vals}")
+
+    # Point at the median reps' heap profiles: the profile diff is what explains a
+    # heap delta, and it is the part reviewers actually check.
+    def median_profile(runs):
+        ordered = sorted(runs, key=lambda r: dig(r, ("steadyHeap", "heapAllocBytes")))
+        return ordered[len(ordered) // 2].get("heapProfile", "")
+
+    b_prof, c_prof = median_profile(base), median_profile(cand)
+    if b_prof and c_prof and os.path.exists(b_prof) and os.path.exists(c_prof):
+        print()
+        print("attribute the heap delta (median reps):")
+        print(f"  go tool pprof -top -nodecount=25 -diff_base={b_prof} {c_prof}")
+        print(f"  go tool pprof -http=: -diff_base={b_prof} {c_prof}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/perf/status_scale_sweep_report.py
+++ b/hack/perf/status_scale_sweep_report.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Report a scale sweep: one table per metric, scales down the rows, trees across.
+
+The question a sweep answers is whether a cost grows with route count, so each
+cell also shows the ratio to the first tree (treated as the reference) at that
+scale.
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import statistics
+import sys
+
+METRICS = [
+    ("load cpu, create+settle (s)", lambda r: r["create"]["cpuSeconds"] + r["settle"]["cpuSeconds"], "{:.2f}"),
+    ("load alloc, create+settle (MiB)", lambda r: (r["create"]["allocBytes"] + r["settle"]["allocBytes"]) / 2**20, "{:.0f}"),
+    ("convergence cpu, incl idle (s)", lambda r: r["create"]["cpuSeconds"] + r["settle"]["cpuSeconds"] + r["idle"]["cpuSeconds"], "{:.2f}"),
+    ("convergence alloc, incl idle (MiB)", lambda r: (r["create"]["allocBytes"] + r["settle"]["allocBytes"] + r["idle"]["allocBytes"]) / 2**20, "{:.0f}"),
+    ("settle cpu (s)", lambda r: r["settle"]["cpuSeconds"], "{:.2f}"),
+    # settle alone ends when writes stop, which is not when work stops; settle+idle is
+    # the honest cost of converging.
+    ("idle cpu after writes stop (s)", lambda r: r["idle"]["cpuSeconds"], "{:.2f}"),
+    ("settle+idle cpu (s)", lambda r: r["settle"]["cpuSeconds"] + r["idle"]["cpuSeconds"], "{:.2f}"),
+    ("settle+idle alloc (MiB)", lambda r: (r["settle"]["allocBytes"] + r["idle"]["allocBytes"]) / 2**20, "{:.0f}"),
+    ("settle alloc (MiB)", lambda r: r["settle"]["allocBytes"] / 2**20, "{:.0f}"),
+    ("churn cpu, constant churn (s)", lambda r: r["churnNeutral"]["cpuSeconds"] + r["churnStatus"]["cpuSeconds"], "{:.2f}"),
+    ("churn alloc, constant churn (MiB)", lambda r: (r["churnNeutral"]["allocBytes"] + r["churnStatus"]["allocBytes"]) / 2**20, "{:.0f}"),
+    ("live heap (MiB)", lambda r: r["steadyHeap"]["heapAllocBytes"] / 2**20, "{:.0f}"),
+    ("heap span inuse, secondary (MiB)", lambda r: r["steadyHeap"]["heapInuseBytes"] / 2**20, "{:.0f}"),
+    ("peak rss, secondary (MiB)", lambda r: r["maxRSSBytes"] / 2**20, "{:.0f}"),
+    ("route writes per route", lambda r: (r["create"]["routeStatusWrites"] + r["settle"]["routeStatusWrites"]) / r["config"]["routes"], "{:.2f}"),
+	("convergence wall (s)", lambda r: r["load"]["convergenceWallSeconds"], "{:.2f}"),
+	("p95 route status staleness (s)", lambda r: r["load"]["p95StalenessSeconds"], "{:.2f}"),
+	("max route status staleness (s)", lambda r: r["load"]["maxStalenessSeconds"], "{:.2f}"),
+	("successful status write qps", lambda r: r["load"]["writeQPS"], "{:.1f}"),
+	("status write conflicts", lambda r: r["load"]["conflicts"], "{:.0f}"),
+    ("gateway writes, batching-sensitive", lambda r: r["create"]["gatewayStatusWrites"] + r["settle"]["gatewayStatusWrites"], "{:.0f}"),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--ref", default="main",
+                    help="reference tree for ratios (default: main, if present)")
+    args = ap.parse_args()
+
+    scales = []
+    for d in glob.glob(os.path.join(args.out, "scale-*")):
+        m = re.match(r"scale-(\d+)$", os.path.basename(d))
+        if m:
+            scales.append(int(m.group(1)))
+    scales.sort()
+    if not scales:
+        print(f"no scale-* directories under {args.out}", file=sys.stderr)
+        return 1
+
+    # Tree order is taken from the largest complete scale so the reference column
+    # is stable even if a big scale partly failed.
+    sides = []
+    for scale in scales:
+        for d in sorted(glob.glob(os.path.join(args.out, f"scale-{scale}", "*"))):
+            side = os.path.basename(d)
+            if side not in sides and glob.glob(os.path.join(d, "rep*", "result-*.json")):
+                sides.append(side)
+
+    data = {}
+    for scale in scales:
+        for side in sides:
+            runs = []
+            for p in sorted(glob.glob(os.path.join(args.out, f"scale-{scale}", side, "rep*", "result-*.json"))):
+                with open(p) as f:
+                    runs.append(json.load(f))
+            if runs:
+                data[(scale, side)] = runs
+
+    # Ratios are only meaningful against the baseline being argued about, so put the
+    # reference tree first rather than taking whatever sorted() returned.
+    ref = args.ref if args.ref in sides else sides[0]
+    sides = [ref] + [s for s in sides if s != ref]
+    print(f"scale sweep: reference tree = {ref}; cells are median (ratio vs {ref} at that scale)")
+    print(f"reps per cell: " + ", ".join(
+        f"{scale}: " + "/".join(str(len(data.get((scale, s), []))) for s in sides) for scale in scales))
+    print()
+
+    for label, fn, fmt in METRICS:
+        print(label)
+        header = f"  {'routes':>8}" + "".join(f"{s:>22}" for s in sides)
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        def vals(runs):
+            out = []
+            for r in runs or []:
+                try:
+                    out.append(fn(r))
+                except (KeyError, TypeError):
+                    pass
+            return out
+
+        for scale in scales:
+            row = f"  {scale:>8}"
+            ref_vals = vals(data.get((scale, ref)))
+            ref_med = statistics.median(ref_vals) if ref_vals else None
+            for side in sides:
+                side_vals = vals(data.get((scale, side)))
+                if not side_vals:
+                    row += f"{'-':>22}"
+                    continue
+                med = statistics.median(side_vals)
+                cell = fmt.format(med)
+                if side != ref and ref_med:
+                    cell += f" ({med / ref_med:.2f}x)"
+                row += f"{cell:>22}"
+            print(row)
+        # Growth factor across the scale range makes O(N) vs flat obvious.
+        if len(scales) > 1:
+            growth = f"  {'growth':>8}"
+            for side in sides:
+                lo, hi = vals(data.get((scales[0], side))), vals(data.get((scales[-1], side)))
+                if not lo or not hi:
+                    growth += f"{'-':>22}"
+                    continue
+                lo_med = statistics.median(lo)
+                hi_med = statistics.median(hi)
+                growth += f"{(hi_med / lo_med if lo_med else float('nan')):>21.2f}x"
+            print(growth + f"   <- {scales[0]} -> {scales[-1]} routes")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/perf/statusscale/README.md
+++ b/test/perf/statusscale/README.md
@@ -92,7 +92,24 @@ stdout for scripted collection.
 | `SCALEPERF_PARALLEL` | 8 | concurrent creates/patches |
 | `SCALEPERF_WRITE_LATENCY` | `0s` | latency injected before each Gateway and HTTPRoute status request reaches the API server |
 | `SCALEPERF_OUT` | test temp dir | output directory |
+| `SCALEPERF_IDLE_CPUPROFILE` | unset | set to any value to CPU-profile the idle phase to `cpuidle-<label>.pprof` |
 | `KGW_LOG_LEVEL` | `error` (forced) | log I/O is CPU; raise it only when debugging |
+
+## Attributing the idle phase
+
+At high route counts most CPU lands in the post-write idle phase, and the whole-run
+heap profile cannot separate it from load. `SCALEPERF_IDLE_CPUPROFILE=1` writes a CPU
+profile covering only that phase:
+
+```bash
+SCALEPERF_IDLE_CPUPROFILE=1 ... go test -tags e2e -run TestScaleFootprint ./test/perf/statusscale/
+go tool pprof -top -cum -nodecount=200 cpuidle-<label>.pprof
+```
+
+Read it with `-cum` and filter to application frames: the flat view is dominated by
+runtime GC and map internals, which are a symptom of the allocation rather than its
+source. Profiling costs a few percent, so a run with it enabled is for attribution and
+should not be compared against runs without it.
 
 ## Comparing two branches
 

--- a/test/perf/statusscale/README.md
+++ b/test/perf/statusscale/README.md
@@ -1,0 +1,138 @@
+# Control plane scale footprint
+
+`TestScaleFootprint` runs the whole kgateway control plane in-process against
+envtest, loads it with N Gateways and M HTTPRoutes, and measures what the process
+costs at that scale. It exists to A/B two builds of the control plane — typically
+a branch against `main` — not to assert a threshold, so it is skipped unless
+`SCALEPERF` is set.
+
+Everything is measured inside the test process. The envtest apiserver and etcd run
+as separate processes, so their CPU is excluded and the numbers reflect control
+plane work plus the test's own client work.
+
+A run assumes it has the machine to itself. Nothing enforces that: a concurrent
+build, a second measurement, or another agent driving the same harness will
+contend for CPU and quietly invalidate the numbers. Check that the machine is idle
+before starting a sweep, and establish the noise floor with the `--control` run
+described under "Comparing two branches" before trusting any delta.
+
+## What it measures
+
+| Metric | Meaning |
+| --- | --- |
+| `baselineHeap` | post-GC live heap after startup, before the fixture exists |
+| `steadyHeap` | post-GC live heap after every route carries our status and post-write work has gone idle |
+| `create` | creating the fixture; CPU here is mostly the test's own client work |
+| `settle` | from "objects exist" to "all routes have status and nothing is being written"; work can move across the create/settle boundary |
+| `idle` | control-plane work that continues after writes stop; included in convergence totals and before the steady heap snapshot |
+| `churnNeutral` | patching route hostnames: translation re-runs and only `observedGeneration` moves in the status, so exactly one route write per patch is correct. Anything above that, or any Gateway write at all, is churn |
+| `churnStatus` | flipping a route's `backendRef` between a real and a missing Service, which forces a genuine `ResolvedRefs` transition each round; measures the cost of writes that must happen |
+| `maxRSSBytes` | peak RSS of the test process (secondary — peak, not steady, and includes envtest client machinery) |
+| `load.convergenceWallSeconds` | wall time from the start of fixture creation until every route has status and the watch is quiet |
+| `load.routeWritesPerRoute` | watch-observed HTTPRoute status writes during initial convergence divided by route count |
+| `load.writeQPS` | successful Gateway and HTTPRoute status writes divided by the active interval from the first write attempt to the last completion |
+| `load.conflicts` | HTTP 409 responses from Gateway and HTTPRoute status writes during initial convergence |
+| `load.p95StalenessSeconds` / `maxStalenessSeconds` | time from each HTTPRoute create submission to its first matching status event on the watch stream |
+
+Both heap snapshots are taken after two forced collections. `HeapAlloc` is the
+primary steady-memory metric because it measures live allocations. `HeapInuse`
+measures allocator spans, includes unused space within spans, and can be bimodal;
+it and peak RSS are reported as secondary diagnostics.
+
+For load cost, compare `create + settle` CPU and allocation. Controllers process
+objects while the fixture is still being submitted, so either phase alone is
+sensitive to scheduling. The report also shows `create + settle + idle` as the
+full convergence cost. Wall time is retained in JSON for diagnostics but omitted
+from comparison tables: every convergence wait contains a configured quiet
+interval, which dominates small performance differences.
+
+Status writes are counted from a watch on HTTPRoutes and Gateways: a `MODIFIED`
+event whose `metadata.generation` is unchanged from the previously observed
+version is a status write, and a generation bump is one of the harness's own spec
+patches. That makes the write counts independent of either build's metric names.
+
+Always compare write counts summed over `create` **and** `settle`. A build that
+converges faster lands more of its writes while objects are still being created,
+so a single phase's count can look like a large reduction when the total is
+unchanged or worse. `status_scale_report.py` reports the summed count and the
+writes-per-route ratio for this reason.
+
+Load-time Gateway write counts are informational, not a redundant-write score.
+`AttachedRoutes` legitimately changes as routes arrive, and nondeterministic
+translation batching can substantially change the number of intermediate
+Gateway statuses. Gateway writes during neutral churn remain actionable because
+the churn does not change Gateway status.
+
+## Running one measurement
+
+```bash
+SCALEPERF=1 \
+  SCALEPERF_LABEL=mybranch \
+  SCALEPERF_GATEWAYS=10 \
+  SCALEPERF_ROUTES=1000 \
+  SCALEPERF_OUT=/tmp/scaleperf \
+  go test -tags e2e -count=1 -timeout 60m -run TestScaleFootprint ./test/perf/statusscale/
+```
+
+Results land in `$SCALEPERF_OUT` as `result-<label>.json` and
+`heap-<label>.pb.gz`, and a single `SCALEPERF_JSON {...}` line is printed to
+stdout for scripted collection.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SCALEPERF` | unset | must be set or the test skips |
+| `SCALEPERF_LABEL` | `unlabeled` | names the output files |
+| `SCALEPERF_GATEWAYS` | 10 | Gateways created |
+| `SCALEPERF_ROUTES` | 1000 | HTTPRoutes created, spread over the Gateways |
+| `SCALEPERF_SERVICES` | 20 | backend Services created |
+| `SCALEPERF_CHURN_ROUNDS` | 3 | rounds in each churn phase |
+| `SCALEPERF_CHURN_ROUTES` | 100 | routes patched per round |
+| `SCALEPERF_QUIET` | `3s` | idle period on the watch that counts as converged |
+| `SCALEPERF_TIMEOUT` | `5m` | per-phase timeout |
+| `SCALEPERF_PARALLEL` | 8 | concurrent creates/patches |
+| `SCALEPERF_WRITE_LATENCY` | `0s` | latency injected before each Gateway and HTTPRoute status request reaches the API server |
+| `SCALEPERF_OUT` | test temp dir | output directory |
+| `KGW_LOG_LEVEL` | `error` (forced) | log I/O is CPU; raise it only when debugging |
+
+## Comparing two branches
+
+```bash
+hack/perf/status-scale-compare.sh --base main --reps 3 --routes 1000
+```
+
+The driver creates a detached worktree for the base ref, copies this harness into
+it so both sides run byte-identical measurement code, alternates run order
+(candidate/base, then base/candidate) so machine drift does not consistently
+favor one side, and prints median comparisons with both sides' per-rep spreads.
+
+Establish the noise floor before trusting any delta:
+
+```bash
+hack/perf/status-scale-compare.sh --base main --reps 3 --control
+```
+
+That runs `main` against `main`. If the control shows a 6% heap gap, a 6% branch
+delta is noise.
+
+## Attributing a heap delta
+
+A number alone is weak; the profile diff shows the mechanism. The driver prints
+the exact command for the median reps:
+
+```bash
+go tool pprof -top -nodecount=25 -diff_base=<base>/heap-base.pb.gz <cand>/heap-candidate.pb.gz
+```
+
+## Caveats
+
+- Sweep the scale (0 / 1000 / 5000 routes). A win from removing per-object
+  duplication grows with object count; a fixed offset does not.
+- `GOGC`, `GOMAXPROCS` and machine load all move steady-state heap. The driver
+  pins the first two; you have to handle the third.
+- Peak RSS and `HeapInuse` are noisy for Go processes. Treat post-GC `HeapAlloc`
+  as the primary live-memory number.
+- Gateways use `selfManaged` GatewayParameters, so the deployer creates nothing
+  per Gateway. This isolates translation and status, and understates the footprint
+  of a real install.
+- Services have no selector and envtest populates no EndpointSlices, so endpoint
+  translation is not exercised.

--- a/test/perf/statusscale/probe_test.go
+++ b/test/perf/statusscale/probe_test.go
@@ -1,0 +1,55 @@
+package statusscale_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestIsGatewayAPIStatusWrite(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		{name: "route status", method: http.MethodPut, path: "/apis/gateway.networking.k8s.io/v1/namespaces/gwtest/httproutes/r/status", want: true},
+		{name: "gateway status", method: http.MethodPatch, path: "/apis/gateway.networking.k8s.io/v1/namespaces/gwtest/gateways/g/status", want: true},
+		{name: "route spec", method: http.MethodPut, path: "/apis/gateway.networking.k8s.io/v1/namespaces/gwtest/httproutes/r"},
+		{name: "read status", method: http.MethodGet, path: "/apis/gateway.networking.k8s.io/v1/namespaces/gwtest/httproutes/r/status"},
+		{name: "core status", method: http.MethodPut, path: "/api/v1/namespaces/gwtest/pods/p/status"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{Method: tt.method, URL: &url.URL{Path: tt.path}}
+			if got := isGatewayAPIStatusWrite(req); got != tt.want {
+				t.Fatalf("isGatewayAPIStatusWrite() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadMetricsSince(t *testing.T) {
+	base := time.Unix(100, 0)
+	p := &statusWriteProbe{events: []statusWriteEvent{
+		{start: base, finish: base.Add(time.Second), statusCode: http.StatusOK},
+		{start: base.Add(time.Second), finish: base.Add(2 * time.Second), statusCode: http.StatusConflict},
+		{start: base.Add(2 * time.Second), finish: base.Add(4 * time.Second), statusCode: http.StatusNoContent},
+	}}
+	staleness := make([]time.Duration, 100)
+	for i := range staleness {
+		staleness[i] = time.Duration(i+1) * time.Second
+	}
+
+	got := p.loadMetricsSince(0, 10*time.Second, staleness)
+	if got.WriteAttempts != 3 || got.SuccessfulWrites != 2 || got.Conflicts != 1 {
+		t.Fatalf("unexpected write counts: %+v", got)
+	}
+	if got.WriteActiveSeconds != 4 || got.WriteQPS != 0.5 {
+		t.Fatalf("unexpected write rate: %+v", got)
+	}
+	if got.P95StalenessSeconds != 95 || got.MaxStalenessSeconds != 100 {
+		t.Fatalf("unexpected staleness: %+v", got)
+	}
+}

--- a/test/perf/statusscale/scale_test.go
+++ b/test/perf/statusscale/scale_test.go
@@ -474,7 +474,9 @@ func measure(t *testing.T, ctx context.Context, client istiokube.CLIClient, cfg 
 	// the settle phase above reports whatever translation happened to be in flight,
 	// which is window-dependent and not a steady state.
 	idleStart := w.mark()
+	stopIdleCPUProfile := startIdleCPUProfile(t, cfg)
 	waitHeapStable(t, cfg)
+	stopIdleCPUProfile()
 	res.Idle = w.since(idleStart)
 
 	runtime.GC()
@@ -998,6 +1000,30 @@ func maxRSSBytes() uint64 {
 		return uint64(ru.Maxrss)
 	}
 	return uint64(ru.Maxrss) * 1024
+}
+
+// startIdleCPUProfile profiles only the post-write idle phase, which is where most
+// of the CPU goes at high route counts and which the whole-run heap profile cannot
+// separate from load. Off by default: CPU profiling costs a few percent, so a run
+// with it enabled is for attribution, not for comparison against runs without it.
+func startIdleCPUProfile(t *testing.T, cfg config) func() {
+	if os.Getenv("SCALEPERF_IDLE_CPUPROFILE") == "" {
+		return func() {}
+	}
+	path := filepath.Join(cfg.outDir, fmt.Sprintf("cpuidle-%s.pprof", cfg.Label))
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create idle cpu profile %s: %v", path, err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		f.Close()
+		t.Fatalf("failed to start idle cpu profile: %v", err)
+	}
+	return func() {
+		pprof.StopCPUProfile()
+		f.Close()
+		t.Logf("idle cpu profile: %s", path)
+	}
 }
 
 func writeHeapProfile(t *testing.T, path string) {

--- a/test/perf/statusscale/scale_test.go
+++ b/test/perf/statusscale/scale_test.go
@@ -1,0 +1,1111 @@
+// Package statusscale measures the control plane's steady-state memory footprint
+// and CPU cost at route scale, in-process, against envtest.
+//
+// It exists to A/B two builds of the control plane (e.g. main vs a branch). The
+// harness intentionally depends only on APIs that are stable across branches so
+// the exact same file can be dropped into two worktrees and produce comparable
+// numbers. See README.md for the procedure.
+package statusscale_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	istiokube "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
+	"github.com/kgateway-dev/kgateway/v2/test/envtestassets"
+	"github.com/kgateway-dev/kgateway/v2/test/envtestutil"
+)
+
+const (
+	// controllerName is the controller that owns the status entries we count.
+	controllerName = "kgateway.dev/kgateway"
+	// fixtureNamespace holds every Gateway, HTTPRoute and Service we create.
+	fixtureNamespace = "gwtest"
+	// missingBackend is a Service name that intentionally does not exist, used to
+	// force a real status transition during the status-churn phase.
+	missingBackend = "svc-does-not-exist"
+)
+
+// bootstrapYAML is applied before the control plane starts. selfManaged keeps the
+// deployer out of the measurement: no Deployments, Services or ConfigMaps are
+// created per Gateway.
+const bootstrapYAML = `kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: kgateway
+spec:
+  controllerName: kgateway.dev/kgateway
+  parametersRef:
+    group: gateway.kgateway.dev
+    kind: GatewayParameters
+    name: kgateway
+    namespace: default
+---
+kind: GatewayParameters
+apiVersion: gateway.kgateway.dev/v1alpha1
+metadata:
+  name: kgateway
+spec:
+  selfManaged: {}
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gwtest
+---
+# The install namespace exists so the bootstrap controller can create its OAuth2
+# HMAC secret once instead of retrying on a backoff loop for the whole run.
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kgateway-system
+`
+
+type config struct {
+	Label        string        `json:"label"`
+	Commit       string        `json:"commit"`
+	Gateways     int           `json:"gateways"`
+	Routes       int           `json:"routes"`
+	Services     int           `json:"services"`
+	ChurnRounds  int           `json:"churnRounds"`
+	ChurnRoutes  int           `json:"churnRoutes"`
+	WriteLatency time.Duration `json:"writeLatency"`
+
+	quiet    time.Duration
+	timeout  time.Duration
+	outDir   string
+	parallel int
+	// Idle detection: how many consecutive post-GC live-heap readings must agree,
+	// how closely, and how long to wait between them.
+	stableSamples   int
+	stableTolerance float64
+	stableInterval  time.Duration
+}
+
+func loadConfig(t *testing.T) config {
+	c := config{
+		Label:        envOr("SCALEPERF_LABEL", "unlabeled"),
+		Gateways:     envInt(t, "SCALEPERF_GATEWAYS", 10),
+		Routes:       envInt(t, "SCALEPERF_ROUTES", 1000),
+		Services:     envInt(t, "SCALEPERF_SERVICES", 20),
+		ChurnRounds:  envInt(t, "SCALEPERF_CHURN_ROUNDS", 3),
+		ChurnRoutes:  envInt(t, "SCALEPERF_CHURN_ROUTES", 100),
+		WriteLatency: envDuration(t, "SCALEPERF_WRITE_LATENCY", 0),
+		quiet:        envDuration(t, "SCALEPERF_QUIET", 3*time.Second),
+		timeout:      envDuration(t, "SCALEPERF_TIMEOUT", 5*time.Minute),
+		outDir:       envOr("SCALEPERF_OUT", ""),
+		parallel:     envInt(t, "SCALEPERF_PARALLEL", 8),
+
+		stableSamples:   envInt(t, "SCALEPERF_STABLE_SAMPLES", 4),
+		stableTolerance: float64(envInt(t, "SCALEPERF_STABLE_TOLERANCE_PCT", 3)) / 100,
+		stableInterval:  envDuration(t, "SCALEPERF_STABLE_INTERVAL", 5*time.Second),
+	}
+	if c.ChurnRoutes > c.Routes {
+		c.ChurnRoutes = c.Routes
+	}
+	if c.outDir == "" {
+		c.outDir = t.TempDir()
+	}
+	if err := os.MkdirAll(c.outDir, 0o755); err != nil {
+		t.Fatalf("failed to create out dir %s: %v", c.outDir, err)
+	}
+	c.Commit = gitCommit()
+	return c
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(t *testing.T, key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		t.Fatalf("invalid %s=%q: %v", key, v, err)
+	}
+	return n
+}
+
+func envDuration(t *testing.T, key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		t.Fatalf("invalid %s=%q: %v", key, v, err)
+	}
+	return d
+}
+
+func gitCommit() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+type memSnapshot struct {
+	HeapAllocBytes  uint64 `json:"heapAllocBytes"`
+	HeapInuseBytes  uint64 `json:"heapInuseBytes"`
+	HeapObjects     uint64 `json:"heapObjects"`
+	StackInuseBytes uint64 `json:"stackInuseBytes"`
+	SysBytes        uint64 `json:"sysBytes"`
+	NumGC           uint32 `json:"numGC"`
+	Goroutines      int    `json:"goroutines"`
+}
+
+type phase struct {
+	WallSeconds float64 `json:"wallSeconds"`
+	CPUSeconds  float64 `json:"cpuSeconds"`
+	// AllocBytes and Mallocs are cumulative allocation during the phase, not live
+	// heap. They are the clearest signal of GC pressure and of recomputation that
+	// allocates and is then thrown away.
+	AllocBytes    uint64 `json:"allocBytes"`
+	Mallocs       uint64 `json:"mallocs"`
+	RouteStatuses int    `json:"routeStatusWrites"`
+	GwStatuses    int    `json:"gatewayStatusWrites"`
+	SpecWrites    int    `json:"specWrites"`
+}
+
+type result struct {
+	Config     config      `json:"config"`
+	GOMAXPROCS int         `json:"gomaxprocs"`
+	GOGC       string      `json:"gogc"`
+	GOOS       string      `json:"goos"`
+	GOARCH     string      `json:"goarch"`
+	Baseline   memSnapshot `json:"baselineHeap"`
+	Steady     memSnapshot `json:"steadyHeap"`
+
+	Create phase `json:"create"`
+	Settle phase `json:"settle"`
+	// Idle covers the work that continues after status writes stop: each write is an
+	// informer event that can re-trigger translation, and that translation produces
+	// no further writes, so a quiet watch does not mean the control plane is done.
+	// Costs here are real but invisible to a watch-only convergence test.
+	Idle         phase       `json:"idle"`
+	ChurnNeutral phase       `json:"churnNeutral"`
+	ChurnStatus  phase       `json:"churnStatus"`
+	Load         loadMetrics `json:"load"`
+
+	MaxRSSBytes uint64 `json:"maxRSSBytes"`
+	// TotalAllocBytes is every byte allocated over the whole run.
+	TotalAllocBytes uint64 `json:"totalAllocBytes"`
+	HeapProfile     string `json:"heapProfile"`
+	ResultFile      string `json:"resultFile"`
+}
+
+type loadMetrics struct {
+	ConvergenceWallSeconds float64 `json:"convergenceWallSeconds"`
+	WriteAttempts          int     `json:"writeAttempts"`
+	SuccessfulWrites       int     `json:"successfulWrites"`
+	Conflicts              int     `json:"conflicts"`
+	WriteActiveSeconds     float64 `json:"writeActiveSeconds"`
+	WriteQPS               float64 `json:"writeQPS"`
+	RouteWritesPerRoute    float64 `json:"routeWritesPerRoute"`
+	StalenessSamples       int     `json:"stalenessSamples"`
+	P95StalenessSeconds    float64 `json:"p95StalenessSeconds"`
+	MaxStalenessSeconds    float64 `json:"maxStalenessSeconds"`
+}
+
+type statusWriteEvent struct {
+	start      time.Time
+	finish     time.Time
+	statusCode int
+}
+
+// statusWriteProbe injects latency immediately before Gateway API status requests
+// reach the API server and records their outcomes. Installing it on the shared REST
+// config covers every typed KRT writer without changing production code.
+type statusWriteProbe struct {
+	latency time.Duration
+	mu      sync.Mutex
+	events  []statusWriteEvent
+}
+
+func newStatusWriteProbe(latency time.Duration) *statusWriteProbe {
+	return &statusWriteProbe{latency: latency}
+}
+
+func (p *statusWriteProbe) wrapTransport(previous func(http.RoundTripper) http.RoundTripper) func(http.RoundTripper) http.RoundTripper {
+	return func(base http.RoundTripper) http.RoundTripper {
+		if previous != nil {
+			base = previous(base)
+		}
+		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if !isGatewayAPIStatusWrite(req) {
+				return base.RoundTrip(req)
+			}
+
+			started := time.Now()
+			if p.latency > 0 {
+				timer := time.NewTimer(p.latency)
+				select {
+				case <-req.Context().Done():
+					if !timer.Stop() {
+						<-timer.C
+					}
+					p.record(statusWriteEvent{start: started, finish: time.Now()})
+					return nil, req.Context().Err()
+				case <-timer.C:
+				}
+			}
+
+			resp, err := base.RoundTrip(req)
+			statusCode := 0
+			if resp != nil {
+				statusCode = resp.StatusCode
+			}
+			p.record(statusWriteEvent{start: started, finish: time.Now(), statusCode: statusCode})
+			return resp, err
+		})
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func isGatewayAPIStatusWrite(req *http.Request) bool {
+	if req.Method != http.MethodPut && req.Method != http.MethodPatch {
+		return false
+	}
+	path := req.URL.Path
+	if !strings.Contains(path, "/apis/gateway.networking.k8s.io/") || !strings.HasSuffix(path, "/status") {
+		return false
+	}
+	return strings.Contains(path, "/httproutes/") || strings.Contains(path, "/gateways/")
+}
+
+func (p *statusWriteProbe) record(event statusWriteEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, event)
+}
+
+func (p *statusWriteProbe) snapshot() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.events)
+}
+
+func (p *statusWriteProbe) loadMetricsSince(start int, convergence time.Duration, staleness []time.Duration) loadMetrics {
+	p.mu.Lock()
+	events := slices.Clone(p.events[start:])
+	p.mu.Unlock()
+
+	m := loadMetrics{
+		ConvergenceWallSeconds: convergence.Seconds(),
+		WriteAttempts:          len(events),
+		StalenessSamples:       len(staleness),
+	}
+	if len(events) > 0 {
+		first, last := events[0].start, events[0].finish
+		for _, event := range events {
+			if event.start.Before(first) {
+				first = event.start
+			}
+			if event.finish.After(last) {
+				last = event.finish
+			}
+			if event.statusCode >= http.StatusOK && event.statusCode < http.StatusMultipleChoices {
+				m.SuccessfulWrites++
+			}
+			if event.statusCode == http.StatusConflict {
+				m.Conflicts++
+			}
+		}
+		m.WriteActiveSeconds = last.Sub(first).Seconds()
+		if m.WriteActiveSeconds > 0 {
+			m.WriteQPS = float64(m.SuccessfulWrites) / m.WriteActiveSeconds
+		}
+	}
+	if len(staleness) > 0 {
+		slices.Sort(staleness)
+		p95Index := (95*len(staleness)+99)/100 - 1
+		m.P95StalenessSeconds = staleness[p95Index].Seconds()
+		m.MaxStalenessSeconds = staleness[len(staleness)-1].Seconds()
+	}
+	return m
+}
+
+func TestScaleFootprint(t *testing.T) {
+	if os.Getenv("SCALEPERF") == "" {
+		t.Skip("set SCALEPERF=1 to run the control plane scale footprint measurement")
+	}
+	cfg := loadConfig(t)
+	t.Logf("scale footprint: label=%s commit=%s gateways=%d routes=%d services=%d",
+		cfg.Label, cfg.Commit, cfg.Gateways, cfg.Routes, cfg.Services)
+
+	// The default 512KiB sampling rate is too coarse to attribute a few MiB of live
+	// heap. Lower it for attribution runs only: sampling every allocation costs CPU,
+	// so profiles taken this way pair with CPU numbers from a default-rate run.
+	if rate := envInt(t, "SCALEPERF_MEMPROFILERATE", 0); rate > 0 {
+		runtime.MemProfileRate = rate
+		t.Logf("MemProfileRate=%d: heap attribution is finer, CPU numbers are not comparable to default-rate runs", rate)
+	}
+
+	st, err := envtestutil.BuildSettings()
+	if err != nil {
+		t.Fatalf("failed to build settings: %v", err)
+	}
+	// Log I/O is real CPU and its volume differs between builds; keep it out of the
+	// measurement unless explicitly asked for.
+	if os.Getenv("KGW_LOG_LEVEL") == "" {
+		st.LogLevel = "error"
+	}
+
+	assetsDir, err := envtestassets.GetEnvTestAssetsDir()
+	if err != nil {
+		t.Fatalf("failed to get envtest assets dir: %v", err)
+	}
+	root := filepath.Join("..", "..", "..")
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join(root, "pkg", "kgateway", "crds"),
+			filepath.Join(root, "install", "helm", "kgateway-crds", "templates"),
+		},
+		ErrorIfCRDPathMissing:   true,
+		BinaryAssetsDirectory:   assetsDir,
+		ControlPlaneStopTimeout: time.Millisecond,
+	}
+
+	bootstrap := filepath.Join(t.TempDir(), "bootstrap.yaml")
+	if err := os.WriteFile(bootstrap, []byte(bootstrapYAML), 0o600); err != nil {
+		t.Fatalf("failed to write bootstrap yaml: %v", err)
+	}
+
+	writeProbe := newStatusWriteProbe(cfg.WriteLatency)
+	envtestutil.RunController(
+		t,
+		st,
+		testEnv,
+		nil,
+		[][]string{{"default", bootstrap}},
+		nil,
+		func(t *testing.T, ctx context.Context, _ *krt.DebugHandler, client istiokube.CLIClient, _ int) {
+			measure(t, ctx, client, cfg, writeProbe)
+		},
+		func(cfg *rest.Config) (apiclient.Client, error) {
+			cfg.WrapTransport = writeProbe.wrapTransport(cfg.WrapTransport)
+			return apiclient.New(cfg)
+		},
+	)
+}
+
+func measure(t *testing.T, ctx context.Context, client istiokube.CLIClient, cfg config, writeProbe *statusWriteProbe) {
+	res := result{
+		Config:     cfg,
+		GOMAXPROCS: runtime.GOMAXPROCS(0),
+		GOGC:       envOr("GOGC", "default(100)"),
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+	}
+
+	w := newWatcher(t, ctx, client)
+	defer w.stop()
+
+	// Let the control plane finish its initial sync before taking the baseline, so
+	// the baseline reflects an idle-but-started process rather than a starting one.
+	w.waitQuiet(t, cfg.quiet, cfg.timeout, "initial control plane sync")
+	// Both heap snapshots are taken after two collections so they measure live data
+	// and are comparable to each other.
+	runtime.GC()
+	runtime.GC()
+	res.Baseline = snapshotHeap()
+	t.Logf("baseline live heap: %s", humanBytes(res.Baseline.HeapAllocBytes))
+
+	// Phase 1: create the fixture. CPU here is dominated by our own client work,
+	// so it is reported but is the weakest of the CPU signals.
+	loadStart := time.Now()
+	writeStart := writeProbe.snapshot()
+	createStart := w.mark()
+	createFixture(t, ctx, client, cfg, w)
+	res.Create = w.since(createStart)
+
+	// Phase 2: settle. From "all objects exist" to "all routes carry our status and
+	// nothing else is being written". This is control plane work almost exclusively.
+	settleStart := w.mark()
+	w.waitFor(t, func(s snapshot) bool { return s.routesWithOurStatus >= cfg.Routes },
+		cfg.quiet, cfg.timeout, fmt.Sprintf("%d routes to reach status", cfg.Routes))
+	res.Settle = w.since(settleStart)
+	res.Load = writeProbe.loadMetricsSince(writeStart, time.Since(loadStart), w.staleness())
+	res.Load.RouteWritesPerRoute = float64(res.Create.RouteStatuses+res.Settle.RouteStatuses) / float64(cfg.Routes)
+	if res.Load.StalenessSamples != cfg.Routes {
+		t.Fatalf("staleness tracking saw %d/%d first route statuses", res.Load.StalenessSamples, cfg.Routes)
+	}
+
+	// Then wait for the process to actually go idle. Measuring the heap at the end of
+	// the settle phase above reports whatever translation happened to be in flight,
+	// which is window-dependent and not a steady state.
+	idleStart := w.mark()
+	waitHeapStable(t, cfg)
+	res.Idle = w.since(idleStart)
+
+	runtime.GC()
+	runtime.GC()
+	res.Steady = snapshotHeap()
+	t.Logf("steady live heap: %s (%+d objects vs baseline)",
+		humanBytes(res.Steady.HeapAllocBytes),
+		int64(res.Steady.HeapObjects)-int64(res.Baseline.HeapObjects))
+
+	res.HeapProfile = filepath.Join(cfg.outDir, fmt.Sprintf("heap-%s.pb.gz", cfg.Label))
+	writeHeapProfile(t, res.HeapProfile)
+
+	// Phase 3: hostname churn. Patching a route's hostnames re-runs translation
+	// without changing what the status says, but observedGeneration in the parent
+	// conditions still has to advance, so one write per patch is correct. What this
+	// phase measures is the cost of that re-translation, and any writes beyond one
+	// per patch — including writes to Gateways, whose status should not move at all.
+	if cfg.ChurnRounds > 0 && cfg.ChurnRoutes > 0 {
+		res.ChurnNeutral = churn(t, ctx, client, cfg, w, "neutral", neutralPatch, nil)
+		// Phase 4: status-changing churn. Flipping the backendRef to a missing
+		// Service and back forces a genuine ResolvedRefs transition each round, so
+		// this measures the cost of writes that actually have to happen.
+		res.ChurnStatus = churn(t, ctx, client, cfg, w, "status", statusPatch, statusSettled(cfg))
+	}
+
+	res.MaxRSSBytes = maxRSSBytes()
+	var final runtime.MemStats
+	runtime.ReadMemStats(&final)
+	res.TotalAllocBytes = final.TotalAlloc
+	res.ResultFile = filepath.Join(cfg.outDir, fmt.Sprintf("result-%s.json", cfg.Label))
+	writeResult(t, res)
+	report(t, res)
+}
+
+// createFixture creates Services, Gateways and HTTPRoutes. Routes are spread
+// round-robin over gateways and services.
+func createFixture(t *testing.T, ctx context.Context, client istiokube.CLIClient, cfg config, w *watcher) {
+	kube := client.Kube()
+	gwapi := client.GatewayAPI()
+
+	for i := range cfg.Services {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName(i), Namespace: fixtureNamespace},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Name: "http", Port: 8080}},
+				// No selector: nothing in envtest would populate EndpointSlices anyway,
+				// and backend resolution for status only needs the Service to exist.
+			},
+		}
+		if _, err := kube.CoreV1().Services(fixtureNamespace).Create(ctx, svc, metav1.CreateOptions{}); err != nil &&
+			!apierrors.IsAlreadyExists(err) {
+			t.Fatalf("failed to create service %s: %v", svc.Name, err)
+		}
+	}
+
+	for i := range cfg.Gateways {
+		gw := &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: gatewayName(i), Namespace: fixtureNamespace},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: "kgateway",
+				Listeners: []gwv1.Listener{{
+					Name:     "http",
+					Protocol: gwv1.HTTPProtocolType,
+					Port:     8080,
+					AllowedRoutes: &gwv1.AllowedRoutes{
+						Namespaces: &gwv1.RouteNamespaces{From: ptr(gwv1.NamespacesFromAll)},
+					},
+				}},
+			},
+		}
+		if _, err := gwapi.GatewayV1().Gateways(fixtureNamespace).Create(ctx, gw, metav1.CreateOptions{}); err != nil &&
+			!apierrors.IsAlreadyExists(err) {
+			t.Fatalf("failed to create gateway %s: %v", gw.Name, err)
+		}
+	}
+
+	forEachConcurrent(cfg.parallel, cfg.Routes, func(i int) {
+		route := &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: routeName(i), Namespace: fixtureNamespace},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name: gwv1.ObjectName(gatewayName(i % cfg.Gateways)),
+					}},
+				},
+				Hostnames: []gwv1.Hostname{gwv1.Hostname(fmt.Sprintf("r%d.example.com", i))},
+				Rules: []gwv1.HTTPRouteRule{{
+					Matches: []gwv1.HTTPRouteMatch{{
+						Path: &gwv1.HTTPPathMatch{
+							Type:  ptr(gwv1.PathMatchPathPrefix),
+							Value: ptr(fmt.Sprintf("/r%d", i)),
+						},
+					}},
+					BackendRefs: []gwv1.HTTPBackendRef{{
+						BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName(serviceName(i % cfg.Services)),
+								Port: ptr(gwv1.PortNumber(8080)),
+							},
+						},
+					}},
+				}},
+			},
+		}
+		w.expectRouteStatus(route.Name, time.Now())
+		if _, err := gwapi.GatewayV1().HTTPRoutes(fixtureNamespace).Create(ctx, route, metav1.CreateOptions{}); err != nil &&
+			!apierrors.IsAlreadyExists(err) {
+			w.cancelRouteStatus(route.Name)
+			t.Fatalf("failed to create route %s: %v", route.Name, err)
+		}
+	})
+	t.Logf("created %d services, %d gateways, %d routes", cfg.Services, cfg.Gateways, cfg.Routes)
+}
+
+// patchFunc builds the merge patch applied to route i on churn round r.
+type patchFunc func(cfg config, round, i int) string
+
+// neutralPatch changes a hostname: translation re-runs and only observedGeneration
+// changes in the resulting status.
+func neutralPatch(_ config, round, i int) string {
+	return fmt.Sprintf(`{"spec":{"hostnames":["r%d-c%d.example.com"]}}`, i, round)
+}
+
+// statusPatch alternates the backendRef between a real and a missing Service,
+// which flips the ResolvedRefs condition on the route's parent status.
+func statusPatch(cfg config, round, i int) string {
+	name := serviceName(i % cfg.Services)
+	if round%2 == 0 {
+		name = missingBackend
+	}
+	return fmt.Sprintf(
+		`{"spec":{"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/r%d"}}],"backendRefs":[{"name":%q,"port":8080}]}]}}`,
+		i, name)
+}
+
+// statusSettled returns a predicate that waits for every churned route to report
+// the ResolvedRefs value implied by the round's patch.
+func statusSettled(cfg config) func(round int) func(snapshot) bool {
+	return func(round int) func(snapshot) bool {
+		want := "True"
+		if round%2 == 0 {
+			want = "False"
+		}
+		return func(s snapshot) bool {
+			for i := range cfg.ChurnRoutes {
+				if s.resolvedRefs[routeName(i)] != want {
+					return false
+				}
+			}
+			return true
+		}
+	}
+}
+
+func churn(
+	t *testing.T,
+	ctx context.Context,
+	client istiokube.CLIClient,
+	cfg config,
+	w *watcher,
+	kind string,
+	patch patchFunc,
+	settled func(round int) func(snapshot) bool,
+) phase {
+	routes := client.GatewayAPI().GatewayV1().HTTPRoutes(fixtureNamespace)
+	start := w.mark()
+	for round := range cfg.ChurnRounds {
+		forEachConcurrent(cfg.parallel, cfg.ChurnRoutes, func(i int) {
+			body := []byte(patch(cfg, round, i))
+			if _, err := routes.Patch(ctx, routeName(i), types.MergePatchType, body, metav1.PatchOptions{}); err != nil {
+				t.Fatalf("failed to patch route %s: %v", routeName(i), err)
+			}
+		})
+		if settled != nil {
+			w.waitFor(t, settled(round), cfg.quiet, cfg.timeout,
+				fmt.Sprintf("%s churn round %d to settle", kind, round))
+		} else {
+			w.waitQuiet(t, cfg.quiet, cfg.timeout, fmt.Sprintf("%s churn round %d to go quiet", kind, round))
+		}
+	}
+	p := w.since(start)
+	t.Logf("%s churn: %d rounds x %d routes -> %d route status writes, %d gateway status writes, %.2fs cpu",
+		kind, cfg.ChurnRounds, cfg.ChurnRoutes, p.RouteStatuses, p.GwStatuses, p.CPUSeconds)
+	return p
+}
+
+// routeState is the last observed state of one HTTPRoute.
+type routeState struct {
+	generation   int64
+	hasOurStatus bool
+	resolvedRefs string
+}
+
+// snapshot is a consistent view of the watcher's counters.
+type snapshot struct {
+	routeStatusWrites   int
+	gwStatusWrites      int
+	specWrites          int
+	routesWithOurStatus int
+	resolvedRefs        map[string]string
+	lastEvent           time.Time
+}
+
+// watcher counts status-only writes performed by the control plane. A MODIFIED
+// event whose metadata.generation is unchanged from the previously observed
+// version is a status (or metadata) write; a generation bump is one of our own
+// spec writes.
+type watcher struct {
+	mu              sync.Mutex
+	routes          map[string]routeState
+	gateways        map[string]int64
+	routeStatus     int
+	gwStatus        int
+	specWrites      int
+	lastEvent       time.Time
+	statusExpected  map[string]time.Time
+	statusStaleness []time.Duration
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
+}
+
+func newWatcher(t *testing.T, ctx context.Context, client istiokube.CLIClient) *watcher {
+	ctx, cancel := context.WithCancel(ctx)
+	w := &watcher{
+		routes:         map[string]routeState{},
+		gateways:       map[string]int64{},
+		statusExpected: map[string]time.Time{},
+		lastEvent:      time.Now(),
+		cancel:         cancel,
+	}
+
+	w.wg.Go(func() {
+		watchLoop(ctx, t, "httproute", func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.GatewayAPI().GatewayV1().HTTPRoutes(fixtureNamespace).Watch(ctx, opts)
+		}, w.onRoute)
+	})
+	w.wg.Go(func() {
+		watchLoop(ctx, t, "gateway", func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.GatewayAPI().GatewayV1().Gateways(fixtureNamespace).Watch(ctx, opts)
+		}, w.onGateway)
+	})
+	return w
+}
+
+func (w *watcher) stop() {
+	w.cancel()
+	w.wg.Wait()
+}
+
+func (w *watcher) expectRouteStatus(name string, since time.Time) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.statusExpected[name] = since
+}
+
+func (w *watcher) cancelRouteStatus(name string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.statusExpected, name)
+}
+
+func (w *watcher) staleness() []time.Duration {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return slices.Clone(w.statusStaleness)
+}
+
+// watchLoop keeps a watch open, re-establishing it if the server closes it.
+func watchLoop(
+	ctx context.Context,
+	t *testing.T,
+	name string,
+	open func(metav1.ListOptions) (watch.Interface, error),
+	handle func(watch.Event),
+) {
+	for ctx.Err() == nil {
+		iface, err := open(metav1.ListOptions{})
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			t.Logf("watch %s: open failed, retrying: %v", name, err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(200 * time.Millisecond):
+			}
+			continue
+		}
+		for ev := range iface.ResultChan() {
+			handle(ev)
+		}
+		iface.Stop()
+	}
+}
+
+func (w *watcher) onRoute(ev watch.Event) {
+	route, ok := ev.Object.(*gwv1.HTTPRoute)
+	if !ok {
+		return
+	}
+	hasOurs, resolved := ourStatus(route)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lastEvent = time.Now()
+
+	prev, seen := w.routes[route.Name]
+	switch {
+	case ev.Type == watch.Deleted:
+		delete(w.routes, route.Name)
+		return
+	case !seen:
+		// first sighting: creation, not a write we attribute to either side
+	case route.Generation != prev.generation:
+		w.specWrites++
+	default:
+		w.routeStatus++
+	}
+	if hasOurs {
+		if started, expected := w.statusExpected[route.Name]; expected {
+			w.statusStaleness = append(w.statusStaleness, time.Since(started))
+			delete(w.statusExpected, route.Name)
+		}
+	}
+	w.routes[route.Name] = routeState{
+		generation:   route.Generation,
+		hasOurStatus: hasOurs,
+		resolvedRefs: resolved,
+	}
+}
+
+func (w *watcher) onGateway(ev watch.Event) {
+	gw, ok := ev.Object.(*gwv1.Gateway)
+	if !ok {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lastEvent = time.Now()
+
+	prev, seen := w.gateways[gw.Name]
+	switch {
+	case ev.Type == watch.Deleted:
+		delete(w.gateways, gw.Name)
+		return
+	case !seen:
+	case gw.Generation != prev:
+		w.specWrites++
+	default:
+		w.gwStatus++
+	}
+	w.gateways[gw.Name] = gw.Generation
+}
+
+// ourStatus reports whether the route carries a parent status entry from our
+// controller, and the value of that entry's ResolvedRefs condition.
+func ourStatus(route *gwv1.HTTPRoute) (bool, string) {
+	for _, p := range route.Status.Parents {
+		if string(p.ControllerName) != controllerName {
+			continue
+		}
+		resolved := ""
+		for _, c := range p.Conditions {
+			if c.Type == string(gwv1.RouteConditionResolvedRefs) {
+				resolved = string(c.Status)
+			}
+		}
+		return true, resolved
+	}
+	return false, ""
+}
+
+func (w *watcher) snapshot() snapshot {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	s := snapshot{
+		routeStatusWrites: w.routeStatus,
+		gwStatusWrites:    w.gwStatus,
+		specWrites:        w.specWrites,
+		resolvedRefs:      make(map[string]string, len(w.routes)),
+		lastEvent:         w.lastEvent,
+	}
+	for name, st := range w.routes {
+		if st.hasOurStatus {
+			s.routesWithOurStatus++
+		}
+		s.resolvedRefs[name] = st.resolvedRefs
+	}
+	return s
+}
+
+// marker records the counters and clocks at the start of a phase.
+type marker struct {
+	wall       time.Time
+	cpu        float64
+	totalAlloc uint64
+	mallocs    uint64
+	snap       snapshot
+}
+
+func (w *watcher) mark() marker {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return marker{
+		wall:       time.Now(),
+		cpu:        cpuSeconds(),
+		totalAlloc: ms.TotalAlloc,
+		mallocs:    ms.Mallocs,
+		snap:       w.snapshot(),
+	}
+}
+
+func (w *watcher) since(m marker) phase {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	now := w.snapshot()
+	return phase{
+		WallSeconds:   time.Since(m.wall).Seconds(),
+		CPUSeconds:    cpuSeconds() - m.cpu,
+		AllocBytes:    ms.TotalAlloc - m.totalAlloc,
+		Mallocs:       ms.Mallocs - m.mallocs,
+		RouteStatuses: now.routeStatusWrites - m.snap.routeStatusWrites,
+		GwStatuses:    now.gwStatusWrites - m.snap.gwStatusWrites,
+		SpecWrites:    now.specWrites - m.snap.specWrites,
+	}
+}
+
+// waitFor blocks until pred holds and no watch event has been seen for quiet.
+func (w *watcher) waitFor(t *testing.T, pred func(snapshot) bool, quiet, timeout time.Duration, what string) {
+	deadline := time.Now().Add(timeout)
+	for {
+		s := w.snapshot()
+		if pred(s) && time.Since(s.lastEvent) >= quiet {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s waiting for %s (routes with status: %d, route status writes: %d)",
+				timeout, what, s.routesWithOurStatus, s.routeStatusWrites)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// waitQuiet blocks until no watch event has been seen for quiet.
+func (w *watcher) waitQuiet(t *testing.T, quiet, timeout time.Duration, what string) {
+	w.waitFor(t, func(snapshot) bool { return true }, quiet, timeout, what)
+}
+
+// waitHeapStable blocks until live heap stops moving, which is the only reliable
+// signal that the control plane has finished reacting. It forces a collection and
+// samples HeapAlloc until several consecutive readings agree within a tolerance.
+//
+// A quiet watch is not sufficient: status writes stop while the translations those
+// writes triggered are still running, and that work produces no watch events. With a
+// short window the measured heap is dominated by whatever is in flight, so the same
+// binary reports wildly different numbers depending on how long the harness waits.
+func waitHeapStable(t *testing.T, cfg config) {
+	samples := make([]uint64, 0, cfg.stableSamples)
+	deadline := time.Now().Add(cfg.timeout)
+	for {
+		runtime.GC()
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+		samples = append(samples, ms.HeapAlloc)
+		if len(samples) > cfg.stableSamples {
+			samples = samples[1:]
+		}
+		if len(samples) == cfg.stableSamples {
+			lo, hi := samples[0], samples[0]
+			for _, s := range samples {
+				lo = min(lo, s)
+				hi = max(hi, s)
+			}
+			if lo > 0 && float64(hi-lo)/float64(lo) <= cfg.stableTolerance {
+				t.Logf("heap stable after %d samples: %s (spread %.1f%%)",
+					cfg.stableSamples, humanBytes(hi), float64(hi-lo)/float64(lo)*100)
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s waiting for live heap to stabilize (last samples: %v)", cfg.timeout, samples)
+		}
+		time.Sleep(cfg.stableInterval)
+	}
+}
+
+func snapshotHeap() memSnapshot {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return memSnapshot{
+		HeapAllocBytes:  ms.HeapAlloc,
+		HeapInuseBytes:  ms.HeapInuse,
+		HeapObjects:     ms.HeapObjects,
+		StackInuseBytes: ms.StackInuse,
+		SysBytes:        ms.Sys,
+		NumGC:           ms.NumGC,
+		Goroutines:      runtime.NumGoroutine(),
+	}
+}
+
+func cpuSeconds() float64 {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0
+	}
+	tv := func(t syscall.Timeval) float64 {
+		return float64(t.Sec) + float64(t.Usec)/1e6
+	}
+	return tv(ru.Utime) + tv(ru.Stime)
+}
+
+// maxRSSBytes returns peak resident set size. ru_maxrss is bytes on darwin and
+// kilobytes on linux.
+func maxRSSBytes() uint64 {
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0
+	}
+	if runtime.GOOS == "darwin" {
+		return uint64(ru.Maxrss)
+	}
+	return uint64(ru.Maxrss) * 1024
+}
+
+func writeHeapProfile(t *testing.T, path string) {
+	// FreeOSMemory forces a GC and returns free pages, so the profile reflects
+	// live data rather than whatever the last GC cycle happened to leave behind.
+	debug.FreeOSMemory()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create heap profile %s: %v", path, err)
+	}
+	defer f.Close()
+	if err := pprof.Lookup("heap").WriteTo(f, 0); err != nil {
+		t.Fatalf("failed to write heap profile: %v", err)
+	}
+	t.Logf("heap profile: %s", path)
+}
+
+func writeResult(t *testing.T, res result) {
+	b, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal result: %v", err)
+	}
+	if err := os.WriteFile(res.ResultFile, b, 0o600); err != nil {
+		t.Fatalf("failed to write result: %v", err)
+	}
+	compact, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("failed to marshal compact result: %v", err)
+	}
+	// A single grep-able line so a driver script can collect runs without parsing
+	// the whole log.
+	fmt.Printf("SCALEPERF_JSON %s\n", compact)
+}
+
+func report(t *testing.T, res result) {
+	t.Logf("=== scale footprint (%s @ %s) ===", res.Config.Label, res.Config.Commit)
+	t.Logf("  gateways=%d routes=%d services=%d gomaxprocs=%d",
+		res.Config.Gateways, res.Config.Routes, res.Config.Services, res.GOMAXPROCS)
+	t.Logf("  live heap:     baseline %s -> steady %s (delta %s)",
+		humanBytes(res.Baseline.HeapAllocBytes), humanBytes(res.Steady.HeapAllocBytes),
+		humanBytes(int64(res.Steady.HeapAllocBytes)-int64(res.Baseline.HeapAllocBytes)))
+	t.Logf("  heap inuse:    %s (secondary allocator-span metric)", humanBytes(res.Steady.HeapInuseBytes))
+	t.Logf("  heap objects:  %d", res.Steady.HeapObjects)
+	t.Logf("  goroutines:    %d", res.Steady.Goroutines)
+	t.Logf("  peak rss:      %s", humanBytes(res.MaxRSSBytes))
+	t.Logf("  total alloc:   %s", humanBytes(res.TotalAllocBytes))
+	t.Logf("  create:        %.2fs wall %.2fs cpu %s alloc",
+		res.Create.WallSeconds, res.Create.CPUSeconds, humanBytes(res.Create.AllocBytes))
+	t.Logf("  settle:        %.2fs wall incl quiet %.2fs cpu %s alloc (%d route status writes, %d gw status writes)",
+		res.Settle.WallSeconds, res.Settle.CPUSeconds, humanBytes(res.Settle.AllocBytes),
+		res.Settle.RouteStatuses, res.Settle.GwStatuses)
+	t.Logf("  idle wait:     %.2fs wall incl stability wait %.2fs cpu %s alloc (work still running after writes stopped)",
+		res.Idle.WallSeconds, res.Idle.CPUSeconds, humanBytes(res.Idle.AllocBytes))
+	t.Logf("  load total:    %.2fs cpu %s alloc (create + settle; wall omitted)",
+		res.Create.CPUSeconds+res.Settle.CPUSeconds,
+		humanBytes(res.Create.AllocBytes+res.Settle.AllocBytes))
+	t.Logf("  status load:   %.2fs wall, %.2f route writes/route, %.1f writes/s, %d conflicts",
+		res.Load.ConvergenceWallSeconds, res.Load.RouteWritesPerRoute, res.Load.WriteQPS, res.Load.Conflicts)
+	t.Logf("  staleness:     p95 %.2fs, max %.2fs (%d watch-observed first statuses)",
+		res.Load.P95StalenessSeconds, res.Load.MaxStalenessSeconds, res.Load.StalenessSamples)
+	t.Logf("  convergence:   %.2fs cpu %s alloc (create + settle + post-write idle)",
+		res.Create.CPUSeconds+res.Settle.CPUSeconds+res.Idle.CPUSeconds,
+		humanBytes(res.Create.AllocBytes+res.Settle.AllocBytes+res.Idle.AllocBytes))
+	t.Logf("  churn neutral: %.2fs wall incl quiet %.2fs cpu %s alloc (%d route status writes, %d gw)",
+		res.ChurnNeutral.WallSeconds, res.ChurnNeutral.CPUSeconds, humanBytes(res.ChurnNeutral.AllocBytes),
+		res.ChurnNeutral.RouteStatuses, res.ChurnNeutral.GwStatuses)
+	t.Logf("  churn status:  %.2fs wall incl quiet %.2fs cpu %s alloc (%d route status writes, %d gw)",
+		res.ChurnStatus.WallSeconds, res.ChurnStatus.CPUSeconds, humanBytes(res.ChurnStatus.AllocBytes),
+		res.ChurnStatus.RouteStatuses, res.ChurnStatus.GwStatuses)
+	t.Logf("  result: %s", res.ResultFile)
+}
+
+func humanBytes[T int64 | uint64](n T) string {
+	f := float64(n)
+	neg := ""
+	if f < 0 {
+		neg, f = "-", -f
+	}
+	switch {
+	case f >= 1<<30:
+		return fmt.Sprintf("%s%.2fGiB", neg, f/(1<<30))
+	case f >= 1<<20:
+		return fmt.Sprintf("%s%.1fMiB", neg, f/(1<<20))
+	case f >= 1<<10:
+		return fmt.Sprintf("%s%.1fKiB", neg, f/(1<<10))
+	default:
+		return fmt.Sprintf("%s%.0fB", neg, f)
+	}
+}
+
+func serviceName(i int) string { return fmt.Sprintf("svc-%d", i) }
+func gatewayName(i int) string { return fmt.Sprintf("gw-%d", i) }
+func routeName(i int) string   { return fmt.Sprintf("route-%05d", i) }
+
+func ptr[T any](v T) *T { return &v }
+
+func forEachConcurrent(parallel, n int, fn func(i int)) {
+	if parallel < 1 {
+		parallel = 1
+	}
+	sem := make(chan struct{}, parallel)
+	var wg sync.WaitGroup
+	for i := range n {
+		sem <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-sem }()
+			fn(i)
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
# Description

**Motivation:** we have no repeatable way to answer "does this branch make the control plane faster or leaner at route scale?". Reviews of status and translation changes have repeatedly turned into arguments about numbers produced by ad hoc scripts that no longer exist, and several such comparisons turned out to be invalid because the two sides ran different measurement code.

**What changed:** adds `test/perf/statusscale`, an in-process control plane benchmark that runs against envtest, plus the `hack/perf` scripts that drive A/B comparisons between two builds. Nothing in the product changes; this PR is tooling only.

`TestScaleFootprint` is gated on `SCALEPERF=1`, so normal test runs skip it. It runs the whole control plane in-process via `envtestutil.RunController`, creates N Gateways / M HTTPRoutes / S Services with self-managed `GatewayParameters` (so the deployer is out of the picture), and measures:

- per-phase CPU (`getrusage`) and allocation across create, settle, post-write idle, and two churn phases
- peak RSS (`ru_maxrss`) and post-GC live heap
- status write counts, write conflicts, write QPS, and per-route write amplification
- status staleness (p95 and max time from object creation to first status)
- a heap profile per run

Two design points worth calling out:

- **Write counts come from an API server proxy, not from control plane metrics.** The harness sits in front of envtest and classifies status subresource writes itself, so the numbers do not depend on either side's instrumentation and stay comparable across branches that changed that instrumentation.
- **The harness only uses APIs that are stable across branches**, so the identical file can be dropped into two worktrees and produce comparable numbers. `hack/perf/status-scale-compare.sh` and `status-scale-sweep.sh` create detached worktrees, copy one snapshot of the harness into both sides, interleave repetitions, pin `GOMAXPROCS`/`GOGC`, and verify the harness hash in every tree before and after the run.

There is also a post-write **idle** phase, which exists because a quiet status watch does not mean the control plane is done: each status write is an informer event that can re-trigger translation, and that translation produces no further writes. Measuring only up to "all statuses written" hides that cost, and per-phase CPU splits at 10k routes are unstable for exactly this reason — the README says to compare summed totals, not individual phases.

# Change Type

/kind test

# Changelog

```release-note
NONE
```

# Additional Notes

- `make test` and `make unit` are unaffected: without `SCALEPERF` the scale test skips, and `probe_test.go` is a fast unit test of the write classifier.
- Verified on a clean checkout of this PR's base commit: `go test ./test/perf/statusscale/...` passes, `go vet -tags e2e` is clean, and a 1000-route run completes in 50s.
- The README documents the methodology traps that invalidated earlier comparisons: snapshot the harness before copying it into either tree, run the sweep from a copy of the script (bash re-reads a running script from disk), use per-run private worktrees, hash the harness in every tree before *and* after, always run the base-vs-base control first to establish a noise floor, and sum `create+settle+idle` rather than quoting one phase.
