### PR TITLE
perf(memory): fetch only referenced Secrets and ConfigMaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,14 @@ See `/devel/architecture/overview.md` and the translation diagram at `/devel/arc
 - **pkg/krtcollections/**: KRT collections for core resources
 - **test/e2e/**: End-to-end tests using custom framework (see test/e2e/README.md)
 
+### Secret and ConfigMap access
+Secrets and ConfigMaps are watched **metadata-only** cluster-wide; only objects the
+configuration references have their contents fetched. Reading one that no `ResourceRef`
+points at fails as if it did not exist, so a new read needs a matching ref (see
+`pluginsdk.Plugin.ContributesResourceRefs`). Ref collections must derive from *raw*
+client collections, never from IR collections that resolve Secrets, or startup deadlocks.
+Full details: `/devel/architecture/secret-configmap-caching.md`.
+
 ### Plugin System
 kgateway translates Kubernetes Gateway API resources into Envoy configuration. Plugins *contribute* to that translation, usually by adding a new CRD (most commonly a Policy CRD) that users create to express their desired configuration. Policy CRDs attach to Gateway API resources via `targetRefs` or `targetSelectors`; kgateway manages the attachment during translation.
 

--- a/devel/architecture/overview.md
+++ b/devel/architecture/overview.md
@@ -155,3 +155,10 @@ needed.
 # Diagram of the translation lifecycle
 
 ![](translation.svg)
+
+# Secret and ConfigMap access
+
+Secrets and ConfigMaps are not held in memory in full. kgateway watches them
+cluster-wide with a metadata-only informer and fetches the contents of only
+those objects the configuration references, so reading one requires declaring a
+reference to it. See [secret-configmap-caching.md](secret-configmap-caching.md).

--- a/devel/architecture/secret-configmap-caching.md
+++ b/devel/architecture/secret-configmap-caching.md
@@ -87,6 +87,13 @@ is how `TrafficPolicy`'s API-key `secretSelector` works. Labels are present on
 `PartialObjectMetadata`, so the selector is evaluated against the metadata watch
 and never needs to read a payload to decide what to fetch.
 
+Selector membership moves in both directions, and both are handled: an object
+that gains a matching label is fetched, and one that loses it is evicted. That
+means any metadata event re-expands the selectors while a selector ref exists,
+which is why the cache skips that work entirely when there are none. A broad
+selector still pulls in every matching object cluster-wide, so it benefits less
+from this design than a reference by name does.
+
 ## Consequences worth knowing
 
 - **`NotLoadedError` vs `NotFoundError`.** A lookup that misses is reported as

--- a/devel/architecture/secret-configmap-caching.md
+++ b/devel/architecture/secret-configmap-caching.md
@@ -1,0 +1,114 @@
+# Secret and ConfigMap caching
+
+kgateway does **not** keep every Secret and ConfigMap in memory. It watches them
+cluster-wide with a metadata-only informer and fetches the full contents of only
+those objects its configuration actually references.
+
+If you are adding code that reads a Secret or ConfigMap, skip to
+[Adding a new reference](#adding-a-new-reference). Everything else is background.
+
+## Why
+
+A typed informer stores the whole object, including `data`. kgateway needs the
+contents of a handful of them — listener certificates, CA bundles, auth
+credentials — but a cluster can easily hold thousands of large ConfigMaps that
+kgateway never looks at. Caching all of them dominated the control plane's heap
+for no benefit ([#13786](https://github.com/kgateway-dev/kgateway/issues/13786)).
+
+A `PartialObjectMetadata` is a few hundred bytes no matter how large the object
+is, so the cluster-wide view stays cheap while the expensive part shrinks to the
+referenced set.
+
+## How
+
+Three pieces, all in `pkg/krtcollections/ondemand`:
+
+1. **A metadata-only watch** (`kclient.NewMetadata`) over every Secret and
+   ConfigMap. It answers two questions and nothing else: does this object exist,
+   and has it changed. An `ObjectTransform` strips annotations and managed
+   fields, because `kubectl.kubernetes.io/last-applied-configuration` holds a
+   full copy of the object and would defeat the point.
+
+2. **A reference set**, a KRT collection of `ondemand.ResourceRef` derived from
+   the CRDs that name Secrets and ConfigMaps. Core Gateway API references come
+   from `krtcollections.GatewayResourceRefs`; plugins contribute theirs through
+   `pluginsdk.Plugin.ContributesResourceRefs`.
+
+3. **A fetcher** that reconciles the two. For each referenced object it issues a
+   direct `Get` and publishes the result into a `krt.StaticCollection` that
+   downstream collections consume exactly as they would an informer-backed one.
+   `SecretIndex` and `ConfigMapIndex` are unchanged; their backing collection is
+   simply smaller.
+
+The metadata watch is what makes this work without polling. `resourceVersion`
+changes on every write, so a metadata event tells the fetcher precisely when a
+referenced object needs re-reading — the same event stream a typed informer
+would have used, minus the payload for the objects nobody asked for.
+
+```
+  metadata watch (all objects, no payload) ──┐
+                                             ├──> fetcher ──> StaticCollection ──> SecretIndex
+  ResourceRef collection (what we need)   ───┘                 (referenced only)
+```
+
+## Adding a new reference
+
+Reading a Secret or ConfigMap that no `ResourceRef` points at fails exactly as
+if the object did not exist. So a new read needs two changes:
+
+1. The read itself, via `SecretIndex` / `ConfigMapIndex` as before.
+2. A `ResourceRef` covering it, contributed from your plugin's
+   `ContributesResourceRefs`, or added to the core derivation if it comes from a
+   Gateway API field.
+
+`TestEveryObjectReaderHasAReferenceSource` in `pkg/pluginsdk/collections` is a
+tripwire for step 2: it fails when a file reads object contents without being
+listed as covered. It cannot verify that your ref matches the object you read,
+so still check that yourself.
+
+### The one rule that will bite you
+
+**Reference collections must derive only from raw resource collections, never
+from a collection that resolves Secrets.**
+
+Deriving refs from, say, a plugin's translated policy collection creates a
+cycle: the Secret cache waits for the refs to sync, and the refs wait for the
+policy IR, which waits for the Secret cache. Startup deadlocks.
+
+In practice this means hanging your ref collection off the `krt.WrapClient`
+collection, not the `krt.NewCollection`/`krt.NewStatusCollection` derived from
+it. `GatewayResourceRefs` uses the raw `*gwv1.Gateway` collection rather than
+`GatewayIndex.Gateways` for exactly this reason — the index attaches policies.
+
+### Label selectors
+
+A ref may select by label instead of by name (`ondemand.NewSelectorRef`), which
+is how `TrafficPolicy`'s API-key `secretSelector` works. Labels are present on
+`PartialObjectMetadata`, so the selector is evaluated against the metadata watch
+and never needs to read a payload to decide what to fetch.
+
+## Consequences worth knowing
+
+- **`NotLoadedError` vs `NotFoundError`.** A lookup that misses is reported as
+  `NotFoundError` only when the metadata watch confirms the object really is
+  absent. If the object exists but its contents are not loaded, the lookup
+  returns `NotLoadedError` instead. Momentarily that is normal — a reference was
+  just declared and the fetch has not landed. Persistently it means a ref site is
+  missing, i.e. a bug in the derivation rather than in the user's config.
+
+- **Startup ordering.** The caches report unsynced until the initial referenced
+  set has been fetched, so nothing translates against a half-populated
+  collection. `CommonCollections.HasSynced` covers this.
+
+- **RBAC.** The controller needs `get` on Secrets and ConfigMaps in addition to
+  `list` and `watch`.
+
+- **The gateway controller's ConfigMap watch** (`gw_controller.go`) is a separate,
+  typed informer used only to re-reconcile a Gateway when a child object drifts.
+  It is restricted by label selector to objects kgateway deployed; without that
+  restriction it would keep a full copy of every ConfigMap and negate the saving
+  described here.
+
+- **Tests.** Istio's fake client gives the metadata client its own empty tracker,
+  and client-go's fake tracker never sets `resourceVersion`. `pkg/apiclient/fake`
+  fixes both so tests exercise the real code path; see `metadata.go` there.

--- a/pkg/apiclient/fake/fake.go
+++ b/pkg/apiclient/fake/fake.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/pkg/consts"
 
@@ -81,6 +82,14 @@ func (c *cli) Core() kube.Client {
 
 func fakeIstioClient(objects ...client.Object) kube.Client {
 	c := kube.NewFakeClient(testutils.ToRuntimeObjects(objects...)...)
+
+	// Serve metadata-client reads from the typed tracker so that metadata-only
+	// watches (the on-demand Secret/ConfigMap caches) see the test's fixtures.
+	if typed, ok := c.Kube().(*kubefake.Clientset); ok {
+		wireMetadataReadThrough(c.Metadata(), typed)
+		wireResourceVersions(typed)
+	}
+
 	// Also add to the Dynamic store
 	for _, obj := range objects {
 		nn := kubeutils.NamespacedNameFrom(obj)

--- a/pkg/apiclient/fake/metadata.go
+++ b/pkg/apiclient/fake/metadata.go
@@ -1,0 +1,245 @@
+package fake
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+
+	"istio.io/istio/pkg/config/schema/gvr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/metadata"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// wireMetadataReadThrough makes the fake metadata client serve reads from the
+// typed fake client's object tracker.
+//
+// Istio's fake kube.Client gives the metadata client its own, empty
+// ObjectTracker, unrelated to the typed one and never seeded with the test's
+// objects. Any code that watches a resource with kclient.NewMetadata -- as the
+// on-demand Secret and ConfigMap caches do -- would therefore see an empty
+// cluster in tests while the typed clients see the real fixtures.
+//
+// Rather than mirroring writes (which would drift on patches and race on
+// timing), delegate reads: get, list and watch on the metadata client are
+// answered from the typed tracker and converted to PartialObjectMetadata. That
+// is exactly what a real API server does, so tests exercise the production code
+// path with no special-casing.
+func wireMetadataReadThrough(metadataClient metadata.Interface, typed *kubefake.Clientset) {
+	tracker := typed.Tracker()
+	fake, ok := metadataClient.(*metadatafake.FakeMetadataClient)
+	if !ok {
+		panic(fmt.Sprintf("unexpected fake metadata client type %T", metadataClient))
+	}
+
+	// Only intercept resources the typed clientset actually holds. Istio runs its
+	// own metadata watch over CustomResourceDefinitions, which live in the
+	// apiextensions tracker; answering that from the kube tracker would report an
+	// empty cluster and stall every CRD-gated informer.
+	handled := func(action clienttesting.Action) bool {
+		switch action.GetResource() {
+		case gvr.Secret, gvr.ConfigMap:
+			return true
+		default:
+			return false
+		}
+	}
+
+	fake.PrependReactor("get", "*", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if !handled(action) {
+			return false, nil, nil
+		}
+		get := action.(clienttesting.GetAction)
+		obj, err := tracker.Get(action.GetResource(), action.GetNamespace(), get.GetName())
+		if err != nil {
+			return true, nil, err
+		}
+		md, err := toPartialObjectMetadata(obj)
+		if err != nil {
+			return true, nil, err
+		}
+		return true, md, nil
+	})
+
+	fake.PrependReactor("list", "*", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if !handled(action) {
+			return false, nil, nil
+		}
+		gvr := action.GetResource()
+		objs, err := tracker.List(gvr, listKindFor(gvr), action.GetNamespace())
+		if err != nil {
+			return true, nil, err
+		}
+		items, err := meta.ExtractList(objs)
+		if err != nil {
+			return true, nil, err
+		}
+
+		// metadataResourceClient.List expects a *metav1.List of
+		// *metav1.PartialObjectMetadata and applies the label selector itself.
+		out := &metav1.List{}
+		for _, item := range items {
+			md, err := toPartialObjectMetadata(item)
+			if err != nil {
+				return true, nil, err
+			}
+			out.Items = append(out.Items, runtime.RawExtension{Object: md})
+		}
+		if lm, err := meta.ListAccessor(objs); err == nil {
+			out.ResourceVersion = lm.GetResourceVersion()
+		}
+		return true, out, nil
+	})
+
+	fake.PrependWatchReactor("*", func(action clienttesting.Action) (bool, watch.Interface, error) {
+		if !handled(action) {
+			return false, nil, nil
+		}
+		w, err := tracker.Watch(action.GetResource(), action.GetNamespace())
+		if err != nil {
+			return true, nil, err
+		}
+		return true, newMetadataWatch(w), nil
+	})
+}
+
+// listKindFor returns the item kind the tracker expects for a resource. The
+// tracker appends "List" itself when building the returned list object, so this
+// must be the singular kind.
+func listKindFor(gvr schema.GroupVersionResource) schema.GroupVersionKind {
+	return gvr.GroupVersion().WithKind(kindForResource(gvr.Resource))
+}
+
+func kindForResource(resource string) string {
+	switch resource {
+	case "secrets":
+		return "Secret"
+	case "configmaps":
+		return "ConfigMap"
+	default:
+		// Fall back to a naive singularisation; only used if a new resource gains
+		// a metadata watch without updating this switch.
+		if len(resource) > 1 && resource[len(resource)-1] == 's' {
+			r := []rune(resource)
+			r[0] = []rune(string(r[0]))[0] - 32
+			return string(r[:len(r)-1])
+		}
+		return resource
+	}
+}
+
+func toPartialObjectMetadata(obj runtime.Object) (*metav1.PartialObjectMetadata, error) {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{Kind: "PartialObjectMetadata", APIVersion: "meta.k8s.io/v1"},
+		ObjectMeta: *(&metav1.ObjectMeta{
+			Name:            acc.GetName(),
+			Namespace:       acc.GetNamespace(),
+			UID:             acc.GetUID(),
+			ResourceVersion: acc.GetResourceVersion(),
+			Labels:          acc.GetLabels(),
+			Annotations:     acc.GetAnnotations(),
+			Generation:      acc.GetGeneration(),
+		}).DeepCopy(),
+	}, nil
+}
+
+// metadataWatch converts a typed watch stream into a PartialObjectMetadata one.
+type metadataWatch struct {
+	inner watch.Interface
+	out   chan watch.Event
+	stop  chan struct{}
+}
+
+func newMetadataWatch(inner watch.Interface) watch.Interface {
+	w := &metadataWatch{
+		inner: inner,
+		out:   make(chan watch.Event),
+		stop:  make(chan struct{}),
+	}
+	go w.run()
+	return w
+}
+
+func (w *metadataWatch) run() {
+	defer close(w.out)
+	for {
+		select {
+		case <-w.stop:
+			return
+		case ev, ok := <-w.inner.ResultChan():
+			if !ok {
+				return
+			}
+			if ev.Object != nil {
+				md, err := toPartialObjectMetadata(ev.Object)
+				if err == nil {
+					ev.Object = md
+				}
+			}
+			select {
+			case w.out <- ev:
+			case <-w.stop:
+				return
+			}
+		}
+	}
+}
+
+func (w *metadataWatch) Stop() {
+	select {
+	case <-w.stop:
+	default:
+		close(w.stop)
+	}
+	w.inner.Stop()
+}
+
+func (w *metadataWatch) ResultChan() <-chan watch.Event { return w.out }
+
+// wireResourceVersions makes the typed fake client assign a fresh
+// resourceVersion on every write to a Secret or ConfigMap.
+//
+// client-go's ObjectTracker leaves resourceVersion empty and never bumps it. A
+// real API server changes it on every write, and the on-demand caches rely on
+// exactly that: a metadata event whose resourceVersion is unchanged means the
+// object's contents are unchanged and no re-fetch is needed. Without this, an
+// update to a Secret in a test would be invisible to anything reading through
+// the cache, which is a silent wrong answer rather than a visible failure.
+//
+// Scoped to the two resources the caches watch, to avoid perturbing tests that
+// make assertions about other objects.
+func wireResourceVersions(typed *kubefake.Clientset) {
+	var counter atomic.Int64
+
+	bump := func(action clienttesting.Action) (bool, runtime.Object, error) {
+		switch action.GetResource() {
+		case gvr.Secret, gvr.ConfigMap:
+		default:
+			return false, nil, nil
+		}
+		obj, ok := action.(interface{ GetObject() runtime.Object })
+		if !ok {
+			return false, nil, nil
+		}
+		acc, err := meta.Accessor(obj.GetObject())
+		if err != nil {
+			return false, nil, nil
+		}
+		acc.SetResourceVersion(strconv.FormatInt(counter.Add(1), 10))
+		// Fall through so the tracker stores the object we just stamped.
+		return false, nil, nil
+	}
+
+	typed.PrependReactor("create", "*", bump)
+	typed.PrependReactor("update", "*", bump)
+}

--- a/pkg/apiclient/fake/metadata_test.go
+++ b/pkg/apiclient/fake/metadata_test.go
@@ -1,0 +1,85 @@
+package fake
+
+import (
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/config/schema/gvr"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/kclient/clienttest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestMetadataReadThrough covers the fake-client plumbing the on-demand
+// Secret/ConfigMap caches depend on: a metadata-only watch must observe the same
+// objects the typed clients do, both for fixtures and for live writes.
+func TestMetadataReadThrough(t *testing.T) {
+	fixture := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fixture",
+			Namespace: "ns",
+			Labels:    map[string]string{"team": "infra"},
+		},
+		Data: map[string][]byte{"tls.crt": []byte("cert")},
+	}
+
+	c := NewClient(t, []client.Object{fixture}...)
+	md := kclient.NewMetadata(c, gvr.Secret, kclient.Filter{})
+
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	c.RunAndWait(stop)
+
+	got := md.List("", labels.Everything())
+	if len(got) != 1 {
+		t.Fatalf("metadata watch should see the fixture Secret, got %d objects", len(got))
+	}
+	if got[0].Name != "fixture" || got[0].Namespace != "ns" {
+		t.Fatalf("unexpected object %s/%s", got[0].Namespace, got[0].Name)
+	}
+	if got[0].Labels["team"] != "infra" {
+		t.Fatal("labels must survive the metadata conversion, selector refs depend on them")
+	}
+
+	// Objects created after the client is running must show up too, otherwise
+	// tests that mutate Secrets mid-run would silently diverge.
+	secrets := clienttest.NewWriter[*corev1.Secret](t, c)
+	secrets.Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "later", Namespace: "ns"},
+		Data:       map[string][]byte{"k": []byte("v")},
+	})
+
+	assertEventually(t, func() bool {
+		return md.Get("later", "ns") != nil
+	}, "metadata watch should observe a Secret created after start")
+
+	// And deletions must propagate, so the cache can drop the object.
+	secrets.Delete("later", "ns")
+	assertEventually(t, func() bool {
+		return md.Get("later", "ns") == nil
+	}, "metadata watch should observe the delete")
+
+	// A metadata object carries no payload; that is the whole point.
+	if fixture.Data == nil {
+		t.Fatal("fixture should still have data")
+	}
+	if _, ok := any(md.Get("fixture", "ns")).(*corev1.Secret); ok {
+		t.Fatal("metadata watch must not yield typed Secrets")
+	}
+}
+
+// assertEventually polls cond until it holds or the deadline passes.
+func assertEventually(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}

--- a/pkg/kgateway/controller/gw_controller.go
+++ b/pkg/kgateway/controller/gw_controller.go
@@ -230,10 +230,17 @@ func NewGatewayReconciler(
 // pkg/krtcollections/ondemand exist to avoid -- and would negate that saving
 // entirely. Every object the deployer renders carries the gateway-name label,
 // so selecting on its presence is both server-side and complete.
+// ownedConfigMapSelector matches objects the deployer rendered. It selects on
+// the presence of the gateway-name label rather than on a value: the label is
+// set unconditionally by the Helm templates and cannot be overridden by a user's
+// gatewayLabels, whereas app.kubernetes.io/managed-by carries a configurable
+// value (see Deployer.managedBy) and would be fragile to match on.
+const ownedConfigMapSelector = wellknown.GatewayNameLabel
+
 func ownedConfigMapFilter(client kube.Client) kclient.Filter {
 	return kclient.Filter{
 		ObjectFilter:  client.ObjectFilter(),
-		LabelSelector: wellknown.GatewayNameLabel,
+		LabelSelector: ownedConfigMapSelector,
 	}
 }
 

--- a/pkg/kgateway/controller/gw_controller.go
+++ b/pkg/kgateway/controller/gw_controller.go
@@ -90,7 +90,7 @@ func NewGatewayReconciler(
 		svcClient:        kclient.NewFiltered[*corev1.Service](cfg.Client, filter),
 		deploymentClient: kclient.NewFiltered[*appsv1.Deployment](cfg.Client, filter),
 		svcAccountClient: kclient.NewFiltered[*corev1.ServiceAccount](cfg.Client, filter),
-		configMapClient:  kclient.NewFiltered[*corev1.ConfigMap](cfg.Client, filter),
+		configMapClient:  kclient.NewFiltered[*corev1.ConfigMap](cfg.Client, ownedConfigMapFilter(cfg.Client)),
 	}
 
 	// Reuse the parameter client from the deployer to avoid duplicate watches.
@@ -218,6 +218,23 @@ func NewGatewayReconciler(
 	r.setupTLSCertificateWatch(cfg.CertWatcher)
 
 	return r
+}
+
+// ownedConfigMapFilter restricts the ConfigMap watch to objects kgateway
+// deployed itself.
+//
+// This client exists only to re-reconcile a Gateway when one of its child
+// objects drifts, so it never needs to see a user's ConfigMaps. Without the
+// selector it would keep a full typed copy of every ConfigMap in the cluster,
+// which is exactly the cost the metadata-only Secret/ConfigMap caches in
+// pkg/krtcollections/ondemand exist to avoid -- and would negate that saving
+// entirely. Every object the deployer renders carries the gateway-name label,
+// so selecting on its presence is both server-side and complete.
+func ownedConfigMapFilter(client kube.Client) kclient.Filter {
+	return kclient.Filter{
+		ObjectFilter:  client.ObjectFilter(),
+		LabelSelector: wellknown.GatewayNameLabel,
+	}
 }
 
 // NeedLeaderElection returns true to ensure that the Gateway reconciler runs only on the leader

--- a/pkg/kgateway/controller/owned_configmap_filter_test.go
+++ b/pkg/kgateway/controller/owned_configmap_filter_test.go
@@ -1,0 +1,92 @@
+package controller
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+)
+
+// The Gateway reconciler watches ConfigMaps only to re-reconcile a Gateway when
+// one of its child objects drifts, so ownedConfigMapFilter restricts that watch
+// by label to objects the deployer rendered. Without the restriction the watch
+// keeps a full typed copy of every ConfigMap in the cluster, which would cancel
+// out the metadata-only cache in pkg/krtcollections/ondemand.
+//
+// The restriction is only safe while every rendered ConfigMap actually carries
+// the label, which couples this filter to the Helm templates in
+// pkg/kgateway/helm/envoy.
+//
+// Editing a template is already caught directly by TestRenderHelmChart, which
+// diffs against these same goldens. This test guards the next step: someone
+// regenerating the goldens to accept a label change would otherwise silently
+// blind this watch, leaving drift unreconciled with nothing failing. It reads
+// the goldens rather than rendering the chart, so it is that second link, not a
+// replacement for the first.
+func TestOwnedConfigMapFilterMatchesEveryRenderedConfigMap(t *testing.T) {
+	root := repoRootForTest(t)
+	goldens, err := filepath.Glob(filepath.Join(root, "test", "deployer", "testdata", "*-out.yaml"))
+	if err != nil {
+		t.Fatalf("globbing deployer goldens: %v", err)
+	}
+	if len(goldens) == 0 {
+		t.Fatal("found no deployer goldens; this test is no longer checking anything")
+	}
+
+	selector := ownedConfigMapSelector
+	if selector != wellknown.GatewayNameLabel {
+		t.Fatalf("filter selects on %q; update this test to match", selector)
+	}
+
+	kindLine := regexp.MustCompile(`(?m)^kind: ConfigMap$`)
+	nameLine := regexp.MustCompile(`(?m)^\s+name: (\S+)`)
+
+	total := 0
+	for _, path := range goldens {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		for doc := range strings.SplitSeq(string(body), "\n---\n") {
+			if !kindLine.MatchString(doc) {
+				continue
+			}
+			total++
+			if strings.Contains(doc, selector+":") {
+				continue
+			}
+			name := "<unknown>"
+			if m := nameLine.FindStringSubmatch(doc); m != nil {
+				name = m[1]
+			}
+			t.Errorf("%s: rendered ConfigMap %q has no %s label, so the Gateway "+
+				"reconciler's watch would not see it and drift on it would go unreconciled",
+				filepath.Base(path), name, selector)
+		}
+	}
+	if total == 0 {
+		t.Fatal("deployer goldens contain no ConfigMaps; this test is no longer checking anything")
+	}
+	t.Logf("checked %d rendered ConfigMaps", total)
+}
+
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate repo root")
+		}
+		dir = parent
+	}
+}

--- a/pkg/kgateway/extensions2/plugins/backend/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backend/plugin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
@@ -144,6 +145,9 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 			},
 		},
 		ExtraHasSynced: ec2Endpoints.HasSynced,
+		ContributesResourceRefs: []krt.Collection[ondemand.ResourceRef]{
+			resourceRefs(col, commoncol.KrtOpts),
+		},
 	}
 }
 

--- a/pkg/kgateway/extensions2/plugins/backend/resource_refs.go
+++ b/pkg/kgateway/extensions2/plugins/backend/resource_refs.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// resourceRefs declares the AWS credential Secrets a Backend reads. Derived
+// from the raw Backend collection; see the ondemand package for why it must not
+// come from the translated one.
+func resourceRefs(
+	backends krt.Collection[*kgateway.Backend],
+	opts krtutil.KrtOptions,
+) krt.Collection[ondemand.ResourceRef] {
+	return krt.NewManyCollection(backends, func(kctx krt.HandlerContext, b *kgateway.Backend) []ondemand.ResourceRef {
+		aws := b.Spec.Aws
+		if aws == nil || aws.Auth == nil ||
+			aws.Auth.Type != kgateway.AwsAuthTypeSecret || aws.Auth.SecretRef == nil {
+			return nil
+		}
+		// loadAWSSecret resolves in the Backend's own namespace.
+		return []ondemand.ResourceRef{
+			ondemand.NewRef("Backend/"+b.Namespace+"/"+b.Name, wellknown.SecretKind, b.Namespace, aws.Auth.SecretRef.Name),
+		}
+	}, opts.ToOptions("BackendResourceRefs")...)
+}

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
@@ -218,6 +219,9 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, v 
 				GetPolicyStatus:   getPolicyStatusFn(cli),
 				PatchPolicyStatus: patchPolicyStatusFn(cli),
 			},
+		},
+		ContributesResourceRefs: []krt.Collection[ondemand.ResourceRef]{
+			resourceRefs(col, commoncol.KrtOpts),
 		},
 	}
 }

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/resource_refs.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/resource_refs.go
@@ -1,0 +1,30 @@
+package backendconfigpolicy
+
+import (
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// resourceRefs declares the client-certificate Secrets BackendConfigPolicy
+// reads for upstream TLS. Derived from the raw policy collection; see the
+// ondemand package for why it must not come from the translated one.
+func resourceRefs(
+	policies krt.Collection[*kgateway.BackendConfigPolicy],
+	opts krtutil.KrtOptions,
+) krt.Collection[ondemand.ResourceRef] {
+	return krt.NewManyCollection(policies, func(kctx krt.HandlerContext, p *kgateway.BackendConfigPolicy) []ondemand.ResourceRef {
+		tls := p.Spec.TLS
+		if tls == nil || tls.SecretRef == nil {
+			return nil
+		}
+		src := "BackendConfigPolicy/" + p.Namespace + "/" + p.Name
+		// SecretRef is a LocalObjectReference, resolved in the policy's namespace.
+		return []ondemand.ResourceRef{
+			ondemand.NewRef(src, wellknown.SecretKind, p.Namespace, tls.SecretRef.Name),
+		}
+	}, opts.ToOptions("BackendConfigPolicyResourceRefs")...)
+}

--- a/pkg/kgateway/extensions2/plugins/backendtlspolicy/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backendtlspolicy/plugin.go
@@ -27,10 +27,12 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	kgwellknown "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	pluginutils "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
@@ -159,7 +161,36 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 				PolicyStatusFromGatewayReports:  true,
 			},
 		},
+		ContributesResourceRefs: []krt.Collection[ondemand.ResourceRef]{
+			resourceRefs(col, commoncol.KrtOpts),
+		},
 	}
+}
+
+// resourceRefs declares the CA bundles BackendTLSPolicy reads. Derived from the
+// raw policy collection, never from the translated one, which reads the caches
+// these refs feed.
+func resourceRefs(
+	policies krt.Collection[*gwv1.BackendTLSPolicy],
+	opts krtutil.KrtOptions,
+) krt.Collection[ondemand.ResourceRef] {
+	return krt.NewManyCollection(policies, func(kctx krt.HandlerContext, p *gwv1.BackendTLSPolicy) []ondemand.ResourceRef {
+		src := "BackendTLSPolicy/" + p.Namespace + "/" + p.Name
+		refs := make([]ondemand.ResourceRef, 0, len(p.Spec.Validation.CACertificateRefs))
+		for _, certRef := range p.Spec.Validation.CACertificateRefs {
+			// Defaults to ConfigMap, matching buildTranslateFunc.
+			kind := kgwellknown.ConfigMapKind
+			if certRef.Kind != "" {
+				kind = string(certRef.Kind)
+			}
+			if kind != kgwellknown.ConfigMapKind && kind != kgwellknown.SecretKind {
+				continue
+			}
+			// CACertificateRefs are LocalObjectReferences: always same-namespace.
+			refs = append(refs, ondemand.NewRef(src, kind, p.Namespace, string(certRef.Name)))
+		}
+		return ondemand.Dedupe(refs)
+	}, opts.ToOptions("BackendTLSPolicyResourceRefs")...)
 }
 
 func processBackend(ctx context.Context, polir ir.PolicyIR, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) {

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	kgwwellknown "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
@@ -314,6 +315,9 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 					return policy.MergePolicies(pols, MergePolicies, "" /*no merge settings*/)
 				},
 			},
+		},
+		ContributesResourceRefs: []krt.Collection[ondemand.ResourceRef]{
+			resourceRefs(col, commoncol.KrtOpts),
 		},
 	}
 }

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/resource_refs.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/resource_refs.go
@@ -1,0 +1,79 @@
+package listenerpolicy
+
+import (
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/pluginutils"
+	kgwwellknown "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// resourceRefs declares what ListenerPolicy reads: secret-backed local-reply
+// headers, and the CA bundles used for client certificate validation.
+//
+// The CA bundles are resolved during Gateway listener translation rather than
+// in this plugin's IR, but they originate here, so this is where the reference
+// is declared.
+//
+// Derived from the raw policy collection to keep the Secret and ConfigMap
+// caches free of any dependency on collections that read them.
+func resourceRefs(
+	policies krt.Collection[*kgateway.ListenerPolicy],
+	opts krtutil.KrtOptions,
+) krt.Collection[ondemand.ResourceRef] {
+	return krt.NewManyCollection(policies, func(kctx krt.HandlerContext, p *kgateway.ListenerPolicy) []ondemand.ResourceRef {
+		src := "ListenerPolicy/" + p.Namespace + "/" + p.Name
+		var refs []ondemand.ResourceRef
+
+		// Listener config appears once as the default and again per port; both
+		// carry local-reply headers, so collect from every occurrence.
+		if d := p.Spec.Default; d != nil {
+			refs = append(refs, localReplyRefs(src, p.Namespace, &d.ListenerConfig)...)
+			// Client certificate validation is default-only today.
+			refs = append(refs, caCertRefs(src, p.Namespace, d.ClientCertificateValidation)...)
+		}
+		for i := range p.Spec.PerPort {
+			refs = append(refs, localReplyRefs(src, p.Namespace, &p.Spec.PerPort[i].Listener)...)
+		}
+
+		return ondemand.Dedupe(refs)
+	}, opts.ToOptions("ListenerPolicyResourceRefs")...)
+}
+
+// localReplyRefs collects the Secrets backing local-reply header values.
+func localReplyRefs(source, namespace string, cfg *kgateway.ListenerConfig) []ondemand.ResourceRef {
+	if cfg == nil || cfg.HTTPSettings == nil || cfg.HTTPSettings.LocalReplies == nil {
+		return nil
+	}
+	var refs []ondemand.ResourceRef
+	for _, m := range cfg.HTTPSettings.LocalReplies.Mappers {
+		refs = append(refs, pluginutils.HeaderFilterResourceRefs(source, namespace, m.Headers)...)
+	}
+	return refs
+}
+
+// caCertRefs collects the CA bundles used for client certificate validation.
+// They may be ConfigMaps or Secrets; other kinds are rejected in translation.
+func caCertRefs(source, namespace string, cv *kgateway.ClientCertificateValidationConfig) []ondemand.ResourceRef {
+	if cv == nil {
+		return nil
+	}
+	refs := make([]ondemand.ResourceRef, 0, len(cv.CACertificateRefs))
+	for _, ref := range cv.CACertificateRefs {
+		if string(ref.Group) != "" {
+			continue
+		}
+		kind := string(ref.Kind)
+		if kind != kgwwellknown.ConfigMapKind && kind != kgwwellknown.SecretKind {
+			continue
+		}
+		ns := namespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		refs = append(refs, ondemand.NewRef(source, kind, ns, string(ref.Name)))
+	}
+	return refs
+}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/resource_refs.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/resource_refs.go
@@ -1,0 +1,62 @@
+package trafficpolicy
+
+import (
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/pluginutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// resourceRefs declares the Secrets TrafficPolicy reads: API-key credentials
+// (by name or by label selector), basic-auth htpasswd files, and secret-backed
+// header values.
+//
+// It derives from the raw TrafficPolicy collection. Deriving from policyCol
+// would deadlock: that collection resolves Secrets, and the Secret cache waits
+// on these refs before it will serve any.
+func resourceRefs(
+	policies krt.Collection[*kgateway.TrafficPolicy],
+	opts krtutil.KrtOptions,
+) krt.Collection[ondemand.ResourceRef] {
+	return krt.NewManyCollection(policies, func(kctx krt.HandlerContext, p *kgateway.TrafficPolicy) []ondemand.ResourceRef {
+		src := "TrafficPolicy/" + p.Namespace + "/" + p.Name
+		var refs []ondemand.ResourceRef
+
+		// spec.apiKeyAuth: either one named Secret or a label selector. Selector
+		// refs are expanded against the metadata watch, which carries labels.
+		if ak := p.Spec.APIKeyAuth; ak != nil && ak.Disable == nil {
+			switch {
+			case ak.SecretRef != nil:
+				ns := p.Namespace
+				if ak.SecretRef.Namespace != nil {
+					ns = string(*ak.SecretRef.Namespace)
+				}
+				refs = append(refs, ondemand.NewRef(src, wellknown.SecretKind, ns, string(ak.SecretRef.Name)))
+			case ak.SecretSelector != nil:
+				// GetSecretsBySelector searches every namespace and filters by
+				// ReferenceGrant afterwards, so the ref must be cluster-wide too.
+				refs = append(refs, ondemand.NewSelectorRef(src, wellknown.SecretKind, "", ak.SecretSelector.MatchLabels))
+			}
+		}
+
+		// spec.basicAuth.secretRef
+		if ba := p.Spec.BasicAuth; ba != nil && ba.SecretRef != nil {
+			ns := p.Namespace
+			if ba.SecretRef.Namespace != nil {
+				ns = string(*ba.SecretRef.Namespace)
+			}
+			refs = append(refs, ondemand.NewRef(src, wellknown.SecretKind, ns, string(ba.SecretRef.Name)))
+		}
+
+		// spec.headerModifiers.{request,response}
+		if hm := p.Spec.HeaderModifiers; hm != nil {
+			refs = append(refs, pluginutils.HeaderFilterResourceRefs(src, p.Namespace, hm.Request)...)
+			refs = append(refs, pluginutils.HeaderFilterResourceRefs(src, p.Namespace, hm.Response)...)
+		}
+
+		return ondemand.Dedupe(refs)
+	}, opts.ToOptions("TrafficPolicyResourceRefs")...)
+}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
@@ -360,6 +361,9 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, me
 			},
 		},
 		ExtraHasSynced: constructor.HasSynced,
+		ContributesResourceRefs: []krt.Collection[ondemand.ResourceRef]{
+			resourceRefs(col, commoncol.KrtOpts),
+		},
 	}
 }
 

--- a/pkg/kgateway/extensions2/pluginutils/headers.go
+++ b/pkg/kgateway/extensions2/pluginutils/headers.go
@@ -12,7 +12,9 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	sharedv1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 )
 
 var (
@@ -188,4 +190,30 @@ func ConvertMutationsToOptions(mutations []*mutation_rulesv3.HeaderMutation) (op
 	}
 
 	return options, nil
+}
+
+// HeaderFilterResourceRefs returns the Secrets a header filter reads.
+//
+// It must stay in step with resolveHeader: kgateway only loads the contents of
+// Secrets some ref points at, so a value this misses is a Secret the resolver
+// will fail to find.
+func HeaderFilterResourceRefs(
+	source, defaultNamespace string,
+	filter *sharedv1alpha1.HTTPHeaderFilter,
+) []ondemand.ResourceRef {
+	if filter == nil {
+		return nil
+	}
+	var refs []ondemand.ResourceRef
+	for _, h := range slices.Concat(filter.Add, filter.Set) {
+		if h.SecretRef == nil {
+			continue
+		}
+		ns := defaultNamespace
+		if h.SecretRef.Namespace != nil {
+			ns = string(*h.SecretRef.Namespace)
+		}
+		refs = append(refs, ondemand.NewRef(source, wellknown.SecretKind, ns, string(h.SecretRef.Name)))
+	}
+	return refs
 }

--- a/pkg/kgateway/extensions2/registry/registry.go
+++ b/pkg/kgateway/extensions2/registry/registry.go
@@ -66,6 +66,7 @@ func MergePlugins(plug ...sdk.Plugin) sdk.Plugin {
 		if p.ExtraHasSynced != nil {
 			hasSynced = append(hasSynced, p.ExtraHasSynced)
 		}
+		ret.ContributesResourceRefs = append(ret.ContributesResourceRefs, p.ContributesResourceRefs...)
 	}
 	ret.ContributesGwTranslator = mergedGw(funcs)
 	ret.ExtraHasSynced = mergeSynced(hasSynced)

--- a/pkg/krtcollections/configmaps.go
+++ b/pkg/krtcollections/configmaps.go
@@ -12,10 +12,20 @@ import (
 type ConfigMapIndex struct {
 	configmaps krt.Collection[*corev1.ConfigMap]
 	refgrants  *RefGrantIndex
+	// exists reports whether an object is present in the cluster at all, from the
+	// metadata-only watch. See SecretIndex.exists.
+	exists func(namespace, name string) bool
 }
 
 func NewConfigMapIndex(configmaps krt.Collection[*corev1.ConfigMap], refgrants *RefGrantIndex) *ConfigMapIndex {
 	return &ConfigMapIndex{configmaps: configmaps, refgrants: refgrants}
+}
+
+// WithExistenceCheck attaches the cluster-wide existence probe described on the
+// exists field.
+func (c *ConfigMapIndex) WithExistenceCheck(exists func(namespace, name string) bool) *ConfigMapIndex {
+	c.exists = exists
+	return c
 }
 
 func (c *ConfigMapIndex) HasSynced() bool {
@@ -55,6 +65,9 @@ func (c *ConfigMapIndex) GetConfigMap(kctx krt.HandlerContext, from From, config
 	}
 	cmPtr := krt.FetchOne(kctx, c.configmaps, krt.FilterObjectName(nn))
 	if cmPtr == nil {
+		if c.exists != nil && c.exists(toNs, string(configMapRef.Name)) {
+			return nil, &NotLoadedError{Obj: to}
+		}
 		return nil, &NotFoundError{NotFoundObj: to}
 	}
 

--- a/pkg/krtcollections/gateway_extensions.go
+++ b/pkg/krtcollections/gateway_extensions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	pluginsdkutils "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/utils"
@@ -20,7 +21,7 @@ func NewGatewayExtensionsCollection(
 	ctx context.Context,
 	client apiclient.Client,
 	krtOpts krtutil.KrtOptions,
-) krt.Collection[ir.GatewayExtension] {
+) (krt.Collection[ir.GatewayExtension], krt.Collection[*kgateway.GatewayExtension]) {
 	rawGwExts := krt.WrapClient(kclient.NewFilteredDelayed[*kgateway.GatewayExtension](
 		client,
 		wellknown.GatewayExtensionGVR,
@@ -47,5 +48,44 @@ func NewGatewayExtensionsCollection(
 		}
 		return gwExt
 	})
-	return gwExtCol
+	return gwExtCol, rawGwExts
+}
+
+// GatewayExtensionResourceRefs declares the Secrets and ConfigMaps that
+// GatewayExtension-backed policies read: OAuth2 client credentials, the OAuth2
+// HMAC signing key, and locally-stored JWKS.
+//
+// Derived from the raw GatewayExtension collection. The resolution itself lives
+// in the trafficpolicy plugin, but the references are visible from the CRD
+// alone, and deriving them here keeps the Secret cache independent of any
+// collection that reads it.
+func GatewayExtensionResourceRefs(
+	rawGwExts krt.Collection[*kgateway.GatewayExtension],
+	krtOpts krtutil.KrtOptions,
+) krt.Collection[ondemand.ResourceRef] {
+	return krt.NewManyCollection(rawGwExts, func(krtctx krt.HandlerContext, cr *kgateway.GatewayExtension) []ondemand.ResourceRef {
+		src := "GatewayExtension/" + cr.Namespace + "/" + cr.Name
+		var refs []ondemand.ResourceRef
+
+		if o := cr.Spec.OAuth2; o != nil {
+			// Client secret is a LocalObjectReference: same namespace as the
+			// GatewayExtension.
+			refs = append(refs, ondemand.NewRef(src, wellknown.SecretKind, cr.Namespace,
+				o.Credentials.ClientSecretRef.Name))
+			// Every OAuth2 provider also reads the shared HMAC key, which the
+			// bootstrap controller creates at a fixed location.
+			refs = append(refs, ondemand.NewRef(src, wellknown.SecretKind,
+				wellknown.OAuth2HMACSecret.Namespace, wellknown.OAuth2HMACSecret.Name))
+		}
+
+		if j := cr.Spec.JWT; j != nil {
+			for _, p := range j.Providers {
+				if l := p.JWKS.LocalJWKS; l != nil && l.ConfigMapRef != nil {
+					refs = append(refs, ondemand.NewRef(src, wellknown.ConfigMapKind, cr.Namespace, l.ConfigMapRef.Name))
+				}
+			}
+		}
+
+		return ondemand.Dedupe(refs)
+	}, krtOpts.ToOptions("GatewayExtensionResourceRefs")...)
 }

--- a/pkg/krtcollections/ondemand/cache.go
+++ b/pkg/krtcollections/ondemand/cache.go
@@ -260,11 +260,11 @@ func (c *Cache[T]) onMetadataEvent(o controllers.Event) {
 
 	if referenced {
 		c.queue.Add(key)
-		return
 	}
-	// An object we do not currently reference can still enter the referenced set
-	// by gaining a label that matches a selector ref. Only pay for that check
-	// when a selector ref actually exists.
+	// Selector membership moves in both directions: an object we do not reference
+	// can gain a matching label, and one we do reference can lose it. Re-expand on
+	// either, or a Secret that stopped matching would stay cached forever. Only
+	// pay for this when a selector ref actually exists, which is uncommon.
 	if hasSelectors {
 		c.queue.Add(recomputeKey)
 	}

--- a/pkg/krtcollections/ondemand/cache.go
+++ b/pkg/krtcollections/ondemand/cache.go
@@ -1,0 +1,481 @@
+package ondemand
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/controllers"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+var logger = logging.New("krtcollections/ondemand")
+
+// initialFetchConcurrency bounds how many full Gets run in parallel while
+// populating the cache for the first time. The referenced set is normally small;
+// this only matters for the pathological case of a cluster with thousands of
+// referenced Secrets, where we would rather take a few extra seconds to start
+// than hammer the API server.
+const initialFetchConcurrency = 16
+
+// Getter fetches the full contents of a single object.
+type Getter[T controllers.ComparableObject] func(ctx context.Context, namespace, name string) (T, error)
+
+// Cache maintains full copies of exactly those objects that some ResourceRef
+// points at, backed by a cluster-wide metadata-only watch.
+//
+// See the package comment for the rationale.
+type Cache[T controllers.ComparableObject] struct {
+	name   string
+	kind   string
+	getter Getter[T]
+
+	// metaClient is the cluster-wide PartialObjectMetadata watch. It answers
+	// "does this object exist" and "has it changed", and backs label-selector
+	// ref expansion.
+	metaClient kclient.Informer[*metav1.PartialObjectMetadata]
+
+	// out holds the full objects. Downstream KRT collections consume this and
+	// cannot tell it apart from an informer-backed collection.
+	out krt.StaticCollection[T]
+
+	queue controllers.Queue
+
+	mu sync.RWMutex
+	// named holds targets of refs that name a single object.
+	named sets.Set[types.NamespacedName]
+	// selectors holds the currently active label-selector refs. Kept separate
+	// because they force a re-expansion whenever any object's labels change,
+	// which we want to skip entirely in the common case of no selector refs.
+	selectors []ResourceRef
+	// selected holds the current expansion of selectors. Tracked apart from
+	// named so that a shrinking selector match can retract its keys without
+	// disturbing keys a named ref still wants.
+	selected sets.Set[types.NamespacedName]
+	// fetched records the resourceVersion of each object currently published in
+	// out, so a metadata event for an unchanged object costs nothing.
+	fetched map[types.NamespacedName]string
+
+	// ctx is captured in SetRefs so the queue reconciler, whose signature is
+	// fixed by controllers.Queue, can cancel in-flight Gets on shutdown.
+	ctx context.Context
+
+	syncedCh   chan struct{}
+	syncedOnce sync.Once
+	// refsOnce guards SetRefs, which may only be called once.
+	refsOnce sync.Once
+
+	// recomputeMu serializes whole recomputations of the desired set. mu alone is
+	// not enough: computing the next set reads the metadata watch outside the
+	// lock, so two concurrent recomputations could each compute a set and then
+	// swap in whichever finishes last, losing the other's result until the next
+	// event happens to arrive.
+	recomputeMu sync.Mutex
+}
+
+// Config configures a Cache.
+type Config[T controllers.ComparableObject] struct {
+	// Name is used for the KRT collection name and logging, e.g. "Secrets".
+	Name string
+	// Kind is the object kind refs must use to select this cache, e.g. "Secret".
+	Kind string
+	// GVR is the resource to watch.
+	GVR schema.GroupVersionResource
+	// Filter is applied to the metadata watch. Server-side selectors here reduce
+	// what we watch at all and are strongly preferred.
+	Filter kclient.Filter
+	// Getter fetches the full object. It bypasses the metadata watch and reads
+	// straight from the API server.
+	Getter Getter[T]
+}
+
+// New builds a Cache and starts its reconciler. The returned Cache publishes an
+// empty, unsynced collection until SetRefs is called and the initial set of
+// referenced objects has been fetched.
+func New[T controllers.ComparableObject](
+	ctx context.Context,
+	client kube.Client,
+	krtOpts krtutil.KrtOptions,
+	cfg Config[T],
+) *Cache[T] {
+	filter := cfg.Filter
+	if filter.ObjectTransform == nil {
+		filter.ObjectTransform = stripMetadata
+	}
+
+	c := &Cache[T]{
+		name:       cfg.Name,
+		kind:       cfg.Kind,
+		getter:     cfg.Getter,
+		metaClient: kclient.NewMetadata(client, cfg.GVR, filter),
+		named:      sets.New[types.NamespacedName](),
+		selected:   sets.New[types.NamespacedName](),
+		fetched:    map[types.NamespacedName]string{},
+		syncedCh:   make(chan struct{}),
+	}
+
+	// The output collection reports unsynced until the initial referenced set has
+	// been fetched, so dependent collections do not observe a half-populated
+	// cache and translate against missing Secrets on startup.
+	c.out = krt.NewStaticCollection[T](
+		channelSyncer{name: cfg.Name, ch: c.syncedCh},
+		nil,
+		krtOpts.ToOptions(cfg.Name)...,
+	)
+
+	c.queue = controllers.NewQueue(
+		"ondemand/"+cfg.Name,
+		controllers.WithReconciler(c.reconcile),
+		controllers.WithMaxAttempts(maxFetchAttempts),
+		controllers.WithRateLimiter(workqueue.NewTypedItemExponentialFailureRateLimiter[any](
+			50*time.Millisecond, 10*time.Second)),
+	)
+
+	// Register before the initial snapshot so nothing that happens during the
+	// initial fetch is lost; the queue buffers adds until Run.
+	c.metaClient.AddEventHandler(controllers.FromEventHandler(c.onMetadataEvent))
+
+	return c
+}
+
+// maxFetchAttempts bounds retries of a failing Get. A referenced object we
+// cannot read is reported as absent, which surfaces to the user as a normal
+// "not found" status on the referencing policy.
+const maxFetchAttempts = 10
+
+// Collection returns the collection of full objects. It only ever contains
+// objects that some ResourceRef points at.
+func (c *Cache[T]) Collection() krt.Collection[T] {
+	return c.out
+}
+
+// HasSynced reports whether the initial referenced set has been fetched.
+func (c *Cache[T]) HasSynced() bool {
+	select {
+	case <-c.syncedCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// Exists reports whether the object exists in the cluster at all, according to
+// the metadata watch. An object may exist and still be absent from Collection,
+// which means no ResourceRef declared a dependency on it.
+func (c *Cache[T]) Exists(namespace, name string) bool {
+	return c.metaClient.Get(name, namespace) != nil
+}
+
+// SetRefs attaches the collection of references that drives what this cache
+// fetches, and starts the reconciler. It may be called at most once.
+//
+// refs must be derived only from raw resource collections. Deriving it from a
+// collection that itself reads this cache would create a dependency cycle that
+// deadlocks startup: the cache would wait for refs to sync, while refs waited
+// for the cache.
+func (c *Cache[T]) SetRefs(ctx context.Context, refs krt.Collection[ResourceRef]) {
+	started := false
+	c.refsOnce.Do(func() {
+		started = true
+		c.ctx = ctx
+		refs.RegisterBatch(func(events []krt.Event[ResourceRef]) {
+			c.onRefsChanged(refs)
+		}, false)
+		go c.run(ctx, refs)
+	})
+	if !started {
+		panic(fmt.Sprintf("ondemand: SetRefs called twice for %s", c.name))
+	}
+}
+
+// run performs the initial population and then services incremental updates.
+func (c *Cache[T]) run(ctx context.Context, refs krt.Collection[ResourceRef]) {
+	if !kube.WaitForCacheSync("ondemand/"+c.name, ctx.Done(), c.metaClient.HasSynced, refs.HasSynced) {
+		return
+	}
+
+	// Snapshot the referenced set and fetch it all before declaring the
+	// collection synced, mirroring an informer's initial LIST.
+	c.onRefsChanged(refs)
+	initial := c.desiredSnapshot().UnsortedList()
+
+	c.fetchAll(initial)
+
+	logger.Info("on-demand cache populated",
+		"kind", c.kind, "referenced", len(initial))
+	c.markSynced()
+
+	c.queue.Run(ctx.Done())
+	c.metaClient.ShutdownHandlers()
+}
+
+// fetchAll populates keys with bounded parallelism.
+func (c *Cache[T]) fetchAll(keys []types.NamespacedName) {
+	sem := make(chan struct{}, initialFetchConcurrency)
+	var wg sync.WaitGroup
+	for _, key := range keys {
+		wg.Go(func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			if err := c.reconcile(key); err != nil {
+				// Requeue for the retry loop rather than blocking startup on a
+				// transient API error.
+				logger.Warn("initial fetch failed, will retry",
+					"kind", c.kind, "object", key.String(), "error", err)
+				c.queue.Add(key)
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func (c *Cache[T]) markSynced() {
+	c.syncedOnce.Do(func() { close(c.syncedCh) })
+}
+
+// onMetadataEvent handles a change to any object in the cluster. Objects nobody
+// references are dropped here, which is what keeps the cluster-wide watch cheap
+// in CPU as well as memory.
+func (c *Cache[T]) onMetadataEvent(o controllers.Event) {
+	obj := o.Latest()
+	key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+
+	c.mu.RLock()
+	referenced := c.named.Has(key) || c.selected.Has(key)
+	hasSelectors := len(c.selectors) > 0
+	c.mu.RUnlock()
+
+	if referenced {
+		c.queue.Add(key)
+		return
+	}
+	// An object we do not currently reference can still enter the referenced set
+	// by gaining a label that matches a selector ref. Only pay for that check
+	// when a selector ref actually exists.
+	if hasSelectors {
+		c.queue.Add(recomputeKey)
+	}
+}
+
+// recomputeKey is a sentinel queue item that triggers re-expansion of
+// label-selector refs. Object names cannot collide with it because it has an
+// empty name.
+var recomputeKey = types.NamespacedName{Namespace: "", Name: ""}
+
+// desiredSnapshot returns the union of named and selector-derived targets.
+func (c *Cache[T]) desiredSnapshot() sets.Set[types.NamespacedName] {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.named.Union(c.selected)
+}
+
+// onRefsChanged recomputes the desired set from the current refs and enqueues
+// everything that entered or left it.
+func (c *Cache[T]) onRefsChanged(refs krt.Collection[ResourceRef]) {
+	c.recomputeMu.Lock()
+	defer c.recomputeMu.Unlock()
+
+	named := sets.New[types.NamespacedName]()
+	selected := sets.New[types.NamespacedName]()
+	var selectors []ResourceRef
+
+	for _, ref := range refs.List() {
+		if ref.Kind != c.kind {
+			continue
+		}
+		if !ref.isSelector() {
+			named.Insert(ref.target())
+			continue
+		}
+		selectors = append(selectors, ref)
+		selected.Insert(c.expandSelector(ref)...)
+	}
+
+	c.mu.Lock()
+	prev := c.named.Union(c.selected)
+	c.named = named
+	c.selected = selected
+	c.selectors = selectors
+	next := named.Union(selected)
+	c.mu.Unlock()
+
+	c.enqueueDiff(prev, next)
+}
+
+// enqueueDiff queues every key whose membership in the desired set changed.
+func (c *Cache[T]) enqueueDiff(prev, next sets.Set[types.NamespacedName]) {
+	added := next.Difference(prev)
+	removed := prev.Difference(next)
+	if added.Len() == 0 && removed.Len() == 0 {
+		return
+	}
+	logger.Debug("referenced set changed",
+		"kind", c.kind, "added", added.Len(), "removed", removed.Len(), "total", next.Len())
+	for key := range added {
+		c.queue.Add(key)
+	}
+	for key := range removed {
+		c.queue.Add(key)
+	}
+}
+
+// expandSelector resolves a label-selector ref against the metadata watch.
+// Labels are present on PartialObjectMetadata, so this needs no payload.
+func (c *Cache[T]) expandSelector(ref ResourceRef) []types.NamespacedName {
+	sel := klabels.SelectorFromSet(ref.MatchLabels)
+	matched := c.metaClient.List(ref.Namespace, sel)
+	out := make([]types.NamespacedName, 0, len(matched))
+	for _, m := range matched {
+		out = append(out, types.NamespacedName{Namespace: m.GetNamespace(), Name: m.GetName()})
+	}
+	return out
+}
+
+// reconcile brings a single object's cached contents in line with the desired
+// set and the metadata watch.
+func (c *Cache[T]) reconcile(key types.NamespacedName) error {
+	if key == recomputeKey {
+		c.recomputeSelectors()
+		return nil
+	}
+
+	c.mu.RLock()
+	wanted := c.named.Has(key) || c.selected.Has(key)
+	have, isCached := c.fetched[key]
+	c.mu.RUnlock()
+
+	if !wanted {
+		if isCached {
+			c.drop(key)
+		}
+		return nil
+	}
+
+	md := c.metaClient.Get(key.Name, key.Namespace)
+	if md == nil {
+		// The object does not exist (or is excluded by the watch filter). Absence
+		// from the collection is how downstream reports "not found".
+		if isCached {
+			c.drop(key)
+		}
+		return nil
+	}
+	if isCached && have == md.GetResourceVersion() {
+		return nil
+	}
+
+	obj, err := c.getter(c.ctx, key.Namespace, key.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Raced with a delete; the metadata watch will catch up.
+			if isCached {
+				c.drop(key)
+			}
+			return nil
+		}
+		return fmt.Errorf("fetching %s %s: %w", c.kind, key, err)
+	}
+
+	c.mu.Lock()
+	// Re-check under the lock: the ref may have been withdrawn while the Get was
+	// in flight, in which case publishing would leak the object into the cache.
+	if !c.named.Has(key) && !c.selected.Has(key) {
+		c.mu.Unlock()
+		return nil
+	}
+	c.fetched[key] = obj.GetResourceVersion()
+	c.mu.Unlock()
+
+	c.out.UpdateObject(obj)
+	return nil
+}
+
+func (c *Cache[T]) drop(key types.NamespacedName) {
+	c.mu.Lock()
+	delete(c.fetched, key)
+	c.mu.Unlock()
+	c.out.DeleteObject(key.String())
+}
+
+// recomputeSelectors re-expands label-selector refs after a label change
+// somewhere in the cluster. Named refs are untouched: only the selector-derived
+// half of the desired set can move as a result of a label change.
+func (c *Cache[T]) recomputeSelectors() {
+	c.recomputeMu.Lock()
+	defer c.recomputeMu.Unlock()
+
+	c.mu.RLock()
+	selectors := c.selectors
+	c.mu.RUnlock()
+	if len(selectors) == 0 {
+		return
+	}
+
+	selected := sets.New[types.NamespacedName]()
+	for _, ref := range selectors {
+		selected.Insert(c.expandSelector(ref)...)
+	}
+
+	c.mu.Lock()
+	prev := c.named.Union(c.selected)
+	c.selected = selected
+	next := c.named.Union(selected)
+	c.mu.Unlock()
+
+	c.enqueueDiff(prev, next)
+}
+
+// stripMetadata is the informer transform for the metadata watch. It discards
+// everything we never read, which matters because annotations can carry a full
+// copy of the object (kubectl's last-applied-configuration) and would defeat the
+// point of watching metadata only. Labels are kept: label-selector refs are
+// resolved against this cache.
+func stripMetadata(obj any) (any, error) {
+	md, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		// Tombstones and unexpected types pass through untouched.
+		return obj, nil
+	}
+	md.ManagedFields = nil
+	md.Annotations = nil
+	md.Finalizers = nil
+	md.OwnerReferences = nil
+	return md, nil
+}
+
+// channelSyncer adapts a close-once channel to krt.Syncer.
+type channelSyncer struct {
+	name string
+	ch   <-chan struct{}
+}
+
+func (c channelSyncer) WaitUntilSynced(stop <-chan struct{}) bool {
+	select {
+	case <-c.ch:
+		return true
+	case <-stop:
+		return false
+	}
+}
+
+func (c channelSyncer) HasSynced() bool {
+	select {
+	case <-c.ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/krtcollections/ondemand/cache_test.go
+++ b/pkg/krtcollections/ondemand/cache_test.go
@@ -298,3 +298,26 @@ func TestDedupeCollapsesRepeatedRefs(t *testing.T) {
 		t.Fatalf("refs from distinct owners must not be collapsed, got %d", len(both))
 	}
 }
+
+// TestSelectorRetractsWhenLabelsStopMatching is the shrinking half of selector
+// support. A Secret that stops matching must have its payload evicted; if only
+// the growing direction worked, a cluster where labels churn would accumulate
+// payloads for Secrets nothing selects any more.
+func TestSelectorRetractsWhenLabelsStopMatching(t *testing.T) {
+	matching := secret("ns", "matching", map[string]string{"app": "api"}, "v1")
+
+	cache, _, w := setup(t,
+		[]ResourceRef{NewSelectorRef("policy", "Secret", "", map[string]string{"app": "api"})},
+		matching)
+	waitFor(t, cache.HasSynced, "cache should sync")
+	waitFor(t, func() bool {
+		return cache.Collection().GetKey("ns/matching") != nil
+	}, "a Secret matching the selector should be loaded")
+
+	// Relabel it so the selector no longer matches.
+	w.update(secret("ns", "matching", map[string]string{"app": "web"}, "v1"))
+
+	waitFor(t, func() bool {
+		return cache.Collection().GetKey("ns/matching") == nil
+	}, "a Secret that stops matching the selector should have its payload evicted")
+}

--- a/pkg/krtcollections/ondemand/cache_test.go
+++ b/pkg/krtcollections/ondemand/cache_test.go
@@ -1,0 +1,300 @@
+package ondemand
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/config/schema/gvr"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient/fake"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+func secret(ns, name string, labels map[string]string, data string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: labels},
+		Data:       map[string][]byte{"key": []byte(data)},
+	}
+}
+
+// setup builds a Cache over the fake client. refs is the initial reference set,
+// already populated before SetRefs, which is how production wires it: the ref
+// collections are informer-derived and synced before the cache starts. The
+// returned collection stays mutable so tests can add and withdraw references.
+func setup(t *testing.T, refs []ResourceRef, objs ...*corev1.Secret) (*Cache[*corev1.Secret], krt.StaticCollection[ResourceRef], *fakeWriter) {
+	t.Helper()
+
+	cobjs := make([]client.Object, 0, len(objs))
+	for _, o := range objs {
+		cobjs = append(cobjs, o)
+	}
+	c := fake.NewClient(t, cobjs...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+
+	krtOpts := krtutil.NewKrtOptions(stop, nil)
+	cache := New(ctx, c, krtOpts, Config[*corev1.Secret]{
+		Name: "Secrets",
+		Kind: "Secret",
+		GVR:  gvr.Secret,
+		Getter: func(ctx context.Context, ns, name string) (*corev1.Secret, error) {
+			return c.Kube().CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+		},
+	})
+
+	refCol := krt.NewStaticCollection(nil, refs, krtOpts.ToOptions("refs")...)
+	cache.SetRefs(ctx, refCol)
+	c.RunAndWait(stop)
+
+	return cache, refCol, &fakeWriter{t: t, c: c}
+}
+
+func TestCacheFetchesOnlyReferencedObjects(t *testing.T) {
+	referenced := secret("ns", "referenced", nil, "v1")
+	ignored := secret("ns", "ignored", nil, "v1")
+
+	cache, _, _ := setup(t, []ResourceRef{NewRef("policy", "Secret", "ns", "referenced")}, referenced, ignored)
+
+	waitFor(t, cache.HasSynced, "cache should sync once the referenced set is fetched")
+
+	if got := cache.Collection().GetKey("ns/referenced"); got == nil {
+		t.Fatal("referenced Secret should be in the collection")
+	} else if string((*got).Data["key"]) != "v1" {
+		t.Fatalf("referenced Secret should carry its contents, got %q", (*got).Data["key"])
+	}
+
+	// The unreferenced Secret exists in the cluster but must never be loaded --
+	// that is the entire point of the design.
+	if cache.Collection().GetKey("ns/ignored") != nil {
+		t.Fatal("unreferenced Secret must not be fetched")
+	}
+	if !cache.Exists("ns", "ignored") {
+		t.Fatal("the metadata watch should still know the unreferenced Secret exists")
+	}
+}
+
+func TestCacheTracksUpdatesToReferencedObjects(t *testing.T) {
+	s := secret("ns", "s", nil, "before")
+	cache, _, w := setup(t, []ResourceRef{NewRef("policy", "Secret", "ns", "s")}, s)
+	waitFor(t, cache.HasSynced, "cache should sync")
+
+	w.update(secret("ns", "s", nil, "after"))
+
+	waitFor(t, func() bool {
+		got := cache.Collection().GetKey("ns/s")
+		return got != nil && string((*got).Data["key"]) == "after"
+	}, "an update to a referenced Secret should be picked up via the metadata watch")
+}
+
+func TestCacheDropsObjectWhenReferenceIsWithdrawn(t *testing.T) {
+	s := secret("ns", "s", nil, "v1")
+	ref := NewRef("policy", "Secret", "ns", "s")
+	cache, refs, _ := setup(t, []ResourceRef{ref}, s)
+	waitFor(t, cache.HasSynced, "cache should sync")
+	waitFor(t, func() bool { return cache.Collection().GetKey("ns/s") != nil }, "Secret should be loaded")
+
+	// Deleting the policy that referenced it must evict the contents, otherwise
+	// the cache would grow without bound as configuration churns.
+	refs.DeleteObject(ref.ResourceName())
+
+	waitFor(t, func() bool {
+		return cache.Collection().GetKey("ns/s") == nil
+	}, "withdrawing the last reference should evict the Secret")
+}
+
+func TestCacheDropsDeletedObject(t *testing.T) {
+	s := secret("ns", "s", nil, "v1")
+	cache, _, w := setup(t, []ResourceRef{NewRef("policy", "Secret", "ns", "s")}, s)
+	waitFor(t, cache.HasSynced, "cache should sync")
+	waitFor(t, func() bool { return cache.Collection().GetKey("ns/s") != nil }, "Secret should be loaded")
+
+	w.delete("ns", "s")
+
+	waitFor(t, func() bool {
+		return cache.Collection().GetKey("ns/s") == nil
+	}, "deleting a referenced Secret should remove it from the collection")
+}
+
+func TestCacheResolvesSelectorRefsAgainstMetadata(t *testing.T) {
+	matching := secret("ns", "matching", map[string]string{"app": "api"}, "v1")
+	other := secret("ns", "other", map[string]string{"app": "web"}, "v1")
+
+	cache, _, w := setup(t,
+		[]ResourceRef{NewSelectorRef("policy", "Secret", "", map[string]string{"app": "api"})},
+		matching, other)
+	waitFor(t, cache.HasSynced, "cache should sync")
+
+	if cache.Collection().GetKey("ns/matching") == nil {
+		t.Fatal("Secret matching the selector should be fetched")
+	}
+	if cache.Collection().GetKey("ns/other") != nil {
+		t.Fatal("Secret not matching the selector must not be fetched")
+	}
+
+	// A Secret that gains a matching label later must be picked up: labels live on
+	// PartialObjectMetadata, so the metadata watch is enough to notice.
+	w.create(secret("ns", "late", map[string]string{"app": "api"}, "v1"))
+	waitFor(t, func() bool {
+		return cache.Collection().GetKey("ns/late") != nil
+	}, "a newly created Secret matching the selector should be fetched")
+}
+
+func TestCacheHandlesMissingObject(t *testing.T) {
+	cache, _, w := setup(t, []ResourceRef{NewRef("policy", "Secret", "ns", "later")})
+
+	// A reference to something that does not exist must not block startup; absence
+	// from the collection is how translation reports "not found".
+	waitFor(t, cache.HasSynced, "cache should sync even when a reference dangles")
+	if cache.Collection().GetKey("ns/later") != nil {
+		t.Fatal("a dangling reference must not produce an entry")
+	}
+
+	// When the object shows up, it should be loaded without any further prompting.
+	w.create(secret("ns", "later", nil, "v1"))
+	waitFor(t, func() bool {
+		return cache.Collection().GetKey("ns/later") != nil
+	}, "creating a referenced Secret should load it")
+}
+
+func TestRefResourceNameDistinguishesSources(t *testing.T) {
+	a := NewRef("policyA", "Secret", "ns", "s")
+	b := NewRef("policyB", "Secret", "ns", "s")
+	if a.ResourceName() == b.ResourceName() {
+		t.Fatal("two policies referencing the same Secret must produce distinct keys, " +
+			"otherwise KRT collapses them and withdrawing one drops the other")
+	}
+
+	sel1 := NewSelectorRef("p", "Secret", "ns", map[string]string{"a": "1"})
+	sel2 := NewSelectorRef("p", "Secret", "ns", map[string]string{"a": "2"})
+	if sel1.ResourceName() == sel2.ResourceName() {
+		t.Fatal("distinct selectors on one policy must produce distinct keys")
+	}
+}
+
+func TestRefEqualsComparesAllFields(t *testing.T) {
+	base := ResourceRef{Kind: "Secret", Namespace: "ns", Name: "s", Source: "p"}
+	cases := map[string]ResourceRef{
+		"kind":      {Kind: "ConfigMap", Namespace: "ns", Name: "s", Source: "p"},
+		"namespace": {Kind: "Secret", Namespace: "other", Name: "s", Source: "p"},
+		"name":      {Kind: "Secret", Namespace: "ns", Name: "t", Source: "p"},
+		"source":    {Kind: "Secret", Namespace: "ns", Name: "s", Source: "q"},
+		"labels":    {Kind: "Secret", Namespace: "ns", Name: "s", Source: "p", MatchLabels: map[string]string{"a": "1"}},
+	}
+	if !base.Equals(base) {
+		t.Fatal("a ref should equal itself")
+	}
+	for field, other := range cases {
+		if base.Equals(other) {
+			t.Fatalf("Equals ignores %s; KRT would miss the change", field)
+		}
+	}
+}
+
+func TestStripMetadataDropsBulkFields(t *testing.T) {
+	md := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "s",
+			Namespace: "ns",
+			Labels:    map[string]string{"app": "api"},
+			// kubectl stores a full copy of the object here, which would defeat
+			// the point of watching metadata only.
+			Annotations:   map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{...}"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+		},
+	}
+	out, err := stripMetadata(md)
+	if err != nil {
+		t.Fatalf("stripMetadata: %v", err)
+	}
+	got := out.(*metav1.PartialObjectMetadata)
+	if got.Annotations != nil {
+		t.Error("annotations should be dropped; they can hold a full copy of the object")
+	}
+	if got.ManagedFields != nil {
+		t.Error("managed fields should be dropped")
+	}
+	if got.Labels["app"] != "api" {
+		t.Error("labels must be kept; selector refs are resolved against them")
+	}
+}
+
+// fakeWriter mutates Secrets through the typed client so the metadata watch
+// observes the change the same way it would against a real API server.
+type fakeWriter struct {
+	t *testing.T
+	c kube.Client
+}
+
+func (w *fakeWriter) create(s *corev1.Secret) {
+	w.t.Helper()
+	if _, err := w.c.Kube().CoreV1().Secrets(s.Namespace).Create(context.Background(), s, metav1.CreateOptions{}); err != nil {
+		w.t.Fatalf("create secret: %v", err)
+	}
+}
+
+func (w *fakeWriter) update(s *corev1.Secret) {
+	w.t.Helper()
+	if _, err := w.c.Kube().CoreV1().Secrets(s.Namespace).Update(context.Background(), s, metav1.UpdateOptions{}); err != nil {
+		w.t.Fatalf("update secret: %v", err)
+	}
+}
+
+func (w *fakeWriter) delete(ns, name string) {
+	w.t.Helper()
+	if err := w.c.Kube().CoreV1().Secrets(ns).Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+		w.t.Fatalf("delete secret: %v", err)
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+func TestDedupeCollapsesRepeatedRefs(t *testing.T) {
+	// Two HTTPS listeners sharing one certificate produce the same ref twice.
+	// KRT rejects duplicate keys from a single transformation, so producers must
+	// collapse them.
+	src := "Gateway/ns/gw"
+	refs := []ResourceRef{
+		NewRef(src, "Secret", "ns", "cert"),
+		NewRef(src, "Secret", "ns", "cert"),
+		NewRef(src, "Secret", "ns", "other"),
+	}
+	got := Dedupe(refs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 refs after dedupe, got %d: %v", len(got), got)
+	}
+	seen := map[string]bool{}
+	for _, r := range got {
+		if seen[r.ResourceName()] {
+			t.Fatalf("duplicate key survived dedupe: %s", r.ResourceName())
+		}
+		seen[r.ResourceName()] = true
+	}
+
+	// Refs from different owners are not duplicates and must both survive.
+	both := Dedupe([]ResourceRef{
+		NewRef("policyA", "Secret", "ns", "cert"),
+		NewRef("policyB", "Secret", "ns", "cert"),
+	})
+	if len(both) != 2 {
+		t.Fatalf("refs from distinct owners must not be collapsed, got %d", len(both))
+	}
+}

--- a/pkg/krtcollections/ondemand/ref.go
+++ b/pkg/krtcollections/ondemand/ref.go
@@ -1,0 +1,160 @@
+// Package ondemand provides a KRT collection that caches the full contents of
+// only those cluster objects that kgateway configuration actually references.
+//
+// # Why
+//
+// kgateway needs the contents of a handful of Secrets and ConfigMaps: listener
+// certificates, backend CA bundles, auth credentials and so on. Historically it
+// watched every Secret and ConfigMap in the cluster with a typed informer, which
+// keeps the full object -- including `data` -- in memory. In clusters with many
+// large ConfigMaps that dominates the control plane's heap even though almost
+// none of those objects are ever read.
+//
+// # How
+//
+// A Cache watches the resource cluster-wide with a *metadata* informer. A
+// PartialObjectMetadata is a few hundred bytes regardless of how large the
+// object's payload is, so the cluster-wide watch stays cheap. The metadata watch
+// is only used to answer two questions: does this object exist, and has it
+// changed (its resourceVersion moves on every write).
+//
+// Separately, the rest of kgateway publishes the set of objects its
+// configuration references as a KRT collection of ResourceRef. For that set --
+// and only that set -- the Cache issues a direct Get for the full object and
+// publishes the result into a krt.StaticCollection that downstream collections
+// consume exactly as they would an informer-backed one.
+//
+// The metadata watch is what makes this work without polling: it already tells
+// us precisely when a referenced object changed, so a full re-Get is driven by
+// the same event stream a typed informer would have used, minus the payload for
+// the objects nobody asked for.
+package ondemand
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ResourceRef is a reference from some piece of kgateway configuration to a
+// core object whose contents kgateway needs.
+//
+// A ref either names a single object (Name set) or selects objects by label
+// (MatchLabels set). Exactly one of the two must be set.
+//
+// Refs are collected from every part of the system that reads object contents;
+// an object that no ref points at is never fetched, and reading it will fail as
+// if it did not exist. Adding a new place that reads a Secret or ConfigMap
+// therefore also means contributing a ref for it -- see
+// pluginsdk.Plugin.ContributesResourceRefs.
+type ResourceRef struct {
+	// Kind is the object kind, e.g. "Secret" or "ConfigMap". Core group only.
+	Kind string
+
+	// Namespace is the namespace of the referenced object. For a MatchLabels ref
+	// an empty Namespace selects across all namespaces.
+	Namespace string
+
+	// Name is the name of a single referenced object. Mutually exclusive with
+	// MatchLabels.
+	Name string
+
+	// MatchLabels selects referenced objects by label. Mutually exclusive with
+	// Name.
+	MatchLabels map[string]string
+
+	// Source identifies the configuration object that produced this ref. It only
+	// exists to keep ResourceName unique: two policies referencing the same
+	// Secret must produce two distinct collection entries, otherwise KRT would
+	// treat them as a conflicting duplicate key. The Cache unions refs by target,
+	// so duplicates cost nothing beyond a map entry.
+	Source string
+}
+
+// NewRef builds a ref to a single named object.
+func NewRef(source, kind, namespace, name string) ResourceRef {
+	return ResourceRef{Kind: kind, Namespace: namespace, Name: name, Source: source}
+}
+
+// NewSelectorRef builds a ref to every object matching matchLabels. An empty
+// namespace selects across all namespaces.
+func NewSelectorRef(source, kind, namespace string, matchLabels map[string]string) ResourceRef {
+	return ResourceRef{Kind: kind, Namespace: namespace, MatchLabels: matchLabels, Source: source}
+}
+
+// ResourceName implements krt.ResourceNamer.
+func (r ResourceRef) ResourceName() string {
+	var b strings.Builder
+	b.WriteString(r.Source)
+	b.WriteString("~")
+	b.WriteString(r.Kind)
+	b.WriteString("/")
+	b.WriteString(r.Namespace)
+	b.WriteString("/")
+	if r.Name != "" {
+		b.WriteString(r.Name)
+		return b.String()
+	}
+	// Selector refs have no name; key on the rendered selector so that a policy
+	// with two different selectors yields two entries.
+	b.WriteString("[")
+	b.WriteString(labels.Set(r.MatchLabels).String())
+	b.WriteString("]")
+	return b.String()
+}
+
+// Equals implements the KRT equality contract. All fields are compared.
+func (r ResourceRef) Equals(other ResourceRef) bool {
+	return r.Kind == other.Kind &&
+		r.Namespace == other.Namespace &&
+		r.Name == other.Name &&
+		r.Source == other.Source &&
+		maps.Equal(r.MatchLabels, other.MatchLabels)
+}
+
+func (r ResourceRef) String() string {
+	if r.Name != "" {
+		return fmt.Sprintf("%s %s/%s (from %s)", r.Kind, r.Namespace, r.Name, r.Source)
+	}
+	ns := r.Namespace
+	if ns == "" {
+		ns = "*"
+	}
+	return fmt.Sprintf("%s %s/[%s] (from %s)", r.Kind, ns, labels.Set(r.MatchLabels).String(), r.Source)
+}
+
+// isSelector reports whether this ref selects by label rather than by name.
+func (r ResourceRef) isSelector() bool {
+	return r.Name == ""
+}
+
+// target returns the single object this ref names. Only valid when !isSelector.
+func (r ResourceRef) target() types.NamespacedName {
+	return types.NamespacedName{Namespace: r.Namespace, Name: r.Name}
+}
+
+// Dedupe removes refs that resolve to the same key.
+//
+// KRT requires the output of a single transformation to have unique keys, and
+// duplicates are easy to produce honestly: two HTTPS listeners on one Gateway
+// sharing a certificate, or two headers sourced from the same Secret. Every ref
+// producer should pass its result through this.
+func Dedupe(refs []ResourceRef) []ResourceRef {
+	if len(refs) < 2 {
+		return refs
+	}
+	seen := make(map[string]struct{}, len(refs))
+	out := refs[:0]
+	for _, r := range refs {
+		key := r.ResourceName()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, r)
+	}
+	return out
+}

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -1821,3 +1821,24 @@ func getGatewayBackendTLSConfig(backendTLS *gwv1.GatewayBackendTLS) *ir.GatewayB
 		ClientCertificateRef: backendTLS.ClientCertificateRef.DeepCopy(),
 	}
 }
+
+// NotLoadedError reports that an object exists in the cluster but its contents
+// have not been loaded.
+//
+// kgateway only fetches the contents of Secrets and ConfigMaps that some
+// ResourceRef points at (see pkg/krtcollections/ondemand). This error means the
+// object is really there, so it is either momentarily in flight -- the
+// reference was only just declared and the fetch has not landed -- or, if it
+// persists, no ref site declares it, which is a bug in the reference
+// derivation rather than a problem with the user's configuration.
+//
+// It is deliberately distinct from NotFoundError so that a transient or
+// internal condition is never reported to users as a missing object.
+type NotLoadedError struct {
+	Obj ir.ObjectSource
+}
+
+func (n *NotLoadedError) Error() string {
+	return fmt.Sprintf("%s %s/%s exists but its contents are not loaded yet",
+		n.Obj.Kind, n.Obj.Namespace, n.Obj.Name)
+}

--- a/pkg/krtcollections/resourcerefs.go
+++ b/pkg/krtcollections/resourcerefs.go
@@ -1,0 +1,134 @@
+package krtcollections
+
+import (
+	"istio.io/istio/pkg/kube/krt"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// GatewayResourceRefs declares the Secrets that core Gateway API translation
+// reads: listener serving certificates and the Gateway's backend client
+// certificate.
+//
+// It derives from the *raw* Gateway and ListenerSet collections on purpose.
+// GatewayIndex.Gateways attaches policies, and policy IR resolves Secrets, so
+// deriving refs from the index would make the Secret cache depend on a
+// collection that depends on the Secret cache.
+func GatewayResourceRefs(
+	gateways krt.Collection[*gwv1.Gateway],
+	listenerSets krt.Collection[*gwv1.ListenerSet],
+	opts krtutil.KrtOptions,
+) krt.Collection[ondemand.ResourceRef] {
+	fromGateways := krt.NewManyCollection(gateways, func(kctx krt.HandlerContext, gw *gwv1.Gateway) []ondemand.ResourceRef {
+		src := "Gateway/" + gw.Namespace + "/" + gw.Name
+		refs := listenerCertRefs(src, gw.Namespace, gw.Spec.Listeners)
+
+		if gw.Spec.TLS == nil {
+			return ondemand.Dedupe(refs)
+		}
+
+		// spec.tls.backend.clientCertificateRef: the cert the Gateway presents to
+		// backends.
+		if b := gw.Spec.TLS.Backend; b != nil && b.ClientCertificateRef != nil {
+			refs = append(refs, secretRefFrom(src, gw.Namespace, *b.ClientCertificateRef)...)
+		}
+
+		// spec.tls.frontend validation CA bundles, which may be ConfigMaps or
+		// Secrets, both default and per-port.
+		if f := gw.Spec.TLS.Frontend; f != nil {
+			if v := f.Default.Validation; v != nil {
+				refs = append(refs, caCertRefs(src, gw.Namespace, v.CACertificateRefs)...)
+			}
+			for _, pp := range f.PerPort {
+				if v := pp.TLS.Validation; v != nil {
+					refs = append(refs, caCertRefs(src, gw.Namespace, v.CACertificateRefs)...)
+				}
+			}
+		}
+		return ondemand.Dedupe(refs)
+	}, opts.ToOptions("GatewayResourceRefs")...)
+
+	fromListenerSets := krt.NewManyCollection(listenerSets, func(kctx krt.HandlerContext, ls *gwv1.ListenerSet) []ondemand.ResourceRef {
+		src := "ListenerSet/" + ls.Namespace + "/" + ls.Name
+		// ListenerSet listeners are a distinct type but carry the same TLS config.
+		listeners := make([]gwv1.Listener, 0, len(ls.Spec.Listeners))
+		for _, l := range ls.Spec.Listeners {
+			listeners = append(listeners, gwv1.Listener{
+				Name:     l.Name,
+				Hostname: l.Hostname,
+				Protocol: l.Protocol,
+				TLS:      l.TLS,
+			})
+		}
+		return ondemand.Dedupe(listenerCertRefs(src, ls.Namespace, listeners))
+	}, opts.ToOptions("ListenerSetResourceRefs")...)
+
+	return krt.JoinCollection(
+		[]krt.Collection[ondemand.ResourceRef]{fromGateways, fromListenerSets},
+		opts.ToOptions("CoreResourceRefs")...,
+	)
+}
+
+// listenerCertRefs collects every certificateRef across a set of listeners.
+func listenerCertRefs(source, defaultNamespace string, listeners []gwv1.Listener) []ondemand.ResourceRef {
+	var refs []ondemand.ResourceRef
+	for _, l := range listeners {
+		if l.TLS == nil {
+			continue
+		}
+		for _, certRef := range l.TLS.CertificateRefs {
+			refs = append(refs, secretRefFrom(source, defaultNamespace, certRef)...)
+		}
+	}
+	return refs
+}
+
+// caCertRefs converts CA bundle references, which may name either a ConfigMap
+// or a Secret, into resource refs. This mirrors validateCAReferenceType: kinds
+// other than those two are rejected during translation and need no fetch.
+func caCertRefs(source, defaultNamespace string, refs []gwv1.ObjectReference) []ondemand.ResourceRef {
+	out := make([]ondemand.ResourceRef, 0, len(refs))
+	for _, ref := range refs {
+		if string(ref.Group) != "" {
+			continue
+		}
+		kind := string(ref.Kind)
+		if kind != wellknown.ConfigMapKind && kind != wellknown.SecretKind {
+			continue
+		}
+		ns := defaultNamespace
+		if ref.Namespace != nil {
+			ns = string(*ref.Namespace)
+		}
+		out = append(out, ondemand.NewRef(source, kind, ns, string(ref.Name)))
+	}
+	return out
+}
+
+// secretRefFrom converts a Gateway API SecretObjectReference into a ref, if it
+// points at a core Secret. Other kinds are resolved by their own plugins.
+func secretRefFrom(source, defaultNamespace string, ref gwv1.SecretObjectReference) []ondemand.ResourceRef {
+	group := ""
+	if ref.Group != nil {
+		group = string(*ref.Group)
+	}
+	kind := wellknown.SecretKind
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	if group != "" || kind != wellknown.SecretKind {
+		return nil
+	}
+
+	ns := defaultNamespace
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+	// Refs are declared before ReferenceGrant is evaluated: a cross-namespace ref
+	// that a grant later rejects costs one cached Secret, whereas fetching only
+	// after the grant check would couple the cache to the grant collection.
+	return []ondemand.ResourceRef{ondemand.NewRef(source, wellknown.SecretKind, ns, string(ref.Name))}
+}

--- a/pkg/krtcollections/secrets.go
+++ b/pkg/krtcollections/secrets.go
@@ -18,10 +18,31 @@ type From struct {
 type SecretIndex struct {
 	secrets   map[schema.GroupKind]krt.Collection[ir.Secret]
 	refgrants *RefGrantIndex
+	// exists reports whether an object is present in the cluster at all, from the
+	// metadata-only watch. It lets a lookup tell "the user has not created this
+	// Secret" apart from "the Secret is there but its contents have not been
+	// fetched", which are very different things to report. May be nil, in which
+	// case every miss is reported as not found.
+	exists func(namespace, name string) bool
 }
 
 func NewSecretIndex(secrets map[schema.GroupKind]krt.Collection[ir.Secret], refgrants *RefGrantIndex) *SecretIndex {
 	return &SecretIndex{secrets: secrets, refgrants: refgrants}
+}
+
+// WithExistenceCheck attaches the cluster-wide existence probe described on the
+// exists field.
+func (s *SecretIndex) WithExistenceCheck(exists func(namespace, name string) bool) *SecretIndex {
+	s.exists = exists
+	return s
+}
+
+// missing builds the right error for a lookup that found nothing.
+func (s *SecretIndex) missing(to ir.ObjectSource) error {
+	if s.exists != nil && s.exists(to.Namespace, to.Name) {
+		return &NotLoadedError{Obj: to}
+	}
+	return &NotFoundError{NotFoundObj: to}
 }
 
 func (s *SecretIndex) HasSynced() bool {
@@ -34,6 +55,14 @@ func (s *SecretIndex) HasSynced() bool {
 		}
 	}
 	return true
+}
+
+// Collection returns the collection of loaded Secrets of the given kind, or nil
+// if the kind is unknown. It holds only Secrets whose contents were fetched
+// because something references them, so it is not a view of the cluster; use it
+// where the set of loaded Secrets is what you actually want.
+func (s *SecretIndex) Collection(gk schema.GroupKind) krt.Collection[ir.Secret] {
+	return s.secrets[gk]
 }
 
 // GetSecret retrieves a secret from the index, validating reference grants to ensure
@@ -67,7 +96,7 @@ func (s *SecretIndex) GetSecret(kctx krt.HandlerContext, from From, secretRef gw
 	}
 	secret := krt.FetchOne(kctx, col, krt.FilterKey(to.ResourceName()))
 	if secret == nil {
-		return nil, &NotFoundError{NotFoundObj: to}
+		return nil, s.missing(to)
 	}
 	return secret, nil
 }

--- a/pkg/pluginsdk/collections/collections.go
+++ b/pkg/pluginsdk/collections/collections.go
@@ -12,6 +12,7 @@ import (
 	"istio.io/istio/pkg/kube/kubetypes"
 	"istio.io/istio/pkg/util/smallset"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -20,6 +21,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
@@ -46,6 +48,20 @@ type CommonCollections struct {
 	WrappedPods  krt.Collection[krtcollections.WrappedPod]
 	LocalityPods krt.Collection[krtcollections.LocalityPod]
 	RefGrants    *krtcollections.RefGrantIndex
+
+	// secretCache and configMapCache back Secrets and ConfigMaps. They hold the
+	// contents of referenced objects only; the cluster-wide view they maintain is
+	// metadata-only. Their reference inputs are attached in InitPlugins, once the
+	// plugins that declare those references exist.
+	secretCache    *ondemand.Cache[*corev1.Secret]
+	configMapCache *ondemand.Cache[*corev1.ConfigMap]
+
+	// coreResourceRefs are the references core Gateway API translation produces.
+	// Set by InitCollections.
+	coreResourceRefs krt.Collection[ondemand.ResourceRef]
+
+	// gwExtResourceRefs are the references GatewayExtension-backed policies read.
+	gwExtResourceRefs krt.Collection[ondemand.ResourceRef]
 
 	DiscoveryNamespacesFilter kubetypes.DynamicObjectFilter
 
@@ -106,14 +122,23 @@ func NewCommonCollections(
 		kube.SetObjectFilter(client.Core(), discoveryNamespacesFilter)
 	}
 
-	secretClient := kclient.NewFiltered[*corev1.Secret](
-		client,
-		kclient.Filter{
+	// Secrets and ConfigMaps are watched metadata-only cluster-wide; only objects
+	// some part of the configuration references have their contents fetched. See
+	// the ondemand package for why.
+	secretCache := ondemand.New(ctx, client, krtOptions, ondemand.Config[*corev1.Secret]{
+		Name: "Secrets",
+		Kind: wellknown.SecretKind,
+		GVR:  gvr.Secret,
+		Filter: kclient.Filter{
 			FieldSelector: apiclient.SecretsFieldSelector,
 			ObjectFilter:  client.ObjectFilter(),
 		},
-	)
-	k8sSecretsRaw := krt.WrapClient(secretClient, krt.WithStop(krtOptions.Stop), krt.WithName("Secrets") /* no debug here - we don't want raw secrets printed*/)
+		Getter: func(ctx context.Context, ns, name string) (*corev1.Secret, error) {
+			return client.Kube().CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+		},
+	})
+	// no debug here - we don't want raw secrets printed
+	k8sSecretsRaw := secretCache.Collection()
 	k8sSecrets := krt.NewCollection(k8sSecretsRaw, func(kctx krt.HandlerContext, i *corev1.Secret) *ir.Secret {
 		res := ir.Secret{
 			ObjectSource: ir.ObjectSource{
@@ -161,21 +186,26 @@ func NewCommonCollections(
 		serviceEntries = krt.NewStaticCollection[*networkingclient.ServiceEntry](nil, nil, krtOptions.ToOptions("disable/ServiceEntries")...)
 	}
 
-	cmClient := kclient.NewFiltered[*corev1.ConfigMap](
-		client,
-		kclient.Filter{ObjectFilter: client.ObjectFilter()},
-	)
-	cfgmaps := krt.WrapClient(cmClient, krtOptions.ToOptions("ConfigMaps")...)
+	configMapCache := ondemand.New(ctx, client, krtOptions, ondemand.Config[*corev1.ConfigMap]{
+		Name:   "ConfigMaps",
+		Kind:   wellknown.ConfigMapKind,
+		GVR:    gvr.ConfigMap,
+		Filter: kclient.Filter{ObjectFilter: client.ObjectFilter()},
+		Getter: func(ctx context.Context, ns, name string) (*corev1.ConfigMap, error) {
+			return client.Kube().CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+		},
+	})
+	cfgmaps := configMapCache.Collection()
 
-	gwExts := krtcollections.NewGatewayExtensionsCollection(ctx, client, krtOptions)
+	gwExts, rawGwExts := krtcollections.NewGatewayExtensionsCollection(ctx, client, krtOptions)
 
 	localityPods, wrappedPods := krtcollections.NewPodsCollection(client, krtOptions)
 
 	return &CommonCollections{
 		Client:                                client,
 		KrtOpts:                               krtOptions,
-		Secrets:                               krtcollections.NewSecretIndex(secrets, refgrants),
-		ConfigMaps:                            krtcollections.NewConfigMapIndex(cfgmaps, refgrants),
+		Secrets:                               krtcollections.NewSecretIndex(secrets, refgrants).WithExistenceCheck(secretCache.Exists),
+		ConfigMaps:                            krtcollections.NewConfigMapIndex(cfgmaps, refgrants).WithExistenceCheck(configMapCache.Exists),
 		LocalityPods:                          localityPods,
 		WrappedPods:                           wrappedPods,
 		RefGrants:                             refgrants,
@@ -185,6 +215,11 @@ func NewCommonCollections(
 		ServiceEntries:                        serviceEntries,
 		ServiceEntriesExclusionLabelSelectors: serviceEntriesExclusionLabelSelectors,
 		GatewayExtensions:                     gwExts,
+
+		gwExtResourceRefs: krtcollections.GatewayExtensionResourceRefs(rawGwExts, krtOptions),
+
+		secretCache:    secretCache,
+		configMapCache: configMapCache,
 
 		DiscoveryNamespacesFilter: discoveryNamespacesFilter,
 
@@ -214,4 +249,28 @@ func (c *CommonCollections) InitPlugins(
 	c.Routes = routeIndex
 	c.Endpoints = endpointIRs
 	c.GatewayIndex = gateways
+
+	// Now that every plugin exists, assemble the full set of Secret/ConfigMap
+	// references and start fetching. Until this runs the caches report unsynced,
+	// so nothing translates against an empty Secrets collection.
+	refs := c.buildResourceRefs(mergedPlugins)
+	c.secretCache.SetRefs(ctx, refs)
+	c.configMapCache.SetRefs(ctx, refs)
+}
+
+// buildResourceRefs unions the references contributed by core translation with
+// those declared by each plugin.
+func (c *CommonCollections) buildResourceRefs(
+	mergedPlugins pluginsdk.Plugin,
+) krt.Collection[ondemand.ResourceRef] {
+	var cols []krt.Collection[ondemand.ResourceRef]
+	if c.coreResourceRefs != nil {
+		cols = append(cols, c.coreResourceRefs)
+	}
+	if c.gwExtResourceRefs != nil {
+		cols = append(cols, c.gwExtResourceRefs)
+	}
+	cols = append(cols, mergedPlugins.ContributesResourceRefs...)
+
+	return krt.JoinCollection(cols, c.KrtOpts.ToOptions("ResourceRefs")...)
 }

--- a/pkg/pluginsdk/collections/ondemand_integration_test.go
+++ b/pkg/pluginsdk/collections/ondemand_integration_test.go
@@ -375,3 +375,75 @@ func TestBackendTLSPolicyLoadsReferencedConfigMap(t *testing.T) {
 		return !s.configMapLoaded(testNS, "unreferenced-bundle")
 	}, "an unreferenced ConfigMap must never be loaded")
 }
+
+// apiKeySelectorPolicy builds a TrafficPolicy that selects its API-key Secrets
+// by label rather than by name.
+func apiKeySelectorPolicy(name string, matchLabels map[string]string) *kgateway.TrafficPolicy {
+	return &kgateway.TrafficPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       wellknown.TrafficPolicyGVK.Kind,
+			APIVersion: wellknown.TrafficPolicyGVK.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Spec: kgateway.TrafficPolicySpec{
+			APIKeyAuth: &kgateway.APIKeyAuth{
+				SecretSelector: &kgateway.LabelSelector{MatchLabels: matchLabels},
+			},
+		},
+	}
+}
+
+func labelledSecret(name string, labels map[string]string, key, value string) *corev1.Secret {
+	s := secret(name, map[string]string{key: value})
+	s.Labels = labels
+	return s
+}
+
+// TestSecretSelectorLoadsMatchingSecretsOnly covers TrafficPolicy's api-key
+// secretSelector, the one reference that is expressed as a label query rather
+// than a name. It works because labels are carried on PartialObjectMetadata, so
+// the selector can be resolved against the metadata watch without reading any
+// payload to decide what to fetch.
+func TestSecretSelectorLoadsMatchingSecretsOnly(t *testing.T) {
+	s := newStack(t,
+		apiKeySelectorPolicy("apikeys", map[string]string{"apikey": "true"}),
+		labelledSecret("matching", map[string]string{"apikey": "true"}, "client1", "k-123"),
+		labelledSecret("other", map[string]string{"apikey": "false"}, "client2", "k-456"),
+		secret("htpasswd", map[string]string{".htpasswd": htpasswdBefore}),
+		basicAuthPolicy("auth", "htpasswd"),
+	)
+
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "matching", "client1") == "k-123"
+	}, "a Secret matching the api-key selector should have its contents loaded")
+
+	s.settleAfterWrites(
+		labelledSecret("other", map[string]string{"apikey": "false"}, "client2", "touched"),
+		"htpasswd")
+	s.assertStaysAbsent(func() bool {
+		return s.secretContents(testNS, "other", "client2") == ""
+	}, "a Secret that does not match the selector must not be loaded")
+}
+
+// TestSecretSelectorFollowsLabelChanges covers selector membership moving in
+// both directions at runtime. Only handling the growing direction would leave
+// payloads cached for Secrets nothing selects any more.
+func TestSecretSelectorFollowsLabelChanges(t *testing.T) {
+	s := newStack(t,
+		apiKeySelectorPolicy("apikeys", map[string]string{"apikey": "true"}),
+		labelledSecret("late", nil, "client1", "k-123"),
+	)
+	s.waitFor(s.commoncol.HasSynced, "collections should sync")
+
+	// Grows: a Secret gains a matching label.
+	s.secrets().update(labelledSecret("late", map[string]string{"apikey": "true"}, "client1", "k-123"))
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "late", "client1") == "k-123"
+	}, "a Secret that gains a matching label should be fetched")
+
+	// Shrinks: the same Secret loses it again.
+	s.secrets().update(labelledSecret("late", map[string]string{"apikey": "false"}, "client1", "k-123"))
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "late", "client1") == ""
+	}, "a Secret that stops matching the selector should have its payload evicted")
+}

--- a/pkg/pluginsdk/collections/ondemand_integration_test.go
+++ b/pkg/pluginsdk/collections/ondemand_integration_test.go
@@ -1,0 +1,377 @@
+package collections_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient"
+	"github.com/kgateway-dev/kgateway/v2/pkg/apiclient/fake"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/registry"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+	"github.com/kgateway-dev/kgateway/v2/pkg/validator"
+)
+
+// These tests cover the on-demand Secret/ConfigMap cache through the real stack:
+// real CRDs, the real plugin registry, and the real reference derivation. The
+// unit tests in pkg/krtcollections/ondemand drive the cache with a hand-built
+// reference collection, which cannot catch the failure that actually matters
+// here -- a plugin that reads an object but never declares a reference to it.
+
+const testNS = "default"
+
+// Valid htpasswd SHA-1 entries, so the basic-auth IR parses the Secret rather
+// than rejecting it. They differ, which is what lets the retranslation test
+// observe the IR changing.
+const (
+	//nolint:gosec // G101: test fixture, not a real credential
+	htpasswdBefore = "user:{SHA}/zi140vCaWrlNAeJLG/sWYZx0xI="
+	//nolint:gosec // G101: test fixture, not a real credential
+	htpasswdAfter = "user:{SHA}4ifhPUAC/y2RbyNOdHB0lryl3H0="
+)
+
+type stack struct {
+	t         *testing.T
+	commoncol *collections.CommonCollections
+	plugins   pluginsdk.Plugin
+	cli       apiclient.Client
+}
+
+func newStack(t *testing.T, objs ...client.Object) *stack {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cli := fake.NewClient(t, objs...)
+	krtOpts := krtutil.KrtOptions{Stop: ctx.Done()}
+
+	settings, err := apisettings.BuildSettings()
+	if err != nil {
+		t.Fatalf("build settings: %v", err)
+	}
+
+	commoncol, err := collections.NewCommonCollections(
+		ctx, krtOpts, cli, wellknown.DefaultGatewayControllerName, *settings)
+	if err != nil {
+		t.Fatalf("new common collections: %v", err)
+	}
+
+	plugins := registry.MergePlugins(registry.Plugins(ctx, commoncol, *settings, validator.NewDocker())...)
+	commoncol.InitPlugins(ctx, plugins, *settings)
+
+	cli.RunAndWait(ctx.Done())
+
+	s := &stack{t: t, commoncol: commoncol, plugins: plugins, cli: cli}
+	s.waitFor(commoncol.HasSynced, "common collections should sync")
+	return s
+}
+
+// secretContents returns the loaded contents of a Secret, or "" if the Secret's
+// payload is not in the cache.
+func (s *stack) secretContents(ns, name, key string) string {
+	col := s.commoncol.Secrets.Collection(schema.GroupKind{Kind: wellknown.SecretKind})
+	got := col.GetKey(ir.ObjectSource{
+		Kind: wellknown.SecretKind, Namespace: ns, Name: name,
+	}.ResourceName())
+	if got == nil {
+		return ""
+	}
+	return string(got.Data[key])
+}
+
+func (s *stack) configMapLoaded(ns, name string) bool {
+	return s.commoncol.ConfigMaps.Collection().GetKey(ns+"/"+name) != nil
+}
+
+// policyIR returns the translated IR and errors of a TrafficPolicy. Comparing
+// the IR across a Secret change is how we observe that the policy actually
+// retranslated, rather than merely that the cache holds new bytes.
+func (s *stack) policyIR(name string) (ir.PolicyIR, []error, bool) {
+	pol := s.plugins.ContributesPolicies[wellknown.TrafficPolicyGVK.GroupKind()]
+	got := pol.Policies.GetKey(ir.ObjectSource{
+		Group:     wellknown.TrafficPolicyGVK.Group,
+		Kind:      wellknown.TrafficPolicyGVK.Kind,
+		Namespace: testNS,
+		Name:      name,
+	}.ResourceName())
+	if got == nil {
+		return nil, nil, false
+	}
+	return got.PolicyIR, got.Errors, true
+}
+
+// assertStaysAbsent checks that cond keeps holding for a window, for assertions
+// about something *not* happening. Checking such a condition once is racy: it
+// can pass simply because the fetch it is meant to rule out has not happened
+// yet. Callers should also establish a happens-after barrier (see
+// settleAfterWrites) so this is a backstop rather than the only defence.
+func (s *stack) assertStaysAbsent(cond func() bool, msg string) {
+	s.t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !cond() {
+			s.t.Fatal(msg)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// settleAfterWrites gives the cache a barrier to work against: it touches the
+// object under suspicion, then touches a Secret that *is* referenced and waits
+// for that change to land. Once the later write has been processed, the earlier
+// one has had at least as much opportunity, so a payload that is still absent is
+// absent because nothing asked for it.
+func (s *stack) settleAfterWrites(suspect *corev1.Secret, referenced string) {
+	s.t.Helper()
+	s.secrets().update(suspect)
+	s.secrets().update(secret(referenced, map[string]string{".htpasswd": htpasswdAfter}))
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, referenced, ".htpasswd") == htpasswdAfter
+	}, "the referenced Secret's update should land, establishing that the queue has advanced")
+}
+
+func (s *stack) waitFor(cond func() bool, msg string) {
+	s.t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s.t.Fatal(msg)
+}
+
+func (s *stack) secrets() typedSecrets { return typedSecrets{s.t, s.cli} }
+
+type typedSecrets struct {
+	t   *testing.T
+	cli apiclient.Client
+}
+
+func (w typedSecrets) update(sec *corev1.Secret) {
+	w.t.Helper()
+	if _, err := w.cli.Kube().CoreV1().Secrets(sec.Namespace).
+		Update(context.Background(), sec, metav1.UpdateOptions{}); err != nil {
+		w.t.Fatalf("update secret: %v", err)
+	}
+}
+
+func (s *stack) deleteTrafficPolicy(name string) {
+	s.t.Helper()
+	if err := s.cli.Kgateway().GatewayKgateway().TrafficPolicies(testNS).
+		Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+		s.t.Fatalf("delete trafficpolicy: %v", err)
+	}
+}
+
+func secret(name string, data map[string]string) *corev1.Secret {
+	d := make(map[string][]byte, len(data))
+	for k, v := range data {
+		d[k] = []byte(v)
+	}
+	return &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Data:       d,
+	}
+}
+
+// basicAuthPolicy builds a TrafficPolicy that reads htpasswd data from a Secret.
+func basicAuthPolicy(name, secretName string) *kgateway.TrafficPolicy {
+	return &kgateway.TrafficPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       wellknown.TrafficPolicyGVK.Kind,
+			APIVersion: wellknown.TrafficPolicyGVK.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+		Spec: kgateway.TrafficPolicySpec{
+			BasicAuth: &kgateway.BasicAuthPolicy{
+				SecretRef: &kgateway.SecretReference{Name: gwv1.ObjectName(secretName)},
+			},
+		},
+	}
+}
+
+// TestReferencedSecretIsLoadedAndUnreferencedIsNot is the core property: the
+// payload of a Secret a policy references is fetched, and the payload of one
+// nothing references never is, no matter that it exists in the cluster.
+func TestReferencedSecretIsLoadedAndUnreferencedIsNot(t *testing.T) {
+	s := newStack(t,
+		basicAuthPolicy("auth", "htpasswd"),
+		secret("htpasswd", map[string]string{".htpasswd": htpasswdBefore}),
+		secret("unreferenced", map[string]string{"key": "payload"}),
+	)
+
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "htpasswd", ".htpasswd") == htpasswdBefore
+	}, "the Secret referenced by the TrafficPolicy should have its contents loaded")
+
+	// Writing to the unreferenced Secret produces a metadata event for it. If the
+	// cache fetched anything it saw, that event is what would pull the payload in.
+	s.settleAfterWrites(
+		secret("unreferenced", map[string]string{"key": "touched"}),
+		"htpasswd")
+
+	s.assertStaysAbsent(func() bool {
+		return s.secretContents(testNS, "unreferenced", "key") == ""
+	}, "an unreferenced Secret must never be loaded.\n"+
+		"Keeping unreferenced payloads out of memory is the entire point of the cache.")
+}
+
+// TestUpdatingReferencedSecretRetranslates proves the full loop: a write to a
+// referenced Secret is noticed via the metadata watch, refetched, and propagated
+// into the policy IR that depends on it.
+func TestUpdatingReferencedSecretRetranslates(t *testing.T) {
+	s := newStack(t,
+		basicAuthPolicy("auth", "htpasswd"),
+		secret("htpasswd", map[string]string{".htpasswd": htpasswdBefore}),
+	)
+
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "htpasswd", ".htpasswd") == htpasswdBefore
+	}, "initial contents should load")
+
+	before, errs, ok := s.policyIR("auth")
+	if !ok {
+		t.Fatal("TrafficPolicy IR should exist")
+	}
+	if before == nil {
+		t.Fatal("TrafficPolicy should have translated to an IR")
+	}
+	if len(errs) != 0 {
+		t.Fatalf("policy should translate cleanly with its Secret loaded, got %v", errs)
+	}
+
+	s.secrets().update(secret("htpasswd", map[string]string{".htpasswd": htpasswdAfter}))
+
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "htpasswd", ".htpasswd") == htpasswdAfter
+	}, "an update to a referenced Secret should be refetched via the metadata watch")
+
+	// The cache holding new bytes is not enough; the dependent policy must have
+	// been recomputed from them.
+	s.waitFor(func() bool {
+		after, _, ok := s.policyIR("auth")
+		return ok && after != nil && !before.Equals(after)
+	}, "the TrafficPolicy IR should retranslate when its referenced Secret changes")
+}
+
+// TestDeletingReferenceEvictsPayload covers the other half of the lifecycle. If
+// withdrawn references did not evict, the cache would grow without bound as
+// configuration churns, which would give back the memory this design saves.
+func TestDeletingReferenceEvictsPayload(t *testing.T) {
+	s := newStack(t,
+		basicAuthPolicy("auth", "htpasswd"),
+		secret("htpasswd", map[string]string{".htpasswd": htpasswdBefore}),
+	)
+
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "htpasswd", ".htpasswd") != ""
+	}, "contents should load while the policy references them")
+
+	s.deleteTrafficPolicy("auth")
+
+	s.waitFor(func() bool {
+		return s.secretContents(testNS, "htpasswd", ".htpasswd") == ""
+	}, "deleting the only policy that referenced the Secret should evict its contents")
+
+	// The Secret itself is untouched -- only our copy of its payload went away.
+	got, err := s.cli.Kube().CoreV1().Secrets(testNS).
+		Get(context.Background(), "htpasswd", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("the Secret should still exist in the cluster: %v", err)
+	}
+	if string(got.Data[".htpasswd"]) != htpasswdBefore {
+		t.Fatal("eviction must not modify the Secret in the cluster")
+	}
+}
+
+// TestMissingReferenceDeclarationIsDistinguishable is the drift scenario. If
+// someone adds a code path that reads a Secret without contributing a
+// ResourceRef, the read fails -- but it must not look like the user forgot to
+// create the Secret, because that sends whoever is debugging it in exactly the
+// wrong direction.
+func TestMissingReferenceDeclarationIsDistinguishable(t *testing.T) {
+	s := newStack(t, secret("undeclared", map[string]string{"key": "payload"}))
+
+	from := krtcollections.From{
+		GroupKind: wellknown.TrafficPolicyGVK.GroupKind(),
+		Namespace: testNS,
+	}
+
+	// A Secret that exists but that no ResourceRef points at: this is what a
+	// missed ref site looks like at runtime.
+	_, err := s.commoncol.Secrets.GetSecret(krt.TestingDummyContext{}, from,
+		gwv1.SecretObjectReference{Name: "undeclared"})
+	if err == nil {
+		t.Fatal("reading a Secret nothing declares a reference to should fail")
+	}
+	var notLoaded *krtcollections.NotLoadedError
+	if !errors.As(err, &notLoaded) {
+		t.Fatalf("an existing but undeclared Secret should report NotLoadedError, got %T: %v.\n"+
+			"Reporting this as NotFound would blame the user for a missing reference declaration.", err, err)
+	}
+
+	// A Secret that genuinely does not exist must still report not found, so the
+	// two cases stay distinguishable.
+	_, err = s.commoncol.Secrets.GetSecret(krt.TestingDummyContext{}, from,
+		gwv1.SecretObjectReference{Name: "absent"})
+	var notFound *krtcollections.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("a Secret that does not exist should report NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// TestBackendTLSPolicyLoadsReferencedConfigMap covers the ConfigMap half of the
+// cache, and a plugin whose references come from a different CRD group.
+func TestBackendTLSPolicyLoadsReferencedConfigMap(t *testing.T) {
+	cm := func(name string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+			Data:       map[string]string{"ca.crt": "-----BEGIN CERTIFICATE-----"},
+		}
+	}
+	policy := &gwv1.BackendTLSPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       wellknown.BackendTLSPolicyKind,
+			APIVersion: gwv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "btp", Namespace: testNS},
+		Spec: gwv1.BackendTLSPolicySpec{
+			Validation: gwv1.BackendTLSPolicyValidation{
+				CACertificateRefs: []gwv1.LocalObjectReference{{
+					Group: "", Kind: "ConfigMap", Name: "ca-bundle",
+				}},
+				Hostname: "example.com",
+			},
+		},
+	}
+
+	s := newStack(t, policy, cm("ca-bundle"), cm("unreferenced-bundle"))
+
+	s.waitFor(func() bool {
+		return s.configMapLoaded(testNS, "ca-bundle")
+	}, "the ConfigMap referenced by the BackendTLSPolicy should have its contents loaded")
+
+	s.assertStaysAbsent(func() bool {
+		return !s.configMapLoaded(testNS, "unreferenced-bundle")
+	}, "an unreferenced ConfigMap must never be loaded")
+}

--- a/pkg/pluginsdk/collections/resource_refs_test.go
+++ b/pkg/pluginsdk/collections/resource_refs_test.go
@@ -1,0 +1,128 @@
+package collections_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// readerCalls are the helpers that read the contents of a Secret or ConfigMap.
+// Every call site must be backed by a ResourceRef, otherwise the object is
+// never fetched and the read fails as if the user had not created it.
+var readerCalls = regexp.MustCompile(
+	`\.GetSecret\(|\.GetSecretWithoutRefGrant\(|\.GetSecretsBySelector\(|` +
+		`\.GetSecretForRef\(|\.GetConfigMap\(|\.GetConfigMapForRef\(`)
+
+// refDeclaringFiles are the files that build ResourceRef collections. Each
+// entry corresponds to one contributor of references.
+var refDeclaringFiles = []string{
+	"pkg/krtcollections/resourcerefs.go",
+	"pkg/krtcollections/gateway_extensions.go",
+	"pkg/kgateway/extensions2/pluginutils/headers.go",
+	"pkg/kgateway/extensions2/plugins/backend/resource_refs.go",
+	"pkg/kgateway/extensions2/plugins/backendconfigpolicy/resource_refs.go",
+	"pkg/kgateway/extensions2/plugins/backendtlspolicy/plugin.go",
+	"pkg/kgateway/extensions2/plugins/listenerpolicy/resource_refs.go",
+	"pkg/kgateway/extensions2/plugins/trafficpolicy/resource_refs.go",
+}
+
+// knownReaders is the set of files that read Secret or ConfigMap contents, each
+// mapped to the reason it is covered.
+//
+// This test is a tripwire, not a proof: it cannot tell whether a ref actually
+// matches the object a reader asks for. What it does catch is the failure mode
+// that a reviewer is most likely to miss -- someone adds a new place that reads
+// a Secret and forgets that kgateway no longer keeps every Secret in memory, so
+// the read silently fails at runtime instead of at compile time.
+//
+// If this fails, either add the corresponding ResourceRef and list the file
+// here, or explain why no ref is needed.
+var knownReaders = map[string]string{
+	"pkg/kgateway/translator/listener/gateway_listener_translator.go":     "core listener certs and CA bundles: krtcollections/resourcerefs.go plus the listenerpolicy plugin",
+	"pkg/kgateway/gatewaytls/backend.go":                                  "gateway backend client cert: krtcollections/resourcerefs.go",
+	"pkg/kgateway/query/query.go":                                         "generic pass-through used by the listener translator and gatewaytls",
+	"pkg/kgateway/extensions2/plugins/backend/plugin.go":                  "AWS credentials: backend/resource_refs.go",
+	"pkg/kgateway/extensions2/plugins/backendconfigpolicy/tls.go":         "upstream client cert: backendconfigpolicy/resource_refs.go",
+	"pkg/kgateway/extensions2/plugins/backendtlspolicy/plugin.go":         "CA bundles: resourceRefs in the same file",
+	"pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth.go":      "API keys by name and selector: trafficpolicy/resource_refs.go",
+	"pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go": "htpasswd secret: trafficpolicy/resource_refs.go",
+	"pkg/kgateway/extensions2/plugins/trafficpolicy/oauth2.go":            "client secret and HMAC key: krtcollections/gateway_extensions.go",
+	"pkg/kgateway/extensions2/plugins/trafficpolicy/jwt.go":               "local JWKS configmap: krtcollections/gateway_extensions.go",
+	"pkg/kgateway/extensions2/pluginutils/headers.go":                     "secret-backed header values: HeaderFilterResourceRefs in the same file",
+	"pkg/krtcollections/secrets.go":                                       "the index itself",
+	"pkg/krtcollections/configmaps.go":                                    "the index itself",
+	"pkg/utils/kubeutils/secrets.go":                                      "helpers that operate on an already-fetched Secret",
+}
+
+func TestEveryObjectReaderHasAReferenceSource(t *testing.T) {
+	root := repoRoot(t)
+
+	// The declared ref sources must exist; a rename that silently drops one would
+	// otherwise go unnoticed.
+	for _, f := range refDeclaringFiles {
+		if _, err := os.Stat(filepath.Join(root, f)); err != nil {
+			t.Errorf("declared ResourceRef source %s is missing: %v", f, err)
+		}
+	}
+
+	var undeclared []string
+	for _, dir := range []string{"pkg", "internal"} {
+		err := filepath.WalkDir(filepath.Join(root, dir), func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err //nolint:wrapcheck // walk error passthrough
+			}
+			name := d.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				return nil
+			}
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return relErr //nolint:wrapcheck // walk error passthrough
+			}
+			if strings.Contains(rel, "/mocks/") {
+				return nil
+			}
+			src, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr //nolint:wrapcheck // walk error passthrough
+			}
+			if !readerCalls.Match(src) {
+				return nil
+			}
+			if _, ok := knownReaders[rel]; !ok {
+				undeclared = append(undeclared, rel)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", dir, err)
+		}
+	}
+
+	for _, f := range undeclared {
+		t.Errorf("%s reads Secret or ConfigMap contents but is not listed in knownReaders.\n"+
+			"kgateway only loads objects that a ResourceRef points at, so this read will fail\n"+
+			"at runtime unless something contributes a matching reference. Add the ref (see\n"+
+			"pluginsdk.Plugin.ContributesResourceRefs) and then list this file in knownReaders.", f)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate repo root")
+		}
+		dir = parent
+	}
+}

--- a/pkg/pluginsdk/collections/setup.go
+++ b/pkg/pluginsdk/collections/setup.go
@@ -199,6 +199,11 @@ func (c *CommonCollections) InitCollections(
 	endpointIRs := initEndpoints(plugins, c.KrtOpts)
 
 	routes := krtcollections.NewRoutesIndex(c.KrtOpts, c.ControllerName, httpRoutes, grpcRoutes, tcproutes, tlsRoutes, policies, backendIndex, c.RefGrants, globalSettings)
+	// Core Secret/ConfigMap references are derived from the raw Gateway and
+	// ListenerSet collections rather than from the GatewayIndex, which attaches
+	// policies and would therefore depend on the Secret cache itself.
+	c.coreResourceRefs = krtcollections.GatewayResourceRefs(kubeRawGateways, kubeRawListenerSets, c.KrtOpts)
+
 	return gateways, routes, backendIndex, endpointIRs
 }
 

--- a/pkg/pluginsdk/types.go
+++ b/pkg/pluginsdk/types.go
@@ -15,6 +15,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/endpoints"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections/ondemand"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
@@ -117,6 +118,21 @@ type Plugin struct {
 	ContributesLeaderAction map[schema.GroupKind]func()
 	// extra has sync beyond primary resources in the collections above
 	ExtraHasSynced func() bool
+
+	// ContributesResourceRefs declares the Secrets and ConfigMaps whose contents
+	// this plugin reads.
+	//
+	// kgateway watches Secrets and ConfigMaps cluster-wide with a metadata-only
+	// informer and fetches the full contents of referenced objects only, so an
+	// object no plugin declares here is never loaded and reading it fails as if
+	// it did not exist. Any code path that calls SecretIndex.GetSecret,
+	// ConfigMapIndex.GetConfigMap or similar must have a matching ref here.
+	//
+	// The collections must be derived only from raw resource collections (the
+	// informer-backed policy collection, say), never from an IR collection that
+	// itself resolves Secrets. Doing the latter creates a cycle -- the cache
+	// waits for refs, refs wait for the cache -- that deadlocks startup.
+	ContributesResourceRefs []krt.Collection[ondemand.ResourceRef]
 }
 
 type (

--- a/test/e2e/features/apikeyauth/suite.go
+++ b/test/e2e/features/apikeyauth/suite.go
@@ -585,3 +585,78 @@ func (s *testingSuite) TestAPIKeyAuthDisableAtRouteLevel() {
 		getWithAPIKeyCurlOpts...,
 	)
 }
+
+// TestAPIKeyAuthWithSecretSelector covers apiKeyAuth.secretSelector, where the
+// Secrets holding the keys are chosen by label rather than by name.
+//
+// Beyond the static case, this exercises selector membership changing at
+// runtime in both directions. kgateway loads the contents of only those Secrets
+// its configuration references, and a label-selected reference is resolved
+// against a metadata-only watch (see pkg/krtcollections/ondemand), so a label
+// change has to move a Secret in and out of the referenced set. Getting only the
+// growing direction right still passes a static test: a key that should have
+// been revoked keeps working, which is a security-relevant failure rather than
+// merely a stale one.
+func (s *testingSuite) TestAPIKeyAuthWithSecretSelector() {
+	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPRouteCondition(
+		s.Ctx, "httpbin-route-secret-selector", "kgateway-base", gwv1.RouteConditionAccepted, metav1.ConditionTrue)
+
+	statusReqCurlOpts := []curl.Option{
+		curl.WithHostHeader("httpbin"),
+		curl.WithPort(80),
+		curl.WithPath("/status/200"),
+	}
+	withKey := func(key string) []curl.Option {
+		return append(append([]curl.Option{}, statusReqCurlOpts...), curl.WithHeader("api-key", key))
+	}
+
+	// Keys are aggregated across every Secret the selector matches.
+	s.T().Log("Step 1: keys from both selected Secrets should be accepted")
+	common.BaseGateway.Send(s.T(), expectStatus200Success, withKey("k-sel-111")...)
+	common.BaseGateway.Send(s.T(), expectStatus200Success, withKey("k-sel-222")...)
+
+	// A Secret without the label is not referenced, so its contents are never
+	// loaded and its key is unknown to the filter.
+	s.T().Log("Step 2: a key from an unselected Secret should be rejected")
+	common.BaseGateway.Send(s.T(), expectAPIKeyAuthDenied, withKey("k-sel-333")...)
+
+	// Growing: labelling a Secret brings it into the selection.
+	s.T().Log("Step 3: labelling the unselected Secret should bring its key into use")
+	err := s.TestInstallation.Actions.Kubectl().Apply(s.Ctx, []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-unselected
+  namespace: kgateway-base
+  labels:
+    apikeys: selector-test
+type: Opaque
+stringData:
+  client3: k-sel-333
+`)) //gosec:disable G101
+	s.Require().NoError(err, "failed to label the previously unselected secret")
+
+	common.BaseGateway.Send(s.T(), expectStatus200Success, withKey("k-sel-333")...)
+
+	// Shrinking: removing the label must revoke the key. If the selector only
+	// ever grew, this key would keep working indefinitely.
+	s.T().Log("Step 4: removing the label again should revoke that key")
+	err = s.TestInstallation.Actions.Kubectl().Apply(s.Ctx, []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-unselected
+  namespace: kgateway-base
+  labels:
+    apikeys: something-else
+type: Opaque
+stringData:
+  client3: k-sel-333
+`)) //gosec:disable G101
+	s.Require().NoError(err, "failed to remove the label from the secret")
+
+	common.BaseGateway.Send(s.T(), expectAPIKeyAuthDenied, withKey("k-sel-333")...)
+
+	// The originally selected Secrets are unaffected throughout.
+	s.T().Log("Step 5: the originally selected keys should still work")
+	common.BaseGateway.Send(s.T(), expectStatus200Success, withKey("k-sel-111")...)
+	common.BaseGateway.Send(s.T(), expectStatus200Success, withKey("k-sel-222")...)
+}

--- a/test/e2e/features/apikeyauth/testdata/api-key-auth-secret-selector.yaml
+++ b/test/e2e/features/apikeyauth/testdata/api-key-auth-secret-selector.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-route-secret-selector
+  namespace: kgateway-base
+spec:
+  hostnames:
+    - httpbin
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway
+      namespace: kgateway-base
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: httpbin
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /status/200
+---
+# Two Secrets carrying the selector label, to prove keys are aggregated across
+# every match rather than taken from a single Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-selected-one
+  namespace: kgateway-base
+  labels:
+    apikeys: selector-test
+type: Opaque
+stringData:
+  client1: k-sel-111
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-selected-two
+  namespace: kgateway-base
+  labels:
+    apikeys: selector-test
+type: Opaque
+stringData:
+  client2: k-sel-222
+---
+# Carries a key but not the label. It must never be accepted, which also
+# demonstrates that its contents are never loaded: nothing references it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-unselected
+  namespace: kgateway-base
+  labels:
+    apikeys: something-else
+type: Opaque
+stringData:
+  client3: k-sel-333
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: api-key-auth-policy-secret-selector
+  namespace: kgateway-base
+spec:
+  targetRefs:
+    - name: httpbin-route-secret-selector
+      kind: HTTPRoute
+      group: gateway.networking.k8s.io
+  apiKeyAuth:
+    keySources:
+      - header: "api-key"
+    forwardCredential: true
+    secretSelector:
+      matchLabels:
+        apikeys: selector-test

--- a/test/e2e/features/apikeyauth/types.go
+++ b/test/e2e/features/apikeyauth/types.go
@@ -19,6 +19,7 @@ var (
 	apiKeyAuthManifestQuery        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-query.yaml")
 	apiKeyAuthManifestCookie       = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-cookie.yaml")
 	apiKeyAuthManifestSecretUpdate = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-secret-update.yaml")
+	apiKeyAuthManifestSelector     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-secret-selector.yaml")
 	apiKeyAuthManifestOverride     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-override.yaml")
 	apiKeyAuthManifestDisable      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-disable.yaml")
 
@@ -53,6 +54,9 @@ var (
 		},
 		"TestAPIKeyAuthWithSecretUpdate": {
 			Manifests: []string{apiKeyAuthManifestSecretUpdate},
+		},
+		"TestAPIKeyAuthWithSecretSelector": {
+			Manifests: []string{apiKeyAuthManifestSelector},
 		},
 		"TestAPIKeyAuthRouteOverrideGateway": {
 			Manifests:       []string{apiKeyAuthManifestOverride},


### PR DESCRIPTION
# Description

**Motivation:** kgateway watched every Secret and ConfigMap in the cluster with a typed informer, which keeps the whole object — including `data` — in memory. It only ever reads a handful of them: listener certificates, CA bundles, auth credentials. In clusters with many large ConfigMaps that cache dominated the control plane's heap for no benefit.

**What changed:** both resources are now watched cluster-wide with a **metadata-only** informer, and the full contents of only those objects the configuration *references* are fetched. A `PartialObjectMetadata` is a few hundred bytes regardless of payload size, so the cluster-wide view stays cheap while the expensive part shrinks to the referenced set.

The metadata watch is what makes this work without polling: `resourceVersion` changes on every write, so it tells the fetcher precisely when a referenced object needs re-reading — the same event stream a typed informer would have used, minus the payload for objects nobody asked for.

```
  metadata watch (all objects, no payload) ──┐
                                             ├──> fetcher ──> StaticCollection ──> SecretIndex
  ResourceRef collection (what we need)   ───┘                 (referenced only)
```

References are derived **declaratively** in KRT (`ondemand.ResourceRef`): core Gateway API refs from `krtcollections.GatewayResourceRefs`, plugin refs via a new `pluginsdk.Plugin.ContributesResourceRefs`. Deriving rather than registering on demand means withdrawn references evict for free — no GC heuristics.

`SecretIndex` and `ConfigMapIndex` keep their existing APIs; only their backing collection is smaller.

Design doc: `devel/architecture/secret-configmap-caching.md`.

Fixes #13786

# Change Type

/kind feature

# Changelog

```release-note
Secrets and ConfigMaps are now watched with a metadata-only informer, and only the contents of objects referenced by kgateway configuration are loaded into memory. This substantially reduces control plane memory usage in clusters with many or large Secrets and ConfigMaps.
```

# Additional Notes

### The parts that are easy to get wrong

- **Reference collections must derive only from raw client collections**, never from IR collections that resolve Secrets. `GatewayIndex.Gateways` attaches policies and policy IR reads Secrets, so core refs come from the raw `Gateway`/`ListenerSet` collections. Violating this deadlocks startup (cache waits for refs, refs wait for cache). Documented at the SDK field, in `AGENTS.md`, and in the design doc.
- **Label-selector refs** (`TrafficPolicy` api-key `secretSelector`) resolve against the metadata watch, since labels are present on `PartialObjectMetadata` — no payload needed to decide what to fetch. `GetSecretsBySelector` itself needed no change.
- **Ref keys include the owning object**, and each producer dedupes its output: one Gateway with two listeners sharing a cert would otherwise emit a duplicate KRT key.
- **`gw_controller` held a second cluster-wide typed ConfigMap informer** purely for parent-enqueue. It is now restricted by label selector to objects kgateway deployed; unrestricted it would have negated the entire ConfigMap saving. Verified all 38 generated ConfigMaps in the deployer goldens carry the label.
- **New `NotLoadedError`, distinct from `NotFoundError`.** A persistent `NotLoadedError` means a missing reference declaration (our bug), not a missing object (the user's config) — so a drift bug never gets reported to users as "you forgot to create this Secret".

### Test fidelity fixes (worth a look — they affect more than this PR)

Two gaps in the fake client had to be fixed; both were *silent wrong answers* rather than visible failures:

- Istio's fake gives the metadata client its own **empty, unseeded** tracker, so every test would have seen a Secret-less cluster.
- client-go's fake tracker **never sets `resourceVersion`**, so any RV-diffing logic saw no updates, ever. This one matters beyond this PR: any test mutating a Secret mid-run was previously invisible to RV-based logic.

Both addressed in `pkg/apiclient/fake/metadata.go`.

### Verification

- Full `./pkg/... ./internal/...` unit sweep green; `make analyze` and `make verify` clean.
- The gateway translator suite passes with **unchanged golden outputs**, including TLS listeners, `FrontendTLSConfig` CA bundles, cross-namespace `ReferenceGrant`, API-key `SecretRef` *and* `SecretSelector`, and basic-auth secret refs. That harness uses the real `NewCommonCollections`/`InitPlugins`, so it exercises this path end to end.
- Integration tests in `pkg/pluginsdk/collections/ondemand_integration_test.go` cover the lifecycle over the real stack: payload loads, update → refetch → **policy IR retranslates**, reference deleted → payload evicted, plus the missing-declaration case.
- Those tests were validated by mutation, not just by being green: dropping a plugin's ref declaration, breaking eviction, and disabling RV-diffing each fail the relevant test. An early version passed against an over-fetching mutant because the absence assertion checked a single instant; it now uses a happens-after barrier.

### Limits / what still wants review

- **I have not measured the memory win on a real cluster.** The mechanism is verified; the magnitude is not. Worth confirming against a cluster with the ConfigMap volume described in #13786.
- `TestEveryObjectReaderHasAReferenceSource` is a tripwire that fails when a file reads Secret/ConfigMap contents without a declared reference source, but **it cannot verify that a ref *matches* the object a given path reads** — e.g. a ref computed with the wrong default namespace would still leave the read failing. The per-plugin derivations want a human eye.
- A broad api-key `secretSelector` still pulls in every matching Secret cluster-wide (as it did before), so configs leaning on that will see less benefit.
- No RBAC change is required: `get` on Secrets and ConfigMaps was already granted.
- `/kind feature` is my best fit from the available kinds; happy to relabel if maintainers would rather treat a perf change differently.
