### PR TITLE
fix: keep ConfigMap contents out of the krt debug snapshot

### DIFF
--- a/pkg/pluginsdk/collections/collections.go
+++ b/pkg/pluginsdk/collections/collections.go
@@ -165,7 +165,14 @@ func NewCommonCollections(
 		client,
 		kclient.Filter{ObjectFilter: client.ObjectFilter()},
 	)
-	cfgmaps := krt.WrapClient(cmClient, krtOptions.ToOptions("ConfigMaps")...)
+	// No debug here: this collection holds every ConfigMap in the discovered
+	// namespaces and the krt debugger serializes each one in full, data included.
+	// On a large cluster that alone can push /snapshots/krt past 100MB, which both
+	// discloses ConfigMap contents and makes the snapshot impractical for support.
+	// Secrets are withheld for the same reason; ir.Secret additionally redacts Data
+	// in its MarshalJSON, which is why the derived secrets collection stays
+	// registered while this one cannot.
+	cfgmaps := krt.WrapClient(cmClient, krtOptions.ToOptionsNoDebug("ConfigMaps")...)
 
 	gwExts := krtcollections.NewGatewayExtensionsCollection(ctx, client, krtOptions)
 

--- a/pkg/pluginsdk/collections/krt_snapshot_test.go
+++ b/pkg/pluginsdk/collections/krt_snapshot_test.go
@@ -1,0 +1,88 @@
+package collections_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
+	apifake "github.com/kgateway-dev/kgateway/v2/pkg/apiclient/fake"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// TestKrtSnapshotExcludesSecretAndConfigMapContents guards the /snapshots/krt dump
+// against Secret and ConfigMap contents. The krt debugger serializes every object of
+// every registered collection, so a collection holding every object of its type in
+// the discovered namespaces both discloses user data and inflates the snapshot far
+// beyond what is useful for support.
+//
+// Secrets are protected two ways: the raw collection is not registered, and
+// ir.Secret redacts Data in its MarshalJSON. ConfigMaps have no such redaction
+// because the collection holds *corev1.ConfigMap directly, so the collection itself
+// must stay out of the debugger.
+func TestKrtSnapshotExcludesSecretAndConfigMapContents(t *testing.T) {
+	ctx := t.Context()
+
+	const (
+		secretValue    = "s3cret-tls-private-key-material"
+		configMapValue = "configmap-ca-bundle-contents"
+	)
+
+	fakeClient := apifake.NewClient(
+		t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "listener-tls", Namespace: "default"},
+			Type:       corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": []byte(secretValue),
+				"tls.key": []byte(secretValue),
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "ca-bundle", Namespace: "default"},
+			Data:       map[string]string{"ca.crt": configMapValue},
+		},
+	)
+
+	debugger := new(krt.DebugHandler)
+	krtopts := krtutil.NewKrtOptions(ctx.Done(), debugger)
+
+	commoncol, err := collections.NewCommonCollections(
+		ctx,
+		krtopts,
+		fakeClient,
+		wellknown.DefaultGatewayControllerName,
+		apisettings.Settings{},
+	)
+	require.NoError(t, err)
+
+	fakeClient.RunAndWait(ctx.Done())
+
+	require.Eventually(t, func() bool {
+		return commoncol.Secrets.HasSynced() && commoncol.ConfigMaps.HasSynced()
+	}, 5*time.Second, 50*time.Millisecond, "secret and configmap collections should sync")
+
+	// Sanity check: the collections really do hold the objects, so an empty snapshot
+	// below reflects debugger registration rather than an empty cache.
+	require.Eventually(t, func() bool {
+		return len(commoncol.ConfigMaps.Collection().List()) == 1
+	}, 5*time.Second, 50*time.Millisecond, "configmap collection should contain the test configmap")
+
+	dump, err := json.Marshal(debugger)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(dump), secretValue,
+		"krt snapshot must not contain Secret data")
+	require.NotContains(t, string(dump), configMapValue,
+		"krt snapshot must not contain ConfigMap data")
+	require.NotContains(t, string(dump), "ca-bundle",
+		"krt snapshot must not enumerate ConfigMaps")
+}

--- a/pkg/pluginsdk/krtutil/options.go
+++ b/pkg/pluginsdk/krtutil/options.go
@@ -36,3 +36,20 @@ func (k KrtOptions) ToOptions(name string) []krt.CollectionOption {
 		krt.WithStop(k.Stop),
 	}
 }
+
+// ToOptionsNoDebug is ToOptions without registering the collection with the krt
+// debugger, so its contents are excluded from the /snapshots/krt dump.
+//
+// Use this for collections of arbitrary user data. The debugger serializes every
+// object in a registered collection, which both leaks object contents into the
+// snapshot and, for collections that hold every object of a type in the cluster,
+// can inflate the snapshot to a size that makes it useless for debugging.
+func (k KrtOptions) ToOptionsNoDebug(name string) []krt.CollectionOption {
+	if k.namePrefix != "" {
+		name = k.namePrefix + "/" + name
+	}
+	return []krt.CollectionOption{
+		krt.WithName(name),
+		krt.WithStop(k.Stop),
+	}
+}


### PR DESCRIPTION
# Description

**What this is not:** this is not a steady-state memory fix. Registering a collection with the krt debugger costs a slice entry and a closure over a collection that already exists (`krt/debug.go:65-78`) — there is no per-object copy retained. Please don't read this as reducing control plane heap; it doesn't.

**What it is:** the ConfigMap collection holds every ConfigMap in the discovered namespaces and is registered with the krt debugger, which serializes each object in full. So `GET /snapshots/krt` returns the `data` of every ConfigMap in the cluster. Two consequences:

1. **Disclosure.** ConfigMap contents end up in an artifact that gets collected and attached to support tickets. The included test demonstrates the data appearing verbatim in the dump.
2. **A transient allocation spike, and an unusable snapshot.** `writeJSON` marshals the entire payload into one `[]byte` before writing (`admin/server.go:64-71`), so the request allocates roughly twice the payload size at once. On a cluster with tens of thousands of ConfigMaps that is a large spike in a memory-limited control plane, at precisely the moment someone is trying to debug it. The resulting file is also large enough to be awkward to collect and read, which undercuts the point of having the endpoint.

The debugger is on by default — `setup.go:262-264` creates one whenever the caller didn't inject it — so this applies to normal deployments, not just explicitly-enabled debug setups. The admin server binds to `localhost` by default, so reaching the endpoint requires an exec or port-forward.

**What changed:** added `KrtOptions.ToOptionsNoDebug` and used it for the ConfigMap collection.

**Why Secrets are not changed here**, since the asymmetry looks odd otherwise. Secrets are already protected two ways:

1. The raw Secret collection is deliberately not registered (`// no debug here - we don't want raw secrets printed`).
2. The *derived* `secrets` collection of `ir.Secret` **is** registered, but `ir.Secret.MarshalJSON` redacts `Data` (`pkg/pluginsdk/ir/backend.go:442`), so the dump shows name/namespace/kind with `"Data":"[REDACTED]"`.

That redaction hook is what ConfigMaps lack: the collection holds `*corev1.ConfigMap` directly, so there is nowhere to attach a `MarshalJSON` without changing the collection's element type and every consumer of it. Hence dropping the collection from the debugger instead.

# Change Type

/kind fix

# Changelog

```release-note
Excludes ConfigMap contents from the krt debug snapshot, which previously contained the data of every ConfigMap in the discovered namespaces.
```

# Additional Notes

The test asserts against the marshaled `DebugHandler` output rather than internals, so it covers the actual endpoint payload. Confirmed it fails on `main` (`should not contain "configmap-ca-bundle-contents"`) and passes with the fix. It also pins the existing `ir.Secret` redaction, so a future change to that `MarshalJSON` cannot silently start leaking Secret data.

This does cost visibility: operators can no longer see which ConfigMaps kgateway has discovered, which is genuinely useful when debugging "why isn't my CA bundle being picked up". If that is missed, the better fix is a derived collection that dumps ConfigMap keys without values. I'd happily do that instead if reviewers prefer keeping the visibility — it's more code but strictly better than dropping the collection.

Verified with `go build -tags e2e ./...`, `pkg/pluginsdk/...` tests, `make analyze` (0 issues) and `make verify`, all in a clean worktree.
