### PR TITLE
fix: reject unknown validator modes

### DIFF
--- a/pkg/kgateway/setup/setup.go
+++ b/pkg/kgateway/setup/setup.go
@@ -275,7 +275,11 @@ func New(opts ...func(*setup)) (*setup, error) {
 	}
 
 	if s.validator == nil {
-		s.validator = validator.New(*s.globalSettings)
+		var err error
+		s.validator, err = validator.New(*s.globalSettings)
+		if err != nil {
+			return nil, fmt.Errorf("error creating validator: %w", err)
+		}
 	}
 
 	return s, nil

--- a/pkg/validator/factory.go
+++ b/pkg/validator/factory.go
@@ -1,19 +1,22 @@
 package validator
 
 import (
+	"fmt"
+
 	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
 )
 
 // New constructs a Validator according to the given settings. The default
 // (mode=CACHE) wraps the binary validator with a content-hash result cache, a
-// pure memoization that cannot change verdicts. Unknown modes fall back to
-// plain BINARY so misconfiguration cannot block startup.
-func New(s apisettings.Settings) Validator {
+// pure memoization that cannot change verdicts.
+func New(s apisettings.Settings) (Validator, error) {
 	base := NewBinary()
 	switch s.ValidatorMode {
+	case apisettings.ValidatorBinary:
+		return base, nil
 	case apisettings.ValidatorCache:
-		return NewCaching(base, s.ValidatorCacheSize)
+		return NewCaching(base, s.ValidatorCacheSize), nil
 	default:
-		return base
+		return nil, fmt.Errorf("invalid validator mode: %q", s.ValidatorMode)
 	}
 }

--- a/pkg/validator/factory_test.go
+++ b/pkg/validator/factory_test.go
@@ -9,25 +9,29 @@ import (
 	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
 )
 
-func TestNew_ZeroValueModeYieldsBinary(t *testing.T) {
-	// A zero-valued Settings struct bypasses the envconfig default tag, which
-	// selects CACHE; an empty mode falls through to plain binary.
-	v := New(apisettings.Settings{})
-	_, ok := v.(*binaryValidator)
-	assert.True(t, ok, "zero-valued settings should yield plain binaryValidator")
+func TestNew_ZeroValueModeReturnsError(t *testing.T) {
+	_, err := New(apisettings.Settings{})
+	require.EqualError(t, err, `invalid validator mode: ""`)
 }
 
-func TestNew_UnknownModeFallsBackToBinary(t *testing.T) {
-	v := New(apisettings.Settings{ValidatorMode: "nonsense"})
+func TestNew_UnknownModeReturnsError(t *testing.T) {
+	_, err := New(apisettings.Settings{ValidatorMode: "nonsense"})
+	require.EqualError(t, err, `invalid validator mode: "nonsense"`)
+}
+
+func TestNew_BinaryMode(t *testing.T) {
+	v, err := New(apisettings.Settings{ValidatorMode: apisettings.ValidatorBinary})
+	require.NoError(t, err)
 	_, ok := v.(*binaryValidator)
-	assert.True(t, ok)
+	assert.True(t, ok, "binary mode should return *binaryValidator")
 }
 
 func TestNew_CacheMode(t *testing.T) {
-	v := New(apisettings.Settings{
+	v, err := New(apisettings.Settings{
 		ValidatorMode:      apisettings.ValidatorCache,
 		ValidatorCacheSize: 16,
 	})
+	require.NoError(t, err)
 	c, ok := v.(*cachingValidator)
 	require.True(t, ok, "cache mode should return *cachingValidator")
 	_, innerOK := c.inner.(*binaryValidator)
@@ -35,7 +39,8 @@ func TestNew_CacheMode(t *testing.T) {
 }
 
 func TestNew_CacheZeroSizeFallsBackToDefault(t *testing.T) {
-	v := New(apisettings.Settings{ValidatorMode: apisettings.ValidatorCache})
+	v, err := New(apisettings.Settings{ValidatorMode: apisettings.ValidatorCache})
+	require.NoError(t, err)
 	_, ok := v.(*cachingValidator)
 	require.True(t, ok)
 }


### PR DESCRIPTION
# Description

Reject unknown or empty validator modes instead of silently falling back to the uncached `BINARY` validator.

The validator factory now returns an error for unsupported modes, and setup propagates that error. Valid `BINARY` and `CACHE` behavior remains unchanged.

Caching should clearly be the default. And there's no reason not to fail hard at startup because anyone changing the configuration of the control plane will be watching to make sure that that change rolls out to production smoothly.

# Change Type

/kind fix

# Changelog

```release-note
Reject unknown KGW_VALIDATOR_MODE values instead of silently falling back to uncached validation.
```

# Additional Notes

Validated with:

`go test -tags e2e ./api/settings ./pkg/validator ./pkg/kgateway/setup`
