### PR TITLE
Enable core correctness linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
     - ginkgolinter
     - gomodguard
     - gosec
+    - govet
     - importas
     - ineffassign
     - krtequals
@@ -26,6 +27,7 @@ linters:
     - modernize
     - nakedret
     - nestif
+    - nilerr
     - predeclared
     - promlinter
     - sloglint
@@ -154,8 +156,7 @@ linters:
       min-complexity: 20
     staticcheck:
       checks:
-        - SA1019 # deprecated usage
-        - SA2002 # testing.T FailNow/SkipNow called from goroutine
+        - SA* # correctness checks
         - ST1019 # duplicate imports
     testifylint:
       disable-all: true

--- a/pkg/kgateway/controller/controller.go
+++ b/pkg/kgateway/controller/controller.go
@@ -67,7 +67,7 @@ func NewBaseGatewayController(
 
 	// Initialize Gateway reconciler
 	if err := watchGw(cfg, helmValuesGeneratorOverride, gatewayControllerExtension); err != nil {
-		return nil
+		return err
 	}
 
 	// Initialize GatewayClass reconciler

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -92,7 +92,7 @@ func (e TrafficPolicyGatewayExtensionIR) Equals(other TrafficPolicyGatewayExtens
 func (e TrafficPolicyGatewayExtensionIR) Validate() error {
 	if e.Err != nil {
 		// If there's an error in the IR, validation doesn't make sense.
-		return nil
+		return nil //nolint:nilerr // The stored IR error is reported separately; skip redundant validation.
 	}
 	if e.ExtAuth != nil {
 		if err := e.ExtAuth.ValidateAll(); err != nil {

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -400,26 +400,12 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 			if e.Event != controllers.EventDelete {
 				snapWrap := e.Latest()
 				s.proxyTranslator.syncXds(ctx, snapWrap)
-			} else {
-				// Intentional no-op. When snapshotPerClient returns nil (its
-				// per-client inputs weren't derived yet, so it deferred
-				// publishing), KRT surfaces a Delete for this UCC. Clearing
-				// the xDS cache here would withdraw Envoy's last coherent
-				// Snapshot for the duration of the defer, causing 500/NC on
-				// valid routes. Leaving the cache alone means Envoy keeps
-				// serving its previously-published config until a new
-				// snapshot overwrites it — "retain last good".
-				//
-				// Known leak: this branch also fires when a UCC truly goes
-				// away (Envoy pod replaced on rollout, scaled down, etc.),
-				// and we cannot distinguish that from the "defer" case here.
-				// The SnapshotCache entry for that UCC is therefore never
-				// cleared and accumulates over the controller's lifetime.
-				// Pre-existing behavior (the prior ClearSnapshot call was
-				// already commented out); reclaiming these entries requires
-				// a separate signal — e.g. cross-referencing uccCol
-				// membership — and is left to a follow-up.
 			}
+			// Delete events intentionally leave the cache unchanged. When snapshotPerClient
+			// returns nil because its inputs were not derived yet, KRT surfaces a Delete
+			// for this UCC. Retaining the last coherent snapshot avoids transient 500/NC
+			// responses. This also retains entries for UCCs that truly disappear; reclaiming
+			// those entries requires a separate signal and is left to a follow-up.
 
 			kmetrics.EndResourceXDSSync(kmetrics.ResourceSyncDetails{
 				Namespace:    cd.Namespace,

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -397,15 +397,26 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 		for _, e := range o {
 			cd := getDetailsFromXDSClientResourceName(e.Latest().ResourceName())
 
+			// Deletes are an intentional no-op. When snapshotPerClient returns
+			// nil (its per-client inputs weren't derived yet, so it deferred
+			// publishing), KRT surfaces a Delete for this UCC. Clearing the xDS
+			// cache here would withdraw Envoy's last coherent Snapshot for the
+			// duration of the defer, causing 500/NC on valid routes. Leaving the
+			// cache alone means Envoy keeps serving its previously-published
+			// config until a new snapshot overwrites it — "retain last good".
+			//
+			// Known leak: a Delete also arrives when a UCC truly goes away (Envoy
+			// pod replaced on rollout, scaled down, etc.), and we cannot
+			// distinguish that from the "defer" case here. The SnapshotCache entry
+			// for that UCC is therefore never cleared and accumulates over the
+			// controller's lifetime. Pre-existing behavior (the prior ClearSnapshot
+			// call was already commented out); reclaiming these entries requires a
+			// separate signal — e.g. cross-referencing uccCol membership — and is
+			// left to a follow-up.
 			if e.Event != controllers.EventDelete {
 				snapWrap := e.Latest()
 				s.proxyTranslator.syncXds(ctx, snapWrap)
 			}
-			// Delete events intentionally leave the cache unchanged. When snapshotPerClient
-			// returns nil because its inputs were not derived yet, KRT surfaces a Delete
-			// for this UCC. Retaining the last coherent snapshot avoids transient 500/NC
-			// responses. This also retains entries for UCCs that truly disappear; reclaiming
-			// those entries requires a separate signal and is left to a follow-up.
 
 			kmetrics.EndResourceXDSSync(kmetrics.ResourceSyncDetails{
 				Namespace:    cd.Namespace,

--- a/pkg/kgateway/translator/listener/gateway_listener_translator.go
+++ b/pkg/kgateway/translator/listener/gateway_listener_translator.go
@@ -82,11 +82,6 @@ func mergeGWListeners(
 	}
 	for _, listener := range listeners {
 		result := routesForGw.GetListenerResult(listener.Parent, string(listener.Name))
-		if result == nil || result.Error != nil {
-			// TODO report
-			// TODO, if Error is not nil, this is a user-config error on selectors
-			// continue
-		}
 		parentReporter := listener.GetParentReporter(reporter)
 		listenerReporter := parentReporter.ListenerName(string(listener.Name))
 		var routes []*query.RouteInfo

--- a/pkg/kgateway/translator/listener/validation.go
+++ b/pkg/kgateway/translator/listener/validation.go
@@ -164,10 +164,6 @@ func validateSupportedRoutes(listeners []ir.Listener, reporter reports.Reporter)
 }
 
 func validateListeners(gw *ir.Gateway, reporter reports.Reporter, settings ListenerTranslatorConfig) []ir.Listener {
-	if len(gw.Listeners) == 0 {
-		// gwReporter.Err("gateway must contain at least 1 listener")
-	}
-
 	validListeners := validateSupportedRoutes(gw.Listeners, reporter)
 
 	portListeners := map[gwv1.PortNumber]*portProtocol{}

--- a/pkg/kgateway/utils/hash.go
+++ b/pkg/kgateway/utils/hash.go
@@ -34,18 +34,8 @@ func HashProtoWithHasher(hasher hash.Hash, resource proto.Message) {
 	var buffer [1024]byte
 	mo := proto.MarshalOptions{Deterministic: true}
 	buf := buffer[:0]
-	out, err := mo.MarshalAppend(buf, resource)
-	if err != nil {
-		//if e.logger != nil {
-		//	e.logger.DPanic("marshalling envoy snapshot components", zap.Error(err))
-		//}
-	}
-	_, err = hasher.Write(out)
-	if err != nil {
-		//if e.logger != nil {
-		//	e.logger.DPanic("constructing hash for envoy snapshot components", zap.Error(err))
-		//}
-	}
+	out, _ := mo.MarshalAppend(buf, resource)
+	_, _ = hasher.Write(out)
 }
 
 func HashMetadata(newhash func() hash.Hash64, md *envoycorev3.Metadata) uint64 {

--- a/pkg/kgateway/xds/utils.go
+++ b/pkg/kgateway/xds/utils.go
@@ -13,6 +13,8 @@ import (
 
 var _ cache.NodeHash = new(nodeRoleHasher)
 
+type contextKey string
+
 const (
 	// KeyDelimiter is the character used to join segments of a cache key
 	KeyDelimiter = "~"
@@ -21,7 +23,7 @@ const (
 	RoleKey = "role"
 
 	// PeerCtxKey is the key used to store the peer information in the context
-	PeerCtxKey = "peer"
+	PeerCtxKey contextKey = "peer"
 
 	// FallbackNodeCacheKey is used to let nodes know they have a bad config
 	// we assign a "fix me" snapshot for bad nodes

--- a/pkg/krtcollections/builtin.go
+++ b/pkg/krtcollections/builtin.go
@@ -530,7 +530,7 @@ func parseRedirectStatusCode(
 		return nil, fmt.Errorf("invalid redirect status code: %s; %s", val, httpRedirectStatusCodesAllowedMsg)
 	}
 
-	return new(code), nil
+	return &code, nil
 }
 
 // MIRROR IR

--- a/pkg/sds/server/x509_godebug_test.go
+++ b/pkg/sds/server/x509_godebug_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -62,12 +63,7 @@ func defaultGODEBUG(t *testing.T) godebugSettings {
 type godebugSettings string
 
 func (settings godebugSettings) contains(key, value string) bool {
-	for _, setting := range strings.Split(string(settings), ",") {
-		if setting == key+"="+value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(string(settings), ","), key+"="+value)
 }
 
 const negativeSerialCertPEM = `-----BEGIN CERTIFICATE-----

--- a/pkg/utils/kubeutils/portforward/api_forwarder.go
+++ b/pkg/utils/kubeutils/portforward/api_forwarder.go
@@ -145,7 +145,7 @@ func (f *apiPortForwarder) portForwarderToPod(podName string, readyCh chan struc
 	}
 
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", f.properties.resourceNamespace, podName)
-	hostIP := strings.TrimLeft(f.restConfig.Host, "https:/")
+	hostIP := strings.TrimPrefix(f.restConfig.Host, "https://")
 	serverURL := url.URL{Scheme: "https", Path: path, Host: hostIP}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL)
 

--- a/pkg/utils/requestutils/curl/native_request.go
+++ b/pkg/utils/requestutils/curl/native_request.go
@@ -181,23 +181,6 @@ func (c *requestConfig) buildHTTPClient() *http.Client {
 			tlsConfig.MaxVersion = parseTLSVersion(c.tlsMaxVersion)
 		}
 
-		// Configure cipher suites (simplified)
-		if c.ciphers != "" {
-			// Note: Go's TLS implementation uses predefined cipher suites
-			// This would require parsing the cipher string and mapping to Go's constants
-			// For simplicity, this is left as a placeholder
-		}
-
-		// Configure curves (simplified)
-		if c.curves != "" {
-			// Similar to ciphers, this would require parsing and mapping
-		}
-
-		// Configure signature algorithms (simplified)
-		if c.signatureAlgorithms != "" {
-			// Similar to ciphers, this would require parsing and mapping
-		}
-
 		transport.TLSClientConfig = tlsConfig
 	}
 

--- a/test/e2e/features/services/tcproute/suite.go
+++ b/test/e2e/features/services/tcproute/suite.go
@@ -38,9 +38,14 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	}
 }
 
-func (s *testingSuite) TearDownSuite() {
-	defer s.cancel()
-	s.BaseTestingSuite.TearDownSuite()
+// SetupSuite registers the suite context's cancel before delegating to the base
+// suite. Registration must happen here rather than in TearDownSuite: the base
+// SetupSuite skips the whole suite when the cluster's Gateway API predates
+// GwApiRequireTcpRoutes, and testify only registers its TearDownSuite deferral
+// after SetupSuite returns — so a skip would leave the timeout context alive.
+func (s *testingSuite) SetupSuite() {
+	testutils.Cleanup(s.T(), s.cancel)
+	s.BaseTestingSuite.SetupSuite()
 }
 
 var (

--- a/test/e2e/features/services/tcproute/suite.go
+++ b/test/e2e/features/services/tcproute/suite.go
@@ -25,15 +25,22 @@ import (
 // testingSuite is the entire suite of tests for testing K8s Service-specific features/fixes
 type testingSuite struct {
 	*base.BaseTestingSuite
+	cancel context.CancelFunc
 }
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
-	tcpRouteCtx, _ := context.WithTimeout(ctx, ctxTimeout)
+	tcpRouteCtx, cancel := context.WithTimeout(ctx, ctxTimeout)
 	return &testingSuite{
 		BaseTestingSuite: base.NewBaseTestingSuite(tcpRouteCtx, testInst, setup, testCases,
 			base.WithMinGwApiVersion(base.GwApiRequireTcpRoutes),
 		),
+		cancel: cancel,
 	}
+}
+
+func (s *testingSuite) TearDownSuite() {
+	defer s.cancel()
+	s.BaseTestingSuite.TearDownSuite()
 }
 
 var (

--- a/test/e2e/features/services/tlsroute/suite.go
+++ b/test/e2e/features/services/tlsroute/suite.go
@@ -45,9 +45,14 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	}
 }
 
-func (s *testingSuite) TearDownSuite() {
-	defer s.cancel()
-	s.BaseTestingSuite.TearDownSuite()
+// SetupSuite registers the suite context's cancel before delegating to the base
+// suite. Registration must happen here rather than in TearDownSuite: the base
+// SetupSuite skips the whole suite when the cluster's Gateway API predates
+// GwApiRequireTlsRoutes, and testify only registers its TearDownSuite deferral
+// after SetupSuite returns — so a skip would leave the timeout context alive.
+func (s *testingSuite) SetupSuite() {
+	testutils.Cleanup(s.T(), s.cancel)
+	s.BaseTestingSuite.SetupSuite()
 }
 
 type tlsRouteTestCase struct {

--- a/test/e2e/features/services/tlsroute/suite.go
+++ b/test/e2e/features/services/tlsroute/suite.go
@@ -25,6 +25,7 @@ import (
 // testingSuite is the entire suite of tests for testing K8s Service-specific features/fixes
 type testingSuite struct {
 	*base.BaseTestingSuite
+	cancel context.CancelFunc
 }
 
 var (
@@ -35,12 +36,18 @@ var (
 )
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
-	tlsRouteCtx, _ := context.WithTimeout(ctx, ctxTimeout)
+	tlsRouteCtx, cancel := context.WithTimeout(ctx, ctxTimeout)
 	return &testingSuite{
 		BaseTestingSuite: base.NewBaseTestingSuite(tlsRouteCtx, testInst, setup, testCases,
 			base.WithMinGwApiVersion(base.GwApiRequireTlsRoutes),
 		),
+		cancel: cancel,
 	}
+}
+
+func (s *testingSuite) TearDownSuite() {
+	defer s.cancel()
+	s.BaseTestingSuite.TearDownSuite()
 }
 
 type tlsRouteTestCase struct {

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -880,12 +880,8 @@ func (tc TestCase) Run(
 		referencedClusters := extractRouteConfigurationClusterNames(xdsSnap.Routes)
 		for _, col := range commoncol.BackendIndex.BackendsWithPolicy() {
 			for _, backend := range col.List() {
-				cluster, err := t.TranslateBackend(ctx, krt.TestingDummyContext{}, ucc, backend)
-				if err != nil {
-					// In strict mode, backend validation errors are expected and should not fail the test
-					// The cluster will be nil or a blackhole cluster, which will be filtered out by perclient.go
-					// Note: These errors are expected when xDS validation is enabled in strict mode
-				}
+				// In strict mode, backend validation errors are expected and should not fail the test.
+				cluster, _ := t.TranslateBackend(ctx, krt.TestingDummyContext{}, ucc, backend)
 				if cluster != nil {
 					clusters = append(clusters, cluster)
 				}


### PR DESCRIPTION
# Description

Enable the `govet` and `nilerr` analyzers and expand Staticcheck from two selected SA checks to the full correctness-oriented `SA*` family.

The rollout fixes the findings exposed by these analyzers, including:

- leaked timeout contexts in TCPRoute and TLSRoute E2E suites
- a swallowed gateway-controller initialization error
- unsafe string-cutset URL scheme removal
- a built-in string context key
- empty branches and intentionally ignored errors that obscured control flow

This also includes the existing `slices.Contains` modernization needed for the complete lint suite to remain clean independently of other open PRs.

# Change Type

/kind cleanup
/kind fix

# Changelog

```release-note
NONE
```

# Additional Notes

Validation:

- full custom golangci-lint run with the `e2e` build tag
- targeted Go tests for all affected packages
- `git diff --check`
