### PR TITLE
ci: warm-start Go build caches across go.sum changes, seed only from main

### DIFF
--- a/.github/actions/prep-go-runner/action.yaml
+++ b/.github/actions/prep-go-runner/action.yaml
@@ -18,6 +18,9 @@ outputs:
   go-build-cache-key-race:
     description: 'primary key for the race-instrumented (CGO + -race) Go build cache used by the unit tests'
     value: ${{ steps.go-cache-keys.outputs.go-build-race }}
+  go-build-cache-restore-key-race:
+    description: 'restore-keys prefix for the race Go build cache: matches the most recent same-Go-version race cache when the go.sum-exact key misses'
+    value: ${{ steps.go-cache-keys.outputs.go-build-race-restore }}
   go-build-cache-path:
     description: 'path to the Go build cache directory'
     value: ${{ steps.go-cache-paths.outputs.go-build }}
@@ -90,13 +93,24 @@ runs:
       shell: bash
       run: |
         echo "go-build=${{ runner.os }}-go-build-v3-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
+        echo "go-build-restore=${{ runner.os }}-go-build-v3-${{ steps.setup-go.outputs.go-version }}-" >> $GITHUB_OUTPUT
         echo "go-build-race=${{ runner.os }}-go-build-race-v3-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
+        echo "go-build-race-restore=${{ runner.os }}-go-build-race-v3-${{ steps.setup-go.outputs.go-version }}-" >> $GITHUB_OUTPUT
     - name: Restore Go Build Cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: go-build-cache
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ steps.go-cache-keys.outputs.go-build }}
+        # A go.sum change makes the exact key miss; without a fallback that
+        # means recompiling the world and saving a fresh ~0.8GB cache
+        # generation into the repo's 10GB budget. Fall back to the most recent
+        # same-Go-version cache so only the delta is rebuilt. Go trims GOCACHE
+        # entries unused for 5 days, so generations built on top of a fallback
+        # don't grow without bound. cache-hit stays 'false' on a fallback
+        # match, so Cache Setup still re-primes and saves under the new key.
+        restore-keys: |
+          ${{ steps.go-cache-keys.outputs.go-build-restore }}
     - name: Cache Go Modules
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: go-mod-cache

--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -1,11 +1,26 @@
 name: Cache Setup
 
 on:
-  # We utilize this job to seed the GitHub action cache(s) for the LTS branch
+  # Seed the shared GitHub Actions Go caches from main, and only from main.
+  # (A previous 'v1.**.x' filter here referred to branches that have never
+  # existed in this repo, so it never fired.)
+  #
+  # Deliberately NOT seeding the v2.**.x LTS branches:
+  #   - The repo's 10GB cache budget is already near-saturated by main's cache
+  #     generations; a full seed set (build + race + modules) is ~2.25GB per
+  #     branch, so each LTS line seeded would immediately force LRU eviction.
+  #   - LRU favors main's constant PR traffic. Release-branch PRs are sparse,
+  #     so a seed pushed on an LTS branch is typically evicted before the next
+  #     release-branch PR can use it — costing the seeding run and transiently
+  #     evicting hot main caches for nothing.
+  #   - Release-branch PRs can already restore main's caches (default-branch
+  #     caches are visible to every branch). When an LTS branch's go.sum
+  #     diverges from main, the restore-keys prefix fallback in prep-go-runner
+  #     still gives it a warm start from main's most recent generation (as
+  #     long as the Go toolchain version matches).
   push:
     branches:
       - 'main'
-      - 'v1.**.x'
 
 env:
   CGO_ENABLED: '0'
@@ -42,6 +57,10 @@ jobs:
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}
+          # No restore-keys here on purpose: the prime step below starts with
+          # `go clean -cache`, which would discard a fallback-restored cache
+          # anyway, and skipping the clean would make the saved race cache a
+          # bloated union of race and non-race entries.
       - name: Prime Race Go Build Cache
         if: steps.race-build-cache.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -39,6 +39,11 @@ jobs:
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}
+          # This job only restores (never saves), so falling back to the
+          # previous race-cache generation on a go.sum change is a strict win:
+          # the -race build recompiles just the delta instead of the world.
+          restore-keys: |
+            ${{ steps.prep-go-runner.outputs.go-build-cache-restore-key-race }}
       - name: Detect validator image rebuild
         id: validator-image
         shell: bash


### PR DESCRIPTION
# Description

The Go build/race/module caches are keyed on `hashFiles('**/go.sum')` with no `restore-keys` fallback. Any dependency bump therefore makes every job miss the cache exactly, recompile the world, and save a fresh cache generation (~2.25GB per build + race + mod set). The repo's 10GB Actions cache budget is currently at ~9.7GB, carrying several stale generations of main's caches, so LRU eviction is effectively continuous.

Separately, the Cache Setup workflow's trigger includes `v1.**.x`, which matches branches that have never existed in this repo — that half of the trigger has never fired.

Changes:

- **`.github/actions/prep-go-runner/action.yaml`**: add a `restore-keys` prefix fallback (`{os}-go-build-v3-{go-version}-`) to the Go build cache restore. A `go.sum` change now warm-starts from the most recent same-Go- version generation and recompiles only the delta. `cache-hit` remains `false` on a fallback match, so Cache Setup still re-primes and saves under the new exact key. Go's built-in GOCACHE trimming (entries unused for 5 days) keeps generations built on a fallback base from growing without bound. Also exposes a matching restore-prefix output for the race cache.
- **`.github/workflows/unit.yaml`**: use the race restore-prefix as `restore-keys` when restoring the race build cache. This job only restores (never saves), so the fallback is a strict win with no storage cost.
- **`.github/workflows/cache-setup.yaml`**: drop the dead `v1.**.x` branch filter and document why the `v2.**.x` LTS branches are deliberately not seeded: each seeded line would add ~2.25GB to a near-saturated 10GB budget, and LRU (which favors main's constant traffic) would typically evict a sparse release-branch seed before its next PR could use it. Release-branch PRs already read main's caches (default-branch caches are visible to every branch), and with the new fallback they get a warm start from main even when their `go.sum` has diverged, as long as the Go toolchain version matches. Also documents why the race-cache restore in this workflow must stay exact-match: its prime step runs `go clean -cache`, which would discard a fallback anyway.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Alternative: Some people bypass GitHub Actions cache and use s3 to get more cache space
