### PR TITLE
perf: exclude more never-referenced Secret types from the informer cache

### DIFF
--- a/pkg/apiclient/filters.go
+++ b/pkg/apiclient/filters.go
@@ -12,10 +12,28 @@ import (
 // kgateway references Secrets of many types (TLS listener certificates,
 // backend TLS material, the OAuth2 HMAC key, API-key auth secrets selected
 // by TrafficPolicy, and other user-defined types), so a positive type
-// allow-list would be wrong. Instead, we exclude two high-volume types that
-// are never referenced by Gateway API or kgateway CRDs: Helm release storage
-// and ServiceAccount token secrets. In clusters with many workloads these
-// two types typically account for the bulk of Secret memory cost.
+// allow-list would be wrong. Instead, we exclude high-volume types that are
+// never referenced by Gateway API or kgateway CRDs. In clusters with many
+// workloads these typically account for the bulk of Secret memory cost.
+//
+// Excluded types, and why each is safe:
+//   - helm.sh/release.v1: Helm release storage. Never referenced, and large,
+//     since each entry is a gzipped copy of a rendered release.
+//   - kubernetes.io/service-account-token: legacy ServiceAccount tokens. Never
+//     referenced, and present once per ServiceAccount on older clusters.
+//   - kubernetes.io/dockerconfigjson and kubernetes.io/dockercfg: image pull
+//     secrets. GatewayParameters exposes imagePullSecrets, but only as
+//     LocalObjectReferences that are copied into the pod spec by name; kgateway
+//     never reads their contents.
+//   - bootstrap.kubernetes.io/token: node bootstrap tokens in kube-system.
+//     Never referenced.
+//
+// Note that this only narrows what the API server sends us. Excluding a type here
+// means a Secret of that type can never be resolved, so only add types that no
+// kgateway or Gateway API field can reference.
 var SecretsFieldSelector = fields.AndSelectors(
 	fields.OneTermNotEqualSelector("type", "helm.sh/release.v1"),
-	fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeServiceAccountToken))).String()
+	fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeServiceAccountToken)),
+	fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeDockerConfigJson)),
+	fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeDockercfg)),
+	fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeBootstrapToken))).String()

--- a/pkg/apiclient/filters_test.go
+++ b/pkg/apiclient/filters_test.go
@@ -23,8 +23,12 @@ func TestSecretsFieldSelector(t *testing.T) {
 		{"basic auth secret is watched", corev1.SecretTypeBasicAuth, true},
 		{"custom user-defined type is watched", corev1.SecretType("example.com/custom"), true},
 		{"empty type is watched", corev1.SecretType(""), true},
+		{"ssh auth secret is watched", corev1.SecretTypeSSHAuth, true},
 		{"helm release secret is filtered out", corev1.SecretType("helm.sh/release.v1"), false},
 		{"service account token secret is filtered out", corev1.SecretTypeServiceAccountToken, false},
+		{"dockerconfigjson secret is filtered out", corev1.SecretTypeDockerConfigJson, false},
+		{"dockercfg secret is filtered out", corev1.SecretTypeDockercfg, false},
+		{"bootstrap token secret is filtered out", corev1.SecretTypeBootstrapToken, false},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
# Description

**Motivation:** #13875 established the pattern of excluding Secret types that kgateway can never reference via a server-side field selector, which is the cheapest possible reduction: the API server never sends the objects at all. This extends that list.

**What changed:** Extended `SecretsFieldSelector` with three more types, alongside the existing `helm.sh/release.v1` and `kubernetes.io/service-account-token`:

- `kubernetes.io/dockerconfigjson` and `kubernetes.io/dockercfg` — image pull secrets. `GatewayParameters` does expose `imagePullSecrets`, but only as `LocalObjectReference`s that are copied into the pod spec by name (`pkg/kgateway/deployer/gateway_parameters.go:417`); kgateway never reads their contents.
- `bootstrap.kubernetes.io/token` — node bootstrap tokens in `kube-system`. Never referenced.

Also expanded the doc comment to record *why* each exclusion is safe, and to warn that excluding a type here makes Secrets of that type permanently unresolvable — so the list should only grow with types no kgateway or Gateway API field can name.

**Expected magnitude — please calibrate before merging.** This is a small win, smaller than the existing two exclusions. Those recover real bytes per object: a Helm release secret is a gzipped release manifest, often tens to hundreds of KB. An image pull secret is a small JSON blob, roughly 400 bytes of payload and perhaps 1–2KB cached with Go object overhead, so the saving here comes from object *count*, not size. A cluster with a pull secret in each of 1,000 namespaces recovers on the order of 1–2MB. Bootstrap tokens are a handful in `kube-system`. Against the 543MB heap reported in #13786 this is noise; it is worth landing because it is cheap, safe and makes the exclusion list more complete, not because it moves that number.

**Behaviour change, stated precisely.** This is not strictly a no-op. Secrets of these types are in the cache today, so a reference to one resolves today and will stop resolving after this change; the error surfaces as an ordinary "secret not found". No sane configuration is affected — the data shape is wrong for every credential path kgateway supports (`.dockerconfigjson`, not `tls.crt` or `username`/`password`) — but "no sane config breaks" is the accurate claim, not "nothing can break". The one type-agnostic path is `GetSecretsBySelector` for API-key auth, which matches on labels regardless of type, so a labelled image pull secret currently pulled into that set would silently drop out of it.

**Related:** #13786, #13875

# Change Type

/kind cleanup

# Changelog

```release-note
Excludes image pull secrets and node bootstrap tokens from the control plane's Secret cache.
```

# Additional Notes

**No duplicate-watch hazard.** `SecretsFieldSelector` is part of the informer cache key (`{Type, LabelSelector, FieldSelector}`), so changing it matters only if some other Secret client shares that key. There are exactly two Secret informers, and they already differ: this one, and `pkg/kgateway/bootstrap/controller.go:46`, which uses `metadata.name=<hmac-secret>` plus a `Namespace` and is a single-object watch. So there is no second call site to keep in sync and no unfiltered Secret watch elsewhere that would nullify the narrowing. Worth stating explicitly because the sibling project hit exactly this: agentgateway/agentgateway#1383 had to fix a duplicate ConfigMap watch caused by two call sites filtering differently.

**Nothing in the repo depends on these types** — no Go code, test, or e2e manifest references dockerconfigjson, dockercfg or bootstrap tokens.

**Deliberately conservative.** I did not exclude `kubernetes.io/basic-auth` or `kubernetes.io/ssh-auth`: basic-auth is plausibly referenced by TrafficPolicy basic auth, and there is no volume argument for either. The test asserts both directions, including that TLS, Opaque, basic-auth, ssh-auth, empty and custom user-defined types stay watched.

**Known rough edge:** if someone does hit an excluded type, the "secret not found" error is indistinguishable from a typo or a missing ReferenceGrant, and nothing logs that a field selector excluded it. That is already true of the two existing exclusions; this widens the surface slightly. Happy to add a startup log line listing the excluded types if reviewers think the debuggability is worth it.

One finding worth recording separately, because it constrains the design in #13786: **`discoveryNamespaceSelectors` does not reduce the informer cache at all.** It is plumbed as a `kclient.Filter.ObjectFilter`, which Istio applies only in the client wrapper's `List`/`Get`/event handlers (`kclient/client.go:427-436`); it never reaches the underlying `SharedIndexInformer`. Only `LabelSelector`, `FieldSelector`, `Namespace` and `ObjectTransform` make it into the ListWatch (`kubeclient/common.go:483-495`). A server-side field selector like this one is therefore one of the few levers that actually shrinks the cache today, which is also why any proposal whose reduction comes from client-side filtering will not deliver one.

Verified with `go build -tags e2e ./...`, `pkg/apiclient` and `pkg/pluginsdk/collections` tests, `make analyze` (0 issues) and `make verify`, all in a clean worktree. CI is green (30 pass, 2 skipping).
