### PR TITLE
refactor: drop the unused ReferenceGrant validation bypass

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"istio.io/istio/pkg/kube/krt"
 	corev1 "k8s.io/api/core/v1"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
@@ -133,7 +132,7 @@ func TranslateGatewayExtensionBuilder(
 		switch {
 		case gExt.ExtAuth != nil:
 			if gExt.ExtAuth.GrpcService != nil {
-				envoyGrpcService, err := ResolveExtGrpcService(krtctx, commoncol.BackendIndex, false, gExt.ObjectSource, gExt.ExtAuth.GrpcService)
+				envoyGrpcService, err := ResolveExtGrpcService(krtctx, commoncol.BackendIndex, gExt.ObjectSource, gExt.ExtAuth.GrpcService)
 				if err != nil {
 					// TODO: should this be a warning, and set cluster to blackhole?
 					p.Err = fmt.Errorf("failed to resolve ExtAuth gRPC backend: %w", err)
@@ -150,7 +149,7 @@ func TranslateGatewayExtensionBuilder(
 					StatusOnError:         &envoytypev3.HttpStatus{Code: envoytypev3.StatusCode(gExt.ExtAuth.StatusOnError)}, //nolint:gosec // G115: StatusOnError is HTTP status code, valid range fits in int32
 				}
 			} else if gExt.ExtAuth.HttpService != nil {
-				envoyHttpService, err := ResolveExtHttpService(krtctx, commoncol.BackendIndex, false, gExt.ObjectSource, gExt.ExtAuth.HttpService)
+				envoyHttpService, err := ResolveExtHttpService(krtctx, commoncol.BackendIndex, gExt.ObjectSource, gExt.ExtAuth.HttpService)
 				if err != nil {
 					p.Err = fmt.Errorf("failed to resolve ExtAuth HTTP backend: %w", err)
 					return p
@@ -186,7 +185,7 @@ func TranslateGatewayExtensionBuilder(
 			}
 
 		case gExt.ExtProc != nil:
-			envoyGrpcService, err := ResolveExtGrpcService(krtctx, commoncol.BackendIndex, false, gExt.ObjectSource, &gExt.ExtProc.GrpcService)
+			envoyGrpcService, err := ResolveExtGrpcService(krtctx, commoncol.BackendIndex, gExt.ObjectSource, &gExt.ExtProc.GrpcService)
 			if err != nil {
 				p.Err = fmt.Errorf("failed to resolve ExtProc backend: %w", err)
 				return p
@@ -195,7 +194,7 @@ func TranslateGatewayExtensionBuilder(
 			p.FilterStage = gExt.ExtProc.FilterStage
 
 		case gExt.RateLimit != nil:
-			grpcService, err := ResolveExtGrpcService(krtctx, commoncol.BackendIndex, false, gExt.ObjectSource, &gExt.RateLimit.GrpcService)
+			grpcService, err := ResolveExtGrpcService(krtctx, commoncol.BackendIndex, gExt.ObjectSource, &gExt.RateLimit.GrpcService)
 			if err != nil {
 				p.Err = fmt.Errorf("ratelimit: %w", err)
 				return p
@@ -266,23 +265,9 @@ func resolveJwtProviders(
 	}, nil
 }
 
-func resolveBackend(
-	krtctx krt.HandlerContext,
-	backends *krtcollections.BackendIndex,
-	disableExtensionRefValidation bool,
-	objectSource ir.ObjectSource,
-	backendRef gwv1.BackendObjectReference,
-) (*ir.BackendObjectIR, error) {
-	if disableExtensionRefValidation {
-		return backends.GetBackendFromRefWithoutRefGrantValidation(krtctx, objectSource, backendRef)
-	}
-	return backends.GetBackendFromRef(krtctx, objectSource, backendRef)
-}
-
 func ResolveExtGrpcService(
 	krtctx krt.HandlerContext,
 	backends *krtcollections.BackendIndex,
-	disableExtensionRefValidation bool,
 	objectSource ir.ObjectSource,
 	grpcService *kgateway.ExtGrpcService,
 ) (*envoycorev3.GrpcService, error) {
@@ -291,10 +276,8 @@ func ResolveExtGrpcService(
 		return nil, errors.New("grpcService not provided")
 	}
 
-	var backend *ir.BackendObjectIR
-	var err error
 	backendRef := grpcService.BackendRef.BackendObjectReference
-	backend, err = resolveBackend(krtctx, backends, disableExtensionRefValidation, objectSource, backendRef)
+	backend, err := backends.GetBackendFromRef(krtctx, objectSource, backendRef)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +312,6 @@ func ResolveExtGrpcService(
 func ResolveExtHttpService(
 	krtctx krt.HandlerContext,
 	backends *krtcollections.BackendIndex,
-	disableExtensionRefValidation bool,
 	objectSource ir.ObjectSource,
 	httpService *kgateway.ExtHttpService,
 ) (*envoy_ext_authz_v3.HttpService, error) {
@@ -338,14 +320,8 @@ func ResolveExtHttpService(
 	}
 
 	// Resolve backend
-	var backend *ir.BackendObjectIR
-	var err error
 	backendRef := httpService.BackendRef.BackendObjectReference
-	if disableExtensionRefValidation {
-		backend, err = backends.GetBackendFromRefWithoutRefGrantValidation(krtctx, objectSource, backendRef)
-	} else {
-		backend, err = backends.GetBackendFromRef(krtctx, objectSource, backendRef)
-	}
+	backend, err := backends.GetBackendFromRef(krtctx, objectSource, backendRef)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/oauth2.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/oauth2.go
@@ -170,7 +170,7 @@ func buildOAuth2ProviderConfig(
 		return nil, errors.New("oauth2 authorization endpoint not specified or not found in issuer well-known configuration")
 	}
 
-	backend, err := resolveBackend(krtctx, backends, false, ext.ObjectSource, in.BackendRef.BackendObjectReference)
+	backend, err := backends.GetBackendFromRef(krtctx, ext.ObjectSource, in.BackendRef.BackendObjectReference)
 	if err != nil || backend == nil {
 		return nil, fmt.Errorf("error resolving oauth2 backend %v: %w", in.BackendRef.BackendObjectReference, err)
 	}
@@ -179,7 +179,7 @@ func buildOAuth2ProviderConfig(
 	// This is needed when the JWKS endpoint is on a different domain than the token endpoint.
 	jwksBackend := backend
 	if in.JWT != nil && in.JWT.JWKSBackendRef != nil {
-		resolved, err := resolveBackend(krtctx, backends, false, ext.ObjectSource, *in.JWT.JWKSBackendRef)
+		resolved, err := backends.GetBackendFromRef(krtctx, ext.ObjectSource, *in.JWT.JWKSBackendRef)
 		if err != nil {
 			return nil, fmt.Errorf("error resolving JWKS backend %v: %w", *in.JWT.JWKSBackendRef, err)
 		}

--- a/pkg/kgateway/query/query.go
+++ b/pkg/kgateway/query/query.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
@@ -310,35 +309,4 @@ func (r *gatewayQueries) GetConfigMapForRef(kctx krt.HandlerContext, ctx context
 		Namespace: fromns,
 	}
 	return r.collections.ConfigMaps.GetConfigMap(kctx, f, configMapRef)
-}
-
-func ReferenceAllowed(ctx context.Context, fromgk metav1.GroupKind, fromns string, togk metav1.GroupKind, toname string, grantsInToNs []gwv1b1.ReferenceGrant) bool {
-	for _, refGrant := range grantsInToNs {
-		for _, from := range refGrant.Spec.From {
-			if string(from.Namespace) != fromns {
-				continue
-			}
-			if coreIfEmpty(fromgk.Group) == coreIfEmpty(string(from.Group)) && fromgk.Kind == string(from.Kind) {
-				for _, to := range refGrant.Spec.To {
-					if coreIfEmpty(togk.Group) == coreIfEmpty(string(to.Group)) && togk.Kind == string(to.Kind) {
-						if to.Name == nil || string(*to.Name) == toname {
-							return true
-						}
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
-// Note that the spec has examples where the "core" api group is explicitly specified.
-// so this helper function converts an empty string (which implies core api group) to the
-// explicit "core" api group. It should only be used in places where the spec specifies that empty
-// group means "core" api group (some place in the spec may default to the "gateway" api group instead.
-func coreIfEmpty(s string) string {
-	if s == "" {
-		return "core"
-	}
-	return s
 }

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -381,11 +381,6 @@ func (i *BackendIndex) GetBackendFromRef(kctx krt.HandlerContext, src ir.ObjectS
 	return i.getBackendFromRef(kctx, src.Namespace, ref)
 }
 
-// Intentionally long name, to make sure the user doesn't use this by mistake.
-func (i *BackendIndex) GetBackendFromRefWithoutRefGrantValidation(kctx krt.HandlerContext, src ir.ObjectSource, ref gwv1.BackendObjectReference) (*ir.BackendObjectIR, error) {
-	return i.getBackendFromRef(kctx, src.Namespace, ref)
-}
-
 // MARK: GatewayIndex
 
 type GatewayIndex struct {

--- a/pkg/plugins/gwextbase/base.go
+++ b/pkg/plugins/gwextbase/base.go
@@ -3,12 +3,7 @@ package gwextbase
 import (
 	"context"
 
-	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"istio.io/istio/pkg/kube/krt"
-
-	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/plugins/trafficpolicy"
-	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/reporter"
@@ -44,20 +39,4 @@ func NewTrafficPolicyConstructor(
 
 func NewGatewayTranslationPass(tctx ir.GwTranslationCtx, reporter reporter.Reporter, enableAuthSucceededMetadata bool) ir.ProxyTranslationPass {
 	return trafficpolicy.NewGatewayTranslationPass(tctx, reporter, enableAuthSucceededMetadata)
-}
-
-// ResolveExtGrpcService resolves a gateway extension gRPC service by looking up the backend reference
-// and constructing an Envoy gRPC service configuration. It takes the following parameters:
-//   - krtctx: The KRT context
-//   - backends: The backend index collection
-//   - disableExtensionRefValidation: Whether to skip reference grant validation
-//   - objectSource: The source object making the request
-//   - grpcService: The gRPC service configuration to resolve
-//
-// Returns:
-//   - *envoycorev3.GrpcService: The resolved Envoy gRPC service configuration
-//   - error: Any error that occurred during resolution
-
-func ResolveExtGrpcService(krtctx krt.HandlerContext, backends *krtcollections.BackendIndex, disableExtensionRefValidation bool, objectSource ir.ObjectSource, grpcService *kgateway.ExtGrpcService) (*envoycorev3.GrpcService, error) {
-	return trafficpolicy.ResolveExtGrpcService(krtctx, backends, disableExtensionRefValidation, objectSource, grpcService)
 }


### PR DESCRIPTION
# Description

tldr: remove dead code

**Motivation:** `resolveBackend` in the trafficpolicy plugin forked on a `disableExtensionRefValidation bool`, taking either `BackendIndex.GetBackendFromRef` (ReferenceGrant enforced) or `BackendIndex.GetBackendFromRefWithoutRefGrantValidation` (enforcement skipped). Every one of the six call sites passed `false`, so the bypass branch was unreachable and the "without validation" accessor had no live caller.

The capability it was built for now has a supported, settings-driven home: `KGW_REFERENCE_GRANT_MODE=OFF` short-circuits `RefGrantIndex.ReferenceAllowed` for every reference type, including the GatewayExtension → Service BackendRef this flag guarded (see the coverage table in `devel/reference_grant/reference-grant-mode.md`). A hardcoded per-call-site bool is strictly less expressive than the mode and duplicates its purpose.

**What changed:**

- Removed the `disableExtensionRefValidation` parameter from `ResolveExtGrpcService` and `ResolveExtHttpService`, and deleted the single-caller `resolveBackend` helper. All six sites now call `GetBackendFromRef` directly:
  - `gateway_extension.go` — ExtAuth gRPC, ExtAuth HTTP, ExtProc, RateLimit
  - `oauth2.go` — client backend and JWKS backend
- Deleted `BackendIndex.GetBackendFromRefWithoutRefGrantValidation`, now unreferenced.
- Deleted `query.ReferenceAllowed` and its `coreIfEmpty` helper. This slice-scanning grant matcher had no callers at all and is superseded by the KRT-indexed `RefGrantIndex.ReferenceAllowed`, which also registers the dependency needed for recomputation when grants change.
- Dropped the unused `ResolveExtGrpcService` wrapper from `pkg/plugins/gwextbase`. The package's other re-exports are unchanged.

Net: 90 lines removed, 8 added.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

**No behavior change.** `false` was already the effective value at every call site, and in `OFF` mode `ReferenceAllowed` returns `true` before any grant lookup — so `GetBackendFromRef` and the deleted bypass produce identical results in all three enforcement modes.

Verification:

- `go build -tags e2e ./...` clean
- `make analyze` — 0 issues
- `go test ./pkg/kgateway/translator/...` green, including the full gateway golden suite, **with no golden file changes**
- The four `TestBasic/ReferenceGrantMode_*` golden tests (Off / Permissive / Strict-reject / Strict-allow) pass
- Package tests pass for `trafficpolicy`, `krtcollections`, `query`, and `plugins`
