### PR TITLE
Enable correctness-focused GoCritic checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     - depguard
     - forbidigo
     - ginkgolinter
+    - gocritic
     - gomodguard
     - gosec
     - importas
@@ -85,6 +86,24 @@ linters:
           msg: require testutils.Cleanup in e2e tests (test/e2e/)
         - pattern: ^slog\.(Debug|DebugContext|Info|InfoContext|Warn|WarnContext|Error|ErrorContext|Log|LogAttrs)$
           msg: use a package-level logger created with logging.New instead of the global slog logger
+    gocritic:
+      disable-all: true
+      enabled-checks:
+        - appendAssign
+        - argOrder
+        - badCall
+        - badCond
+        - caseOrder
+        - dupBranchBody
+        - dupCase
+        - dupSubExpr
+        - exitAfterDefer
+        - mapKey
+        - newDeref
+        - offBy1
+        - regexpMust
+        - sloppyLen
+        - sloppyTypeAssert
     gomodguard:
       blocked:
         modules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -87,23 +87,42 @@ linters:
         - pattern: ^slog\.(Debug|DebugContext|Info|InfoContext|Warn|WarnContext|Error|ErrorContext|Log|LogAttrs)$
           msg: use a package-level logger created with logging.New instead of the global slog logger
     gocritic:
+      # Opt in to an explicit allowlist of correctness checks rather than gocritic's
+      # default set, which is dominated by style opinions we don't want to enforce.
+      #
+      # Deliberately excluded, with current finding counts, so they aren't re-litigated:
+      #   dupArg (10) - all x.Equals(x) self-comparisons in Equals unit tests, which is
+      #     the intended pattern given the IR Equals convention (see CLAUDE.md)
+      #   filepathJoin (29), sloppyReassign (5), deferInLoop (4) - style, not correctness
+      #   nilValReturn (1), uncheckedInlineErr (1) - both benign in context
       disable-all: true
       enabled-checks:
         - appendAssign
         - argOrder
         - badCall
         - badCond
+        - badLock
+        - badSorting
         - caseOrder
         - dupBranchBody
         - dupCase
         - dupSubExpr
+        - evalOrder
         - exitAfterDefer
+        - externalErrorReassign
+        - flagDeref
+        - flagName
         - mapKey
         - newDeref
         - offBy1
         - regexpMust
+        - returnAfterHttpError
         - sloppyLen
         - sloppyTypeAssert
+        - sortSlice
+        - syncMapLoadAndDelete
+        - truncateCmp
+        - weakCond
     gomodguard:
       blocked:
         modules:

--- a/cmd/kgateway/main.go
+++ b/cmd/kgateway/main.go
@@ -15,6 +15,12 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -40,7 +46,5 @@ func main() {
 	}
 	cmd.Flags().BoolVarP(&kgatewayVersion, "version", "v", false, "Print the version of kgateway")
 
-	if err := cmd.ExecuteContext(ctx); err != nil {
-		log.Fatal(err)
-	}
+	return cmd.ExecuteContext(ctx)
 }

--- a/pkg/apiclient/fake/fake.go
+++ b/pkg/apiclient/fake/fake.go
@@ -3,6 +3,7 @@ package fake
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"istio.io/istio/pkg/config/schema/gvr"
 	"istio.io/istio/pkg/kube"
@@ -58,7 +59,7 @@ func NewClientWithExtraGVRs(t test.Failer, extraGVRs []schema.GroupVersionResour
 		kgateway: fakeKgwClient(kgw...),
 	}
 
-	allCRDs := append(testutils.AllCRDs, extraGVRs...)
+	allCRDs := slices.Concat(testutils.AllCRDs, extraGVRs)
 	for _, crd := range allCRDs {
 		clienttest.MakeCRDWithAnnotations(t, c.Client, crd, map[string]string{
 			consts.BundleVersionAnnotation: consts.BundleVersion,

--- a/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
@@ -2,6 +2,7 @@ package waypoint
 
 import (
 	"context"
+	"slices"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -255,13 +256,13 @@ func sortAddressesByDnsLookupFamily(addresses []string, settings *apisettings.Se
 		sortedAddresses = ipv6Addrs
 	case apisettings.DnsLookupFamilyV4Preferred:
 		// IPv4 first, then IPv6 as additional addresses
-		sortedAddresses = append(ipv4Addrs, ipv6Addrs...)
+		sortedAddresses = slices.Concat(ipv4Addrs, ipv6Addrs)
 	case apisettings.DnsLookupFamilyAuto:
 		// IPv6 first, then IPv4 as additional addresses
-		sortedAddresses = append(ipv6Addrs, ipv4Addrs...)
+		sortedAddresses = slices.Concat(ipv6Addrs, ipv4Addrs)
 	default:
 		// Default to V4_PREFERRED for unknown values
-		sortedAddresses = append(ipv4Addrs, ipv6Addrs...)
+		sortedAddresses = slices.Concat(ipv4Addrs, ipv6Addrs)
 	}
 
 	return sortedAddresses

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -569,7 +569,8 @@ func GatewaysForEnvoyTransformationFunc(config *GatewayIndexConfig) func(kctx kr
 				// The Gateway Polices applies to all listeners but we need to apply them to listeners within the LS.
 				// Since there is no LS equivalent in Envoy, apply them on each listener in the LS.
 				// Ensure the sectioned policies are first
-				listenerPolicies := append(listenerSpecificPolicies, listenerSetPolicies...)
+				listenerPolicies := slices.Clone(listenerSpecificPolicies)
+				listenerPolicies = append(listenerPolicies, listenerSetPolicies...)
 
 				lsIR.Listeners = append(lsIR.Listeners, ir.Listener{
 					Listener:         utils.ToListener(l),

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -238,7 +238,7 @@ func (c *Cli) DeleteFileWithOutput(ctx context.Context, fileName string, extraAr
 // DeleteFileSafe deletes the resources defined in a file, and returns an error if one occurred
 // This differs from DeleteFile in that we always append --ignore-not-found
 func (c *Cli) DeleteFileSafe(ctx context.Context, fileName string, extraArgs ...string) error {
-	safeArgs := append(extraArgs, "--ignore-not-found")
+	safeArgs := slices.Concat(extraArgs, []string{"--ignore-not-found"})
 	return c.DeleteFile(ctx, fileName, safeArgs...)
 }
 

--- a/pkg/utils/requestutils/curl/option.go
+++ b/pkg/utils/requestutils/curl/option.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -36,6 +37,15 @@ const (
 
 // Option represents an option for a curl request.
 type Option func(config *requestConfig)
+
+// Extend returns a new Option slice containing base followed by extra.
+//
+// Use this instead of append(base, extra...) whenever base is a shared or reused
+// slice: append may write into base's spare capacity, so two callers extending
+// the same base can silently clobber each other's options.
+func Extend(base []Option, extra ...Option) []Option {
+	return slices.Concat(base, extra)
+}
 
 // WithContext returns the Option to set a context on the curl request. The context
 // is used by ExecuteRequest to build the http.Request and aborts the in-flight

--- a/test/controllerutils/admincli/client.go
+++ b/test/controllerutils/admincli/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"path"
+	"slices"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmdutils"
@@ -62,10 +63,10 @@ func (c *Client) WithCurlOptions(options ...curl.Option) *Client {
 
 // Command returns a curl Command, using the provided curl.Option as well as the client.curlOptions
 func (c *Client) Command(ctx context.Context, options ...curl.Option) cmdutils.Cmd {
-	commandCurlOptions := append(
+	commandCurlOptions := slices.Concat(
 		c.curlOptions,
 		// Ensure any options defined for this command can override any defaults that the Client has defined
-		options...)
+		options)
 	curlArgs := curl.BuildArgs(commandCurlOptions...)
 
 	return cmdutils.Command(ctx, "curl", curlArgs...).

--- a/test/controllerutils/admincli/client.go
+++ b/test/controllerutils/admincli/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"path"
-	"slices"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/cmdutils"
@@ -63,10 +62,8 @@ func (c *Client) WithCurlOptions(options ...curl.Option) *Client {
 
 // Command returns a curl Command, using the provided curl.Option as well as the client.curlOptions
 func (c *Client) Command(ctx context.Context, options ...curl.Option) cmdutils.Cmd {
-	commandCurlOptions := slices.Concat(
-		c.curlOptions,
-		// Ensure any options defined for this command can override any defaults that the Client has defined
-		options)
+	// Ensure any options defined for this command can override any defaults that the Client has defined
+	commandCurlOptions := curl.Extend(c.curlOptions, options...)
 	curlArgs := curl.BuildArgs(commandCurlOptions...)
 
 	return cmdutils.Command(ctx, "curl", curlArgs...).

--- a/test/e2e/common/gateway.go
+++ b/test/e2e/common/gateway.go
@@ -104,7 +104,7 @@ func (g *Gateway) SendConsistentlyFor(ctx context.Context, t *testing.T, match *
 // (the underlying gomega HaveHttpResponse matcher does not print the actual body —
 // see test/gomega/matchers/have_http_response.go).
 func (g *Gateway) matchOnce(ctx context.Context, fullOpts []curl.Option, match *matchers.HttpResponse) error {
-	r, err := curl.ExecuteRequest(append(fullOpts, curl.WithContext(ctx))...)
+	r, err := curl.ExecuteRequest(curl.Extend(fullOpts, curl.WithContext(ctx))...)
 	if err != nil {
 		return err
 	}
@@ -134,5 +134,5 @@ func (g *Gateway) curlOpts(opts []curl.Option) []curl.Option {
 	} else {
 		hostOpt = curl.WithHost(g.Address)
 	}
-	return append([]curl.Option{hostOpt}, opts...)
+	return curl.Extend([]curl.Option{hostOpt}, opts...)
 }

--- a/test/e2e/features/apikeyauth/suite.go
+++ b/test/e2e/features/apikeyauth/suite.go
@@ -4,6 +4,7 @@ package apikeyauth
 
 import (
 	"context"
+	"slices"
 
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +17,10 @@ import (
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite
+
+func withCurlOptions(base []curl.Option, additional ...curl.Option) []curl.Option {
+	return slices.Concat(base, additional)
+}
 
 // testingSuite is a suite of tests for API key authentication functionality
 type testingSuite struct {
@@ -298,13 +303,13 @@ func (s *testingSuite) TestAPIKeyAuthWithSecretUpdate() {
 
 	// Step 1: Verify initial API keys work (k-123, k-456)
 	s.T().Log("Step 1: Verifying initial API keys (k-123, k-456) work")
-	statusWithK123 := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithK123 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK123...,
 	)
-	statusWithK456 := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithK456 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -348,13 +353,13 @@ stringData:
 
 	// Step 3: Verify new keys work
 	s.T().Log("Step 3: Verifying new API keys (k-789, k-999) work")
-	statusWithK789 := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	statusWithK789 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK789...,
 	)
-	statusWithK999 := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
+	statusWithK999 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -363,13 +368,13 @@ stringData:
 
 	// Step 4: Verify old keys no longer work
 	s.T().Log("Step 4: Verifying old API keys (k-123, k-456) no longer work")
-	statusWithK123Old := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithK123Old := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
 		statusWithK123Old...,
 	)
-	statusWithK456Old := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithK456Old := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -396,25 +401,25 @@ stringData:
 	// Step 6: Verify the final set of keys work
 	// After Step 5 merge update, the secret has: client1 (k-123), client3 (k-789), client4 (k-999), client5 (k-111)
 	s.T().Log("Step 6: Verifying final API keys (k-123, k-789, k-999, k-111) works")
-	statusWithK123Final := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithK123Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK123Final...,
 	)
-	statusWithK789Final := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	statusWithK789Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK789Final...,
 	)
-	statusWithK999Final := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
+	statusWithK999Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK999Final...,
 	)
-	statusWithK111Final := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-111"))
+	statusWithK111Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-111"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -424,7 +429,7 @@ stringData:
 	// Step 7: Verify removed keys no longer work
 	// k-456 was removed in Step 2, so it should not work
 	s.T().Log("Step 7: Verifying removed API key (k-456) no longer work")
-	statusWithK456Removed := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithK456Removed := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -456,7 +461,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has valid API key from route-level secret, should succeed
 	s.T().Log("The /get route should succeed with valid API key from route-level secret (k-789)")
-	getWithRouteAPIKeyCurlOpts := append(getReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	getWithRouteAPIKeyCurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -465,7 +470,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has another valid API key from route-level secret, should succeed
 	s.T().Log("The /get route should succeed with another valid API key from route-level secret (k-999)")
-	getWithRouteAPIKey2CurlOpts := append(getReqCurlOpts, curl.WithHeader("api-key", "k-999"))
+	getWithRouteAPIKey2CurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-999"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -474,7 +479,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has API key from gateway-level secret, should fail (route-level policy overrides)
 	s.T().Log("The /get route should fail with API key from gateway-level secret (k-123) - route-level policy overrides")
-	getWithGatewayAPIKeyCurlOpts := append(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	getWithGatewayAPIKeyCurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -483,7 +488,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has another API key from gateway-level secret, should fail
 	s.T().Log("The /get route should fail with another API key from gateway-level secret (k-456) - route-level policy overrides")
-	getWithGatewayAPIKey2CurlOpts := append(getReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	getWithGatewayAPIKey2CurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -507,7 +512,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has valid API key from gateway-level secret, should succeed
 	s.T().Log("The /status/200 route should succeed with valid API key from gateway-level secret (k-123)")
-	statusWithGatewayAPIKeyCurlOpts := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithGatewayAPIKeyCurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -516,7 +521,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has another valid API key from gateway-level secret, should succeed
 	s.T().Log("The /status/200 route should succeed with another valid API key from gateway-level secret (k-456)")
-	statusWithGatewayAPIKey2CurlOpts := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithGatewayAPIKey2CurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -525,7 +530,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has API key from route-level secret, should fail (only applies to /get route)
 	s.T().Log("The /status/200 route should fail with API key from route-level secret (k-789) - only gateway-level policy applies")
-	statusWithRouteAPIKeyCurlOpts := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	statusWithRouteAPIKeyCurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -555,7 +560,7 @@ func (s *testingSuite) TestAPIKeyAuthDisableAtRouteLevel() {
 
 	// has valid API key, should succeed
 	s.T().Log("The /status/200 route should succeed with valid API key from gateway-level policy")
-	statusWithAPIKeyCurlOpts := append(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithAPIKeyCurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -578,7 +583,7 @@ func (s *testingSuite) TestAPIKeyAuthDisableAtRouteLevel() {
 
 	// has API key, should still succeed (API key is ignored when disabled)
 	s.T().Log("The /get route with disable should succeed even with API key present")
-	getWithAPIKeyCurlOpts := append(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	getWithAPIKeyCurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,

--- a/test/e2e/features/apikeyauth/suite.go
+++ b/test/e2e/features/apikeyauth/suite.go
@@ -4,7 +4,6 @@ package apikeyauth
 
 import (
 	"context"
-	"slices"
 
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,10 +16,6 @@ import (
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite
-
-func withCurlOptions(base []curl.Option, additional ...curl.Option) []curl.Option {
-	return slices.Concat(base, additional)
-}
 
 // testingSuite is a suite of tests for API key authentication functionality
 type testingSuite struct {
@@ -303,13 +298,13 @@ func (s *testingSuite) TestAPIKeyAuthWithSecretUpdate() {
 
 	// Step 1: Verify initial API keys work (k-123, k-456)
 	s.T().Log("Step 1: Verifying initial API keys (k-123, k-456) work")
-	statusWithK123 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithK123 := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK123...,
 	)
-	statusWithK456 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithK456 := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -348,18 +343,18 @@ stringData:
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
-		append(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))...,
+		curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))...,
 	)
 
 	// Step 3: Verify new keys work
 	s.T().Log("Step 3: Verifying new API keys (k-789, k-999) work")
-	statusWithK789 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	statusWithK789 := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK789...,
 	)
-	statusWithK999 := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
+	statusWithK999 := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -368,13 +363,13 @@ stringData:
 
 	// Step 4: Verify old keys no longer work
 	s.T().Log("Step 4: Verifying old API keys (k-123, k-456) no longer work")
-	statusWithK123Old := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithK123Old := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
 		statusWithK123Old...,
 	)
-	statusWithK456Old := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithK456Old := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -401,25 +396,25 @@ stringData:
 	// Step 6: Verify the final set of keys work
 	// After Step 5 merge update, the secret has: client1 (k-123), client3 (k-789), client4 (k-999), client5 (k-111)
 	s.T().Log("Step 6: Verifying final API keys (k-123, k-789, k-999, k-111) works")
-	statusWithK123Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithK123Final := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK123Final...,
 	)
-	statusWithK789Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	statusWithK789Final := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK789Final...,
 	)
-	statusWithK999Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
+	statusWithK999Final := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-999"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
 		statusWithK999Final...,
 	)
-	statusWithK111Final := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-111"))
+	statusWithK111Final := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-111"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -429,7 +424,7 @@ stringData:
 	// Step 7: Verify removed keys no longer work
 	// k-456 was removed in Step 2, so it should not work
 	s.T().Log("Step 7: Verifying removed API key (k-456) no longer work")
-	statusWithK456Removed := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithK456Removed := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -461,7 +456,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has valid API key from route-level secret, should succeed
 	s.T().Log("The /get route should succeed with valid API key from route-level secret (k-789)")
-	getWithRouteAPIKeyCurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	getWithRouteAPIKeyCurlOpts := curl.Extend(getReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -470,7 +465,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has another valid API key from route-level secret, should succeed
 	s.T().Log("The /get route should succeed with another valid API key from route-level secret (k-999)")
-	getWithRouteAPIKey2CurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-999"))
+	getWithRouteAPIKey2CurlOpts := curl.Extend(getReqCurlOpts, curl.WithHeader("api-key", "k-999"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -479,7 +474,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has API key from gateway-level secret, should fail (route-level policy overrides)
 	s.T().Log("The /get route should fail with API key from gateway-level secret (k-123) - route-level policy overrides")
-	getWithGatewayAPIKeyCurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	getWithGatewayAPIKeyCurlOpts := curl.Extend(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -488,7 +483,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has another API key from gateway-level secret, should fail
 	s.T().Log("The /get route should fail with another API key from gateway-level secret (k-456) - route-level policy overrides")
-	getWithGatewayAPIKey2CurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	getWithGatewayAPIKey2CurlOpts := curl.Extend(getReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -512,7 +507,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has valid API key from gateway-level secret, should succeed
 	s.T().Log("The /status/200 route should succeed with valid API key from gateway-level secret (k-123)")
-	statusWithGatewayAPIKeyCurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithGatewayAPIKeyCurlOpts := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -521,7 +516,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has another valid API key from gateway-level secret, should succeed
 	s.T().Log("The /status/200 route should succeed with another valid API key from gateway-level secret (k-456)")
-	statusWithGatewayAPIKey2CurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
+	statusWithGatewayAPIKey2CurlOpts := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-456"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -530,7 +525,7 @@ func (s *testingSuite) TestAPIKeyAuthRouteOverrideGateway() {
 
 	// has API key from route-level secret, should fail (only applies to /get route)
 	s.T().Log("The /status/200 route should fail with API key from route-level secret (k-789) - only gateway-level policy applies")
-	statusWithRouteAPIKeyCurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
+	statusWithRouteAPIKeyCurlOpts := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-789"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectAPIKeyAuthDenied,
@@ -560,7 +555,7 @@ func (s *testingSuite) TestAPIKeyAuthDisableAtRouteLevel() {
 
 	// has valid API key, should succeed
 	s.T().Log("The /status/200 route should succeed with valid API key from gateway-level policy")
-	statusWithAPIKeyCurlOpts := withCurlOptions(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	statusWithAPIKeyCurlOpts := curl.Extend(statusReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,
@@ -583,7 +578,7 @@ func (s *testingSuite) TestAPIKeyAuthDisableAtRouteLevel() {
 
 	// has API key, should still succeed (API key is ignored when disabled)
 	s.T().Log("The /get route with disable should succeed even with API key present")
-	getWithAPIKeyCurlOpts := withCurlOptions(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
+	getWithAPIKeyCurlOpts := curl.Extend(getReqCurlOpts, curl.WithHeader("api-key", "k-123"))
 	common.BaseGateway.Send(
 		s.T(),
 		expectStatus200Success,

--- a/test/e2e/features/services/httproute/types.go
+++ b/test/e2e/features/services/httproute/types.go
@@ -23,7 +23,7 @@ var (
 	routeWithGwManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "route-with-gw.yaml")
 	routeMissingGwManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "route-missing-gw.yaml")
 	serviceManifest          = filepath.Join(fsutils.MustGetThisDir(), "testdata", "service-for-route.yaml")
-	tcpRouteCrdManifest      = filepath.Join(crds.AbsPathToCrd("tcproute-crd.yaml"))
+	tcpRouteCrdManifest      = crds.AbsPathToCrd("tcproute-crd.yaml")
 
 	expectedSvcResp = &testmatchers.HttpResponse{
 		StatusCode: http.StatusOK,

--- a/test/envoyutils/admincli/client.go
+++ b/test/envoyutils/admincli/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 
 	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -118,10 +119,10 @@ func (c *Client) WithCurlOptions(options ...curl.Option) *Client {
 
 // Command returns a curl Command, using the provided curl.Option as well as the client.curlOptions
 func (c *Client) Command(ctx context.Context, options ...curl.Option) cmdutils.Cmd {
-	commandCurlOptions := append(
+	commandCurlOptions := slices.Concat(
 		c.curlOptions,
 		// Ensure any options defined for this command can override any defaults that the Client has defined
-		options...)
+		options)
 	curlArgs := curl.BuildArgs(commandCurlOptions...)
 
 	return cmdutils.Command(ctx, "curl", curlArgs...).

--- a/test/envoyutils/admincli/client.go
+++ b/test/envoyutils/admincli/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 
 	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -119,10 +118,8 @@ func (c *Client) WithCurlOptions(options ...curl.Option) *Client {
 
 // Command returns a curl Command, using the provided curl.Option as well as the client.curlOptions
 func (c *Client) Command(ctx context.Context, options ...curl.Option) cmdutils.Cmd {
-	commandCurlOptions := slices.Concat(
-		c.curlOptions,
-		// Ensure any options defined for this command can override any defaults that the Client has defined
-		options)
+	// Ensure any options defined for this command can override any defaults that the Client has defined
+	commandCurlOptions := curl.Extend(c.curlOptions, options...)
 	curlArgs := curl.BuildArgs(commandCurlOptions...)
 
 	return cmdutils.Command(ctx, "curl", curlArgs...).


### PR DESCRIPTION
# Description

Enable an explicit allowlist of correctness-focused GoCritic checks in golangci-lint, and fix the findings.

**Why an allowlist:** `disable-all: true` plus `enabled-checks` opts out of GoCritic's default set, which is dominated by style opinions (`ifElseChain`, `singleCaseSwitch`, ...) we don't want to enforce. The 26 enabled checks target suspicious calls and conditions, duplicated expressions and branches, off-by-one errors, regexp misuse, invalid type assertions, lock/sort misuse, deferred cleanup bypasses, and slice append aliasing. Checks that were considered and deliberately left out are listed in a comment in `.golangci.yaml` with their current finding counts, so they aren't re-litigated.

**What changed, by finding:**

*Real latent aliasing, now fixed:*
- `test/{controllerutils,envoyutils}/admincli/client.go` — `c.curlOptions` is grown via `append` in `WithCurlOptions`, so it can carry spare capacity. Two `Command()` calls on the same client could write into the same backing array and clobber each other's options.
- `pkg/utils/kubeutils/kubectl/cli.go` — `DeleteFileSafe` appended `--ignore-not-found` to a variadic parameter; a caller spreading a slice with spare capacity would have that slice mutated.
- `test/e2e/common/gateway.go` — `curlOpts()` returns `append([]curl.Option{hostOpt}, opts...)`, which reallocates to a size class with spare capacity; `matchOnce` then appended `WithContext` to it on every poll iteration.

*Defensive, no reachable bug today, changed to satisfy the check and stay correct under future edits:*
- `pkg/apiclient/fake/fake.go` — `testutils.AllCRDs` is a composite literal (`cap == len`), so `append` always reallocates.
- `pkg/krtcollections/policy.go` — `GetTargetingPolicies` builds its result from `var ret []ir.PolicyAtt`, so the returned slice is fresh per call and used once. Uses `slices.Clone` + `append` rather than `slices.Concat` because `slices` in that file is `istio.io/istio/pkg/slices`, which has `Clone` but no `Concat`.
- `pkg/kgateway/extensions2/plugins/waypoint/plugin.go` — `ipv4Addrs`/`ipv6Addrs` are function-local and not retained.

*Other:*
- `cmd/kgateway/main.go` — `exitAfterDefer`: `log.Fatal` skipped `defer stop()`, leaking the signal handler registration on the error path. Moved the fatal logging into `main` so `run()` can return the error and unwind normally.
- `test/e2e/features/services/httproute/types.go` — `crds.AbsPathToCrd` already ends in `filepath.Join`, so the outer single-argument `Join` was a no-op.

**New shared helper:** `curl.Extend(base, extra...)` wraps `slices.Concat` and is now the one way to extend a curl option slice. `appendAssign` only fires on the assignment form, so the inline `append(shared, x)...` spread is invisible to the linter — putting the helper in the `curl` package alongside the `Option` type makes it the obvious tool at every call site rather than something each suite reinvents.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validation:
- `make analyze` — 0 issues
- `make verify`
- `go build -tags e2e ./...`
- targeted `go test -tags=e2e` for affected packages

Finding counts for the excluded checks were measured against this tree, not guessed. The most notable exclusion is `dupArg` (10 findings): all of them are `x.Equals(x)` self-comparisons in `Equals` unit tests, which is the intended pattern given the IR `Equals` convention in `CLAUDE.md`.
