### PR TITLE
Fix restricted header modifiers

### DIFF
--- a/pkg/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/httplistenerpolicy/httplistener_plugin.go
@@ -55,7 +55,7 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 				},
 			},
 		}
-		polIr, errs := listenerpolicy.NewListenerPolicyIR(krtctx, commoncol, i.CreationTimestamp.Time, &spec, objSrc)
+		polIr, errs, warnings := listenerpolicy.NewListenerPolicyIR(krtctx, commoncol, i.CreationTimestamp.Time, &spec, objSrc)
 		polIr.NoOrigin = true
 		pol := &ir.PolicyWrapper{
 			ObjectSource: objSrc,
@@ -63,6 +63,7 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 			PolicyIR:     polIr,
 			TargetRefs:   pluginsdkutils.TargetRefsToPolicyRefs(i.Spec.TargetRefs, i.Spec.TargetSelectors),
 			Errors:       errs,
+			Warnings:     warnings,
 		}
 
 		return statusMarker, pol

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
@@ -230,11 +230,12 @@ func (d *HttpListenerPolicyIr) Equals(in any) bool {
 	return true
 }
 
-func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.CommonCollections, h *kgateway.HTTPSettings, objSrc ir.ObjectSource) (*HttpListenerPolicyIr, []error) {
+func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.CommonCollections, h *kgateway.HTTPSettings, objSrc ir.ObjectSource) (*HttpListenerPolicyIr, []error, []string) {
 	if h == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	errs := []error{}
+	var dropped []string
 	accessLog, err := convertAccessLogConfig(h, commoncol, krtctx, objSrc)
 	if err != nil {
 		logger.Error("error translating access log", "error", err)
@@ -247,7 +248,8 @@ func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.Com
 		errs = append(errs, err)
 	}
 
-	localReplyConfig, err := convertLocalReplyConfig(h, commoncol, krtctx, objSrc)
+	localReplyConfig, localReplyDropped, err := convertLocalReplyConfig(h, commoncol, krtctx, objSrc)
+	dropped = append(dropped, localReplyDropped...)
 	if err != nil {
 		logger.Error("error translating local reply config", "error", err)
 		errs = append(errs, err)
@@ -383,6 +385,8 @@ func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.Com
 		}
 	}
 
+	dropped = append(dropped, pluginutils.RestrictedHeaderNames(h.EarlyRequestHeaderModifier)...)
+
 	return &HttpListenerPolicyIr{
 		accessLogConfig:               accessLog,
 		accessLogPolicies:             h.AccessLog,
@@ -413,7 +417,7 @@ func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.Com
 		forwardClientCertMode:         forwardClientCertMode,
 		setCurrentClientCertDetails:   setCurrentClientCertDetails,
 		stripHostPortMode:             h.StripHostPortMode,
-	}, errs
+	}, errs, dropped
 }
 
 func convertUpgradeConfig(policy *kgateway.HTTPSettings) []*envoy_hcm.HttpConnectionManager_UpgradeConfig {

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
@@ -3,6 +3,7 @@ package listenerpolicy
 import (
 	"context"
 	"fmt"
+	"strings"
 	"maps"
 	"time"
 
@@ -66,9 +67,9 @@ type listenerPolicy struct {
 func newListenerPolicy(
 	krtctx krt.HandlerContext, commoncol *collections.CommonCollections,
 	objSrc ir.ObjectSource, i *kgateway.ListenerConfig,
-) (listenerPolicy, []error) {
+) (listenerPolicy, []error, []string) {
 	if i == nil {
-		return listenerPolicy{}, nil
+		return listenerPolicy{}, nil, nil
 	}
 	var perConnectionBufferLimitBytes *uint32
 	if i.PerConnectionBufferLimitBytes != nil {
@@ -78,7 +79,7 @@ func newListenerPolicy(
 	if i.TransportSocketConnectTimeout != nil {
 		tsct = durationpb.New(i.TransportSocketConnectTimeout.Duration)
 	}
-	http, errs := NewHttpListenerPolicy(krtctx, commoncol, i.HTTPSettings, objSrc)
+	http, errs, dropped := NewHttpListenerPolicy(krtctx, commoncol, i.HTTPSettings, objSrc)
 
 	return listenerPolicy{
 		proxyProtocol:                 convertProxyProtocolConfig(objSrc, i.ProxyProtocol),
@@ -86,22 +87,22 @@ func newListenerPolicy(
 		perConnectionBufferLimitBytes: perConnectionBufferLimitBytes,
 		transportSocketConnectTimeout: tsct,
 		http:                          http,
-	}, errs
+	}, errs, dropped
 }
 
 func newDefaultListenerPolicy(
 	krtctx krt.HandlerContext, commoncol *collections.CommonCollections,
 	objSrc ir.ObjectSource, i *kgateway.ListenerDefaultConfig,
-) (listenerPolicy, []error) {
+) (listenerPolicy, []error, []string) {
 	if i == nil {
-		return listenerPolicy{}, nil
+		return listenerPolicy{}, nil, nil
 	}
 
-	listenerPolicy, errs := newListenerPolicy(krtctx, commoncol, objSrc, &i.ListenerConfig)
+	listenerPolicy, errs, dropped := newListenerPolicy(krtctx, commoncol, objSrc, &i.ListenerConfig)
 
 	listenerPolicy.clientCertificateValidation = convertClientCertificateValidationConfig(objSrc, i.ClientCertificateValidation)
 
-	return listenerPolicy, errs
+	return listenerPolicy, errs, dropped
 }
 
 func (d *ListenerPolicyIR) CreationTime() time.Time {
@@ -222,26 +223,37 @@ func NewListenerPolicyIR(
 	ct time.Time,
 	spec *kgateway.ListenerPolicySpec,
 	objSrc ir.ObjectSource,
-) (*ListenerPolicyIR, []error) {
+) (*ListenerPolicyIR, []error, []error) {
 	if spec == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	errs := []error{}
+	var dropped []string
 	perPort := map[uint32]listenerPolicy{}
 	for _, portConfig := range spec.PerPort {
-		pol, errs2 := newListenerPolicy(krtctx, commoncol, objSrc, &portConfig.Listener)
+		pol, errs2, dropped2 := newListenerPolicy(krtctx, commoncol, objSrc, &portConfig.Listener)
 		perPort[uint32(portConfig.Port)] = pol //nolint:gosec // G115: we have CEL validation that this is at least 1.
 		errs = append(errs, errs2...)
+		dropped = append(dropped, dropped2...)
 	}
 
-	defaultPolicy, errs2 := newDefaultListenerPolicy(krtctx, commoncol, objSrc, spec.Default)
+	defaultPolicy, errs2, dropped2 := newDefaultListenerPolicy(krtctx, commoncol, objSrc, spec.Default)
 	errs = append(errs, errs2...)
+	dropped = append(dropped, dropped2...)
+
+	var warnings []error
+	if len(dropped) > 0 {
+		warnings = append(warnings, fmt.Errorf(
+			"dropped header modifier(s) targeting restricted headers that Envoy refuses to mutate (Host or :-prefixed pseudo-headers): %s",
+			strings.Join(dropped, ", "),
+		))
+	}
 
 	return &ListenerPolicyIR{
 		ct:            ct,
 		defaultPolicy: defaultPolicy,
 		perPortPolicy: perPort,
-	}, errs
+	}, errs, warnings
 }
 
 func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sdk.Plugin {
@@ -270,13 +282,14 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 			}
 		}
 
-		polIr, errs := NewListenerPolicyIR(krtctx, commoncol, i.CreationTimestamp.Time, &i.Spec, objSrc)
+		polIr, errs, warnings := NewListenerPolicyIR(krtctx, commoncol, i.CreationTimestamp.Time, &i.Spec, objSrc)
 		pol := &ir.PolicyWrapper{
 			ObjectSource: objSrc,
 			Policy:       i,
 			PolicyIR:     polIr,
 			TargetRefs:   pluginsdkutils.TargetRefsToPolicyRefsWithSectionName(i.Spec.TargetRefs, i.Spec.TargetSelectors),
 			Errors:       errs,
+			Warnings:     warnings,
 		}
 
 		return statusMarker, pol

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/local_reply_converter.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/local_reply_converter.go
@@ -18,11 +18,11 @@ func convertLocalReplyConfig(
 	commoncol *collections.CommonCollections,
 	krtctx krt.HandlerContext,
 	parentSrc ir.ObjectSource,
-) (*envoy_hcm.LocalReplyConfig, error) {
+) (*envoy_hcm.LocalReplyConfig, []string, error) {
 	config := policy.LocalReplies
 
 	if config == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	envoyConfig := &envoy_hcm.LocalReplyConfig{}
@@ -31,27 +31,29 @@ func convertLocalReplyConfig(
 		GroupKind: parentSrc.GetGroupKind(),
 		Namespace: parentSrc.Namespace,
 	}
+	var dropped []string
 	for _, mapper := range config.Mappers {
-		envoyMapper, err := translateLocalReplyBodyMapper(krtctx, from, commoncol.Secrets, mapper)
+		envoyMapper, mapperDropped, err := translateLocalReplyBodyMapper(krtctx, from, commoncol.Secrets, mapper)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		dropped = append(dropped, mapperDropped...)
 		envoyConfig.Mappers = append(envoyConfig.Mappers, envoyMapper)
 	}
 
 	bodyFormat, err := pluginutils.EnvoyBodyFormat(config.DefaultBodyFormat)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	envoyConfig.BodyFormat = bodyFormat
 
-	return envoyConfig, nil
+	return envoyConfig, dropped, nil
 }
 
-func translateLocalReplyBodyMapper(krtctx krt.HandlerContext, from krtcollections.From, secrets *krtcollections.SecretIndex, mapper kgateway.LocalReplyMapper) (*envoy_hcm.ResponseMapper, error) {
+func translateLocalReplyBodyMapper(krtctx krt.HandlerContext, from krtcollections.From, secrets *krtcollections.SecretIndex, mapper kgateway.LocalReplyMapper) (*envoy_hcm.ResponseMapper, []string, error) {
 	filter, err := convertAccessLogFilter(&mapper.Filter)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	envoyMapper := &envoy_hcm.ResponseMapper{
 		Filter: filter,
@@ -73,21 +75,23 @@ func translateLocalReplyBodyMapper(krtctx krt.HandlerContext, from krtcollection
 
 	bodyFormatOverride, err := pluginutils.EnvoyBodyFormat(mapper.BodyFormatOverride)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	envoyMapper.BodyFormatOverride = bodyFormatOverride
 
+	var dropped []string
 	if mapper.Headers != nil {
 		gwFilter, err := pluginutils.ConvertHeaderFilter(krtctx, from, secrets, mapper.Headers)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		options, err := pluginutils.ConvertMutationsToOptions(pluginutils.ConvertMutations(gwFilter))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		envoyMapper.HeadersToAdd = options
+		dropped = pluginutils.RestrictedHeaderNames(gwFilter)
 	}
 
-	return envoyMapper, nil
+	return envoyMapper, dropped, nil
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go
@@ -3,6 +3,7 @@ package trafficpolicy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,13 +48,14 @@ func NewTrafficPolicyConstructor(
 func (c *TrafficPolicyConstructor) ConstructIR(
 	krtctx krt.HandlerContext,
 	policyCR *kgateway.TrafficPolicy,
-) (*TrafficPolicy, []error) {
+) (*TrafficPolicy, []error, []error) {
 	policyIr := TrafficPolicy{
 		ct: policyCR.CreationTimestamp.Time,
 	}
 	outSpec := trafficPolicySpecIr{}
 
 	var errors []error
+	var warnings []error
 
 	// Construct rustformation specific IR
 	if err := constructRustformation(policyCR, &outSpec); err != nil {
@@ -81,8 +83,13 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 	constructCompression(policyCR.Spec, &outSpec)
 
 	// Construct header modifiers specific IR
-	if err := constructHeaderModifiers(krtctx, policyCR, c.commoncol.Secrets, &outSpec); err != nil {
+	if dropped, err := constructHeaderModifiers(krtctx, policyCR, c.commoncol.Secrets, &outSpec); err != nil {
 		errors = append(errors, err)
+	} else if len(dropped) > 0 {
+		warnings = append(warnings, fmt.Errorf(
+			"dropped header modifier(s) targeting restricted headers that Envoy refuses to mutate (Host or :-prefixed pseudo-headers): %s",
+			strings.Join(dropped, ", "),
+		))
 	}
 	// Construct auto host rewrite specific IR
 	constructAutoHostRewrite(policyCR.Spec, &outSpec)
@@ -134,7 +141,7 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 	}
 	policyIr.spec = outSpec
 
-	return &policyIr, errors
+	return &policyIr, errors, warnings
 }
 
 func (c *TrafficPolicyConstructor) FetchGatewayExtension(krtctx krt.HandlerContext, extensionRef shared.NamespacedObjectReference, ns string) (*TrafficPolicyGatewayExtensionIR, error) {

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/header_modifiers.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/header_modifiers.go
@@ -51,9 +51,9 @@ func constructHeaderModifiers(
 	policy *kgateway.TrafficPolicy,
 	secrets *krtcollections.SecretIndex,
 	out *trafficPolicySpecIr,
-) error {
+) ([]string, error) {
 	if policy.Spec.HeaderModifiers == nil {
-		return nil
+		return nil, nil
 	}
 
 	spec := policy.Spec.HeaderModifiers
@@ -68,14 +68,14 @@ func constructHeaderModifiers(
 
 	gwReqFilter, err := pluginutils.ConvertHeaderFilter(krtctx, from, secrets, spec.Request)
 	if err != nil {
-		return fmt.Errorf("request: %w", err)
+		return nil, fmt.Errorf("request: %w", err)
 	}
 	reqMutations := pluginutils.ConvertMutations(gwReqFilter)
 	p.Mutations.RequestMutations = append(p.Mutations.RequestMutations, reqMutations...)
 
 	gwRespFilter, err := pluginutils.ConvertHeaderFilter(krtctx, from, secrets, spec.Response)
 	if err != nil {
-		return fmt.Errorf("response: %w", err)
+		return nil, fmt.Errorf("response: %w", err)
 	}
 	respMutations := pluginutils.ConvertMutations(gwRespFilter)
 	p.Mutations.ResponseMutations = append(p.Mutations.ResponseMutations, respMutations...)
@@ -84,8 +84,10 @@ func constructHeaderModifiers(
 		p.Mutations = nil
 	}
 
+	dropped := append(pluginutils.RestrictedHeaderNames(gwReqFilter), pluginutils.RestrictedHeaderNames(gwRespFilter)...)
+
 	out.headerModifiers = &headerModifiersIR{policy: p}
-	return nil
+	return dropped, nil
 }
 
 // handleHeaderModifiers adds header modifier filters.

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -295,7 +295,7 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, me
 			Name:      policyCR.Name,
 		}
 
-		policyIR, errors := constructor.ConstructIR(krtctx, policyCR)
+		policyIR, errors, warnings := constructor.ConstructIR(krtctx, policyCR)
 		if err := validateWithValidationLevel(ctx, policyIR, v, commoncol.Settings.ValidationMode, commoncol.Settings.EnableAuthMetadata); err != nil {
 			logger.Error("validation failed", "policy", policyCR.Name, "error", err)
 			errors = append(errors, err)
@@ -319,6 +319,7 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, me
 			PolicyIR:         policyIR,
 			TargetRefs:       pluginsdkutils.TargetRefsToPolicyRefsWithSectionName(policyCR.Spec.TargetRefs, policyCR.Spec.TargetSelectors),
 			Errors:           errors,
+			Warnings:         warnings,
 			PrecedenceWeight: precedenceWeight,
 		}
 		return statusMarker, pol

--- a/pkg/kgateway/extensions2/pluginutils/headers.go
+++ b/pkg/kgateway/extensions2/pluginutils/headers.go
@@ -13,6 +13,7 @@ import (
 
 	sharedv1alpha1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/stringutils"
 )
 
 var (
@@ -30,6 +31,9 @@ func ConvertMutations(filter *gwv1.HTTPHeaderFilter) (mutations []*mutation_rule
 	}
 
 	for _, h := range filter.Add {
+		if stringutils.IsRestrictedHeaderName(string(h.Name)) {
+			continue
+		}
 		mutations = append(mutations, &mutation_rulesv3.HeaderMutation{
 			Action: &mutation_rulesv3.HeaderMutation_Append{
 				Append: &envoycorev3.HeaderValueOption{
@@ -44,6 +48,9 @@ func ConvertMutations(filter *gwv1.HTTPHeaderFilter) (mutations []*mutation_rule
 	}
 
 	for _, h := range filter.Set {
+		if stringutils.IsRestrictedHeaderName(string(h.Name)) {
+			continue
+		}
 		mutations = append(mutations, &mutation_rulesv3.HeaderMutation{
 			Action: &mutation_rulesv3.HeaderMutation_Append{
 				Append: &envoycorev3.HeaderValueOption{
@@ -58,6 +65,9 @@ func ConvertMutations(filter *gwv1.HTTPHeaderFilter) (mutations []*mutation_rule
 	}
 
 	for _, h := range filter.Remove {
+		if stringutils.IsRestrictedHeaderName(h) {
+			continue
+		}
 		mutations = append(mutations, &mutation_rulesv3.HeaderMutation{
 			Action: &mutation_rulesv3.HeaderMutation_Remove{
 				Remove: h,
@@ -66,6 +76,29 @@ func ConvertMutations(filter *gwv1.HTTPHeaderFilter) (mutations []*mutation_rule
 	}
 
 	return mutations
+}
+
+func RestrictedHeaderNames(filter *gwv1.HTTPHeaderFilter) []string {
+	if filter == nil {
+		return nil
+	}
+	var dropped []string
+	for _, h := range filter.Add {
+		if stringutils.IsRestrictedHeaderName(string(h.Name)) {
+			dropped = append(dropped, string(h.Name))
+		}
+	}
+	for _, h := range filter.Set {
+		if stringutils.IsRestrictedHeaderName(string(h.Name)) {
+			dropped = append(dropped, string(h.Name))
+		}
+	}
+	for _, h := range filter.Remove {
+		if stringutils.IsRestrictedHeaderName(h) {
+			dropped = append(dropped, h)
+		}
+	}
+	return dropped
 }
 
 func ConvertHeaderFilter(

--- a/pkg/kgateway/extensions2/pluginutils/headers_test.go
+++ b/pkg/kgateway/extensions2/pluginutils/headers_test.go
@@ -130,6 +130,43 @@ func TestConvertHeaderMutations(t *testing.T) {
 			input:    nil,
 			expected: nil,
 		},
+		{
+			name: "drops Host and pseudo-headers that Envoy refuses to mutate, keeps the rest",
+			input: &gwv1.HTTPHeaderFilter{
+				Add: []gwv1.HTTPHeader{
+					{Name: "Host", Value: "evil.example.com"},
+					{Name: "X-Add-Kept", Value: "v"},
+				},
+				Set: []gwv1.HTTPHeader{
+					{Name: "host", Value: "evil.example.com"},
+					{Name: "X-Set-Kept", Value: "v"},
+				},
+				Remove: []string{":authority", "X-Remove-Kept"},
+			},
+			expected: []*mutation_rulesv3.HeaderMutation{
+				{
+					Action: &mutation_rulesv3.HeaderMutation_Append{
+						Append: &envoycorev3.HeaderValueOption{
+							Header:       &envoycorev3.HeaderValue{Key: "X-Add-Kept", Value: "v"},
+							AppendAction: envoycorev3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+						},
+					},
+				},
+				{
+					Action: &mutation_rulesv3.HeaderMutation_Append{
+						Append: &envoycorev3.HeaderValueOption{
+							Header:       &envoycorev3.HeaderValue{Key: "X-Set-Kept", Value: "v"},
+							AppendAction: envoycorev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+						},
+					},
+				},
+				{
+					Action: &mutation_rulesv3.HeaderMutation_Remove{
+						Remove: "X-Remove-Kept",
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -251,6 +251,17 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("http gateway drops restricted HeaderModifier headers and reports PartiallyInvalid", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"http-with-restricted-header-modifier"},
+			outputFile: "http-with-restricted-header-modifier-proxy.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "gw",
+			},
+		})
+	})
+
 	t.Run("Gateway API route sorting", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"route-sort.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/http-with-restricted-header-modifier/manifests.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/http-with-restricted-header-modifier/manifests.yaml
@@ -1,0 +1,72 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: gw
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: gw
+  hostnames:
+  - "example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /route-level
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: Host
+          value: rewritten.example.com
+        - name: X-Header-Set
+          value: header-set
+        add:
+        - name: X-Header-Add
+          value: header-add
+        remove:
+        - host
+        - X-Header-Remove
+    backendRefs:
+    - name: example-svc
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /backend-level
+    backendRefs:
+    - name: example-svc
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: host
+            value: rewritten.example.com
+          - name: X-Backend-Header-Set
+            value: backend-set
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    app.kubernetes.io/name: nginx
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: http-web-svc

--- a/pkg/kgateway/translator/gateway/testutils/outputs/http-with-restricted-header-modifier-proxy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/http-with-restricted-header-modifier-proxy.yaml
@@ -1,0 +1,152 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-svc_8080
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~8080~example_com
+    routes:
+    - match:
+        pathSeparatedPrefix: /backend-level
+      name: listener~8080~example_com-route-0-httproute-example-route-default-1-0-matcher-0
+      requestHeadersToAdd:
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+        header:
+          key: X-Backend-Header-Set
+          value: backend-set
+      route:
+        cluster: kube_default_example-svc_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+    - match:
+        pathSeparatedPrefix: /route-level
+      name: listener~8080~example_com-route-1-httproute-example-route-default-0-0-matcher-0
+      requestHeadersToAdd:
+      - header:
+          key: X-Header-Add
+          value: header-add
+      - appendAction: OVERWRITE_IF_EXISTS_OR_ADD
+        header:
+          key: X-Header-Set
+          value: header-set
+      requestHeadersToRemove:
+      - X-Header-Remove
+      route:
+        cluster: kube_default_example-svc_8080
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/gw:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: 'Dropped header modifier(s) targeting restricted headers that Envoy
+            refuses to mutate (Host or :-prefixed pseudo-headers): Host, host'
+          reason: UnsupportedValue
+          status: "True"
+          type: PartiallyInvalid
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: gw

--- a/pkg/kgateway/translator/irtranslator/policy.go
+++ b/pkg/kgateway/translator/irtranslator/policy.go
@@ -49,6 +49,17 @@ func reportPolicyAcceptanceStatus(
 			continue
 		}
 
+		if len(policy.Warnings) > 0 {
+			r.SetCondition(reporter.PolicyCondition{
+				Type:               string(shared.PolicyConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(shared.PolicyReasonPartiallyValid),
+				Message:            policy.FormatWarnings(),
+				ObservedGeneration: policy.Generation,
+			})
+			continue
+		}
+
 		r.SetCondition(reporter.PolicyCondition{
 			Type:               string(shared.PolicyConditionAccepted),
 			Status:             metav1.ConditionTrue,

--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -635,6 +635,10 @@ func (h *httpRouteConfigurationTranslator) translateRouteAction(
 			FilterChainName:   h.fc.FilterChainName,
 			Backend:           backend.Backend.BackendObject,
 			TypedFilterConfig: backendConfigCtx.typedPerFilterConfigRoute,
+			RouteParentRef:    in.ParentRef,
+		}
+		if in.Parent != nil {
+			pCtx.RouteSource = in.Parent.GetSourceObject()
 		}
 
 		ancestorRef := routeAncestorRef(in, h.listener.PolicyAncestorRef)

--- a/pkg/krtcollections/builtin.go
+++ b/pkg/krtcollections/builtin.go
@@ -740,6 +740,9 @@ func (p *builtinPluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputRoute *
 		if canPostProcessRedirect {
 			applyRedirectPortPostProcessing(pCtx, pol, outputRoute)
 		}
+		if hm, ok := pol.filter.policy.(*headerModifierIr); ok && pCtx.In.Parent != nil {
+			p.reportDroppedHeaders(pCtx.In.Parent.GetSourceObject(), pCtx.In.ParentRef, hm.Dropped)
+		}
 	}
 
 	p.applyRulePolicy(pCtx, pol.rule, mergeOpts, outputRoute)
@@ -748,6 +751,21 @@ func (p *builtinPluginGwPass) ApplyForRoute(pCtx *ir.RouteContext, outputRoute *
 	}
 
 	return errs
+}
+
+func (p *builtinPluginGwPass) reportDroppedHeaders(src metav1.Object, parentRef gwv1.ParentReference, dropped []string) {
+	if len(dropped) == 0 || src == nil {
+		return
+	}
+	p.reporter.Route(src).ParentRef(&parentRef).SetCondition(reporter.RouteCondition{
+		Type:   gwv1.RouteConditionPartiallyInvalid,
+		Status: metav1.ConditionTrue,
+		Reason: gwv1.RouteReasonUnsupportedValue,
+		Message: fmt.Sprintf(
+			"Dropped header modifier(s) targeting restricted headers that Envoy refuses to mutate (Host or :-prefixed pseudo-headers): %s",
+			strings.Join(dropped, ", "),
+		),
+	})
 }
 
 func (p *builtinPluginGwPass) ApplyForRouteBackend(
@@ -770,6 +788,9 @@ func (p *builtinPluginGwPass) ApplyForRouteBackend(
 	}
 	if backendPolicy, ok := inPolicy.filter.policy.(applyToRouteBackend); ok {
 		backendPolicy.applyToBackend(pCtx)
+		if hm, ok := inPolicy.filter.policy.(*headerModifierIr); ok {
+			p.reportDroppedHeaders(pCtx.RouteSource, pCtx.RouteParentRef, hm.Dropped)
+		}
 	} else {
 		logger.Error("filter policy is not supported on backendRef", "filter_type", inPolicy.filter.filterType)
 		// TODO: once we have warnings / non terminal errors we should return it here, so the policy status is updated.

--- a/pkg/krtcollections/builtin.go
+++ b/pkg/krtcollections/builtin.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/policy"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/stringutils"
 )
 
 const (
@@ -589,6 +590,7 @@ type headerModifierIr struct {
 	Add       []*envoycorev3.HeaderValueOption
 	Remove    []string
 	IsRequest bool // true=request, false=response
+	Dropped   []string
 }
 
 func (h *headerModifierIr) apply(
@@ -621,8 +623,14 @@ func convertHeaderModifierIR(_ krt.HandlerContext, f *gwv1.HTTPHeaderFilter, isR
 	if f == nil {
 		return nil
 	}
+	var dropped []string
 	var add []*envoycorev3.HeaderValueOption
 	for _, h := range f.Add {
+		if stringutils.IsRestrictedHeaderName(string(h.Name)) {
+			dropped = append(dropped, string(h.Name))
+			continue
+		}
+
 		add = append(add, &envoycorev3.HeaderValueOption{
 			Header: &envoycorev3.HeaderValue{
 				Key:   string(h.Name),
@@ -632,6 +640,11 @@ func convertHeaderModifierIR(_ krt.HandlerContext, f *gwv1.HTTPHeaderFilter, isR
 		})
 	}
 	for _, h := range f.Set {
+		if stringutils.IsRestrictedHeaderName(string(h.Name)) {
+			dropped = append(dropped, string(h.Name))
+			continue
+		}
+
 		add = append(add, &envoycorev3.HeaderValueOption{
 			Header: &envoycorev3.HeaderValue{
 				Key:   string(h.Name),
@@ -640,10 +653,21 @@ func convertHeaderModifierIR(_ krt.HandlerContext, f *gwv1.HTTPHeaderFilter, isR
 			AppendAction: envoycorev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 		})
 	}
+
+	var remove []string
+	for _, name := range f.Remove {
+		if stringutils.IsRestrictedHeaderName(name) {
+			dropped = append(dropped, name)
+			continue
+		}
+		remove = append(remove, name)
+	}
+
 	return &headerModifierIr{
 		Add:       add,
-		Remove:    f.Remove,
+		Remove:    remove,
 		IsRequest: isRequest,
+		Dropped:   dropped,
 	}
 }
 

--- a/pkg/krtcollections/builtin_test.go
+++ b/pkg/krtcollections/builtin_test.go
@@ -17,6 +17,68 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/policy"
 )
 
+func TestConvertHeaderModifierIRDropsRestrictedHeaders(t *testing.T) {
+	tests := []struct {
+		name         string
+		filter       *gwv1.HTTPHeaderFilter
+		expectAdd    []string // header keys expected to survive in the resulting Add list
+		expectRemove []string
+		expectDrop   []string
+	}{
+		{
+			name: "ordinary headers pass through untouched",
+			filter: &gwv1.HTTPHeaderFilter{
+				Add: []gwv1.HTTPHeader{{Name: "X-Add", Value: "v"}},
+				Set: []gwv1.HTTPHeader{{Name: "X-Set", Value: "v"}},
+			},
+			expectAdd: []string{"X-Add", "X-Set"},
+		},
+		{
+			name: "Host in add is dropped",
+			filter: &gwv1.HTTPHeaderFilter{
+				Add: []gwv1.HTTPHeader{{Name: "Host", Value: "evil.example.com"}},
+			},
+			expectAdd:  nil,
+			expectDrop: []string{"Host"},
+		},
+		{
+			name: "host in set is dropped regardless of case",
+			filter: &gwv1.HTTPHeaderFilter{
+				Set: []gwv1.HTTPHeader{
+					{Name: "host", Value: "evil.example.com"},
+					{Name: "HOST", Value: "evil.example.com"},
+					{Name: "HoSt", Value: "evil.example.com"},
+					{Name: "X-Kept", Value: "v"},
+				},
+			},
+			expectAdd:  []string{"X-Kept"},
+			expectDrop: []string{"host", "HOST", "HoSt"},
+		},
+		{
+			name: "restricted names in remove are dropped, others kept",
+			filter: &gwv1.HTTPHeaderFilter{
+				Remove: []string{"Host", ":authority", "X-Kept"},
+			},
+			expectRemove: []string{"X-Kept"},
+			expectDrop:   []string{"Host", ":authority"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ir := convertHeaderModifierIR(nil, tt.filter, true)
+			require.NotNil(t, ir)
+
+			var gotAdd []string
+			for _, h := range ir.Add {
+				gotAdd = append(gotAdd, h.GetHeader().GetKey())
+			}
+			assert.Equal(t, tt.expectAdd, gotAdd)
+			assert.Equal(t, tt.expectRemove, ir.Remove)
+			assert.Equal(t, tt.expectDrop, ir.Dropped)
+		})
+	}
+}
+
 func TestURLRewriteApply(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -916,6 +916,7 @@ func (p *PolicyIndex) getTargetingPoliciesMaybeForBackends(
 			},
 			PrecedenceWeight: p.PrecedenceWeight,
 			Errors:           p.Errors,
+			Warnings:         p.Warnings,
 		})
 	}
 
@@ -1530,6 +1531,7 @@ func (h *RoutesIndex) resolveExtension(
 			PolicyIr:         policy.PolicyIR,
 			PolicyRef:        policyRef,
 			Errors:           policy.Errors,
+			Warnings:         policy.Warnings,
 			PrecedenceWeight: policy.PrecedenceWeight,
 		}
 		return policyAtt, nil
@@ -1661,6 +1663,7 @@ func ToAttachedPolicies(policies []ir.PolicyAtt, opts ...ir.PolicyAttachmentOpts
 			PolicyRef:        p.PolicyRef,
 			GroupKind:        gk,
 			Errors:           p.Errors,
+			Warnings:         p.Warnings,
 			Generation:       p.Generation,
 			PrecedenceWeight: p.PrecedenceWeight,
 		}

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -52,6 +52,7 @@ func baseHarnessPolicyAtt() PolicyAtt {
 		},
 		InheritedPolicyPriority: apiannotations.ShallowMergePreferParent,
 		Errors:                  []error{errors.New("base error")},
+		Warnings:                []error{errors.New("base warning")},
 		HierarchicalPriority:    5,
 		PrecedenceWeight:        10,
 		// MergeOrigins is +noKrtEquals and listed as exempt below.
@@ -83,6 +84,10 @@ func TestHarnessPolicyAttEquals(t *testing.T) {
 		{
 			Field:  "Errors",
 			Mutate: func(p *PolicyAtt) { p.Errors = []error{errors.New("different error")} },
+		},
+		{
+			Field:  "Warnings",
+			Mutate: func(p *PolicyAtt) { p.Warnings = []error{errors.New("different warning")} },
 		},
 		{
 			Field:  "HierarchicalPriority",

--- a/pkg/pluginsdk/ir/gw.go
+++ b/pkg/pluginsdk/ir/gw.go
@@ -87,6 +87,10 @@ type PolicyAtt struct {
 	// Instead use a well defined error such as ErrInvalidConfig
 	Errors []error
 
+	// Warnings are non-fatal issues detected while processing the policy. The policy
+	// is still accepted, but is reported as PartiallyValid.
+	Warnings []error
+
 	// HierarchicalPriority is the priority of the policy in an inheritance hierarchy.
 	// A higher value means higher priority. It is used to accurately merge policies
 	// that are at different levels in the config tree hierarchy.
@@ -114,6 +118,14 @@ func (c PolicyAtt) FormatErrors() string {
 	return strings.Join(errs, "; ")
 }
 
+func (c PolicyAtt) FormatWarnings() string {
+	warns := make([]string, len(c.Warnings))
+	for i, w := range c.Warnings {
+		warns[i] = w.Error()
+	}
+	return strings.Join(warns, "; ")
+}
+
 type PolicyAttachmentOpts func(*PolicyAtt)
 
 func WithInheritedPolicyPriority(priority apiannotations.InheritedPolicyPriorityValue) PolicyAttachmentOpts {
@@ -131,7 +143,24 @@ func (c PolicyAtt) TargetRef() *AttachedPolicyRef {
 }
 
 func (c PolicyAtt) Equals(in PolicyAtt) bool {
-	if !slices.EqualFunc(c.Errors, in.Errors, func(e1, e2 error) bool {
+	if !errorSlicesEqual(c.Errors, in.Errors) {
+		return false
+	}
+	if !errorSlicesEqual(c.Warnings, in.Warnings) {
+		return false
+	}
+
+	return c.GroupKind == in.GroupKind &&
+		c.Generation == in.Generation &&
+		c.PolicyIr.Equals(in.PolicyIr) &&
+		ptrEquals(c.PolicyRef, in.PolicyRef) &&
+		c.InheritedPolicyPriority == in.InheritedPolicyPriority &&
+		c.HierarchicalPriority == in.HierarchicalPriority &&
+		c.PrecedenceWeight == in.PrecedenceWeight
+}
+
+func errorSlicesEqual(a, b []error) bool {
+	return slices.EqualFunc(a, b, func(e1, e2 error) bool {
 		if e1 == nil && e2 != nil {
 			return false
 		}
@@ -143,17 +172,7 @@ func (c PolicyAtt) Equals(in PolicyAtt) bool {
 		}
 
 		return true
-	}) {
-		return false
-	}
-
-	return c.GroupKind == in.GroupKind &&
-		c.Generation == in.Generation &&
-		c.PolicyIr.Equals(in.PolicyIr) &&
-		ptrEquals(c.PolicyRef, in.PolicyRef) &&
-		c.InheritedPolicyPriority == in.InheritedPolicyPriority &&
-		c.HierarchicalPriority == in.HierarchicalPriority &&
-		c.PrecedenceWeight == in.PrecedenceWeight
+	})
 }
 
 func ptrEquals[T comparable](a, b *T) bool {

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -106,6 +106,8 @@ type RouteBackendContext struct {
 	RequestHeadersToRemove  []string
 	ResponseHeadersToAdd    []*envoycorev3.HeaderValueOption
 	ResponseHeadersToRemove []string
+	RouteSource             metav1.Object
+	RouteParentRef          gwv1.ParentReference
 }
 
 type RouteContext struct {

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -295,6 +295,11 @@ type PolicyWrapper struct {
 	// Instead use a well defined error such as ErrInvalidConfig
 	Errors []error
 
+	// Warnings are non-fatal issues detected while processing the policy. The policy
+	// is still accepted, but is reported as PartiallyValid so users can see what was
+	// dropped or ignored.
+	Warnings []error
+
 	// The IR of the policy objects. ideally with structural errors removed.
 	// Opaque to us other than metadata.
 	PolicyIR PolicyIR

--- a/pkg/utils/stringutils/is_restricted_header_name_test.go
+++ b/pkg/utils/stringutils/is_restricted_header_name_test.go
@@ -1,0 +1,36 @@
+package stringutils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/stringutils"
+)
+
+func TestIsRestrictedHeaderName(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     string
+		restricted bool
+	}{
+		{name: "ordinary header", header: "X-Custom-Header", restricted: false},
+		{name: "host exact case", header: "Host", restricted: true},
+		{name: "host lowercase", header: "host", restricted: true},
+		{name: "host uppercase", header: "HOST", restricted: true},
+		{name: "host mixed case", header: "HoSt", restricted: true},
+		{name: "authority pseudo-header", header: ":authority", restricted: true},
+		{name: "path pseudo-header", header: ":path", restricted: true},
+		{name: "method pseudo-header", header: ":method", restricted: true},
+		{name: "scheme pseudo-header", header: ":scheme", restricted: true},
+		{name: "status pseudo-header", header: ":status", restricted: true},
+		{name: "header containing but not starting with colon", header: "X-Foo:Bar", restricted: false},
+		{name: "header containing host as substring", header: "X-Host-Region", restricted: false},
+		{name: "empty string", header: "", restricted: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.restricted, stringutils.IsRestrictedHeaderName(tt.header))
+		})
+	}
+}

--- a/pkg/utils/stringutils/stringutils.go
+++ b/pkg/utils/stringutils/stringutils.go
@@ -2,6 +2,7 @@ package stringutils
 
 import (
 	slices0 "slices"
+	"strings"
 
 	slices "golang.org/x/exp/slices"
 )
@@ -34,4 +35,12 @@ func TruncateMaxLength(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen]
+}
+
+// IsRestrictedHeaderName reports if a name is a header Envoy refuses to let
+// config add, set, or remove via header alter lists - "host" (case-insensitive),
+// or basically any HTTP/2 pseudo-header, i.e. one starting with ":"
+// (":authority", ":path", ":method", ":scheme", ":status").
+func IsRestrictedHeaderName(name string) bool {
+	return strings.HasPrefix(name, ":") || strings.EqualFold(name, "host")
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

Envoy refuses to mutate certain headers via its header-mutation lists: anything case-insensitive equal to `Host`, or any `:`-prefixed pseudo-header (`HeaderUtility::isModifiableHeader`). Envoy doesn't just ignore the bad entry - it rejects the entire RouteConfiguration/Cluster that contains it, so a single `RequestHeaderModifier` setting `Host` could take down every route on that config, not just the offending one.

Those header names were forwarded straight through. Thus, any user who tried to set/add/remove `Host` could / would break unrelated routes.

What changed:

- Strip restricted header names (`Host` case-insensitive, `:`-prefixed) at the two points where we build Envoy header mutations, before they reach Envoy. The rest of the config is accepted normally.
- Surface the drop back to the user instead of doing it silently:
  - HTTPRoute request/response header modifiers (route- and backend-level) report `PartiallyInvalid=True` / `UnsupportedValue` while the route stays `Accepted=True`.
  - TrafficPolicy and ListenerPolicy (incl. `earlyRequestHeaderModifier` and localReply headers) report `Accepted=True` / `PartiallyValid` via a new non-fatal warnings channel on the policy IR.

Because we drop the header, Envoy gets valid config and everything keeps serving, which is exactly what Gateway API's `PartiallyInvalid` / `PartiallyValid` conditions are for. A hard `Invalid` would probably be inaccurate and, in some paths, would drop the whole policy - worse than losing one header modifier.

Covered paths (all funnel through the two chokepoints): HTTPRoute header modifier (route + backendRef), `TrafficPolicy.headerModifiers`, `ListenerPolicy.earlyRequestHeaderModifier`, and ListenerPolicy localReply headers. Mechanisms that legitimately allow `Host`/authority (transformation/rustformation, `autoHostRewrite`/URLRewrite, ext_authz `headersToAdd`, gRPC authority) are left untouched.

Added a golden translation test covering both a route-level and backend-level drop, the surviving valid headers, and the resulting `PartiallyInvalid` status.

References #14264

# Change Type

/kind fix

# Changelog

```release-note
Header modifiers targeting `Host` or `:`-prefixed pseudo-headers are now dropped instead of being sent to Envoy (which would reject the whole route/cluster config). Affected HTTPRoutes report `PartiallyInvalid`, and affected TrafficPolicy/ListenerPolicy report `PartiallyValid`, so the dropped headers are visible in status.
```

# Additional Notes

The restricted-name check mirrors Envoy's own `isModifiableHeader` (`strings.HasPrefix(name, ":") || strings.EqualFold(name, "host")`), so we drop exactly what Envoy would reject. Names like `X-Host-Region` or `X-Foo:Bar` are unaffected.
