### PR TITLE
Use package-level loggers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,6 +82,8 @@ linters:
           msg: use apiclient.Client instead of controller-runtime's client.Client
         - pattern: (\bt|\bT\(\))\.Cleanup
           msg: require testutils.Cleanup in e2e tests (test/e2e/)
+        - pattern: ^slog\.(Debug|DebugContext|Info|InfoContext|Warn|WarnContext|Error|ErrorContext|Log|LogAttrs)$
+          msg: use a package-level logger created with logging.New instead of the global slog logger
     gomodguard:
       blocked:
         modules:

--- a/pkg/kgateway/admin/server.go
+++ b/pkg/kgateway/admin/server.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/http"
 	"slices"
@@ -18,8 +17,11 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/controller"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/version"
 )
+
+var logger = logging.New("admin")
 
 func RunAdminServer(ctx context.Context, setupOpts *controller.SetupOpts) error {
 	// serverHandlers defines the custom handlers that the Admin Server will support
@@ -95,13 +97,13 @@ func startHandlers(ctx context.Context, bindAddress string, addHandlers ...func(
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-	slog.Info("admin server starting", "address", server.Addr)
+	logger.Info("admin server starting", "address", server.Addr)
 	go func() {
 		err := server.ListenAndServe()
 		if err == http.ErrServerClosed {
-			slog.Info("admin server closed")
+			logger.Info("admin server closed")
 		} else {
-			slog.Warn("admin server closed with unexpected error", "error", err)
+			logger.Warn("admin server closed with unexpected error", "error", err)
 		}
 	}()
 	go func() {
@@ -109,7 +111,7 @@ func startHandlers(ctx context.Context, bindAddress string, addHandlers ...func(
 		if server != nil {
 			err := server.Close()
 			if err != nil {
-				slog.Warn("admin server shutdown returned error", "error", err)
+				logger.Warn("admin server shutdown returned error", "error", err)
 			}
 		}
 	}()

--- a/pkg/kgateway/controller/start.go
+++ b/pkg/kgateway/controller/start.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"maps"
 	"net/http"
 	"strings"
@@ -219,7 +218,7 @@ func pluginFactoryWithBuiltin(cfg StartConfig) extensions2.K8sGatewayExtensionsF
 }
 
 func (c *ControllerBuilder) Build(ctx context.Context) error {
-	slog.Info("creating gateway controllers")
+	logger.Info("creating gateway controllers")
 
 	globalSettings := c.cfg.SetupOpts.GlobalSettings
 
@@ -239,7 +238,7 @@ func (c *ControllerBuilder) Build(ctx context.Context) error {
 	}
 
 	xdsPort := globalSettings.XdsServicePort
-	slog.Info("got xds address for deployer", "xds_host", xdsHost, "xds_port", xdsPort)
+	logger.Info("got xds address for deployer", "xds_host", xdsHost, "xds_port", xdsPort)
 
 	istioAutoMtlsEnabled := globalSettings.EnableIstioAutoMtls
 

--- a/pkg/kgateway/deployer/gateway_parameters.go
+++ b/pkg/kgateway/deployer/gateway_parameters.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -21,9 +20,12 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/deployer/strategicpatch"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/helm"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 )
 
 var (
+	logger = logging.New("gateway-deployer")
+
 	// ErrNoValidPorts is returned when no valid ports are found for the Gateway
 	ErrNoValidPorts = errors.New("no valid ports")
 
@@ -142,7 +144,7 @@ func (gp *GatewayParameters) getHelmValuesGenerator(obj client.Object) (deployer
 	}
 
 	if gp.helmValuesGeneratorOverride != nil {
-		slog.Debug("using override HelmValuesGenerator for Gateway",
+		logger.Debug("using override HelmValuesGenerator for Gateway",
 			"gateway_name", gw.GetName(),
 			"gateway_namespace", gw.GetNamespace(),
 		)
@@ -152,7 +154,7 @@ func (gp *GatewayParameters) getHelmValuesGenerator(obj client.Object) (deployer
 	if gp.kgwParameters == nil {
 		return nil, fmt.Errorf("no parameter clients available")
 	}
-	slog.Debug("using default HelmValuesGenerator for Gateway",
+	logger.Debug("using default HelmValuesGenerator for Gateway",
 		"gateway_name", gw.GetName(),
 		"gateway_namespace", gw.GetNamespace(),
 	)
@@ -201,7 +203,7 @@ func (k *kgatewayParameters) getGatewayParametersForGateway(gw *gwv1.Gateway) (*
 	// attempt to get the GatewayParameters name from the Gateway. If we can't find it,
 	// we'll check for the default GWP for the GatewayClass.
 	if gw.Spec.Infrastructure == nil || gw.Spec.Infrastructure.ParametersRef == nil {
-		slog.Debug("no GatewayParameters found for Gateway, using default",
+		logger.Debug("no GatewayParameters found for Gateway, using default",
 			"gateway_name", gw.GetName(),
 			"gateway_namespace", gw.GetNamespace(),
 		)
@@ -283,7 +285,7 @@ func (k *kgatewayParameters) resolveGatewayClassParameters(gwc *gwv1.GatewayClas
 	gwpName := paramRef.Name
 	if gwpName == "" {
 		err := errors.New("parametersRef.name cannot be empty when parametersRef is specified")
-		slog.Error("could not get gateway parameters for gateway class",
+		logger.Error("could not get gateway parameters for gateway class",
 			"error", err,
 			"gatewayClassName", gwc.GetName(),
 		)

--- a/pkg/kgateway/setup/authn.go
+++ b/pkg/kgateway/setup/authn.go
@@ -116,7 +116,7 @@ func (am *authenticationManager) authenticate(ctx context.Context) *security.Cal
 	for _, authn := range am.Authenticators {
 		u, err := authn.Authenticate(req)
 		if u != nil && err == nil { // we don't validate len(u.Identities) here like Istio does since this isn't relevant
-			logger.Debug("authentication succeeded", "auth_source", u.AuthSource)
+			controlPlaneLogger.Debug("authentication succeeded", "auth_source", u.AuthSource)
 			return u
 		}
 		am.authFailMsgs = append(am.authFailMsgs, fmt.Sprintf("Authenticator %s: %v", authn.AuthenticatorType(), err))

--- a/pkg/kgateway/setup/authn.go
+++ b/pkg/kgateway/setup/authn.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strings"
 
@@ -117,7 +116,7 @@ func (am *authenticationManager) authenticate(ctx context.Context) *security.Cal
 	for _, authn := range am.Authenticators {
 		u, err := authn.Authenticate(req)
 		if u != nil && err == nil { // we don't validate len(u.Identities) here like Istio does since this isn't relevant
-			slog.Debug("authentication succeeded", "auth_source", u.AuthSource)
+			logger.Debug("authentication succeeded", "auth_source", u.AuthSource)
 			return u
 		}
 		am.authFailMsgs = append(am.authFailMsgs, fmt.Sprintf("Authenticator %s: %v", authn.AuthenticatorType(), err))

--- a/pkg/kgateway/setup/controlplane.go
+++ b/pkg/kgateway/setup/controlplane.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/xds"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/metrics"
 )
 
@@ -99,7 +100,7 @@ func NewControlPlane(
 	certWatcher *certwatcher.CertWatcher,
 	orderedADS bool,
 ) envoycache.SnapshotCache {
-	baseLogger := slog.Default().With("component", "envoy-controlplane")
+	baseLogger := logging.New("envoy-controlplane")
 	envoyLoggerAdapter := &slogAdapterForEnvoy{logger: baseLogger}
 	lnc := newLogNackCallback()
 	allCallbacks := chainCallbacks(callbacks, lnc)
@@ -150,7 +151,7 @@ func getGRPCServerOpts(
 			grpc_middleware.ChainStreamServer(
 				grpc_zap.StreamServerInterceptor(zap.NewNop()),
 				func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-					slog.Debug("gRPC call", "method", info.FullMethod)
+					logger.Debug("gRPC call", "method", info.FullMethod)
 					if xdsAuth {
 						xdsAuthRequestTotal.Inc()
 						am := authenticationManager{
@@ -164,10 +165,10 @@ func getGRPCServerOpts(
 							})
 						}
 						xdsAuthFailureTotal.Inc()
-						slog.Error("authentication failed", "reasons", am.authFailMsgs)
+						logger.Error("authentication failed", "reasons", am.authFailMsgs)
 						return fmt.Errorf("authentication failed: %v", am.authFailMsgs)
 					} else {
-						slog.Warn("xDS authentication is disabled")
+						logger.Warn("xDS authentication is disabled")
 						return handler(srv, ss)
 					}
 				},

--- a/pkg/kgateway/setup/controlplane.go
+++ b/pkg/kgateway/setup/controlplane.go
@@ -37,6 +37,8 @@ const (
 )
 
 var (
+	controlPlaneLogger = logging.New("envoy-controlplane")
+
 	xdsAuthRequestTotal = metrics.NewCounter(
 		metrics.CounterOpts{
 			Subsystem: xdsSubsystem,
@@ -100,13 +102,12 @@ func NewControlPlane(
 	certWatcher *certwatcher.CertWatcher,
 	orderedADS bool,
 ) envoycache.SnapshotCache {
-	baseLogger := logging.New("envoy-controlplane")
-	envoyLoggerAdapter := &slogAdapterForEnvoy{logger: baseLogger}
+	envoyLoggerAdapter := &slogAdapterForEnvoy{logger: controlPlaneLogger}
 	lnc := newLogNackCallback()
 	allCallbacks := chainCallbacks(callbacks, lnc)
 
 	// Create separate gRPC servers for each listener
-	serverOpts := getGRPCServerOpts(authenticators, xdsAuth, certWatcher, baseLogger)
+	serverOpts := getGRPCServerOpts(authenticators, xdsAuth, certWatcher)
 	kgwGRPCServer := grpc.NewServer(serverOpts...)
 
 	snapshotCache := envoycache.NewSnapshotCache(true, xds.NewNodeRoleHasher(), envoyLoggerAdapter)
@@ -143,7 +144,6 @@ func getGRPCServerOpts(
 	authenticators []security.Authenticator,
 	xdsAuth bool,
 	certWatcher *certwatcher.CertWatcher,
-	logger *slog.Logger,
 ) []grpc.ServerOption {
 	opts := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(math.MaxInt32),
@@ -151,7 +151,7 @@ func getGRPCServerOpts(
 			grpc_middleware.ChainStreamServer(
 				grpc_zap.StreamServerInterceptor(zap.NewNop()),
 				func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-					logger.Debug("gRPC call", "method", info.FullMethod)
+					controlPlaneLogger.Debug("gRPC call", "method", info.FullMethod)
 					if xdsAuth {
 						xdsAuthRequestTotal.Inc()
 						am := authenticationManager{
@@ -165,10 +165,10 @@ func getGRPCServerOpts(
 							})
 						}
 						xdsAuthFailureTotal.Inc()
-						logger.Error("authentication failed", "reasons", am.authFailMsgs)
+						controlPlaneLogger.Error("authentication failed", "reasons", am.authFailMsgs)
 						return fmt.Errorf("authentication failed: %v", am.authFailMsgs)
 					} else {
-						logger.Warn("xDS authentication is disabled")
+						controlPlaneLogger.Warn("xDS authentication is disabled")
 						return handler(srv, ss)
 					}
 				},
@@ -183,9 +183,9 @@ func getGRPCServerOpts(
 			GetCertificate: certWatcher.GetCertificate,
 		})
 		opts = append(opts, grpc.Creds(creds))
-		logger.Info("TLS enabled for xDS servers with certificate watcher")
+		controlPlaneLogger.Info("TLS enabled for xDS servers with certificate watcher")
 	} else {
-		logger.Warn("TLS disabled for xDS servers: connections will be unencrypted")
+		controlPlaneLogger.Warn("TLS disabled for xDS servers: connections will be unencrypted")
 	}
 
 	return opts

--- a/pkg/kgateway/setup/envoy_error.go
+++ b/pkg/kgateway/setup/envoy_error.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	logger            = logging.New("xds/envoy")
+	envoyLogger       = logging.New("xds/envoy")
 	envoyXdsSubsystem = "envoy_xds"
 	xdsRejectsTotal   = metrics.NewCounter(
 		metrics.CounterOpts{
@@ -122,7 +122,7 @@ func (l *logNackCallback) onNewError(key resourceKey, err *status.Status) {
 	labels := toLabels(key)
 	xdsRejectsTotal.Inc(labels...)
 	xdsRejectsCurrent.Add(1, labels...)
-	logger.Warn("xds error", "gateway_name", key.Name, "gateway_ns", key.Namespace, "resource", key.ResourceTypeUrl, "error", err.Message)
+	envoyLogger.Warn("xds error", "gateway_name", key.Name, "gateway_ns", key.Namespace, "resource", key.ResourceTypeUrl, "error", err.Message)
 }
 
 func (l *logNackCallback) onErrorGone(key resourceKey) {

--- a/pkg/kgateway/setup/setup.go
+++ b/pkg/kgateway/setup/setup.go
@@ -46,6 +46,8 @@ type Server interface {
 	Start(ctx context.Context) error
 }
 
+var logger = logging.New("setup")
+
 func WithAPIClient(apiClient apiclient.Client) func(*setup) {
 	return func(s *setup) {
 		s.apiClient = apiClient
@@ -221,7 +223,7 @@ func New(opts ...func(*setup)) (*setup, error) {
 		var err error
 		s.globalSettings, err = apisettings.BuildSettings()
 		if err != nil {
-			slog.Error("error loading settings from env", "error", err)
+			logger.Error("error loading settings from env", "error", err)
 			return nil, err
 		}
 	}
@@ -267,7 +269,7 @@ func New(opts ...func(*setup)) (*setup, error) {
 		var err error
 		s.xdsListener, err = newXDSListener("0.0.0.0", s.globalSettings.XdsServicePort)
 		if err != nil {
-			slog.Error("error creating xds listener", "error", err)
+			logger.Error("error creating xds listener", "error", err)
 			return nil, err
 		}
 	}
@@ -280,7 +282,7 @@ func New(opts ...func(*setup)) (*setup, error) {
 }
 
 func (s *setup) Start(ctx context.Context) error {
-	slog.Info("starting kgateway")
+	logger.Info("starting kgateway")
 
 	mgrOpts := s.ctrlMgrOptionsInitFunc(ctx)
 
@@ -294,7 +296,7 @@ func (s *setup) Start(ctx context.Context) error {
 	}
 
 	if err := schemes.AddToScheme(mgr.GetScheme()); err != nil {
-		slog.Error("unable to extend scheme", "error", err)
+		logger.Error("unable to extend scheme", "error", err)
 		return err
 	}
 
@@ -329,7 +331,7 @@ func (s *setup) Start(ctx context.Context) error {
 		CertWatcher:    certWatcher,
 	}
 
-	slog.Info("creating krt collections")
+	logger.Info("creating krt collections")
 	krtOpts := krtutil.NewKrtOptions(ctx.Done(), setupOpts.KrtDebugger)
 
 	commoncol, err := collections.NewCommonCollections(
@@ -341,7 +343,7 @@ func (s *setup) Start(ctx context.Context) error {
 		s.commonCollectionsOptions...,
 	)
 	if err != nil {
-		slog.Error("error creating common collections", "error", err)
+		logger.Error("error creating common collections", "error", err)
 		return err
 	}
 
@@ -371,10 +373,10 @@ func (s *setup) Start(ctx context.Context) error {
 		return err
 	}
 
-	slog.Info("starting admin server")
+	logger.Info("starting admin server")
 	go admin.RunAdminServer(ctx, setupOpts)
 
-	slog.Info("starting manager")
+	logger.Info("starting manager")
 	return mgr.Start(ctx)
 }
 
@@ -390,7 +392,7 @@ func (s *setup) buildKgatewayWithConfig(
 	commonCollections *collections.CommonCollections,
 	uccBuilder krtcollections.UniquelyConnectedClientsBuilder,
 ) error {
-	slog.Info("creating krt collections")
+	logger.Info("creating krt collections")
 	krtOpts := krtutil.NewKrtOptions(ctx.Done(), setupOpts.KrtDebugger)
 
 	augmentedPods, _ := krtcollections.NewPodsCollection(s.apiClient, krtOpts)
@@ -409,7 +411,7 @@ func (s *setup) buildKgatewayWithConfig(
 		s.additionalGatewayClasses,
 	)
 
-	slog.Info("initializing controller")
+	logger.Info("initializing controller")
 	c, err := controller.NewControllerBuilder(ctx, controller.StartConfig{
 		Manager:                     mgr,
 		ControllerName:              s.gatewayControllerName,
@@ -432,11 +434,11 @@ func (s *setup) buildKgatewayWithConfig(
 		StatusSyncerOptions:         s.statusSyncerOptions,
 	})
 	if err != nil {
-		slog.Error("failed initializing controller: ", "error", err)
+		logger.Error("failed initializing controller: ", "error", err)
 		return err
 	}
 
-	slog.Info("waiting for cache sync")
+	logger.Info("waiting for cache sync")
 
 	err = c.Build(ctx)
 	if err != nil {
@@ -456,7 +458,7 @@ func (s *setup) buildKgatewayWithConfig(
 func SetupLogging(levelStr string) {
 	level, err := logging.ParseLevel(levelStr)
 	if err != nil {
-		slog.Error("failed to parse log level, defaulting to info", "error", err)
+		logger.Error("failed to parse log level, defaulting to info", "error", err)
 		level = slog.LevelInfo
 	}
 	// set all loggers to the specified level

--- a/pkg/kgateway/translator/httproute/delegation.go
+++ b/pkg/kgateway/translator/httproute/delegation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,7 +57,7 @@ func flattenDelegatedRoutes(
 	for _, child := range children {
 		childRoute, ok := child.Object.(*ir.HttpRouteIR)
 		if !ok {
-			slog.Warn("ignoring unsupported child route type",
+			logger.Warn("ignoring unsupported child route type",
 				"route_type", fmt.Sprintf("%T", child.Object), "parent_resource_ref", parentRef)
 			continue
 		}
@@ -68,7 +67,7 @@ func flattenDelegatedRoutes(
 			// This is an _extra_ safety check, but the given HTTPRouteInfo shouldn't ever contain cycles.
 			msg := fmt.Sprintf("cyclic reference detected while evaluating delegated routes for parent: %s; child route %s will be ignored",
 				parentRef, childRef)
-			slog.Warn(msg) //nolint:sloglint // ignore formatting
+			logger.Warn(msg) //nolint:sloglint // ignore formatting
 			parentReporter.SetCondition(reports.RouteCondition{
 				Type:    gwv1.RouteConditionResolvedRefs,
 				Status:  metav1.ConditionFalse,

--- a/pkg/kgateway/utils/sanitize.go
+++ b/pkg/kgateway/utils/sanitize.go
@@ -3,10 +3,13 @@ package utils
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 	"unicode"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 )
+
+var logger = logging.New("kgateway/utils")
 
 // Virtual host and virtual cluster names cannot contain dots, otherwise Envoy might incorrectly compute
 // its statistics tree. Any occurrences will be replaced with underscores.
@@ -18,7 +21,7 @@ const (
 func SanitizeForEnvoy(ctx context.Context, resourceName, resourceTypeName string) string {
 	if strings.Contains(resourceName, illegalChar) {
 		//nolint:sloglint // ignore formatting
-		slog.Debug(fmt.Sprintf("illegal character(s) '%s' in %s name [%s] will be replaced by '%s'",
+		logger.Debug(fmt.Sprintf("illegal character(s) '%s' in %s name [%s] will be replaced by '%s'",
 			illegalChar, resourceTypeName, resourceName, replacementChar))
 		resourceName = strings.ReplaceAll(resourceName, illegalChar, replacementChar)
 	}

--- a/pkg/krtcollections/uniqueclients.go
+++ b/pkg/krtcollections/uniqueclients.go
@@ -58,7 +58,7 @@ func xdsFirstConnectDelay() time.Duration {
 			if err == nil {
 				d = parsed
 			} else {
-				slog.Warn("invalid KGW_XDS_FIRST_CONNECT_DELAY; using default", "value", v, "default", time.Second, "error", err)
+				logger.Warn("invalid KGW_XDS_FIRST_CONNECT_DELAY; using default", "value", v, "default", time.Second, "error", err)
 			}
 		}
 		xdsFirstConnectDelayNanos.Store(int64(d))

--- a/pkg/pluginsdk/collections/tlsroute_version.go
+++ b/pkg/pluginsdk/collections/tlsroute_version.go
@@ -2,7 +2,6 @@ package collections
 
 import (
 	"context"
-	"log/slog"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,7 +14,10 @@ import (
 	gwv1a3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 )
+
+var logger = logging.New("pluginsdk/collections")
 
 var promotedTLSRouteGVR = wellknown.TLSRouteV1GVR
 
@@ -174,7 +176,7 @@ func convertUnstructuredTLSRouteToV1Alpha2(in *unstructured.Unstructured) *gwv1a
 
 	out := &gwv1a2.TLSRoute{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(in.Object, out); err != nil {
-		slog.Warn("ignoring unstructured TLSRoute with invalid payload",
+		logger.Warn("ignoring unstructured TLSRoute with invalid payload",
 			"name", in.GetName(),
 			"namespace", in.GetNamespace(),
 			"error", err,

--- a/pkg/pluginsdk/policy/cors.go
+++ b/pkg/pluginsdk/policy/cors.go
@@ -2,7 +2,6 @@ package policy
 
 import (
 	"fmt"
-	"log/slog"
 	"regexp"
 	"strings"
 
@@ -156,7 +155,7 @@ func ConvertOriginToEnvoyStringMatcher(origin string) *envoymatcherv3.StringMatc
 
 	// Test the regex pattern to make sure it is a valid RE2 pattern
 	if err := regexutils.CheckRegexString(regexPattern); err != nil {
-		slog.Error("failed to convert origin to regex pattern", "origin", origin, "error", err)
+		logger.Error("failed to convert origin to regex pattern", "origin", origin, "error", err)
 		return nil
 	}
 

--- a/pkg/pluginsdk/policy/merge.go
+++ b/pkg/pluginsdk/policy/merge.go
@@ -2,14 +2,16 @@ package policy
 
 import (
 	"errors"
-	"log/slog"
 	"maps"
 	"reflect"
 	"slices"
 
 	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
+
+var logger = logging.New("pluginsdk/policy")
 
 var ErrUnsupportedMergeStrategy = errors.New("unsupported merge strategy")
 
@@ -59,7 +61,7 @@ func ToInternalMergeStrategy(s string) MergeStrategy {
 	} else if s == ShallowMerge {
 		return AugmentedShallowMerge
 	} else {
-		slog.Error("unsupported value, defaulting to shallow merge; allowed: DeepMerge, ShallowMerge", "strategy", s)
+		logger.Error("unsupported value, defaulting to shallow merge; allowed: DeepMerge, ShallowMerge", "strategy", s)
 		return AugmentedShallowMerge
 	}
 }
@@ -193,7 +195,7 @@ func merge[T any](
 
 		out.Errors = append(out.Errors, ir.WrapPolicyErrors(p2Ref, policies[i].Errors)...)
 		if len(policies[i].Errors) > 0 {
-			slog.Warn("ignoring policy with errors", "resource_ref", p2Ref, "errors", policies[i].FormatErrors())
+			logger.Warn("ignoring policy with errors", "resource_ref", p2Ref, "errors", policies[i].FormatErrors())
 			continue
 		}
 

--- a/pkg/reports/policy.go
+++ b/pkg/reports/policy.go
@@ -2,7 +2,6 @@ package reports
 
 import (
 	"context"
-	"log/slog"
 	"slices"
 	"strings"
 
@@ -184,7 +183,7 @@ func (r *ReportMap) BuildPolicyStatus(
 	if len(status.Ancestors) > MaxPolicyStatusAncestors {
 		// Gateway API caps PolicyStatus.ancestors at 16 real entries. We can't
 		// invent a synthetic ancestor entry here, so log the truncation explicitly.
-		slog.WarnContext(ctx,
+		logger.WarnContext(ctx,
 			"truncating policy status ancestors to Gateway API limit",
 			"policy", key.DisplayString(),
 			"controller", controller,

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -2,7 +2,6 @@ package reports
 
 import (
 	"fmt"
-	"log/slog"
 	"slices"
 	"strings"
 
@@ -15,8 +14,11 @@ import (
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
 )
+
+var logger = logging.New("reports")
 
 type ReportMap struct {
 	Gateways     map[types.NamespacedName]*GatewayReport
@@ -189,7 +191,7 @@ func (r *ReportMap) route(obj metav1.Object) *RouteReport {
 	case *gwv1.GRPCRoute:
 		return r.GRPCRoutes[key]
 	default:
-		slog.Warn("unsupported route type", "route_type", fmt.Sprintf("%T", obj))
+		logger.Warn("unsupported route type", "route_type", fmt.Sprintf("%T", obj))
 		return nil
 	}
 }
@@ -215,7 +217,7 @@ func (r *ReportMap) newRouteReport(obj metav1.Object) *RouteReport {
 	case *gwv1.GRPCRoute:
 		r.GRPCRoutes[key] = rr
 	default:
-		slog.Warn("unsupported route type", "route_type", fmt.Sprintf("%T", obj))
+		logger.Warn("unsupported route type", "route_type", fmt.Sprintf("%T", obj))
 		return nil
 	}
 

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -3,7 +3,6 @@ package reports
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"reflect"
 	"strings"
 
@@ -468,7 +467,7 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 ) *gwv1.RouteStatus {
 	routeReport := r.route(obj)
 	if routeReport == nil {
-		slog.Info("missing route report", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
+		logger.Info("missing route report", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
 		return nil
 	}
 
@@ -479,7 +478,7 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 	// avoids freezing observedGeneration on a cache skew.
 	observedGeneration := routeReport.observedGeneration
 
-	slog.Debug("building status", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
+	logger.Debug("building status", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
 
 	var existingStatus gwv1.RouteStatus
 	// Default to using spec.ParentRefs when building the parent statuses for a route.
@@ -525,7 +524,7 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 			parentRefs = append(parentRefs, routeReport.parentRefs()...)
 		}
 	default:
-		slog.Error("unsupported route type for status reporting", "route_type", fmt.Sprintf("%T", obj))
+		logger.Error("unsupported route type for status reporting", "route_type", fmt.Sprintf("%T", obj))
 		return nil
 	}
 	if defaultParentRef {

--- a/pkg/sds/server/server.go
+++ b/pkg/sds/server/server.go
@@ -9,7 +9,6 @@ import (
 	"hash"
 	"hash/fnv"
 	"log"
-	"log/slog"
 	"math"
 	"net"
 	"os"
@@ -24,7 +23,11 @@ import (
 	server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/mitchellh/hashstructure"
 	"google.golang.org/grpc"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 )
+
+var logger = logging.New("sds/server")
 
 var grpcOptions = []grpc.ServerOption{
 	grpc.MaxConcurrentStreams(10000),
@@ -87,7 +90,7 @@ func (s *Server) Run(ctx context.Context) (<-chan struct{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	slog.Info("sds server listening", "address", s.address)
+	logger.Info("sds server listening", "address", s.address)
 
 	// Create channels for synchronization
 	serveStarted := make(chan struct{})
@@ -109,7 +112,7 @@ func (s *Server) Run(ctx context.Context) (<-chan struct{}, error) {
 
 		// Now wait for context cancellation
 		<-ctx.Done()
-		slog.Info("stopping sds server", "address", s.address)
+		logger.Info("stopping sds server", "address", s.address)
 		s.grpcServer.GracefulStop()
 		serverStopped <- struct{}{}
 	}()
@@ -132,10 +135,10 @@ func (s *Server) UpdateSDSConfig(ctx context.Context) error {
 
 	snapshotVersion, err := GetSnapshotVersion(certs)
 	if err != nil {
-		slog.Error("error getting snapshot version", "error", err)
+		logger.Error("error getting snapshot version", "error", err)
 		return err
 	}
-	slog.Info("updating SDS config", "client", s.sdsClient, "snapshot_version", snapshotVersion)
+	logger.Info("updating SDS config", "client", s.sdsClient, "snapshot_version", snapshotVersion)
 
 	secretSnapshot := &cache.Snapshot{}
 	secretSnapshot.Resources[cache_types.Secret] = cache.NewResources(snapshotVersion, items)
@@ -208,7 +211,7 @@ func readAndValidateSecret(ctx context.Context, sec Secret) ([][]byte, []cache_t
 	}
 
 	if attempts > 1 {
-		slog.Info(
+		logger.Info(
 			"recovered SDS secret after retrying torn cert rotation",
 			"server_cert", sec.ServerCert,
 			"attempts", attempts,

--- a/pkg/utils/kubeutils/portforward/api_forwarder.go
+++ b/pkg/utils/kubeutils/portforward/api_forwarder.go
@@ -3,7 +3,6 @@ package portforward
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -17,8 +16,11 @@ import (
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
+
+var logger = logging.New("kubeutils/portforward")
 
 var _ PortForwarder = &apiPortForwarder{}
 
@@ -113,7 +115,7 @@ func (f *apiPortForwarder) startOnce(ctx context.Context) error {
 		}
 		// Set local port now, as it may have been 0 as input
 		f.properties.localPort = int(p[0].Local)
-		slog.Debug("port forward established", "address", f.Address(), "pod", podName, "remote_port", f.properties.remotePort)
+		logger.Debug("port forward established", "address", f.Address(), "pod", podName, "remote_port", f.properties.remotePort)
 		// The apiPortForwarder is now ready.
 		return nil
 	}

--- a/test/e2e/defaults/extproc/main.go
+++ b/test/e2e/defaults/extproc/main.go
@@ -25,6 +25,7 @@ import (
 )
 
 var (
+	logger    = slog.Default().With("component", "e2e/extproc")
 	grpcport  = flag.String("grpcport", ":18080", "grpcport")
 	addHeader = flag.String("add-header", "", "header to always add to processed requests in key:value format (e.g., x-server-id:server-1)")
 )
@@ -45,7 +46,7 @@ type server struct{}
 type healthServer struct{}
 
 func (s *healthServer) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	slog.Info("handling grpc Check request", "request", in.String())
+	logger.Info("handling grpc Check request", "request", in.String())
 	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
 }
 
@@ -62,12 +63,12 @@ func (s *healthServer) List(ctx context.Context, in *grpc_health_v1.HealthListRe
 }
 
 func (s *server) Process(srv service_ext_proc_v3.ExternalProcessor_ProcessServer) error {
-	slog.Info("process")
+	logger.Info("process")
 	ctx := srv.Context()
 	for {
 		select {
 		case <-ctx.Done():
-			slog.Info("context done")
+			logger.Info("context done")
 			return ctx.Err()
 		default:
 		}
@@ -85,7 +86,7 @@ func (s *server) Process(srv service_ext_proc_v3.ExternalProcessor_ProcessServer
 		resp := &service_ext_proc_v3.ProcessingResponse{}
 		switch v := req.Request.(type) {
 		case *service_ext_proc_v3.ProcessingRequest_RequestHeaders:
-			slog.Info("got RequestHeaders")
+			logger.Info("got RequestHeaders")
 
 			h := req.Request.(*service_ext_proc_v3.ProcessingRequest_RequestHeaders)
 			headersResp, err := getHeadersResponseFromInstructions(h.RequestHeaders)
@@ -100,7 +101,7 @@ func (s *server) Process(srv service_ext_proc_v3.ExternalProcessor_ProcessServer
 			}
 
 		case *service_ext_proc_v3.ProcessingRequest_RequestBody:
-			slog.Info("got RequestBody - forwarding")
+			logger.Info("got RequestBody - forwarding")
 
 			h := req.Request.(*service_ext_proc_v3.ProcessingRequest_RequestBody)
 
@@ -121,11 +122,11 @@ func (s *server) Process(srv service_ext_proc_v3.ExternalProcessor_ProcessServer
 				},
 			}
 		case *service_ext_proc_v3.ProcessingRequest_RequestTrailers:
-			slog.Info("got RequestTrailers (not currently handled)")
+			logger.Info("got RequestTrailers (not currently handled)")
 			resp.Response = &service_ext_proc_v3.ProcessingResponse_RequestTrailers{}
 
 		case *service_ext_proc_v3.ProcessingRequest_ResponseHeaders:
-			slog.Info("got ResponseHeaders")
+			logger.Info("got ResponseHeaders")
 
 			h := req.Request.(*service_ext_proc_v3.ProcessingRequest_ResponseHeaders)
 			headersResp, err := getHeadersResponseFromInstructions(h.ResponseHeaders)
@@ -139,7 +140,7 @@ func (s *server) Process(srv service_ext_proc_v3.ExternalProcessor_ProcessServer
 			}
 
 		case *service_ext_proc_v3.ProcessingRequest_ResponseBody:
-			slog.Info("got ResponseBody - forwarding")
+			logger.Info("got ResponseBody - forwarding")
 
 			h := req.Request.(*service_ext_proc_v3.ProcessingRequest_ResponseBody)
 
@@ -161,19 +162,19 @@ func (s *server) Process(srv service_ext_proc_v3.ExternalProcessor_ProcessServer
 			}
 
 		case *service_ext_proc_v3.ProcessingRequest_ResponseTrailers:
-			slog.Info("got ResponseTrailers (not currently handled)")
+			logger.Info("got ResponseTrailers (not currently handled)")
 			resp.Response = &service_ext_proc_v3.ProcessingResponse_ResponseTrailers{}
 
 		default:
-			slog.Info("unknown request type", "request type", v)
+			logger.Info("unknown request type", "request type", v)
 		}
 
 		// At this point we believe we have created a valid response...
 		// note that this is sometimes not the case
 		// anyways for now just send it
-		slog.Info("sending ProcessingResponse")
+		logger.Info("sending ProcessingResponse")
 		if err := srv.Send(resp); err != nil {
-			slog.Info("send error", "error", err)
+			logger.Info("send error", "error", err)
 			return err
 		}
 
@@ -185,7 +186,7 @@ func main() {
 
 	lis, err := net.Listen("tcp", *grpcport)
 	if err != nil {
-		slog.Error("failed to listen", "error", err)
+		logger.Error("failed to listen", "error", err)
 		os.Exit(1)
 	}
 
@@ -196,20 +197,20 @@ func main() {
 
 	grpc_health_v1.RegisterHealthServer(s, &healthServer{})
 
-	slog.Info("starting gRPC server", "port", *grpcport)
+	logger.Info("starting gRPC server", "port", *grpcport)
 
 	gracefulStop := make(chan os.Signal, 1)
 	signal.Notify(gracefulStop, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		sig := <-gracefulStop
-		slog.Info("caught sig", "sig", sig)
+		logger.Info("caught sig", "sig", sig)
 		time.Sleep(time.Second)
-		slog.Info("graceful stop completed")
+		logger.Info("graceful stop completed")
 		os.Exit(0)
 	}()
 	err = s.Serve(lis)
 	if err != nil {
-		slog.Error("killing server", "error", err)
+		logger.Error("killing server", "error", err)
 		os.Exit(1)
 	}
 }
@@ -257,7 +258,7 @@ func getHeadersResponseFromInstructions(in *service_ext_proc_v3.HttpHeaders) (*s
 	var instructions *Instructions
 	err := json.Unmarshal([]byte(instructionString), &instructions)
 	if err != nil {
-		slog.Info("error unmarshalling instructions", "error", err)
+		logger.Info("error unmarshalling instructions", "error", err)
 		return nil, err
 	}
 

--- a/test/e2e/testutils/cluster/istio.go
+++ b/test/e2e/testutils/cluster/istio.go
@@ -7,16 +7,18 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	testruntime "github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/runtime"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
+
+var logger = logging.New("e2e/cluster")
 
 const (
 	// TODO(npolshak): Add support for other profiles (ambient, etc.)
@@ -29,7 +31,7 @@ func GetIstioctl(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to download istio: %w", err)
 	}
-	slog.Info("using Istio binary", "path", istioctlBinary)
+	logger.Info("using Istio binary", "path", istioctlBinary)
 
 	return istioctlBinary, nil
 }
@@ -120,13 +122,13 @@ func getIstioVersion() string {
 // Download istioctl binary from istio.io/downloadIstio and returns the path to the binary
 func downloadIstio(version string) (string, error) {
 	if version == "" {
-		slog.Info("ISTIO_VERSION not specified, using istioctl from PATH")
+		logger.Info("ISTIO_VERSION not specified, using istioctl from PATH")
 		binaryPath, err := exec.LookPath("istioctl")
 		if err != nil {
 			return "", errors.New("ISTIO_VERSION environment variable must be specified or istioctl must be installed")
 		}
 
-		slog.Info("using istioctl", "path", binaryPath)
+		logger.Info("using istioctl", "path", binaryPath)
 
 		return binaryPath, nil
 	}

--- a/test/testutils/file_loader.go
+++ b/test/testutils/file_loader.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,11 @@ import (
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 )
+
+var logger = logging.New("testutils")
 
 var ErrNoFilesFound = errors.New("no k8s files found")
 
@@ -50,7 +53,7 @@ func LoadFromFileWithTransform(
 
 	var yamlFiles []string
 	if fileOrDir.IsDir() {
-		slog.Debug("looking for YAML files", "path", fileOrDir.Name())
+		logger.Debug("looking for YAML files", "path", fileOrDir.Name())
 		err := filepath.WalkDir(filename, func(path string, d fs.DirEntry, _ error) error {
 			if strings.HasSuffix(path, ".yml") || strings.HasSuffix(path, ".yaml") {
 				yamlFiles = append(yamlFiles, path)
@@ -68,7 +71,7 @@ func LoadFromFileWithTransform(
 		return nil, ErrNoFilesFound
 	}
 
-	slog.Debug("user configuration YAML files found", "files", yamlFiles)
+	logger.Debug("user configuration YAML files found", "files", yamlFiles)
 
 	var resources []client.Object
 	for _, file := range yamlFiles {
@@ -127,7 +130,7 @@ func parseFile(
 
 		var meta metaOnly
 		if err := yaml.Unmarshal(objYaml, &meta); err != nil {
-			slog.Warn("failed to parse resource metadata, skipping YAML document",
+			logger.Warn("failed to parse resource metadata, skipping YAML document",
 				"filename", filename,
 				"data", truncateString(string(objYaml), 100),
 			)
@@ -137,7 +140,7 @@ func parseFile(
 		gvk := schema.FromAPIVersionAndKind(meta.APIVersion, meta.Kind)
 		obj, err := scheme.New(gvk)
 		if err != nil {
-			slog.Warn("unknown resource kind",
+			logger.Warn("unknown resource kind",
 				"filename", filename,
 				"gvk", gvk.String(),
 				"data", truncateString(string(objYaml), 100),
@@ -146,7 +149,7 @@ func parseFile(
 		}
 
 		if err := yaml.Unmarshal(objYaml, obj); err != nil {
-			slog.Warn("failed to parse resource YAML",
+			logger.Warn("failed to parse resource YAML",
 				"error", err,
 				"filename", filename,
 				"gvk", gvk.String(),


### PR DESCRIPTION
# Description

Replace direct calls to the global `slog` logging functions with package-level component loggers. This allows log levels to be managed per component through the existing logging package.

The change also adds a `forbidigo` rule covering the global `slog` emission APIs so new direct usages fail linting. Uses of `slog` for logger types, levels, handlers, and attributes remain allowed.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validation:
- Custom golangci-lint `forbidigo` pass with `-tags e2e`: 0 issues.
- Verified the new rule reports a synthetic `slog.Info` violation.
- All touched packages compile with `-tags e2e`.
- Sandbox-compatible focused tests and the standalone extproc module pass.
- Listener-dependent controller, setup, and SDS tests were compile-checked because the sandbox does not permit local TCP listeners.
- `git diff --check` passes.
