### PR TITLE
Enable perfsprint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,6 +26,7 @@ linters:
     - modernize
     - nakedret
     - nestif
+    - perfsprint
     - predeclared
     - promlinter
     - sloglint

--- a/api/settings/settings_test.go
+++ b/api/settings/settings_test.go
@@ -1,7 +1,6 @@
 package settings
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 	"regexp"
@@ -372,7 +371,7 @@ func expectedEnvVars(settingsValue reflect.Value) map[string]any {
 
 		envVarName = strings.ToUpper(envVarName)
 		// Always have a prefix
-		envVarName = fmt.Sprintf("KGW_%s", envVarName)
+		envVarName = "KGW_" + envVarName
 
 		// If the field has an alt tag, use that as the env var name
 		if fieldType.Tag.Get("alt") != "" {

--- a/pkg/kgateway/controller/controller_test.go
+++ b/pkg/kgateway/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -795,7 +796,7 @@ func (s *ControllerSuite) startController(
 		if err != nil {
 			return fmt.Errorf("controller-manager exited before it was ready: %w", err)
 		}
-		return fmt.Errorf("controller-manager exited before it was ready")
+		return errors.New("controller-manager exited before it was ready")
 	default:
 	}
 

--- a/pkg/kgateway/deployer/gateway_parameters.go
+++ b/pkg/kgateway/deployer/gateway_parameters.go
@@ -152,7 +152,7 @@ func (gp *GatewayParameters) getHelmValuesGenerator(obj client.Object) (deployer
 	}
 
 	if gp.kgwParameters == nil {
-		return nil, fmt.Errorf("no parameter clients available")
+		return nil, errors.New("no parameter clients available")
 	}
 	logger.Debug("using default HelmValuesGenerator for Gateway",
 		"gateway_name", gw.GetName(),

--- a/pkg/kgateway/extensions2/plugins/backend/aws.go
+++ b/pkg/kgateway/extensions2/plugins/backend/aws.go
@@ -87,7 +87,7 @@ func (u *LambdaIr) Equals(other *LambdaIr) bool {
 func processAws(ir *AwsIr, out *envoyclusterv3.Cluster) error {
 	// defensive check; this should never happen with union types
 	if ir == nil {
-		return fmt.Errorf("aws ir is nil")
+		return errors.New("aws ir is nil")
 	}
 	switch {
 	case ir.lambdaIr != nil:
@@ -95,7 +95,7 @@ func processAws(ir *AwsIr, out *envoyclusterv3.Cluster) error {
 	case ir.ec2Ir != nil:
 		return processEc2(ir.ec2Ir, out)
 	default:
-		return fmt.Errorf("aws ir is empty")
+		return errors.New("aws ir is empty")
 	}
 }
 

--- a/pkg/kgateway/extensions2/plugins/backend/ec2.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2.go
@@ -84,7 +84,7 @@ func ec2SecretsEqual(a, b *ir.Secret) bool {
 
 func buildEc2Ir(in *kgateway.AwsBackend, secret *ir.Secret) (*EC2Ir, error) {
 	if in == nil || in.Ec2 == nil {
-		return nil, fmt.Errorf("ec2 config is nil")
+		return nil, errors.New("ec2 config is nil")
 	}
 
 	return &EC2Ir{
@@ -971,7 +971,7 @@ func ec2DiscoveryFailureMessage(cause string, carriedEndpoints int) string {
 	if carriedEndpoints > 0 {
 		return fmt.Sprintf("%s; serving %d endpoints from the last successful poll", cause, carriedEndpoints)
 	}
-	return fmt.Sprintf("%s; no endpoints available from a previous poll", cause)
+	return cause + "; no endpoints available from a previous poll"
 }
 
 // ec2NoMatchMessage builds an operator-facing message for a successful poll that

--- a/pkg/kgateway/extensions2/plugins/backend/gcp.go
+++ b/pkg/kgateway/extensions2/plugins/backend/gcp.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -58,7 +59,7 @@ func (u *GcpIr) Equals(other *GcpIr) bool {
 // processGcp processes a GCP backend and returns an envoy cluster.
 func processGcp(ir *GcpIr, out *envoyclusterv3.Cluster) error {
 	if ir == nil {
-		return fmt.Errorf("gcp ir is nil")
+		return errors.New("gcp ir is nil")
 	}
 
 	dnsClusterConfig, err := utils.MessageToAny(&envoydnsv3.DnsCluster{})
@@ -110,7 +111,7 @@ func buildGcpIr(in *kgateway.GcpBackend) (*GcpIr, error) {
 	}
 
 	// Build audience config (defaults to https://{host} if not specified)
-	audienceURL := ptr.Deref(in.Audience, fmt.Sprintf("https://%s", hostname))
+	audienceURL := ptr.Deref(in.Audience, "https://"+hostname)
 	audienceConfig := &gcp_auth.Audience{
 		Url: audienceURL,
 	}

--- a/pkg/kgateway/extensions2/plugins/backend/static.go
+++ b/pkg/kgateway/extensions2/plugins/backend/static.go
@@ -1,7 +1,7 @@
 package backend
 
 import (
-	"fmt"
+	"errors"
 	"net/netip"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -49,10 +49,10 @@ func buildStaticIr(in *kgateway.StaticBackend) (*StaticIr, error) {
 	var hostname string
 	for _, host := range in.Hosts {
 		if host.Host == "" {
-			return nil, fmt.Errorf("addr cannot be empty for host")
+			return nil, errors.New("addr cannot be empty for host")
 		}
 		if host.Port == 0 {
-			return nil, fmt.Errorf("port cannot be empty for host")
+			return nil, errors.New("port cannot be empty for host")
 		}
 
 		_, err := netip.ParseAddr(host.Host)

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/lb.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/lb.go
@@ -391,7 +391,7 @@ func toSlowStartConfig(cfg *kgateway.SlowStart, name, namespace string) *envoyco
 
 		out.Aggression = &envoycorev3.RuntimeDouble{
 			DefaultValue: aggressionValue,
-			RuntimeKey:   fmt.Sprintf("%s.slowStart.aggression", runtimeKeyPrefix),
+			RuntimeKey:   runtimeKeyPrefix + ".slowStart.aggression",
 		}
 	}
 	return out

--- a/pkg/kgateway/extensions2/plugins/backendtlspolicy/helpers.go
+++ b/pkg/kgateway/extensions2/plugins/backendtlspolicy/helpers.go
@@ -38,7 +38,7 @@ func (e *InvalidCACertificateRefError) Error() string {
 		return ""
 	}
 	if e.Cause == nil {
-		return fmt.Sprintf("invalid CA certificate ref %s", e.Ref)
+		return "invalid CA certificate ref " + e.Ref
 	}
 	return fmt.Sprintf("invalid CA certificate ref %s: %v", e.Ref, e.Cause)
 }

--- a/pkg/kgateway/extensions2/plugins/istio/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/istio/plugin.go
@@ -202,7 +202,7 @@ func createDefaultIstioMatch() *envoyclusterv3.Cluster_TransportSocketMatch {
 	}
 
 	return &envoyclusterv3.Cluster_TransportSocketMatch{
-		Name:            fmt.Sprintf("%s-disabled", ourwellknown.TLSModeLabelShortname),
+		Name:            ourwellknown.TLSModeLabelShortname + "-disabled",
 		Match:           &structpb.Struct{},
 		TransportSocket: rawBufferTransportSocket,
 	}

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/common.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/common.go
@@ -1,6 +1,7 @@
 package listenerpolicy
 
 import (
+	"errors"
 	"fmt"
 
 	envoyaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -265,7 +266,7 @@ func translateFilter(filter *kgateway.FilterType) (*envoyaccesslogv3.AccessLogFi
 		}
 
 	default:
-		return nil, fmt.Errorf("no valid filter type specified")
+		return nil, errors.New("no valid filter type specified")
 	}
 
 	return alCfg, nil

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth.go
@@ -1,6 +1,7 @@
 package trafficpolicy
 
 import (
+	"errors"
 	"fmt"
 
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -113,7 +114,7 @@ func constructAPIKeyAuth(
 		}
 	} else {
 		// We shouldn't get here because the spec validation should catch this
-		return fmt.Errorf("either secretRef or secretSelector must be specified")
+		return errors.New("either secretRef or secretSelector must be specified")
 	}
 
 	// Parse secrets and build credentials
@@ -147,7 +148,7 @@ func constructAPIKeyAuth(
 	}
 
 	if len(credentials) == 0 {
-		return fmt.Errorf("no valid API keys found in secrets")
+		return errors.New("no valid API keys found in secrets")
 	}
 
 	// Convert API KeySources to Envoy KeySource format

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go
@@ -1,6 +1,7 @@
 package trafficpolicy
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -133,7 +134,7 @@ func constructBasicAuth(
 		}
 	} else {
 		// This shouldn't happen due to CEL validation
-		return fmt.Errorf("basic auth: either users or secretRef must be specified")
+		return errors.New("basic auth: either users or secretRef must be specified")
 	}
 
 	// Validate and filter users to only include SHA hashed passwords
@@ -141,7 +142,7 @@ func constructBasicAuth(
 
 	// If there are no valid users after filtering, return an error
 	if len(validUsers) == 0 {
-		return fmt.Errorf("basic auth: no valid users with {SHA} hash format found")
+		return errors.New("basic auth: no valid users with {SHA} hash format found")
 	}
 
 	// Report invalid users if any were found

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -256,7 +256,7 @@ func resolveJwtProviders(
 		uniqProviders[providerNameForExt] = jwtProvider
 	}
 
-	requirementsName := fmt.Sprintf("%s_requirements", extNameNamespace)
+	requirementsName := extNameNamespace + "_requirements"
 	requirements := make(map[string]*envoyjwtauthnv3.JwtRequirement)
 	requirements[requirementsName] = buildJwtRequirementFromProviders(uniqProviders, jwt.ValidationMode)
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin.go
@@ -126,7 +126,7 @@ func createRateLimitActions(descriptors []kgateway.RateLimitDescriptor) ([]*envo
 			switch entry.Type {
 			case kgateway.RateLimitDescriptorEntryTypeGeneric:
 				if entry.Generic == nil {
-					return nil, fmt.Errorf("generic entry requires Generic field to be set")
+					return nil, errors.New("generic entry requires Generic field to be set")
 				}
 				action.ActionSpecifier = &envoyroutev3.RateLimit_Action_GenericKey_{
 					GenericKey: &envoyroutev3.RateLimit_Action_GenericKey{
@@ -136,7 +136,7 @@ func createRateLimitActions(descriptors []kgateway.RateLimitDescriptor) ([]*envo
 				}
 			case kgateway.RateLimitDescriptorEntryTypeHeader:
 				if entry.Header == nil {
-					return nil, fmt.Errorf("header entry requires Header field to be set")
+					return nil, errors.New("header entry requires Header field to be set")
 				}
 				action.ActionSpecifier = &envoyroutev3.RateLimit_Action_RequestHeaders_{
 					RequestHeaders: &envoyroutev3.RateLimit_Action_RequestHeaders{

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/global_rate_limit_plugin_test.go
@@ -540,12 +540,12 @@ func TestToRateLimitFilterConfig(t *testing.T) {
 			if tt.policy == nil {
 				err = errors.New("extensionRef is required")
 			} else if tt.gatewayExtension == nil {
-				err = fmt.Errorf("failed to get referenced GatewayExtension")
+				err = errors.New("failed to get referenced GatewayExtension")
 			} else {
 				// Get the extension's spec
 				extension := tt.gatewayExtension.RateLimit
 				if extension == nil {
-					err = fmt.Errorf("RateLimit configuration is missing in GatewayExtension")
+					err = errors.New("RateLimit configuration is missing in GatewayExtension")
 				} else {
 					// Create a timeout based on the timeout from extension
 					timeout := durationpb.New(extension.Timeout.Duration)

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt.go
@@ -134,7 +134,7 @@ func constructJwt(
 
 	if spec.ExtensionRef == nil {
 		// shouldn't happen due to CRD validation
-		return fmt.Errorf("jwt: extensionRef is required if disable is not set")
+		return errors.New("jwt: extensionRef is required if disable is not set")
 	}
 	provider, err := fetchGatewayExtension(krtctx, *spec.ExtensionRef, in.GetNamespace())
 	if err != nil {

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/merge.go
@@ -2,6 +2,7 @@ package trafficpolicy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -227,7 +228,7 @@ func mergeRustformationJsonInPlace(obj1, obj2 any) error {
 	m1, ok1 := obj1.(map[string]any)
 	m2, ok2 := obj2.(map[string]any)
 	if !ok1 || !ok2 {
-		return fmt.Errorf("both arguments must be map[string]any")
+		return errors.New("both arguments must be map[string]any")
 	}
 
 	mergeRustFormationRequestResponseJson("response", m1, m2)
@@ -830,7 +831,7 @@ func detectHttpACLMergeConflict(m1, m2 map[string]any) []error {
 	da1, hasDA1 := m1["defaultAction"].(string)
 	da2, hasDA2 := m2["defaultAction"].(string)
 	if !hasDA1 || !hasDA2 {
-		conflicts = append(conflicts, fmt.Errorf("defaultAction not set"))
+		conflicts = append(conflicts, errors.New("defaultAction not set"))
 	} else if da1 != da2 {
 		conflicts = append(conflicts, fmt.Errorf("defaultAction conflict: %q vs %q", da1, da2))
 	}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/oauth2.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/oauth2.go
@@ -1,8 +1,10 @@
 package trafficpolicy
 
 import (
+	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,10 +164,10 @@ func buildOAuth2ProviderConfig(
 	}
 
 	if tokenEndpoint == "" {
-		return nil, fmt.Errorf("oauth2 token endpoint not specified or not found in issuer well-known configuration")
+		return nil, errors.New("oauth2 token endpoint not specified or not found in issuer well-known configuration")
 	}
 	if authorizationEndpoint == "" {
-		return nil, fmt.Errorf("oauth2 authorization endpoint not specified or not found in issuer well-known configuration")
+		return nil, errors.New("oauth2 authorization endpoint not specified or not found in issuer well-known configuration")
 	}
 
 	backend, err := resolveBackend(krtctx, backends, false, ext.ObjectSource, in.BackendRef.BackendObjectReference)
@@ -522,5 +524,5 @@ func (p *trafficPolicyPluginGwPass) handleOauth2(filterChain string, perFilterCo
 // getCookieSuffix generates a unique suffix for cookie names based on the given object
 func getCookieSuffix(src ir.ObjectSource) string {
 	hash := utils.HashString(src.NamespacedName().String())
-	return fmt.Sprintf("%x", hash)
+	return strconv.FormatUint(hash, 16)
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/rbac.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/rbac.go
@@ -1,6 +1,7 @@
 package trafficpolicy
 
 import (
+	"errors"
 	"fmt"
 
 	"cel.dev/expr"
@@ -137,7 +138,7 @@ func translateRBAC(rbac *sharedv1alpha1.Authorization) (*envoyauthz.RBACPerRoute
 
 func createCELMatcher(celExprs []sharedv1alpha1.CELExpression, action sharedv1alpha1.AuthorizationPolicyAction) (*cncfmatcherv3.Matcher_MatcherList_FieldMatcher, error) {
 	if len(celExprs) == 0 {
-		return nil, fmt.Errorf("no CEL expressions provided")
+		return nil, errors.New("no CEL expressions provided")
 	}
 
 	// Create CEL match input
@@ -302,7 +303,7 @@ func createDefaultAction(action envoyrbacv3.RBAC_Action) *cncfmatcherv3.Matcher_
 // for use in Envoy matchers. It handles the conversion between different protobuf types.
 func parseCELExpression(env *cel.Env, celExpr sharedv1alpha1.CELExpression) (*expr.ParsedExpr, error) {
 	if env == nil {
-		return nil, fmt.Errorf("CEL environment is nil")
+		return nil, errors.New("CEL environment is nil")
 	}
 
 	ast, iss := env.Parse(string(celExpr))

--- a/pkg/kgateway/extensions2/pluginutils/pluginutils.go
+++ b/pkg/kgateway/extensions2/pluginutils/pluginutils.go
@@ -1,6 +1,7 @@
 package pluginutils
 
 import (
+	"errors"
 	"fmt"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -87,7 +88,7 @@ func EnvoyBodyFormat(format *shared.BodyFormat) (result *envoycorev3.Substitutio
 		}
 	}
 	if result == nil {
-		return nil, fmt.Errorf("body format must specify either text or json")
+		return nil, errors.New("body format must specify either text or json")
 	}
 	result.ContentType = ptr.Deref(format.ContentType, "")
 

--- a/pkg/kgateway/extensions2/pluginutils/status.go
+++ b/pkg/kgateway/extensions2/pluginutils/status.go
@@ -17,13 +17,13 @@ func BuildCondition(resource string, errs []error) metav1.Condition {
 			Type:    string(kgateway.BackendConditionAccepted),
 			Status:  metav1.ConditionTrue,
 			Reason:  string(kgateway.BackendReasonAccepted),
-			Message: fmt.Sprintf("%s accepted", resource),
+			Message: resource + " accepted",
 		}
 	}
 	var aggErrs strings.Builder
 	var prologue string
 	if len(errs) == 1 {
-		prologue = fmt.Sprintf("%s error:", resource)
+		prologue = resource + " error:"
 	} else {
 		prologue = fmt.Sprintf("%s has %d errors:", resource, len(errs))
 	}

--- a/pkg/kgateway/gatewaytls/backend.go
+++ b/pkg/kgateway/gatewaytls/backend.go
@@ -2,6 +2,7 @@ package gatewaytls
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"istio.io/istio/pkg/kube/krt"
@@ -95,7 +96,7 @@ func validateClientCertificateRef(defaultNamespace string, ref *gwv1.SecretObjec
 
 func buildBackendClientCertificate(secret *ir.Secret) (*ir.GatewayBackendClientCertificateIR, error) {
 	if secret == nil {
-		return nil, fmt.Errorf("backend client certificate secret is nil")
+		return nil, errors.New("backend client certificate secret is nil")
 	}
 
 	certChainBytes, ok := secret.Data[corev1.TLSCertKey]

--- a/pkg/kgateway/proxy_syncer/local_cluster.go
+++ b/pkg/kgateway/proxy_syncer/local_cluster.go
@@ -2,9 +2,9 @@ package proxy_syncer
 
 import (
 	"cmp"
-	"fmt"
 	"hash/fnv"
 	"slices"
+	"strconv"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -168,7 +168,7 @@ func hashLocalClusterLoadAssignment(cla *envoyendpointv3.ClusterLoadAssignment) 
 		for _, lbEndpoint := range localityEndpoints.GetLbEndpoints() {
 			socketAddress := lbEndpoint.GetEndpoint().GetAddress().GetSocketAddress()
 			utils.HashStringField(hasher, socketAddress.GetAddress())
-			utils.HashStringField(hasher, fmt.Sprintf("%d", socketAddress.GetPortValue()))
+			utils.HashStringField(hasher, strconv.FormatUint(uint64(socketAddress.GetPortValue()), 10))
 		}
 	}
 	return hasher.Sum64()

--- a/pkg/kgateway/proxy_syncer/perclient.go
+++ b/pkg/kgateway/proxy_syncer/perclient.go
@@ -3,6 +3,7 @@ package proxy_syncer
 import (
 	"fmt"
 	"maps"
+	"strconv"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -87,7 +88,7 @@ func snapshotPerClient(
 			clustersProto = append(clustersProto, envoycachetypes.ResourceWithTTL{Resource: c.Cluster})
 			clustersHash ^= c.ClusterVersion
 		}
-		clustersVersion := fmt.Sprintf("%d", clustersHash)
+		clustersVersion := strconv.FormatUint(clustersHash, 10)
 
 		clusterResources := envoycache.NewResourcesWithTTL(clustersVersion, clustersProto)
 
@@ -112,7 +113,7 @@ func snapshotPerClient(
 			endpointsHash ^= ep.EndpointsHash
 		}
 
-		endpointResources := envoycache.NewResourcesWithTTL(fmt.Sprintf("%d", endpointsHash), endpointsProto)
+		endpointResources := envoycache.NewResourcesWithTTL(strconv.FormatUint(endpointsHash, 10), endpointsProto)
 		return &endpointsWithUccName{
 			endpoints:    endpointResources,
 			resourceName: ucc.ResourceName(),
@@ -164,7 +165,7 @@ func snapshotPerClient(
 			for _, item := range listenerRouteSnapshot.Clusters {
 				clustersProto[envoycache.GetResourceName(item.Resource)] = item
 			}
-			clusterResources.Version = fmt.Sprintf("%d", clustersForUcc.clustersHash^listenerRouteSnapshot.ClustersHash)
+			clusterResources.Version = strconv.FormatUint(clustersForUcc.clustersHash^listenerRouteSnapshot.ClustersHash, 10)
 			clusterResources.Items = clustersProto
 		}
 		// Exclude CLAs for STATIC clusters so ADS snapshot only contains resources Envoy will request.

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync/atomic"
 
 	envoycachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -116,7 +117,7 @@ func sliceToResourcesHash[T proto.Message](slice []T) ([]envoycachetypes.Resourc
 
 func sliceToResources[T proto.Message](slice []T) envoycache.Resources {
 	r, h := sliceToResourcesHash(slice)
-	return envoycache.NewResourcesWithTTL(fmt.Sprintf("%d", h), r)
+	return envoycache.NewResourcesWithTTL(strconv.FormatUint(h, 10), r)
 }
 
 func toResources(gw ir.Gateway, xdsSnap irtranslator.TranslationResult, r reports.ReportMap) *GatewayXdsResources {

--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -3,7 +3,6 @@ package proxy_syncer
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -253,7 +252,7 @@ func (s *StatusSyncer) syncRouteStatus(ctx context.Context, logger *slog.Logger,
 								if finish, exists := finishMetrics[string(ps.ParentRef.Name)]; exists {
 									finishMetrics[string(ps.ParentRef.Name)] = finishMetricsErrors{
 										finishFunc:  finish.finishFunc,
-										statusError: fmt.Errorf("partially invalid route condition"),
+										statusError: errors.New("partially invalid route condition"),
 									}
 									break
 								}
@@ -264,7 +263,7 @@ func (s *StatusSyncer) syncRouteStatus(ctx context.Context, logger *slog.Logger,
 									if finish, exists := finishMetrics[string(ps.ParentRef.Name)]; exists {
 										finishMetrics[string(ps.ParentRef.Name)] = finishMetricsErrors{
 											finishFunc:  finish.finishFunc,
-											statusError: fmt.Errorf("invalid route condition"),
+											statusError: errors.New("invalid route condition"),
 										}
 										break
 									}
@@ -277,7 +276,7 @@ func (s *StatusSyncer) syncRouteStatus(ctx context.Context, logger *slog.Logger,
 									if finish, exists := finishMetrics[string(ps.ParentRef.Name)]; exists {
 										finishMetrics[string(ps.ParentRef.Name)] = finishMetricsErrors{
 											finishFunc:  finish.finishFunc,
-											statusError: fmt.Errorf("invalid route condition"),
+											statusError: errors.New("invalid route condition"),
 										}
 										break
 									}
@@ -550,7 +549,7 @@ func (s *StatusSyncer) syncGatewayStatus(ctx context.Context, logger *slog.Logge
 					cond.Reason != string(gwv1.GatewayReasonPending) {
 					logger.Debug("invalid status condition reason", "reason", cond.Reason, "gateway", gwnn.String())
 
-					statusErr = fmt.Errorf("invalid gateway condition")
+					statusErr = errors.New("invalid gateway condition")
 
 					break
 				}
@@ -620,7 +619,7 @@ func (s *StatusSyncer) syncListenerSetStatus(ctx context.Context, logger *slog.L
 							if cond.Reason != string(gwv1.ListenerSetReasonAccepted) &&
 								cond.Reason != string(gwv1.ListenerSetReasonProgrammed) &&
 								cond.Reason != string(gwv1.ListenerSetReasonPending) {
-								statusErr = fmt.Errorf("invalid listener condition")
+								statusErr = errors.New("invalid listener condition")
 
 								break
 							}
@@ -788,7 +787,7 @@ func (s *StatusSyncer) syncPolicyStatus(ctx context.Context, rm reports.ReportMa
 
 					if cond.Reason != string(shared.PolicyReasonValid) &&
 						cond.Reason != string(shared.PolicyReasonPending) {
-						statusErr = fmt.Errorf("invalid policy condition")
+						statusErr = errors.New("invalid policy condition")
 
 						break
 					}

--- a/pkg/kgateway/query/query.go
+++ b/pkg/kgateway/query/query.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -23,12 +24,12 @@ import (
 )
 
 var (
-	ErrNoMatchingListenerHostname = fmt.Errorf("no matching listener hostname")
-	ErrNoMatchingParent           = fmt.Errorf("no matching parent")
-	ErrNotAllowedByListeners      = fmt.Errorf("not allowed by listeners")
-	ErrLocalObjRefMissingKind     = fmt.Errorf("localObjRef provided with empty kind")
-	ErrCyclicReference            = fmt.Errorf("cyclic reference detected while evaluating delegated routes")
-	ErrUnresolvedReference        = fmt.Errorf("unresolved reference")
+	ErrNoMatchingListenerHostname = errors.New("no matching listener hostname")
+	ErrNoMatchingParent           = errors.New("no matching parent")
+	ErrNotAllowedByListeners      = errors.New("not allowed by listeners")
+	ErrLocalObjRefMissingKind     = errors.New("localObjRef provided with empty kind")
+	ErrCyclicReference            = errors.New("cyclic reference detected while evaluating delegated routes")
+	ErrUnresolvedReference        = errors.New("unresolved reference")
 )
 
 type Error struct {

--- a/pkg/kgateway/query/route.go
+++ b/pkg/kgateway/query/route.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -181,7 +182,7 @@ func (r *gatewayQueries) allowedRoutes(resource client.Object, l *gwv1.Listener)
 				allowedNs = krtcollections.AllNamespace()
 			case gwv1.NamespacesFromSelector:
 				if ar.Namespaces.Selector == nil {
-					return nil, nil, fmt.Errorf("selector must be set")
+					return nil, nil, errors.New("selector must be set")
 				}
 				selector, err := metav1.LabelSelectorAsSelector(ar.Namespaces.Selector)
 				if err != nil {
@@ -416,7 +417,7 @@ func getListeners(resource client.Object) ([]gwv1.Listener, error) {
 	case krtcollections.ListenerCollection:
 		listeners = typed.GetListeners()
 	default:
-		return nil, fmt.Errorf("unknown type")
+		return nil, errors.New("unknown type")
 	}
 	return listeners, nil
 }

--- a/pkg/kgateway/setup/authn.go
+++ b/pkg/kgateway/setup/authn.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -77,10 +78,10 @@ func (a *KubeJWTAuthenticator) authenticate(targetJWT string) (*security.Caller,
 		return nil, fmt.Errorf("failed to validate the JWT token: %v", err)
 	}
 	if id.PodServiceAccount == "" {
-		return nil, fmt.Errorf("failed to parse the JWT; service account required")
+		return nil, errors.New("failed to parse the JWT; service account required")
 	}
 	if id.PodNamespace == "" {
-		return nil, fmt.Errorf("failed to parse the JWT; namespace required")
+		return nil, errors.New("failed to parse the JWT; namespace required")
 	}
 	return &security.Caller{
 		AuthSource:     security.AuthSourceIDToken,
@@ -93,14 +94,14 @@ func (a *KubeJWTAuthenticator) authenticate(targetJWT string) (*security.Caller,
 func extractRequestToken(req *http.Request) (string, error) {
 	value := req.Header.Get(authorizationHeader)
 	if value == "" {
-		return "", fmt.Errorf("no HTTP authorization header exists")
+		return "", errors.New("no HTTP authorization header exists")
 	}
 
 	if after, ok := strings.CutPrefix(value, bearerTokenPrefix); ok {
 		return after, nil
 	}
 
-	return "", fmt.Errorf("no bearer token exists in HTTP authorization header")
+	return "", errors.New("no bearer token exists in HTTP authorization header")
 }
 
 // authenticationManager orchestrates all authenticators to perform authentication.

--- a/pkg/kgateway/setup/setup_test.go
+++ b/pkg/kgateway/setup/setup_test.go
@@ -278,9 +278,9 @@ spec:
 		t.Cleanup(dumper.Close)
 		t.Cleanup(func() {
 			if t.Failed() {
-				logKrtState(t, fmt.Sprintf("krt state for failed test: %s", t.Name()), kdbg)
+				logKrtState(t, "krt state for failed test: "+t.Name(), kdbg)
 			} else if os.Getenv("KGW_DUMP_KRT_ON_SUCCESS") == "true" {
-				logKrtState(t, fmt.Sprintf("krt state for successful test: %s", t.Name()), kdbg)
+				logKrtState(t, "krt state for successful test: "+t.Name(), kdbg)
 			}
 		})
 
@@ -358,9 +358,9 @@ spec:
 		time.Sleep(time.Second * 2)
 		t.Cleanup(func() {
 			if t.Failed() {
-				logKrtState(t, fmt.Sprintf("krt state for failed test: %s", t.Name()), kdbg)
+				logKrtState(t, "krt state for failed test: "+t.Name(), kdbg)
 			} else if os.Getenv("KGW_DUMP_KRT_ON_SUCCESS") == "true" {
-				logKrtState(t, fmt.Sprintf("krt state for successful test: %s", t.Name()), kdbg)
+				logKrtState(t, "krt state for successful test: "+t.Name(), kdbg)
 			}
 		})
 		initialDump, err := dumpXdsConfig(t, ctx, xdsPort, "http-gw")
@@ -396,10 +396,10 @@ spec:
 				return fmt.Errorf("failed to get updated xDS dump: %w", err)
 			}
 			if len(updatedDump.Routes) == 0 {
-				return fmt.Errorf("no routes found in updated dump")
+				return errors.New("no routes found in updated dump")
 			}
 			if !hasWebsocketUpgradeConfig(updatedDump) {
-				return fmt.Errorf("expected websocket upgrade configuration after updating appProtocol, but found none")
+				return errors.New("expected websocket upgrade configuration after updating appProtocol, but found none")
 			}
 			t.Logf("SUCCESS: Found websocket upgrade configuration after updating appProtocol")
 			return nil
@@ -562,9 +562,9 @@ func testScenario(
 
 	t.Cleanup(func() {
 		if t.Failed() {
-			logKrtState(t, fmt.Sprintf("krt state for failed test: %s", t.Name()), kdbg)
+			logKrtState(t, "krt state for failed test: "+t.Name(), kdbg)
 		} else if os.Getenv("KGW_DUMP_KRT_ON_SUCCESS") == "true" {
-			logKrtState(t, fmt.Sprintf("krt state for successful test: %s", t.Name()), kdbg)
+			logKrtState(t, "krt state for successful test: "+t.Name(), kdbg)
 		}
 	})
 
@@ -576,7 +576,7 @@ func testScenario(
 			return err
 		}
 		if len(dump.Listeners) == 0 {
-			return fmt.Errorf("timed out waiting for listeners")
+			return errors.New("timed out waiting for listeners")
 		}
 		if write {
 			t.Logf("writing out file")
@@ -586,7 +586,7 @@ func testScenario(
 				return fmt.Errorf("failed to serialize xdsDump: %v", err)
 			}
 			os.WriteFile(fout, d, 0o600)
-			return fmt.Errorf("wrote out file - nothing to test")
+			return errors.New("wrote out file - nothing to test")
 		}
 		return dump.Compare(expectedXdsDump)
 	}, retry.Converge(2), retry.Timeout(10*time.Second))
@@ -733,11 +733,11 @@ func (x xdsDumper) Dump(t *testing.T, ctx context.Context) (xdsDump, error) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		// don't fatal yet as we want to dump the state while still connected
-		errs = errors.Join(errs, fmt.Errorf("timed out waiting for listener/cluster xds dump"))
+		errs = errors.Join(errs, errors.New("timed out waiting for listener/cluster xds dump"))
 		return xdsDump{}, errs
 	}
 	if len(listeners) == 0 {
-		errs = errors.Join(errs, fmt.Errorf("no listeners found"))
+		errs = errors.Join(errs, errors.New("no listeners found"))
 		return xdsDump{}, errs
 	}
 	t.Logf("xds: found %d listeners and %d clusters", len(listeners), len(clusters))
@@ -819,7 +819,7 @@ func (x xdsDumper) Dump(t *testing.T, ctx context.Context) (xdsDump, error) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		// don't fatal yet as we want to dump the state while still connected
-		errs = errors.Join(errs, fmt.Errorf("timed out waiting for routes/cla xds dump"))
+		errs = errors.Join(errs, errors.New("timed out waiting for routes/cla xds dump"))
 		return xdsDump{}, errs
 	}
 
@@ -931,7 +931,7 @@ func (x *xdsDump) Compare(other xdsDump) error {
 func compareCla(c, otherc *envoyendpointv3.ClusterLoadAssignment) error {
 	if (c == nil) != (otherc == nil) {
 		if c == nil {
-			return fmt.Errorf("cluster is nil")
+			return errors.New("cluster is nil")
 		}
 		return fmt.Errorf("ep %v not found", c.ClusterName)
 	}

--- a/pkg/kgateway/translator/irtranslator/validate.go
+++ b/pkg/kgateway/translator/irtranslator/validate.go
@@ -77,7 +77,7 @@ func validateRoute(
 
 func validateRoutePreEnvoy(route *envoyroutev3.Route, mode apisettings.ValidationMode) error {
 	if route == nil {
-		return fmt.Errorf("route cannot be nil for RDS validation")
+		return errors.New("route cannot be nil for RDS validation")
 	}
 	if err := validateEnvoyRoute(route); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidRoute, err)
@@ -97,7 +97,7 @@ func validateRouteWithEnvoy(
 	v validator.Validator,
 ) error {
 	if route == nil {
-		return fmt.Errorf("route cannot be nil for RDS validation")
+		return errors.New("route cannot be nil for RDS validation")
 	}
 	fullErr := validateFullRoutes(ctx, []*envoyroutev3.Route{route}, v)
 	if fullErr == nil {

--- a/pkg/kgateway/validate/gateway.go
+++ b/pkg/kgateway/validate/gateway.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -15,7 +16,7 @@ const (
 	EnvoyAdminPort gwv1.PortNumber = 19000
 )
 
-var ErrListenerPortReserved = fmt.Errorf("port is reserved")
+var ErrListenerPortReserved = errors.New("port is reserved")
 
 // staticReservedPorts are always reserved regardless of gateway configuration.
 var staticReservedPorts = sets.New(

--- a/pkg/krtcollections/grpc_route.go
+++ b/pkg/krtcollections/grpc_route.go
@@ -133,7 +133,7 @@ func buildGRPCPathMatch(method *gwv1.GRPCMethodMatch) (string, gwv1.PathMatchTyp
 			path = fmt.Sprintf("/%s/.+", string(*method.Service))
 		case method.Method != nil:
 			// Match any valid service name before the method
-			path = fmt.Sprintf("/.+/%s", string(*method.Method))
+			path = "/.+/" + string(*method.Method)
 		}
 	default: // gwv1.GRPCMethodMatchExact
 		switch {
@@ -142,11 +142,11 @@ func buildGRPCPathMatch(method *gwv1.GRPCMethodMatch) (string, gwv1.PathMatchTyp
 			pathType = gwv1.PathMatchExact
 		case method.Service != nil:
 			// Exact service match maps to prefix /service
-			path = fmt.Sprintf("/%s", string(*method.Service))
+			path = "/" + string(*method.Service)
 			pathType = gwv1.PathMatchPathPrefix
 		case method.Method != nil:
 			// Exact method without service isn't directly mappable, use regex
-			path = fmt.Sprintf("/.+/%s", string(*method.Method))
+			path = "/.+/" + string(*method.Method)
 			pathType = gwv1.PathMatchRegularExpression
 		}
 	}

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -629,7 +629,7 @@ func AllowedListenerSet(allowedListeners *gwv1.AllowedListeners, parentNamespace
 				allowedNs = SameNamespace(parentNamespace)
 			case gwv1.NamespacesFromSelector:
 				if allowedListeners.Namespaces.Selector == nil {
-					return nil, fmt.Errorf("selector must be set")
+					return nil, errors.New("selector must be set")
 				}
 				selector, err := metav1.LabelSelectorAsSelector(allowedListeners.Namespaces.Selector)
 				if err != nil {
@@ -732,7 +732,7 @@ func NewPolicyIndex(
 					return nil
 				}
 				return &a
-			}, krtopts.ToOptions(fmt.Sprintf("%s-policiesByTargetRef", gk.String()))...)
+			}, krtopts.ToOptions(gk.String()+"-policiesByTargetRef")...)
 
 			targetRefIndex := krtpkg.UnnamedIndex(policiesByTargetRef, func(p ir.PolicyWrapper) []TargetRefIndexKey {
 				// Every policy is indexed by PolicyRef and PolicyRef without Name (by Group+Kind+Namespace)

--- a/pkg/krtcollections/policy_test.go
+++ b/pkg/krtcollections/policy_test.go
@@ -3,6 +3,7 @@ package krtcollections
 import (
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -757,11 +758,11 @@ func BenchmarkPolicyAttachment(b *testing.B) {
 			for i := range tc.routes {
 				routeLabels := maps.Clone(routeLabels)
 				if tc.byLabel {
-					routeLabels[fmt.Sprint(i)] = "yes"
+					routeLabels[strconv.Itoa(i)] = "yes"
 				}
 				inputs = append(inputs, &gwv1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "httproute-" + fmt.Sprint(i),
+						Name:      "httproute-" + strconv.Itoa(i),
 						Namespace: "default",
 						Labels:    routeLabels,
 					},
@@ -791,7 +792,7 @@ func BenchmarkPolicyAttachment(b *testing.B) {
 						Group:     wellknown.TrafficPolicyGVK.Group,
 						Kind:      wellknown.TrafficPolicyGVK.Kind,
 						Namespace: "default",
-						Name:      "policy-" + fmt.Sprint(i),
+						Name:      "policy-" + strconv.Itoa(i),
 					},
 					Policy:   &kgateway.TrafficPolicy{},
 					PolicyIR: fakePolicyIR{},
@@ -799,7 +800,7 @@ func BenchmarkPolicyAttachment(b *testing.B) {
 				if tc.byLabel {
 					switch tc.selectionPolicy {
 					case onePolicyPerRoute:
-						routeLabels[fmt.Sprint(i)] = "yes"
+						routeLabels[strconv.Itoa(i)] = "yes"
 					case allPoliciesPerRoute:
 					}
 					p.TargetRefs = []ir.PolicyRef{
@@ -816,7 +817,7 @@ func BenchmarkPolicyAttachment(b *testing.B) {
 							{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "HTTPRoute",
-								Name:  "httproute-" + fmt.Sprint(i),
+								Name:  "httproute-" + strconv.Itoa(i),
 							},
 						}
 					case allPoliciesPerRoute:
@@ -825,7 +826,7 @@ func BenchmarkPolicyAttachment(b *testing.B) {
 							p.TargetRefs = append(p.TargetRefs, ir.PolicyRef{
 								Group: "gateway.networking.k8s.io",
 								Kind:  "HTTPRoute",
-								Name:  "httproute-" + fmt.Sprint(r),
+								Name:  "httproute-" + strconv.Itoa(r),
 							})
 						}
 					}
@@ -837,7 +838,7 @@ func BenchmarkPolicyAttachment(b *testing.B) {
 			for b.Loop() {
 				rtidx := preRouteIndex(b, inputs)
 				firstRoute := "httproute-0"
-				lastRoute := "httproute-" + fmt.Sprint(tc.routes-1)
+				lastRoute := "httproute-" + strconv.Itoa(tc.routes-1)
 
 				for _, route := range []string{firstRoute, lastRoute} {
 					h := rtidx.FetchHttp(krt.TestingDummyContext{}, "default", route)

--- a/pkg/krtcollections/uniqueclients.go
+++ b/pkg/krtcollections/uniqueclients.go
@@ -449,7 +449,7 @@ func (x *callbacksCollection) tryConfirmLocalCluster(sid int64, uccName string, 
 // request and respond with an error.
 func (x *callbacks) OnFetchRequest(ctx context.Context, r *envoy_service_discovery_v3.DiscoveryRequest) error {
 	if x.xdsAuth {
-		return fmt.Errorf("OnFetchRequest not supported when xDS auth is enabled")
+		return errors.New("OnFetchRequest not supported when xDS auth is enabled")
 	}
 	if x.extraXDSCallbacks != nil {
 		if err := x.extraXDSCallbacks.OnFetchRequest(ctx, r); err != nil {

--- a/pkg/krtcollections/uniqueclients_test.go
+++ b/pkg/krtcollections/uniqueclients_test.go
@@ -177,7 +177,7 @@ func TestUniqueClients(t *testing.T) {
 					},
 				},
 			},
-			result: sets.New(fmt.Sprintf(wellknown.GatewayApiProxyValue + "~best-proxy-role")),
+			result: sets.New(wellknown.GatewayApiProxyValue + "~best-proxy-role"),
 		},
 	}
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -28,7 +28,7 @@ SOFTWARE.
 package logging
 
 import (
-	"fmt"
+	"errors"
 	"log/slog"
 	"sync"
 )
@@ -102,7 +102,7 @@ func NewWithOptions(component string, opts Options) *slog.Logger {
 // DeleteLeveler deletes the leveler instance for the given component
 func DeleteLeveler(component string) error {
 	if component == "" {
-		return fmt.Errorf("component unspecified")
+		return errors.New("component unspecified")
 	}
 	componentLeveler.Delete(component)
 	return nil

--- a/pkg/metrics/cmd/findmetrics/main.go
+++ b/pkg/metrics/cmd/findmetrics/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"cmp"
+	"errors"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -114,7 +115,7 @@ func findMetrics(target string) ([]metricInfo, error) {
 	} else if strings.HasSuffix(target, ".go") {
 		files = append(files, target)
 	} else {
-		return nil, fmt.Errorf("target must be a .go file or a directory")
+		return nil, errors.New("target must be a .go file or a directory")
 	}
 
 	var allMetrics []metricInfo

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -2,7 +2,7 @@ package ir
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"maps"
 	"slices"
 	"time"
@@ -351,7 +351,7 @@ func (c PolicyWrapper) Equals(in PolicyWrapper) bool {
 	return versionEquals(c.Policy, in.Policy) && c.PolicyIR.Equals(in.PolicyIR) && c.PrecedenceWeight == in.PrecedenceWeight
 }
 
-var ErrNotAttachable = fmt.Errorf("policy is not attachable to this object")
+var ErrNotAttachable = errors.New("policy is not attachable to this object")
 
 type PolicyRun interface {
 	// Allocate state for single listener+rotue translation pass.

--- a/pkg/pluginsdk/ir/model_endpoints_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strconv"
 	"testing"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -46,7 +47,7 @@ func testLbEndpoint(addr string, port uint32) *envoyendpointv3.LbEndpoint {
 func testEndpointWithMd(i int) EndpointWithMd {
 	return EndpointWithMd{
 		LbEndpoint: testLbEndpoint(fmt.Sprintf("10.0.%d.%d", i/256, i%256), 8080),
-		EndpointMd: EndpointMetadata{Labels: map[string]string{"i": fmt.Sprint(i)}},
+		EndpointMd: EndpointMetadata{Labels: map[string]string{"i": strconv.Itoa(i)}},
 	}
 }
 

--- a/pkg/pluginsdk/policy/cors.go
+++ b/pkg/pluginsdk/policy/cors.go
@@ -1,8 +1,8 @@
 package policy
 
 import (
-	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -76,7 +76,7 @@ func BuildCorsPolicy(
 		corsPolicy.ExposeHeaders = strings.Join(headers, ", ")
 	}
 	if f.MaxAge != 0 {
-		corsPolicy.MaxAge = fmt.Sprintf("%d", f.MaxAge)
+		corsPolicy.MaxAge = strconv.Itoa(int(f.MaxAge))
 	}
 	corsPolicy.ForwardNotMatchingPreflights = &wrapperspb.BoolValue{Value: false}
 	return corsPolicy

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -97,9 +97,9 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway, attached
 
 	// If any listeners have Programmed=False, set Gateway Accepted=True with ListenersNotValid reason
 	if len(invalidListeners) > 0 {
-		message := fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidMessages, "; "))
+		message := "Some listeners are not programmed: " + strings.Join(invalidMessages, "; ")
 		if len(invalidMessages) == 0 {
-			message = fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidListeners, ", "))
+			message = "Some listeners are not programmed: " + strings.Join(invalidListeners, ", ")
 		}
 
 		meta.SetStatusCondition(&gwConditions, metav1.Condition{
@@ -326,9 +326,9 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwv1.Listener
 
 	// If any listeners have Programmed=False, set ListenerSet Accepted=True with ListenersNotValid reason
 	if len(invalidListeners) > 0 {
-		message := fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidMessages, "; "))
+		message := "Some listeners are not programmed: " + strings.Join(invalidMessages, "; ")
 		if len(invalidMessages) == 0 {
-			message = fmt.Sprintf("Some listeners are not programmed: %s", strings.Join(invalidListeners, ", "))
+			message = "Some listeners are not programmed: " + strings.Join(invalidListeners, ", ")
 		}
 
 		meta.SetStatusCondition(&lsConditions, metav1.Condition{

--- a/pkg/sds/run.go
+++ b/pkg/sds/run.go
@@ -2,6 +2,7 @@ package sds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -87,7 +88,7 @@ func setup() Config {
 	}
 
 	if !c.IstioMtlsSdsEnabled {
-		err := fmt.Errorf("Istio Cert rotation must be enabled, using env var ISTIO_MTLS_SDS_ENABLED")
+		err := errors.New("Istio Cert rotation must be enabled, using env var ISTIO_MTLS_SDS_ENABLED")
 		log.Fatalf("invalid config: %v", err)
 	}
 	return c

--- a/pkg/sds/server/server.go
+++ b/pkg/sds/server/server.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -228,7 +229,7 @@ func readAndValidateSecret(ctx context.Context, sec Secret) ([][]byte, []cache_t
 // GetSnapshotVersion generates a version string by hashing the certs
 func GetSnapshotVersion(certs ...any) (string, error) {
 	hash, err := hashAllSafe(fnv.New64(), certs...)
-	return fmt.Sprintf("%d", hash), err
+	return strconv.FormatUint(hash, 10), err
 }
 
 // hashAllSafe replicates the behavior of hashutils.HashAllSafe from github.com/solo-io/go-utils

--- a/pkg/sds/server/x509_godebug_test.go
+++ b/pkg/sds/server/x509_godebug_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -62,12 +63,7 @@ func defaultGODEBUG(t *testing.T) godebugSettings {
 type godebugSettings string
 
 func (settings godebugSettings) contains(key, value string) bool {
-	for _, setting := range strings.Split(string(settings), ",") {
-		if setting == key+"="+value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(string(settings), ","), key+"="+value)
 }
 
 const negativeSerialCertPEM = `-----BEGIN CERTIFICATE-----

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -288,7 +288,7 @@ func (c *Cli) DeploymentRolloutStatus(ctx context.Context, deployment string, ex
 	rolloutArgs := append([]string{
 		"rollout",
 		"status",
-		fmt.Sprintf("deployment/%s", deployment),
+		"deployment/" + deployment,
 	}, extraArgs...)
 	return c.RunCommand(ctx, rolloutArgs...)
 }
@@ -413,7 +413,7 @@ func (c *Cli) RestartDeployment(ctx context.Context, name string, extraArgs ...s
 	args := append([]string{
 		"rollout",
 		"restart",
-		fmt.Sprintf("deployment/%s", name),
+		"deployment/" + name,
 	}, extraArgs...)
 	return c.RunCommand(ctx, args...)
 }

--- a/pkg/utils/kubeutils/portforward/api_forwarder.go
+++ b/pkg/utils/kubeutils/portforward/api_forwarder.go
@@ -2,6 +2,7 @@ package portforward
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -111,7 +112,7 @@ func (f *apiPortForwarder) startOnce(ctx context.Context) error {
 			return fmt.Errorf("failed to get ports: %v", err)
 		}
 		if len(p) == 0 {
-			return fmt.Errorf("got no ports")
+			return errors.New("got no ports")
 		}
 		// Set local port now, as it may have been 0 as input
 		f.properties.localPort = int(p[0].Local)

--- a/pkg/utils/kubeutils/portforward/cli_portforwarder.go
+++ b/pkg/utils/kubeutils/portforward/cli_portforwarder.go
@@ -3,6 +3,7 @@ package portforward
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -150,7 +151,7 @@ func getFreePort() (int, error) {
 	defer l.Close()
 	tcpAddr, ok := l.Addr().(*net.TCPAddr)
 	if !ok {
-		return 0, fmt.Errorf("Error occurred looking for an open tcp port")
+		return 0, errors.New("Error occurred looking for an open tcp port")
 	}
 	return tcpAddr.Port, nil
 }

--- a/pkg/utils/kubeutils/portforward/options.go
+++ b/pkg/utils/kubeutils/portforward/options.go
@@ -1,7 +1,6 @@
 package portforward
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -24,7 +23,7 @@ type properties struct {
 }
 
 func WithKindCluster(kindClusterName string) Option {
-	return WithKubeContext(fmt.Sprintf("kind-%s", kindClusterName))
+	return WithKubeContext("kind-" + kindClusterName)
 }
 
 func WithKubeContext(kubeContext string) Option {

--- a/pkg/utils/requestutils/curl/request.go
+++ b/pkg/utils/requestutils/curl/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 // BuildArgs accepts a set of curl.Option and generates the list of arguments
@@ -119,7 +120,7 @@ func (c *requestConfig) generateArgs() []string {
 		args = append(args, "-s")
 	}
 	if c.connectionTimeout > 0 {
-		seconds := fmt.Sprintf("%v", c.connectionTimeout)
+		seconds := strconv.Itoa(c.connectionTimeout)
 		args = append(args, "--connect-timeout", seconds, "--max-time", seconds)
 	}
 	if c.headersOnly {
@@ -141,13 +142,13 @@ func (c *requestConfig) generateArgs() []string {
 		args = append(args, "--data-binary", c.body)
 	}
 	if c.retry != 0 {
-		args = append(args, "--retry", fmt.Sprintf("%d", c.retry))
+		args = append(args, "--retry", strconv.Itoa(c.retry))
 	}
 	if c.retryDelay != -1 {
-		args = append(args, "--retry-delay", fmt.Sprintf("%d", c.retryDelay))
+		args = append(args, "--retry-delay", strconv.Itoa(c.retryDelay))
 	}
 	if c.retryMaxTime != 0 {
-		args = append(args, "--retry-max-time", fmt.Sprintf("%d", c.retryMaxTime))
+		args = append(args, "--retry-max-time", strconv.Itoa(c.retryMaxTime))
 	}
 	if c.retryConnectionRefused {
 		args = append(args, "--retry-connrefused")
@@ -175,7 +176,7 @@ func (c *requestConfig) generateArgs() []string {
 		args = append(args, "--sigalgs", c.signatureAlgorithms)
 	}
 	if c.tlsVersion != "" {
-		args = append(args, fmt.Sprintf("--tlsv%s", c.tlsVersion))
+		args = append(args, "--tlsv"+c.tlsVersion)
 	}
 	if c.tlsMaxVersion != "" {
 		args = append(args, "--tls-max", c.tlsMaxVersion)

--- a/pkg/utils/requestutils/grpcurl/options.go
+++ b/pkg/utils/requestutils/grpcurl/options.go
@@ -2,6 +2,7 @@ package grpcurl
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -49,7 +50,7 @@ func (c *Command) ToArgs() []string {
 		args = append(args, "-v")
 	}
 	if c.ConnectTimeout > 0 {
-		args = append(args, "-connect-timeout", fmt.Sprintf("%d", c.ConnectTimeout))
+		args = append(args, "-connect-timeout", strconv.Itoa(c.ConnectTimeout))
 	}
 
 	if c.Authority != "" {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -160,7 +160,7 @@ func (d *dockerValidator) args() []string {
 		args = append(args, "--pull", d.pull)
 	}
 	if d.etcEnvoy != "" {
-		args = append(args, "-v", fmt.Sprintf("%s:/etc/envoy/:ro", d.etcEnvoy))
+		args = append(args, "-v", d.etcEnvoy+":/etc/envoy/:ro")
 	}
 	args = append(args,
 		"--entrypoint", "/usr/local/bin/envoy",

--- a/test/e2e/features/loadtesting/attachedroutes_suite.go
+++ b/test/e2e/features/loadtesting/attachedroutes_suite.go
@@ -4,6 +4,7 @@ package loadtesting
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -407,12 +408,12 @@ func (s *AttachedRoutesSuite) verifyRouteValid(gatewayName string) error {
 	}
 
 	if len(routeList.Items) == 0 {
-		return fmt.Errorf("no routes found")
+		return errors.New("no routes found")
 	}
 
 	route := &routeList.Items[0]
 	if len(route.Status.Parents) == 0 {
-		return fmt.Errorf("route has no parent status")
+		return errors.New("route has no parent status")
 	}
 
 	parentStatus := route.Status.Parents[0]
@@ -423,7 +424,7 @@ func (s *AttachedRoutesSuite) verifyRouteValid(gatewayName string) error {
 		}
 	}
 
-	return fmt.Errorf("no routes are accepted")
+	return errors.New("no routes are accepted")
 }
 
 func (s *AttachedRoutesSuite) createSingleIncrementalRoute(gatewayName string) *gwv1.HTTPRoute {
@@ -439,12 +440,12 @@ func (s *AttachedRoutesSuite) createSingleIncrementalRoute(gatewayName string) *
 			CommonRouteSpec: gwv1.CommonRouteSpec{
 				ParentRefs: []gwv1.ParentReference{{Name: gwv1.ObjectName(gatewayName)}},
 			},
-			Hostnames: []gwv1.Hostname{gwv1.Hostname(fmt.Sprintf("%s.example.com", routeName))},
+			Hostnames: []gwv1.Hostname{gwv1.Hostname(routeName + ".example.com")},
 			Rules: []gwv1.HTTPRouteRule{{
 				Matches: []gwv1.HTTPRouteMatch{{
 					Path: &gwv1.HTTPPathMatch{
 						Type:  &[]gwv1.PathMatchType{gwv1.PathMatchPathPrefix}[0],
-						Value: &[]string{fmt.Sprintf("/%s", routeName)}[0],
+						Value: &[]string{"/" + routeName}[0],
 					},
 				}},
 				BackendRefs: []gwv1.HTTPBackendRef{{
@@ -558,7 +559,7 @@ func (s *AttachedRoutesSuite) waitForAllGatewaysCondition(gateways []string, exp
 				}
 
 				if len(gateway.Status.Listeners) == 0 {
-					lastObserved = fmt.Sprintf("%s: no listeners", gatewayName)
+					lastObserved = gatewayName + ": no listeners"
 					allReady = false
 					break
 				}

--- a/test/e2e/features/loadtesting/loadtest_manager.go
+++ b/test/e2e/features/loadtesting/loadtest_manager.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -142,7 +143,7 @@ func (ltm *LoadTestManager) WaitForGatewayReadiness(timeout time.Duration) error
 	for {
 		select {
 		case <-timeoutCh:
-			return fmt.Errorf("timeout waiting for gateways to be ready")
+			return errors.New("timeout waiting for gateways to be ready")
 		case <-ticker.C:
 			allReady := true
 
@@ -249,7 +250,7 @@ func (ltm *LoadTestManager) buildRoute(gatewayName string, routeIdx, batchStart 
 			Labels: map[string]string{
 				"loadtest": "true",
 				"gateway":  gatewayName,
-				"batch":    fmt.Sprintf("%d", batchStart/GetOptimalBatchSize(1000)), // Use baseline batch size for labeling
+				"batch":    strconv.Itoa(batchStart / GetOptimalBatchSize(1000)), // Use baseline batch size for labeling
 			},
 		},
 		Spec: gwv1.HTTPRouteSpec{
@@ -402,7 +403,7 @@ func (ltm *LoadTestManager) fetchKGatewayMetrics() ([]byte, error) {
 		if err != nil {
 			lastErr = err
 		} else {
-			lastErr = fmt.Errorf("no ready kgateway controller pods found")
+			lastErr = errors.New("no ready kgateway controller pods found")
 			for _, pod := range pods.Items {
 				if !podReady(&pod) {
 					continue

--- a/test/e2e/features/loadtesting/startup_suite.go
+++ b/test/e2e/features/loadtesting/startup_suite.go
@@ -5,6 +5,7 @@ package loadtesting
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -63,7 +64,7 @@ func (s *LoadTestingSuite) measureControllerRolloutStartup() (*startupBenchmarkR
 			Namespace:       namespace,
 			Deployment:      controllerDeploymentName,
 			DesiredReplicas: desiredReplicas,
-		}, fmt.Errorf("controller deployment has no desired replicas")
+		}, errors.New("controller deployment has no desired replicas")
 	}
 
 	version, channel := s.detectGatewayAPIMetadata()

--- a/test/e2e/features/oauth/client.go
+++ b/test/e2e/features/oauth/client.go
@@ -5,6 +5,7 @@ package oauth
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -151,7 +152,7 @@ func extractLoginForm(htmlContent string) (*LoginForm, error) {
 	// Find the login form for Keycloak
 	form := doc.Find("form#kc-form-login").First()
 	if form.Length() == 0 {
-		return nil, fmt.Errorf("login form not found")
+		return nil, errors.New("login form not found")
 	}
 
 	method, _ := form.Attr("method")

--- a/test/e2e/features/services/tcproute/suite.go
+++ b/test/e2e/features/services/tcproute/suite.go
@@ -4,7 +4,6 @@ package tcproute
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
@@ -292,14 +291,14 @@ func (s *testingSuite) setupTestEnvironment(nsManifest, gtwName, gtwNs, gtwManif
 func (s *testingSuite) applyManifests(ns string, manifests ...string) {
 	for _, manifest := range manifests {
 		err := s.TestInstallation.Actions.Kubectl().ApplyFile(s.Ctx, manifest, "-n", ns)
-		s.Require().NoError(err, fmt.Sprintf("Failed to apply manifest %s", manifest))
+		s.Require().NoError(err, "Failed to apply manifest "+manifest)
 	}
 }
 
 func (s *testingSuite) deleteManifests(manifests ...string) {
 	for _, manifest := range manifests {
 		err := s.TestInstallation.Actions.Kubectl().DeleteFileSafe(s.Ctx, manifest)
-		s.Require().NoError(err, fmt.Sprintf("Failed to delete manifest %s", manifest))
+		s.Require().NoError(err, "Failed to delete manifest "+manifest)
 	}
 }
 

--- a/test/e2e/features/services/tlsroute/suite.go
+++ b/test/e2e/features/services/tlsroute/suite.go
@@ -275,14 +275,14 @@ func (s *testingSuite) setupTestEnvironment(nsManifest, gtwName, gtwNs, gtwManif
 func (s *testingSuite) applyManifests(ns string, manifests ...string) {
 	for _, manifest := range manifests {
 		err := s.TestInstallation.Actions.Kubectl().ApplyFile(s.Ctx, manifest, "-n", ns)
-		s.Require().NoError(err, fmt.Sprintf("Failed to apply manifest %s", manifest))
+		s.Require().NoError(err, "Failed to apply manifest "+manifest)
 	}
 }
 
 func (s *testingSuite) deleteManifests(manifests ...string) {
 	for _, manifest := range manifests {
 		err := s.TestInstallation.Actions.Kubectl().DeleteFileSafe(s.Ctx, manifest)
-		s.Require().NoError(err, fmt.Sprintf("Failed to delete manifest %s", manifest))
+		s.Require().NoError(err, "Failed to delete manifest "+manifest)
 	}
 }
 

--- a/test/e2e/features/session_persistence/suite.go
+++ b/test/e2e/features/session_persistence/suite.go
@@ -60,7 +60,7 @@ func (s *testingSuite) TestHeaderSessionPersistence() {
 // assertSessionPersistence makes multiple requests and verifies they go to the same backend pod
 func (s *testingSuite) assertSessionPersistence(persistenceType string) {
 	gatewayService := metav1.ObjectMeta{
-		Name:      fmt.Sprintf("gw-%s", persistenceType),
+		Name:      "gw-" + persistenceType,
 		Namespace: "default",
 	}
 

--- a/test/e2e/features/tracing/suite.go
+++ b/test/e2e/features/tracing/suite.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -48,7 +49,7 @@ func (s *testingSuite) testOTelTracing() {
 	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPListenerPolicyCondition(s.Ctx, "tracing-policy", "default", gwv1.GatewayConditionAccepted, metav1.ConditionTrue)
 
 	// The headerValue passed is used to differentiate between multiple calls by identifying a unique trace per call
-	headerValue := fmt.Sprintf("%v", rand.Intn(10000)) //nolint:gosec // G404: Using math/rand for test trace identification is acceptable
+	headerValue := strconv.Itoa(rand.Intn(10000)) //nolint:gosec // G404: Using math/rand for test trace identification is acceptable
 	s.TestInstallation.AssertionsT(s.T()).Gomega.Eventually(func(g gomega.Gomega) {
 		// make curl request to httpbin service with the custom header
 		s.TestInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
@@ -115,7 +116,7 @@ func (s *testingSuite) TestRouteTracingCustomAttributes() {
 	// Wait for listener-level tracing policy to be accepted
 	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPListenerPolicyCondition(s.Ctx, "tracing-policy", "default", gwv1.GatewayConditionAccepted, metav1.ConditionTrue)
 
-	headerValue := fmt.Sprintf("%v", rand.Intn(10000)) //nolint:gosec // G404: Using math/rand for test trace identification is acceptable
+	headerValue := strconv.Itoa(rand.Intn(10000)) //nolint:gosec // G404: Using math/rand for test trace identification is acceptable
 	s.TestInstallation.AssertionsT(s.T()).Gomega.Eventually(func(g gomega.Gomega) {
 		s.TestInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
 			s.Ctx,

--- a/test/e2e/features/transformation/suite.go
+++ b/test/e2e/features/transformation/suite.go
@@ -606,7 +606,7 @@ func selectTestCases(indices ...int) []transformationTestCase {
 					// the modification did not happen because "andy" is only 4 characters
 					"x-my-name": gomega.MatchRegexp(`.....+`),
 				},
-				Body: fmt.Sprintf("321-%s", httpbin_echo_base_path),
+				Body: "321-" + httpbin_echo_base_path,
 			},
 		},
 		{

--- a/test/e2e/features/waypoint/suite.go
+++ b/test/e2e/features/waypoint/suite.go
@@ -4,7 +4,6 @@ package waypoint
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -140,7 +139,7 @@ func (s *testingSuite) TearDownSuite() {
 func (s *testingSuite) setDeploymentEnvVariable(name, value string) {
 	controllerNamespace, ok := os.LookupEnv(testutils.InstallNamespace)
 	if !ok {
-		s.FailNow(fmt.Sprintf("%s environment variable not set", testutils.InstallNamespace))
+		s.FailNow(testutils.InstallNamespace + " environment variable not set")
 	}
 
 	// make a copy of the original controller deployment

--- a/test/e2e/features/websocket/suite.go
+++ b/test/e2e/features/websocket/suite.go
@@ -111,7 +111,7 @@ func (s *testingSuite) assertWebsocketUpgradeEnabled() {
 				}
 
 				websocketEnabled := strings.Contains(listener.String(), "upgrade_configs:{upgrade_type:\"websocket\"}")
-				g.Expect(websocketEnabled).To(gomega.BeTrue(), fmt.Sprintf("%v", listener.String()))
+				g.Expect(websocketEnabled).To(gomega.BeTrue(), listener.String())
 			}).
 				WithContext(ctx).
 				WithTimeout(30*time.Second).
@@ -134,6 +134,6 @@ func (s *testingSuite) assertPodsRunning() {
 
 	// websocket server backend
 	s.TestInstallation.AssertionsT(s.T()).EventuallyPodsRunning(s.Ctx, "kgateway-base", metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=websocket-backend", defaults.WellKnownAppLabel),
+		LabelSelector: defaults.WellKnownAppLabel + "=websocket-backend",
 	})
 }

--- a/test/e2e/test.go
+++ b/test/e2e/test.go
@@ -124,7 +124,7 @@ func (i *TestInstallation) String() string {
 
 func (i *TestInstallation) finalize() {
 	if err := os.RemoveAll(i.GeneratedFiles.TempDir); err != nil {
-		panic(fmt.Sprintf("Failed to remove temporary directory: %s", i.GeneratedFiles.TempDir))
+		panic("Failed to remove temporary directory: " + i.GeneratedFiles.TempDir)
 	}
 }
 

--- a/test/e2e/tests/base/base_suite.go
+++ b/test/e2e/tests/base/base_suite.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -736,12 +737,12 @@ func DetectGwApiInfo(ctx context.Context, c client.Client) (GwApiChannel, GwApiV
 
 	channel, hasChannel := crd.Annotations["gateway.networking.k8s.io/channel"]
 	if !hasChannel {
-		return "", GwApiVersion{}, fmt.Errorf("Gateway CRD missing 'gateway.networking.k8s.io/channel' annotation")
+		return "", GwApiVersion{}, errors.New("Gateway CRD missing 'gateway.networking.k8s.io/channel' annotation")
 	}
 
 	versionStr, hasVersion := crd.Annotations["gateway.networking.k8s.io/bundle-version"]
 	if !hasVersion {
-		return "", GwApiVersion{}, fmt.Errorf("Gateway CRD missing 'gateway.networking.k8s.io/bundle-version' annotation")
+		return "", GwApiVersion{}, errors.New("Gateway CRD missing 'gateway.networking.k8s.io/bundle-version' annotation")
 	}
 
 	version, err := semver.NewVersion(versionStr)

--- a/test/e2e/tests/controlplanetls/wiretap.go
+++ b/test/e2e/tests/controlplanetls/wiretap.go
@@ -180,7 +180,7 @@ func stopXDSCapture(ctx context.Context, t *testing.T, testInstallation e2e.Inst
 		xdsWiretapLog,
 	)
 	tcpdumpLog := execWiretap(ctx, t, testInstallation, proxyPod, stopScript)
-	capture := execWiretap(ctx, t, testInstallation, proxyPod, fmt.Sprintf("cat %s", xdsWiretapPcap))
+	capture := execWiretap(ctx, t, testInstallation, proxyPod, "cat "+xdsWiretapPcap)
 
 	return []byte(capture), tcpdumpLog
 }

--- a/test/e2e/tests/zone_aware_routing_test.go
+++ b/test/e2e/tests/zone_aware_routing_test.go
@@ -4,6 +4,7 @@ package tests_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -514,7 +515,7 @@ func collectDistribution(ctx context.Context, ti *e2e.TestInstallation, gatewayP
 func expectEvenDistribution(counts zoneCounts) error {
 	total := counts.total()
 	if total == 0 {
-		return fmt.Errorf("no responses recorded")
+		return errors.New("no responses recorded")
 	}
 	for _, zone := range zoneAwareZones {
 		if counts[zone] < total/5 || counts[zone] > total*3/5 {
@@ -528,7 +529,7 @@ func expectEvenDistribution(counts zoneCounts) error {
 func expectAllLocal(counts zoneCounts) error {
 	total := counts.total()
 	if total == 0 {
-		return fmt.Errorf("no responses recorded")
+		return errors.New("no responses recorded")
 	}
 	if counts[zoneA] != total {
 		return fmt.Errorf("expected all %d requests to route to %s, got %s", total, zoneA, counts)
@@ -542,7 +543,7 @@ func expectAllLocal(counts zoneCounts) error {
 func expectSomeCrossZone(counts zoneCounts) error {
 	total := counts.total()
 	if total == 0 {
-		return fmt.Errorf("no responses recorded")
+		return errors.New("no responses recorded")
 	}
 	if counts[zoneA] == 0 {
 		return fmt.Errorf("expected some local-zone traffic, got %s", counts)

--- a/test/e2e/testutils/assertions/pods.go
+++ b/test/e2e/testutils/assertions/pods.go
@@ -127,7 +127,7 @@ func (p *Provider) EventuallyPodContainerContainsEnvVar(
 	}).
 		WithTimeout(currentTimeout).
 		WithPolling(pollingInterval).
-		Should(gomega.Succeed(), fmt.Sprintf("Failed to match pod in namespace %s", podNamespace))
+		Should(gomega.Succeed(), "Failed to match pod in namespace "+podNamespace)
 }
 
 // EventuallyPodContainerDoesNotContainEnvVar asserts that eventually no pods matching the given pod namespace and selector
@@ -162,5 +162,5 @@ func (p *Provider) EventuallyPodContainerDoesNotContainEnvVar(
 	}).
 		WithTimeout(currentTimeout).
 		WithPolling(pollingInterval).
-		Should(gomega.Succeed(), fmt.Sprintf("Failed to match pod in namespace %s", podNamespace))
+		Should(gomega.Succeed(), "Failed to match pod in namespace "+podNamespace)
 }

--- a/test/e2e/testutils/cluster/istio.go
+++ b/test/e2e/testutils/cluster/istio.go
@@ -115,7 +115,7 @@ func getIstioVersion() string {
 		return version
 	} else {
 		// Fail loudly if ISTIO_VERSION is not set
-		panic(fmt.Sprintf("%s environment variable must be specified to run", testruntime.IstioVersionEnv))
+		panic(testruntime.IstioVersionEnv + " environment variable must be specified to run")
 	}
 }
 
@@ -133,7 +133,7 @@ func downloadIstio(version string) (string, error) {
 		return binaryPath, nil
 	}
 	installLocation := filepath.Join(testutils.GitRootDirectory(), ".bin")
-	binaryDir := filepath.Join(installLocation, fmt.Sprintf("istio-%s", version), "bin")
+	binaryDir := filepath.Join(installLocation, "istio-"+version, "bin")
 	binaryLocation := filepath.Join(binaryDir, "istioctl")
 
 	fileInfo, _ := os.Stat(binaryLocation)
@@ -151,7 +151,7 @@ func downloadIstio(version string) (string, error) {
 		}
 
 		arch := runtime.GOARCH
-		archModifier := fmt.Sprintf("-%s", arch)
+		archModifier := "-" + arch
 
 		if osName == "osx" && arch != "arm64" {
 			archModifier = ""

--- a/test/e2e/testutils/localstack/localstack.go
+++ b/test/e2e/testutils/localstack/localstack.go
@@ -6,6 +6,7 @@ package localstack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -35,7 +36,7 @@ func EndpointURL(ctx context.Context, c client.Client) (endpoint string, found b
 		return "", false, fmt.Errorf("failed to get localstack service: %w", err)
 	}
 	if len(svc.Spec.Ports) == 0 || svc.Spec.Ports[0].NodePort == 0 {
-		return "", false, fmt.Errorf("localstack service is missing a node port")
+		return "", false, errors.New("localstack service is missing a node port")
 	}
 
 	var nodes corev1.NodeList
@@ -43,7 +44,7 @@ func EndpointURL(ctx context.Context, c client.Client) (endpoint string, found b
 		return "", false, fmt.Errorf("failed to list cluster nodes: %w", err)
 	}
 	if len(nodes.Items) == 0 {
-		return "", false, fmt.Errorf("cluster must have at least one node")
+		return "", false, errors.New("cluster must have at least one node")
 	}
 
 	var nodeIP string
@@ -59,7 +60,7 @@ func EndpointURL(ctx context.Context, c client.Client) (endpoint string, found b
 		}
 	}
 	if nodeIP == "" {
-		return "", false, fmt.Errorf("failed to determine localstack node internal IP")
+		return "", false, errors.New("failed to determine localstack node internal IP")
 	}
 
 	parsed, err := url.Parse(fmt.Sprintf("http://%s:%d", nodeIP, svc.Spec.Ports[0].NodePort))

--- a/test/envoyutils/admincli/client.go
+++ b/test/envoyutils/admincli/client.go
@@ -3,6 +3,7 @@ package admincli
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -247,14 +248,14 @@ func (c *Client) ShutdownServer(ctx context.Context) error {
 // FailHealthCheck calls the endpoint to have the server start failing health checks
 func (c *Client) FailHealthCheck(ctx context.Context) error {
 	return c.RunCommand(ctx,
-		curl.WithPath(fmt.Sprintf("%s/fail", HealthCheckPath)),
+		curl.WithPath(HealthCheckPath+"/fail"),
 		curl.WithMethod(http.MethodPost))
 }
 
 // PassHealthCheck calls the endpoint to have the server start passing health checks
 func (c *Client) PassHealthCheck(ctx context.Context) error {
 	return c.RunCommand(ctx,
-		curl.WithPath(fmt.Sprintf("%s/ok", HealthCheckPath)),
+		curl.WithPath(HealthCheckPath+"/ok"),
 		curl.WithMethod(http.MethodPost))
 }
 
@@ -309,7 +310,7 @@ func (c *Client) GetSingleListenerFromDynamicListeners(
 	// before envoy is full configured, dynamic listeners will be missing
 	// and envoy will return an empty object json object `{}`
 	if len(configs) == 0 {
-		return nil, fmt.Errorf("could not get config: config is empty")
+		return nil, errors.New("could not get config: config is empty")
 	}
 
 	listenerDump := adminv3.ListenersConfigDump_DynamicListener{}

--- a/test/envtestassets/assets.go
+++ b/test/envtestassets/assets.go
@@ -1,6 +1,7 @@
 package envtestassets
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,7 +21,7 @@ func GetEnvTestAssetsDir() (string, error) {
 		assetsDir = strings.TrimSpace(string(out))
 	}
 	if assetsDir == "" {
-		return "", fmt.Errorf("envtest assets directory is empty")
+		return "", errors.New("envtest assets directory is empty")
 	}
 
 	info, err := os.Stat(assetsDir)

--- a/test/gomega/matchers/have_http_request.go
+++ b/test/gomega/matchers/have_http_request.go
@@ -278,7 +278,7 @@ func (matcher *HaveHTTPRequestBodyMatcher) FailureMessage(actual any) (message s
 	case types.GomegaMatcher:
 		return e.FailureMessage(body)
 	default:
-		return fmt.Sprintf("HaveHTTPBody matcher expects string, []byte, or GomegaMatcher. Got:\n%s", format.Object(matcher.Expected, 1))
+		return "HaveHTTPBody matcher expects string, []byte, or GomegaMatcher. Got:\n" + format.Object(matcher.Expected, 1)
 	}
 }
 
@@ -296,7 +296,7 @@ func (matcher *HaveHTTPRequestBodyMatcher) NegatedFailureMessage(actual any) (me
 	case types.GomegaMatcher:
 		return e.NegatedFailureMessage(body)
 	default:
-		return fmt.Sprintf("HaveHTTPBody matcher expects string, []byte, or GomegaMatcher. Got:\n%s", format.Object(matcher.Expected, 1))
+		return "HaveHTTPBody matcher expects string, []byte, or GomegaMatcher. Got:\n" + format.Object(matcher.Expected, 1)
 	}
 }
 

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -362,13 +362,13 @@ func ControllerDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog i
 					curl.WithPort(int(wellknown.KgatewayAdminPort)),
 				)
 
-			krtSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.krt_snapshot.log", podName)))
+			krtSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, podName+".krt_snapshot.log"))
 			err = adminClient.KrtSnapshotCmd(ctx).WithQuiet().WithStdout(krtSnapshotFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running krt snapshot command: %v\n", err)
 			}
 
-			xdsSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, fmt.Sprintf("%s.xds_snapshot.log", podName)))
+			xdsSnapshotFile := fileAtPath(filepath.Join(namespaceOutDir, podName+".xds_snapshot.log"))
 			err = adminClient.XdsSnapshotCmd(ctx).WithQuiet().WithStdout(xdsSnapshotFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running xds snapshot command: %v\n", err)
@@ -404,7 +404,7 @@ func EnvoyDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, _ io.Writer, 
 
 		for _, proxy := range proxies {
 			adminCli, shutdown, err := admincli.NewPortForwardedClient(ctx,
-				fmt.Sprintf("pod/%s", proxy), ns, portforward.WithQuiet())
+				"pod/"+proxy, ns, portforward.WithQuiet())
 			if err != nil {
 				fmt.Printf("error creating admin cli: %v\n", err)
 				continue
@@ -412,25 +412,25 @@ func EnvoyDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, _ io.Writer, 
 
 			defer shutdown()
 
-			configDumpFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.config.log", proxy)))
+			configDumpFile := fileAtPath(filepath.Join(envoyOutDir, proxy+".config.log"))
 			err = adminCli.ConfigDumpCmd(ctx, nil).WithQuiet().WithStdout(configDumpFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running config dump command: %v\n", err)
 			}
 
-			statsFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.stats.log", proxy)))
+			statsFile := fileAtPath(filepath.Join(envoyOutDir, proxy+".stats.log"))
 			err = adminCli.StatsCmd(ctx, nil).WithQuiet().WithStdout(statsFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running stats command: %v\n", err)
 			}
 
-			clustersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.clusters.log", proxy)))
+			clustersFile := fileAtPath(filepath.Join(envoyOutDir, proxy+".clusters.log"))
 			err = adminCli.ClustersCmd(ctx).WithQuiet().WithStdout(clustersFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running clusters command: %v\n", err)
 			}
 
-			listenersFile := fileAtPath(filepath.Join(envoyOutDir, fmt.Sprintf("%s.listeners.log", proxy)))
+			listenersFile := fileAtPath(filepath.Join(envoyOutDir, proxy+".listeners.log"))
 			err = adminCli.ListenersCmd(ctx).WithQuiet().WithStdout(listenersFile).Run().Cause()
 			if err != nil {
 				fmt.Printf("error running listeners command: %v\n", err)
@@ -478,7 +478,7 @@ func fileAtPath(path string) *os.File {
 
 func writeControllerLog(ctx context.Context, outDir string, ns string, podName string, kubectlCli *kubectl.Cli) {
 	// Get the kgateway controller logs
-	controllerLogsFile := fileAtPath(filepath.Join(outDir, fmt.Sprintf("%s.controller.log", podName)))
+	controllerLogsFile := fileAtPath(filepath.Join(outDir, podName+".controller.log"))
 	controllerLogsCmd := kubectlCli.WithReceiver(controllerLogsFile).Command(ctx,
 		"-n", ns, "logs", podName, "-c", KgatewayContainerName, "--tail=1000")
 	err := controllerLogsCmd.Run().Cause()
@@ -489,7 +489,7 @@ func writeControllerLog(ctx context.Context, outDir string, ns string, podName s
 
 func writeMetricsLog(ctx context.Context, outDir string, ns string, podName string, kubectlCli *kubectl.Cli) {
 	// Using an ephemeral debug pod fetch the metrics from the kgateway controller
-	metricsFile := fileAtPath(filepath.Join(outDir, fmt.Sprintf("%s.metrics.log", podName)))
+	metricsFile := fileAtPath(filepath.Join(outDir, podName+".metrics.log"))
 	metricsCmd := kubectlCli.Command(ctx, "debug", "-n", ns,
 		"-it", "--image=curlimages/curl:7.83.1", podName, "--",
 		"curl", "http://localhost:9091/metrics")

--- a/test/testutils/crd.go
+++ b/test/testutils/crd.go
@@ -75,7 +75,7 @@ func GetGatewayAPICRDDir() (string, error) {
 
 	modDir := strings.TrimSpace(string(out))
 	if modDir == "" {
-		return "", fmt.Errorf("gateway-api module directory is empty")
+		return "", errors.New("gateway-api module directory is empty")
 	}
 	crdDir := filepath.Join(modDir, "config", "crd", "experimental")
 


### PR DESCRIPTION
# Description

Enable the [perfsprint](https://github.com/catenacyber/perfsprint) golangci-lint analyzer and apply its suggested fixes across the codebase. The resulting changes replace avoidable formatting calls with direct string operations, `strconv` conversions, and `errors.New` where appropriate.

This also applies one existing `modernize` cleanup discovered while validating the complete configured linter set.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validated with the custom golangci-lint binary using the `e2e` build tag; all configured linters report zero issues.
