### PR TITLE
perf: strip unused metadata from Secret and ConfigMap informer caches

### DIFF
--- a/pkg/apiclient/filters.go
+++ b/pkg/apiclient/filters.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 )
 
@@ -19,3 +20,30 @@ import (
 var SecretsFieldSelector = fields.AndSelectors(
 	fields.OneTermNotEqualSelector("type", "helm.sh/release.v1"),
 	fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeServiceAccountToken))).String()
+
+// StripUnusedMetadata is an informer ObjectTransform for Secrets and ConfigMaps.
+// It drops metadata that kgateway never reads but that can dominate the informer
+// cache in clusters with many workloads:
+//
+//   - managedFields. Istio's default transform already strips this, but supplying
+//     an ObjectTransform replaces that default, so we must repeat it here.
+//   - the kubectl.kubernetes.io/last-applied-configuration annotation, which holds
+//     a full serialized copy of the object and therefore roughly doubles the cache
+//     cost of every Secret and ConfigMap managed by `kubectl apply`.
+//
+// This only rewrites the informer's cached copy. kgateway never writes back a
+// Secret or ConfigMap that it read from a cache, so the stripped fields cannot
+// propagate to the API server. A side benefit is that updates touching only these
+// fields no longer produce a krt event, avoiding spurious retranslation.
+func StripUnusedMetadata(obj any) (any, error) {
+	t, ok := obj.(metav1.ObjectMetaAccessor)
+	if !ok {
+		// Tombstones and unexpected types pass through unchanged, matching the
+		// upstream Istio transform.
+		return obj, nil
+	}
+	meta := t.GetObjectMeta()
+	meta.SetManagedFields(nil)
+	delete(meta.GetAnnotations(), corev1.LastAppliedConfigAnnotation)
+	return obj, nil
+}

--- a/pkg/apiclient/filters_test.go
+++ b/pkg/apiclient/filters_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 )
 
@@ -36,4 +37,95 @@ func TestSecretsFieldSelector(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStripUnusedMetadata(t *testing.T) {
+	t.Run("strips managedFields and last-applied-configuration", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ca",
+				Namespace: "app",
+				Annotations: map[string]string{
+					corev1.LastAppliedConfigAnnotation: `{"kind":"ConfigMap","data":{"ca.crt":"..."}}`,
+					"example.com/keep":                 "yes",
+				},
+				Labels:        map[string]string{"example.com/label": "yes"},
+				ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+			},
+			Data: map[string]string{"ca.crt": "..."},
+		}
+
+		out, err := StripUnusedMetadata(cm)
+		if err != nil {
+			t.Fatalf("StripUnusedMetadata: %v", err)
+		}
+		got, ok := out.(*corev1.ConfigMap)
+		if !ok {
+			t.Fatalf("StripUnusedMetadata returned %T, want *corev1.ConfigMap", out)
+		}
+
+		if got.ManagedFields != nil {
+			t.Errorf("managedFields = %v, should be stripped", got.ManagedFields)
+		}
+		if _, present := got.Annotations[corev1.LastAppliedConfigAnnotation]; present {
+			t.Error("last-applied-configuration annotation should be stripped")
+		}
+		if got.Annotations["example.com/keep"] != "yes" {
+			t.Errorf("unrelated annotations should be preserved, got %v", got.Annotations)
+		}
+		if got.Labels["example.com/label"] != "yes" {
+			t.Errorf("labels should be preserved, got %v", got.Labels)
+		}
+		if got.Data["ca.crt"] != "..." {
+			t.Errorf("data should be preserved, got %v", got.Data)
+		}
+		if got.Name != "ca" || got.Namespace != "app" {
+			t.Errorf("identity should be preserved, got %s/%s", got.Namespace, got.Name)
+		}
+	})
+
+	t.Run("secret data is preserved", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "tls",
+				Namespace:   "app",
+				Annotations: map[string]string{corev1.LastAppliedConfigAnnotation: "{}"},
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("key")},
+		}
+
+		out, err := StripUnusedMetadata(secret)
+		if err != nil {
+			t.Fatalf("StripUnusedMetadata: %v", err)
+		}
+		got := out.(*corev1.Secret)
+		if _, present := got.Annotations[corev1.LastAppliedConfigAnnotation]; present {
+			t.Error("last-applied-configuration annotation should be stripped")
+		}
+		if string(got.Data["tls.crt"]) != "cert" || string(got.Data["tls.key"]) != "key" {
+			t.Errorf("secret data should be preserved, got %v", got.Data)
+		}
+		if got.Type != corev1.SecretTypeTLS {
+			t.Errorf("type should be preserved, got %q", got.Type)
+		}
+	})
+
+	t.Run("nil annotations are tolerated", func(t *testing.T) {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "no-annotations"}}
+		if _, err := StripUnusedMetadata(cm); err != nil {
+			t.Fatalf("StripUnusedMetadata: %v", err)
+		}
+	})
+
+	t.Run("non-object types pass through", func(t *testing.T) {
+		tombstone := "not-an-object"
+		out, err := StripUnusedMetadata(tombstone)
+		if err != nil {
+			t.Fatalf("StripUnusedMetadata: %v", err)
+		}
+		if out != tombstone {
+			t.Errorf("StripUnusedMetadata(%v) = %v, want passthrough", tombstone, out)
+		}
+	})
 }

--- a/pkg/kgateway/controller/gw_controller.go
+++ b/pkg/kgateway/controller/gw_controller.go
@@ -31,6 +31,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer"
 	internaldeployer "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/deployer"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
@@ -77,6 +78,14 @@ func NewGatewayReconciler(
 	controllerExtension pluginsdk.GatewayControllerExtension,
 ) *gatewayReconciler {
 	filter := kclient.Filter{ObjectFilter: cfg.Client.ObjectFilter()}
+	// ConfigMaps resolve to the same shared informer as the ConfigMap collection in
+	// pkg/pluginsdk/collections, and whichever registers first supplies the
+	// ObjectTransform. Set it here too so the cache is stripped deterministically
+	// regardless of construction order.
+	configMapFilter := kclient.Filter{
+		ObjectFilter:    cfg.Client.ObjectFilter(),
+		ObjectTransform: apiclient.StripUnusedMetadata,
+	}
 	r := &gatewayReconciler{
 		deployer:            deployer,
 		gwParams:            gwParams,
@@ -90,7 +99,7 @@ func NewGatewayReconciler(
 		svcClient:        kclient.NewFiltered[*corev1.Service](cfg.Client, filter),
 		deploymentClient: kclient.NewFiltered[*appsv1.Deployment](cfg.Client, filter),
 		svcAccountClient: kclient.NewFiltered[*corev1.ServiceAccount](cfg.Client, filter),
-		configMapClient:  kclient.NewFiltered[*corev1.ConfigMap](cfg.Client, filter),
+		configMapClient:  kclient.NewFiltered[*corev1.ConfigMap](cfg.Client, configMapFilter),
 	}
 
 	// Reuse the parameter client from the deployer to avoid duplicate watches.

--- a/pkg/pluginsdk/collections/collections.go
+++ b/pkg/pluginsdk/collections/collections.go
@@ -109,8 +109,9 @@ func NewCommonCollections(
 	secretClient := kclient.NewFiltered[*corev1.Secret](
 		client,
 		kclient.Filter{
-			FieldSelector: apiclient.SecretsFieldSelector,
-			ObjectFilter:  client.ObjectFilter(),
+			FieldSelector:   apiclient.SecretsFieldSelector,
+			ObjectFilter:    client.ObjectFilter(),
+			ObjectTransform: apiclient.StripUnusedMetadata,
 		},
 	)
 	k8sSecretsRaw := krt.WrapClient(secretClient, krt.WithStop(krtOptions.Stop), krt.WithName("Secrets") /* no debug here - we don't want raw secrets printed*/)
@@ -163,7 +164,13 @@ func NewCommonCollections(
 
 	cmClient := kclient.NewFiltered[*corev1.ConfigMap](
 		client,
-		kclient.Filter{ObjectFilter: client.ObjectFilter()},
+		// Keep this Filter in sync with the ConfigMap client in
+		// pkg/kgateway/controller/gw_controller.go: both resolve to the same shared
+		// informer, and whichever registers first supplies the ObjectTransform.
+		kclient.Filter{
+			ObjectFilter:    client.ObjectFilter(),
+			ObjectTransform: apiclient.StripUnusedMetadata,
+		},
 	)
 	cfgmaps := krt.WrapClient(cmClient, krtOptions.ToOptions("ConfigMaps")...)
 


### PR DESCRIPTION
# Description

**Motivation:** Heap profiling of a production deployment in #13786 attributes 543MB of a 722MB heap (75%) to Secrets and ConfigMaps, the vast majority unrelated to any gateway configuration.

While looking at that, one thing worth writing down because it shapes what is even possible here: **`discoveryNamespaceSelectors` does not reduce the informer cache at all.** It is plumbed through `kclient.Filter` as an `ObjectFilter`, and Istio applies `ObjectFilter` only in the client wrapper's `List`/`Get`/event handlers (`kclient/client.go:427-436`). It never reaches the underlying `SharedIndexInformer`. Only `LabelSelector`, `FieldSelector`, `Namespace` and `ObjectTransform` make it into the ListWatch (`kubeclient/common.go:483-495`). So the Secret and ConfigMap informers retain every object in the cluster no matter how discovery namespaces are scoped.

`ObjectTransform` is therefore one of the few levers that reduces what is actually cached today, and it needs no new API surface or user action.

**What changed:** Added `apiclient.StripUnusedMetadata`, an `ObjectTransform` applied to the Secret and ConfigMap informers, which drops:

- `kubectl.kubernetes.io/last-applied-configuration`. This annotation holds a full serialized copy of the object, so it roughly doubles the cache cost of every Secret and ConfigMap managed by `kubectl apply`.
- `managedFields`. Istio's default transform already strips this, but supplying an `ObjectTransform` *replaces* that default, so the transform has to repeat it.

**Why this is safe:**

- Only the informer's cached copy is rewritten. kgateway never writes back a Secret or ConfigMap read from a cache — these are read-only inputs to translation. The deployer does compare against existing objects, but via a live `Dynamic().Get()` (`pkg/deployer/deployer.go:284-285`), not the informer store, and it patches the rendered object rather than the fetched one.
- Nothing in kgateway reads annotations off Secrets or ConfigMaps (only `Data`, plus labels for `GetSecretsBySelector`).
- A side benefit: an update that touches only these fields no longer produces a krt event, so annotation-only churn stops triggering retranslation.

**One subtlety for reviewers:** the ConfigMap collection in `pkg/pluginsdk/collections` and the gateway controller's ConfigMap client resolve to the *same* shared informer (identical `{Type, LabelSelector, FieldSelector}` key), and per the warning at `kclient/client.go:303` whichever registers first supplies the transform. Both call sites set it so the result does not depend on construction order. This is called out in comments at both sites.

**Related:** #13786

# Change Type

/kind cleanup

# Changelog

```release-note
Reduces control plane memory by stripping the kubectl.kubernetes.io/last-applied-configuration annotation and managedFields from cached Secrets and ConfigMaps.
```

# Additional Notes

This is one of three independent, low-risk reductions split out so they can be reviewed separately. The other two are the ConfigMap krt-snapshot fix and additional never-referenced Secret type exclusions.

None of the three is a substitute for the discovery scoping work in #13786 — they reduce the constant factor, not the number of objects watched. They are worth landing first partly to make the follow-up profiling meaningful: the 543MB figure does not separate annotation and `managedFields` overhead from actual `data`, and that ratio determines how much the larger design has left to recover.

Verified with `go build -tags e2e ./...`, package tests for `pkg/apiclient`, `pkg/pluginsdk/collections` and `pkg/kgateway/controller`, and `make analyze` (0 issues), all in a clean worktree.
