### PR TITLE
fix(irtranslator): use only original rule name for source metadata if available

### DIFF
--- a/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/basic.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/basic.yaml
@@ -25,6 +25,10 @@ spec:
     backendRefs:
     - name: example-svc
       port: 80
+  # explicitly unnamed rule
+  - backendRefs:
+      - name: example-svc
+        port: 80
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/basic.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/basic.yaml
@@ -22,13 +22,27 @@ spec:
   - "example.com"
   rules:
   - name: to-backend
+    matches:
+    - path:
+        type: PathPrefix
+        value: /match1
+    - path:
+        type: PathPrefix
+        value: /match2
     backendRefs:
     - name: example-svc
       port: 80
   # explicitly unnamed rule
-  - backendRefs:
-      - name: example-svc
-        port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /match1
+    - path:
+        type: PathPrefix
+        value: /match2
+    backendRefs:
+    - name: example-svc
+      port: 80
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/direct-response.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/direct-response.yaml
@@ -40,3 +40,10 @@ spec:
           name: direct-response
           group: gateway.kgateway.dev
           kind: DirectResponse
+    # explicitly unnamed rule
+    - filters:
+        - type: ExtensionRef
+          extensionRef:
+            name: direct-response
+            group: gateway.kgateway.dev
+            kind: DirectResponse

--- a/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/direct-response.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/route-source-metadata/direct-response.yaml
@@ -34,6 +34,13 @@ spec:
     - "example.com"
   rules:
     - name: direct-response-rule
+      matches:
+        - path:
+            type: PathPrefix
+            value: /match1
+        - path:
+            type: PathPrefix
+            value: /match2
       filters:
       - type: ExtensionRef
         extensionRef:
@@ -41,9 +48,16 @@ spec:
           group: gateway.kgateway.dev
           kind: DirectResponse
     # explicitly unnamed rule
-    - filters:
-        - type: ExtensionRef
-          extensionRef:
-            name: direct-response
-            group: gateway.kgateway.dev
-            kind: DirectResponse
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /match1
+        - path:
+            type: PathPrefix
+            value: /match2
+      filters:
+      - type: ExtensionRef
+        extensionRef:
+          name: direct-response
+          group: gateway.kgateway.dev
+          kind: DirectResponse

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/basic.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/basic.yaml
@@ -54,8 +54,22 @@ Routes:
             kind: HTTPRoute
             name: example-route
             namespace: default
-            rule: httproute-example-route-default-0-0-to-backend
+            rule: to-backend
       name: listener~80~example_com-route-0-httproute-example-route-default-0-0-to-backend-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        prefix: /
+      metadata:
+        filterMetadata:
+          dev.kgateway.route_source:
+            group: gateway.networking.k8s.io
+            kind: HTTPRoute
+            name: example-route
+            namespace: default
+            rule: _rule-1
+      name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/basic.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/basic.yaml
@@ -46,12 +46,13 @@ Routes:
     name: listener~80~example_com
     routes:
     - match:
-        prefix: /
+        pathSeparatedPrefix: /match1
       metadata:
         filterMetadata:
           dev.kgateway.route_source:
             group: gateway.networking.k8s.io
             kind: HTTPRoute
+            match: _match-0
             name: example-route
             namespace: default
             rule: to-backend
@@ -60,16 +61,47 @@ Routes:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
     - match:
-        prefix: /
+        pathSeparatedPrefix: /match2
       metadata:
         filterMetadata:
           dev.kgateway.route_source:
             group: gateway.networking.k8s.io
             kind: HTTPRoute
+            match: _match-1
+            name: example-route
+            namespace: default
+            rule: to-backend
+      name: listener~80~example_com-route-1-httproute-example-route-default-0-1-to-backend-matcher-1
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /match1
+      metadata:
+        filterMetadata:
+          dev.kgateway.route_source:
+            group: gateway.networking.k8s.io
+            kind: HTTPRoute
+            match: _match-0
             name: example-route
             namespace: default
             rule: _rule-1
-      name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
+      name: listener~80~example_com-route-2-httproute-example-route-default-1-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /match2
+      metadata:
+        filterMetadata:
+          dev.kgateway.route_source:
+            group: gateway.networking.k8s.io
+            kind: HTTPRoute
+            match: _match-1
+            name: example-route
+            namespace: default
+            rule: _rule-1
+      name: listener~80~example_com-route-3-httproute-example-route-default-1-1-matcher-1
       route:
         cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/direct-response.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/direct-response.yaml
@@ -42,12 +42,13 @@ Routes:
             Disallow: /direct-response
         status: 510
       match:
-        prefix: /
+        pathSeparatedPrefix: /match1
       metadata:
         filterMetadata:
           dev.kgateway.route_source:
             group: gateway.networking.k8s.io
             kind: HTTPRoute
+            match: _match-0
             name: example
             namespace: default
             rule: direct-response-rule
@@ -59,16 +60,53 @@ Routes:
             Disallow: /direct-response
         status: 510
       match:
-        prefix: /
+        pathSeparatedPrefix: /match2
       metadata:
         filterMetadata:
           dev.kgateway.route_source:
             group: gateway.networking.k8s.io
             kind: HTTPRoute
+            match: _match-1
+            name: example
+            namespace: default
+            rule: direct-response-rule
+      name: listener~8080~example_com-route-1-httproute-example-default-0-1-direct-response-rule-matcher-1
+    - directResponse:
+        body:
+          inlineString: |
+            User-agent: *
+            Disallow: /direct-response
+        status: 510
+      match:
+        pathSeparatedPrefix: /match1
+      metadata:
+        filterMetadata:
+          dev.kgateway.route_source:
+            group: gateway.networking.k8s.io
+            kind: HTTPRoute
+            match: _match-0
             name: example
             namespace: default
             rule: _rule-1
-      name: listener~8080~example_com-route-1-httproute-example-default-1-0-matcher-0
+      name: listener~8080~example_com-route-2-httproute-example-default-1-0-matcher-0
+    - directResponse:
+        body:
+          inlineString: |
+            User-agent: *
+            Disallow: /direct-response
+        status: 510
+      match:
+        pathSeparatedPrefix: /match2
+      metadata:
+        filterMetadata:
+          dev.kgateway.route_source:
+            group: gateway.networking.k8s.io
+            kind: HTTPRoute
+            match: _match-1
+            name: example
+            namespace: default
+            rule: _rule-1
+      name: listener~8080~example_com-route-3-httproute-example-default-1-1-matcher-1
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/direct-response.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-source-metadata/direct-response.yaml
@@ -50,8 +50,25 @@ Routes:
             kind: HTTPRoute
             name: example
             namespace: default
-            rule: httproute-example-default-0-0-direct-response-rule
+            rule: direct-response-rule
       name: listener~8080~example_com-route-0-httproute-example-default-0-0-direct-response-rule-matcher-0
+    - directResponse:
+        body:
+          inlineString: |
+            User-agent: *
+            Disallow: /direct-response
+        status: 510
+      match:
+        prefix: /
+      metadata:
+        filterMetadata:
+          dev.kgateway.route_source:
+            group: gateway.networking.k8s.io
+            kind: HTTPRoute
+            name: example
+            namespace: default
+            rule: _rule-1
+      name: listener~8080~example_com-route-1-httproute-example-default-1-0-matcher-0
 Statuses:
   gateways:
     default/example-gateway:

--- a/pkg/kgateway/translator/httproute/gateway_http_route_translator.go
+++ b/pkg/kgateway/translator/httproute/gateway_http_route_translator.go
@@ -130,6 +130,7 @@ func translateGatewayHTTPRouteRule(
 			ListenerParentRef:    gwroute.ListenerParentRef,
 			ParentRef:            gwroute.ParentRef,
 			Name:                 uniqueRouteName,
+			RuleIndex:            ruleIdx,
 			RuleName:             rule.Name,
 			Backends:             nil,
 			MatchIndex:           idx,

--- a/pkg/kgateway/translator/irtranslator/policy.go
+++ b/pkg/kgateway/translator/irtranslator/policy.go
@@ -151,6 +151,11 @@ func addRouteSourceMetadata(in ir.HttpRouteRuleMatchIR, metadata *envoycorev3.Me
 		// This way, the same field can be used for named and unnamed rules without risk of conflict.
 		fields["rule"] = structpb.NewStringValue(fmt.Sprintf("_rule-%d", in.RuleIndex))
 	}
+	// Gate on unique name being set because default value (0) is a valid index
+	if in.Name != "" {
+		// Use string value so all fields are strings and because struct number type is floating point.
+		fields["match"] = structpb.NewStringValue(fmt.Sprintf("_match-%d", in.MatchIndex))
+	}
 
 	if len(fields) == 0 {
 		return metadata

--- a/pkg/kgateway/translator/irtranslator/policy.go
+++ b/pkg/kgateway/translator/irtranslator/policy.go
@@ -1,6 +1,8 @@
 package irtranslator
 
 import (
+	"fmt"
+
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"google.golang.org/protobuf/types/known/structpb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,8 +144,12 @@ func addRouteSourceMetadata(in ir.HttpRouteRuleMatchIR, metadata *envoycorev3.Me
 	if in.Parent.Namespace != "" {
 		fields["namespace"] = structpb.NewStringValue(in.Parent.Namespace)
 	}
-	if in.Name != "" {
-		fields["rule"] = structpb.NewStringValue(in.Name)
+	if in.RuleName != "" {
+		fields["rule"] = structpb.NewStringValue(in.RuleName)
+	} else if in.Name != "" {
+		// Generate a unique identifier for the rule in the context if its route that is *not* a valid Gateway API section name.
+		// This way, the same field can be used for named and unnamed rules without risk of conflict.
+		fields["rule"] = structpb.NewStringValue(fmt.Sprintf("_rule-%d", in.RuleIndex))
 	}
 
 	if len(fields) == 0 {

--- a/pkg/kgateway/translator/irtranslator/route_test.go
+++ b/pkg/kgateway/translator/irtranslator/route_test.go
@@ -545,6 +545,7 @@ func TestAddRouteSourceMetadata(t *testing.T) {
 				"name":      "test-route",
 				"namespace": "default",
 				"rule":      "test-rule",
+				"match":     "_match-2",
 			},
 		},
 		{
@@ -568,6 +569,7 @@ func TestAddRouteSourceMetadata(t *testing.T) {
 				"name":      "test-route",
 				"namespace": "default",
 				"rule":      "_rule-1",
+				"match":     "_match-2",
 			},
 		},
 		{
@@ -719,6 +721,7 @@ func TestRouteSourceMetadataFlag(t *testing.T) {
 			assert.Equal(t, "my-route", fields["name"].GetStringValue())
 			assert.Equal(t, "default", fields["namespace"].GetStringValue())
 			assert.Equal(t, "_rule-0", fields["rule"].GetStringValue())
+			assert.Equal(t, "_match-0", fields["match"].GetStringValue())
 		})
 	}
 }

--- a/pkg/kgateway/translator/irtranslator/route_test.go
+++ b/pkg/kgateway/translator/irtranslator/route_test.go
@@ -526,7 +526,10 @@ func TestAddRouteSourceMetadata(t *testing.T) {
 		{
 			name: "full metadata",
 			in: ir.HttpRouteRuleMatchIR{
-				Name: "test-rule",
+				RuleIndex:  1,
+				MatchIndex: 2,
+				Name:       "unique-test-rule",
+				RuleName:   "test-rule",
 				Parent: &ir.HttpRouteIR{
 					ObjectSource: ir.ObjectSource{
 						Kind:      "HTTPRoute",
@@ -542,6 +545,29 @@ func TestAddRouteSourceMetadata(t *testing.T) {
 				"name":      "test-route",
 				"namespace": "default",
 				"rule":      "test-rule",
+			},
+		},
+		{
+			name: "missing original rule name",
+			in: ir.HttpRouteRuleMatchIR{
+				RuleIndex:  1,
+				MatchIndex: 2,
+				Name:       "unique-test-rule",
+				Parent: &ir.HttpRouteIR{
+					ObjectSource: ir.ObjectSource{
+						Kind:      "HTTPRoute",
+						Group:     "gateway.networking.k8s.io",
+						Name:      "test-route",
+						Namespace: "default",
+					},
+				},
+			},
+			expected: map[string]string{
+				"kind":      "HTTPRoute",
+				"group":     "gateway.networking.k8s.io",
+				"name":      "test-route",
+				"namespace": "default",
+				"rule":      "_rule-1",
 			},
 		},
 		{
@@ -692,7 +718,7 @@ func TestRouteSourceMetadataFlag(t *testing.T) {
 			assert.Equal(t, "gateway.networking.k8s.io", fields["group"].GetStringValue())
 			assert.Equal(t, "my-route", fields["name"].GetStringValue())
 			assert.Equal(t, "default", fields["namespace"].GetStringValue())
-			assert.Equal(t, "my-rule", fields["rule"].GetStringValue())
+			assert.Equal(t, "_rule-0", fields["rule"].GetStringValue())
 		})
 	}
 }

--- a/pkg/pluginsdk/ir/gw2.go
+++ b/pkg/pluginsdk/ir/gw2.go
@@ -38,6 +38,8 @@ type HttpRouteRuleMatchIR struct {
 	Match      gwv1.HTTPRouteMatch
 	MatchIndex int
 	Name       string
+	// RuleIndex is the position of the route rule in the Gateway API resource's rules slice
+	RuleIndex int
 	// RuleName is the user-authored name of the route rule (Gateway API
 	// rule.name), or empty if the rule is unnamed. Unlike Name, it is not made
 	// unique per match; it is surfaced for user-facing features such as the


### PR DESCRIPTION
# Description

This adjusts the source metadata generation to always use the exact rule name from the original xRoute. In order to keep the information content the same as before, a new `match` field also is added that indicates the index of the match block that originates the Envoy route.

We explicitly use string values and reuse the `rule` field even if there is no rule name specified in order to have all routes generate the same fields. Distinguishing named rules from unnamed ones is achieved by using a `_` prefix for the unnamed value as that is not a valid section and thus rule name in the Gateway API.

The match index is also added as a string value with a similar design for two reasons: It keeps all metadata fields as string values, so consumers do not need to adjust meaningfully, and it keeps the metadata more flexible in case individual match blocks ever can get named akin to rules.

Fixes #14521

# Change Type

```
/kind fix
/kind breaking_change
```

# Changelog

```release-note
Route source metadata now uses exactly the original xRoute's rule name for the `rule` field if available. Otherwise, a generated value that reflects the rule's index in the list of rules is used. Additionally, the originating match's index is added as the `match` field.
```