### PR TITLE
cleanup: follow-ups on the keyed status writer pipeline

### DIFF
--- a/pkg/kgateway/extensions2/pluginutils/policy_status.go
+++ b/pkg/kgateway/extensions2/pluginutils/policy_status.go
@@ -124,22 +124,24 @@ func RegisterPolicyStatusWithBuilder[T controllers.ComparableObject](
 				desired.Ancestors = statussync.MergePolicyAncestorStatuses(controllerName, getStatus(current).Ancestors, desired.Ancestors)
 				return desired
 			},
-			OnSync: func(res statussync.Resource, current T, status gwv1.PolicyStatus, took time.Duration, err error) {
+			OnSync: func(res statussync.Resource, _ T, status gwv1.PolicyStatus, took time.Duration, err error) {
 				statusErr := err
 				if conditionMetric {
 					statusErr = errors.Join(statusErr, policyStatusConditionError(status, controllerName))
 				}
-				statussync.RecordStatusSync(statussync.SyncMetricLabels{
-					Name:      gvk.Kind,
-					Namespace: res.Namespace,
-					Syncer:    "PolicyStatusSyncer",
-				}, took, statusErr)
-				statussync.EndResourceStatusSyncOnWriteSuccess(err, kmetrics.ResourceSyncDetails{
-					Namespace:    res.Namespace,
-					Gateway:      "",
-					ResourceType: gvk.Kind,
-					ResourceName: res.Name,
-				})
+				statussync.RecordStatusSyncOutcome(
+					statussync.SyncMetricLabels{
+						Name:      gvk.Kind,
+						Namespace: res.Namespace,
+						Syncer:    "PolicyStatusSyncer",
+					},
+					kmetrics.ResourceSyncDetails{
+						Namespace:    res.Namespace,
+						Gateway:      "",
+						ResourceType: gvk.Kind,
+						ResourceName: res.Name,
+					},
+					took, err, statusErr)
 			},
 		})
 	}

--- a/pkg/kgateway/extensions2/pluginutils/policy_status.go
+++ b/pkg/kgateway/extensions2/pluginutils/policy_status.go
@@ -9,7 +9,6 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
@@ -102,9 +101,8 @@ func RegisterPolicyStatusWithBuilder[T controllers.ComparableObject](
 			// Read from the collection that enqueues this policy, not from cl: cl is a
 			// delayed client whose Get returns nil until its own informer loads.
 			Current: statussync.CollectionSource(col),
-			Desired: func(pol T) (gwv1.PolicyStatus, bool) {
-				nn := types.NamespacedName{Namespace: pol.GetNamespace(), Name: pol.GetName()}
-				report, ok := statussync.ReportFor(statusReports, gvk, nn)
+			Desired: func(res statussync.Resource, pol T) (gwv1.PolicyStatus, bool) {
+				report, ok := statussync.ReportFor(statusReports, res)
 				if !ok {
 					return gwv1.PolicyStatus{}, false
 				}

--- a/pkg/kgateway/extensions2/pluginutils/policy_status_test.go
+++ b/pkg/kgateway/extensions2/pluginutils/policy_status_test.go
@@ -234,9 +234,9 @@ func TestRegisterPolicyStatusWriterIsIdempotent(t *testing.T) {
 
 	writer, ok := f.writer.(statussync.Writer[*gwv1.BackendTLSPolicy, gwv1.PolicyStatus])
 	require.True(t, ok, "the registered syncer should be the generic writer")
-	require.True(t, statussync.WriterWouldWrite(writer, f.current(t)),
+	require.True(t, statussync.WriterWouldWrite(writer, policyResource(), f.current(t)),
 		"the stale status must actually be written, or the check below proves nothing")
-	require.NoError(t, statussync.CheckWriterIdempotent(writer, f.current(t),
+	require.NoError(t, statussync.CheckWriterIdempotent(writer, policyResource(), f.current(t),
 		func(current *gwv1.BackendTLSPolicy, status gwv1.PolicyStatus) *gwv1.BackendTLSPolicy {
 			next := current.DeepCopy()
 			next.Status = *status.DeepCopy()

--- a/pkg/kgateway/proxy_syncer/option.go
+++ b/pkg/kgateway/proxy_syncer/option.go
@@ -10,13 +10,15 @@ type statusSyncerConfig struct {
 
 type StatusSyncerOption func(*statusSyncerConfig)
 
-// StatusRegistrationInputs exposes the keyed status pipeline to downstream resource
-// types. Registrations construct per-resource report reductions and writers during
-// controller setup; their event handlers are attached only while this replica is leader.
-type StatusRegistrationInputs = statussync.RegistrationInputs
-
-// StatusRegistration adds one resource-scoped status pipeline extension.
-type StatusRegistration func(StatusRegistrationInputs)
+// StatusRegistration adds one resource-scoped status pipeline extension. Registrations
+// construct per-resource report reductions and writers during controller setup; their event
+// handlers are attached only while this replica is leader.
+//
+// It takes statussync.RegistrationInputs under its own name rather than a local alias.
+// RegistrationInputs is deliberately one struct shared by both entry points -- its doc
+// comment explains why -- and re-spelling it per package undoes that in the reader's head:
+// someone who greps the local name finds a type with no fields.
+type StatusRegistration func(statussync.RegistrationInputs)
 
 func processStatusSyncerOptions(opts ...StatusSyncerOption) *statusSyncerConfig {
 	cfg := &statusSyncerConfig{}

--- a/pkg/kgateway/proxy_syncer/option_test.go
+++ b/pkg/kgateway/proxy_syncer/option_test.go
@@ -46,7 +46,7 @@ func TestWithStatusRegistration(t *testing.T) {
 		// The proxy syncer contributes StatusCollections.HasSynced exactly once; the status
 		// syncer must carry it through rather than adding a second copy of its own.
 		CacheSyncs: []cache.InformerSynced{collections.HasSynced},
-	}, WithStatusRegistration(func(in StatusRegistrationInputs) {
+	}, WithStatusRegistration(func(in statussync.RegistrationInputs) {
 		called = true
 		assert.Same(t, collections, in.Collections)
 		assert.NotNil(t, in.StatusContributions)

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -58,7 +58,6 @@ type ProxySyncer struct {
 
 	statusContributions         krt.Collection[reports.StatusContribution]
 	statusContributionsByTarget krt.Index[reports.StatusKey, reports.StatusContribution]
-	gatewayStatusSnapshots      krt.Collection[GatewayStatusSnapshot]
 	mostXdsSnapshots            krt.Collection[GatewayXdsResources]
 	perclientSnapCollection     krt.Collection[XdsSnapWrapper]
 
@@ -98,16 +97,15 @@ func (r GatewayXdsResources) Equals(in GatewayXdsResources) bool {
 		r.Secrets.Version == in.Secrets.Version
 }
 
-// GatewayStatusSnapshot is the status-only projection of one Gateway
-// translation. Keeping it separate prevents status-only changes from
-// invalidating the xDS projection.
+// GatewayStatusSnapshot is the status-only half of one Gateway translation. Keeping it a
+// separate field of gatewayTranslationOutput, with its own Equals, is what stops a
+// status-only change from invalidating the xDS projection derived from the same output.
+//
+// It is not itself a KRT collection element -- gatewayStatusContributions unpacks it straight
+// out of the translation output -- so it needs no ResourceName.
 type GatewayStatusSnapshot struct {
 	types.NamespacedName
 	Contributions []reports.StatusContribution
-}
-
-func (r GatewayStatusSnapshot) ResourceName() string {
-	return xds.OwnerNamespaceNameID(wellknown.GatewayApiProxyValue, r.Namespace, r.Name)
 }
 
 func (r GatewayStatusSnapshot) Equals(other GatewayStatusSnapshot) bool {
@@ -263,10 +261,6 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 	s.mostXdsSnapshots = krt.NewCollection(translationOutputs, func(_ krt.HandlerContext, output gatewayTranslationOutput) *GatewayXdsResources {
 		return &output.Xds
 	}, krtopts.ToOptions("MostXdsSnapshots")...)
-	s.gatewayStatusSnapshots = krt.NewCollection(translationOutputs, func(_ krt.HandlerContext, output gatewayTranslationOutput) *GatewayStatusSnapshot {
-		return &output.Status
-	}, krtopts.ToOptions("GatewayStatusSnapshots")...)
-
 	epPerClient := NewPerClientEnvoyEndpoints(
 		krtopts,
 		s.uniqueClients,
@@ -330,7 +324,7 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 	// ancestors from Gateway and Backend translation naturally reduce under the
 	// same policy key without a competing singleton writer.
 	s.statusContributions = krt.JoinCollection([]krt.Collection[reports.StatusContribution]{
-		gatewayStatusContributions(s.gatewayStatusSnapshots, krtopts),
+		gatewayStatusContributions(translationOutputs, krtopts),
 		backendPolicyContributions,
 		backendContributions,
 	}, krtopts.ToOptions("StatusContributions")...)

--- a/pkg/kgateway/proxy_syncer/status_collections.go
+++ b/pkg/kgateway/proxy_syncer/status_collections.go
@@ -10,7 +10,6 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1a3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
@@ -146,11 +145,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 	s.statusWriters[wellknown.ListenerSetGVK] = listenerSetWriter(cl, f, s.commonCols.RawListenerSets, listenerSetReports)
 	// ON_EXPERIMENTAL_PROMOTION : Remove this registration together with xlistenerset_status.go.
 	// Ref: https://github.com/kgateway-dev/kgateway/issues/12827
-	s.statusWriters[wellknown.XListenerSetGVK] = &xListenerSetStatusSyncer{
-		col:     s.commonCols.RawListenerSets,
-		client:  cl,
-		reports: listenerSetReports,
-	}
+	s.statusWriters[wellknown.XListenerSetGVK] = xListenerSetWriter(cl, s.commonCols.RawListenerSets, listenerSetReports)
 
 	backendPlugin, hasBackendPlugin := s.plugins.ContributesBackends[wellknown.BackendGVK.GroupKind()]
 	var backendReports krt.Collection[statussync.ResourceReports]
@@ -168,8 +163,8 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 	s.statusWriters[wellknown.BackendGVK] = statussync.Writer[*kgateway.Backend, kgateway.BackendStatus]{
 		Name:    "backend",
 		Current: statussync.CollectionSource(backendPlugin.RawBackends),
-		Desired: func(be *kgateway.Backend) (kgateway.BackendStatus, bool) {
-			report, ok := statussync.ReportFor(backendReports, wellknown.BackendGVK, types.NamespacedName{Namespace: be.Namespace, Name: be.Name})
+		Desired: func(res statussync.Resource, be *kgateway.Backend) (kgateway.BackendStatus, bool) {
+			report, ok := statussync.ReportFor(backendReports, res)
 			if !ok {
 				return kgateway.BackendStatus{}, false
 			}
@@ -241,8 +236,8 @@ func gatewayWriter(
 	return statussync.Writer[*gwv1.Gateway, gwv1.GatewayStatus]{
 		Name:    "gateway",
 		Current: statussync.CollectionSource(gateways),
-		Desired: func(gw *gwv1.Gateway) (gwv1.GatewayStatus, bool) {
-			report, ok := statussync.ReportFor(reportCol, wellknown.GatewayGVK, types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name})
+		Desired: func(res statussync.Resource, gw *gwv1.Gateway) (gwv1.GatewayStatus, bool) {
+			report, ok := statussync.ReportFor(reportCol, res)
 			if !ok {
 				return gwv1.GatewayStatus{}, false
 			}
@@ -288,9 +283,8 @@ func routeWriter[R, W controllers.ComparableObject](
 		Current: statussync.CollectionSource(routes),
 		UpdateStatus: statussync.ClientWriter(
 			kclient.NewFilteredDelayed[W](cl, gvr, f), build),
-		Desired: func(current R) (gwv1.RouteStatus, bool) {
-			nn := types.NamespacedName{Namespace: current.GetNamespace(), Name: current.GetName()}
-			report, ok := statussync.ReportFor(reportCol, gvk, nn)
+		Desired: func(res statussync.Resource, current R) (gwv1.RouteStatus, bool) {
+			report, ok := statussync.ReportFor(reportCol, res)
 			if !ok {
 				return gwv1.RouteStatus{}, false
 			}
@@ -310,7 +304,8 @@ func routeWriter[R, W controllers.ComparableObject](
 				// empty status, which Merge reads as "clear every parent we own" — a missing
 				// type switch case must not erase good status.
 				logger.Error("route status builder does not support this type; skipping status update",
-					"gvk", gvk.String(), "resource", nn.String(), "type", fmt.Sprintf("%T", current))
+					"gvk", res.GroupVersionKind.String(), "resource", res.NamespacedName.String(),
+					"type", fmt.Sprintf("%T", current))
 				return gwv1.RouteStatus{}, false
 			}
 			return *status, true
@@ -481,7 +476,7 @@ func listenerSetWriter(
 	return statussync.Writer[*gwv1.ListenerSet, gwv1.ListenerSetStatus]{
 		Name:    "listenerSet",
 		Current: statussync.CollectionSource(listenerSets),
-		Desired: listenerSetDesired(wellknown.ListenerSetGVK, reportCol),
+		Desired: listenerSetDesired(reportCol),
 		UpdateStatus: statussync.ClientWriter(
 			kclient.NewFilteredDelayed[*gwv1.ListenerSet](cl, wellknown.ListenerSetGVR, f),
 			func(om metav1.ObjectMeta, st gwv1.ListenerSetStatus) *gwv1.ListenerSet {
@@ -492,19 +487,18 @@ func listenerSetWriter(
 	}
 }
 
-// listenerSetDesired builds the desired status for one ListenerSet flavor, satisfying
+// listenerSetDesired builds the desired status for either ListenerSet flavor, satisfying
 // Writer.Desired.
 //
-// gvk selects which reduction to read: the promoted and legacy flavors share one normalized
-// collection whose reports are keyed by the object's own GVK, so it is the only thing that
-// differs between the two writers' reads.
+// The promoted and legacy flavors share one normalized collection whose reports are keyed by
+// the object's own GVK, and the enqueued Resource already carries that GVK -- which is the
+// same one the writers are dispatched on. So there is nothing left for the two writers to
+// differ on here, and no captured GVK that can disagree with the queue.
 func listenerSetDesired(
-	gvk schema.GroupVersionKind,
 	reportCol krt.Collection[statussync.ResourceReports],
-) func(*gwv1.ListenerSet) (gwv1.ListenerSetStatus, bool) {
-	return func(current *gwv1.ListenerSet) (gwv1.ListenerSetStatus, bool) {
-		nn := types.NamespacedName{Namespace: current.Namespace, Name: current.Name}
-		report, ok := statussync.ReportFor(reportCol, gvk, nn)
+) func(statussync.Resource, *gwv1.ListenerSet) (gwv1.ListenerSetStatus, bool) {
+	return func(res statussync.Resource, current *gwv1.ListenerSet) (gwv1.ListenerSetStatus, bool) {
+		report, ok := statussync.ReportFor(reportCol, res)
 		if !ok {
 			return gwv1.ListenerSetStatus{}, false
 		}

--- a/pkg/kgateway/proxy_syncer/status_collections.go
+++ b/pkg/kgateway/proxy_syncer/status_collections.go
@@ -44,7 +44,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 	// Gateway
 	gatewayReports := statussync.RegisterKind(s.statusCollections, wellknown.GatewayGVK, s.commonCols.RawGateways,
 		s.statusContributions, contributionsByTarget, krtopts.ToOptions("GatewayStatusReports")...)
-	s.statusWriters[wellknown.GatewayGVK] = gatewayWriter(cl, f, s.commonCols.RawGateways, gatewayReports)
+	registerStatusWriter(s.statusWriters, wellknown.GatewayGVK, gatewayWriter(cl, f, s.commonCols.RawGateways, gatewayReports))
 
 	httpRouteReports := statussync.RegisterKind(s.statusCollections, wellknown.HTTPRouteGVK, s.commonCols.RawHTTPRoutes,
 		s.statusContributions, contributionsByTarget, krtopts.ToOptions("HTTPRouteStatusReports")...)
@@ -61,20 +61,22 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 		s.commonCols.RawTLSRoutes, s.statusContributions, contributionsByTarget,
 		krtopts.ToOptions("TLSRouteStatusReports")...)
 
-	s.statusWriters[wellknown.HTTPRouteGVK] = routeWriter[*gwv1.HTTPRoute, *gwv1.HTTPRoute](cl, f, s.commonCols.RawHTTPRoutes, httpRouteReports, wellknown.HTTPRouteGVK, "httpRoute", wellknown.HTTPRouteGVR, wellknown.HTTPRouteKind, controllerName,
-		func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.HTTPRoute {
-			return &gwv1.HTTPRoute{ObjectMeta: om, Status: gwv1.HTTPRouteStatus{RouteStatus: st}}
-		},
-		func(o *gwv1.HTTPRoute) gwv1.RouteStatus { return o.Status.RouteStatus },
-		func(o *gwv1.HTTPRoute) []gwv1.ParentReference { return o.Spec.ParentRefs },
-	)
-	s.statusWriters[wellknown.GRPCRouteGVK] = routeWriter[*gwv1.GRPCRoute, *gwv1.GRPCRoute](cl, f, s.commonCols.RawGRPCRoutes, grpcRouteReports, wellknown.GRPCRouteGVK, "grpcRoute", wellknown.GRPCRouteGVR, wellknown.GRPCRouteKind, controllerName,
-		func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.GRPCRoute {
-			return &gwv1.GRPCRoute{ObjectMeta: om, Status: gwv1.GRPCRouteStatus{RouteStatus: st}}
-		},
-		func(o *gwv1.GRPCRoute) gwv1.RouteStatus { return o.Status.RouteStatus },
-		func(o *gwv1.GRPCRoute) []gwv1.ParentReference { return o.Spec.ParentRefs },
-	)
+	registerStatusWriter(s.statusWriters, wellknown.HTTPRouteGVK,
+		routeWriter(cl, f, s.commonCols.RawHTTPRoutes, httpRouteReports, wellknown.HTTPRouteGVK, wellknown.HTTPRouteGVR, controllerName,
+			func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.HTTPRoute {
+				return &gwv1.HTTPRoute{ObjectMeta: om, Status: gwv1.HTTPRouteStatus{RouteStatus: st}}
+			},
+			func(o *gwv1.HTTPRoute) gwv1.RouteStatus { return o.Status.RouteStatus },
+			func(o *gwv1.HTTPRoute) []gwv1.ParentReference { return o.Spec.ParentRefs },
+		))
+	registerStatusWriter(s.statusWriters, wellknown.GRPCRouteGVK,
+		routeWriter(cl, f, s.commonCols.RawGRPCRoutes, grpcRouteReports, wellknown.GRPCRouteGVK, wellknown.GRPCRouteGVR, controllerName,
+			func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.GRPCRoute {
+				return &gwv1.GRPCRoute{ObjectMeta: om, Status: gwv1.GRPCRouteStatus{RouteStatus: st}}
+			},
+			func(o *gwv1.GRPCRoute) gwv1.RouteStatus { return o.Status.RouteStatus },
+			func(o *gwv1.GRPCRoute) []gwv1.ParentReference { return o.Spec.ParentRefs },
+		))
 
 	// One writer per served version. A version we do not watch produces no objects, so it
 	// never appears as an enqueued GVK and needs no writer; that is why this iterates the
@@ -87,7 +89,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 		switch gvr {
 		case wellknown.TCPRouteV1GVR:
 			registerStatusWriter(s.statusWriters, wellknown.TCPRouteV1GVK,
-				routeWriter[*gwv1a2.TCPRoute, *gwv1.TCPRoute](cl, f, s.commonCols.RawTCPRoutes, tcpRouteReports, wellknown.TCPRouteV1GVK, "tcpRoute", gvr, wellknown.TCPRouteKind, controllerName,
+				routeWriter(cl, f, s.commonCols.RawTCPRoutes, tcpRouteReports, wellknown.TCPRouteV1GVK, gvr, controllerName,
 					func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.TCPRoute {
 						return &gwv1.TCPRoute{ObjectMeta: om, Status: gwv1.TCPRouteStatus{RouteStatus: st}}
 					},
@@ -95,7 +97,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 				))
 		default:
 			registerStatusWriter(s.statusWriters, wellknown.TCPRouteGVK,
-				routeWriter[*gwv1a2.TCPRoute, *gwv1a2.TCPRoute](cl, f, s.commonCols.RawTCPRoutes, tcpRouteReports, wellknown.TCPRouteGVK, "tcpRoute", gvr, wellknown.TCPRouteKind, controllerName,
+				routeWriter(cl, f, s.commonCols.RawTCPRoutes, tcpRouteReports, wellknown.TCPRouteGVK, gvr, controllerName,
 					func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1a2.TCPRoute {
 						return &gwv1a2.TCPRoute{ObjectMeta: om, Status: gwv1a2.TCPRouteStatus{RouteStatus: st}}
 					},
@@ -110,7 +112,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 		switch gvr {
 		case wellknown.TLSRouteV1GVR:
 			registerStatusWriter(s.statusWriters, wellknown.TLSRouteV1GVK,
-				routeWriter[*gwv1a2.TLSRoute, *gwv1.TLSRoute](cl, f, s.commonCols.RawTLSRoutes, tlsRouteReports, wellknown.TLSRouteV1GVK, "tlsRoute", gvr, wellknown.TLSRouteKind, controllerName,
+				routeWriter[*gwv1a2.TLSRoute, *gwv1.TLSRoute](cl, f, s.commonCols.RawTLSRoutes, tlsRouteReports, wellknown.TLSRouteV1GVK, gvr, controllerName,
 					func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.TLSRoute {
 						return &gwv1.TLSRoute{ObjectMeta: om, Status: gwv1.TLSRouteStatus{RouteStatus: st}}
 					},
@@ -118,7 +120,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 				))
 		case wellknown.TLSRouteV1Alpha3GVR:
 			registerStatusWriter(s.statusWriters, wellknown.TLSRouteV1Alpha3GVK,
-				routeWriter[*gwv1a2.TLSRoute, *gwv1a3.TLSRoute](cl, f, s.commonCols.RawTLSRoutes, tlsRouteReports, wellknown.TLSRouteV1Alpha3GVK, "tlsRoute", gvr, wellknown.TLSRouteKind, controllerName,
+				routeWriter(cl, f, s.commonCols.RawTLSRoutes, tlsRouteReports, wellknown.TLSRouteV1Alpha3GVK, gvr, controllerName,
 					func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1a3.TLSRoute {
 						return &gwv1a3.TLSRoute{ObjectMeta: om, Status: gwv1.TLSRouteStatus{RouteStatus: st}}
 					},
@@ -126,7 +128,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 				))
 		default:
 			registerStatusWriter(s.statusWriters, wellknown.TLSRouteGVK,
-				routeWriter[*gwv1a2.TLSRoute, *gwv1a2.TLSRoute](cl, f, s.commonCols.RawTLSRoutes, tlsRouteReports, wellknown.TLSRouteGVK, "tlsRoute", gvr, wellknown.TLSRouteKind, controllerName,
+				routeWriter(cl, f, s.commonCols.RawTLSRoutes, tlsRouteReports, wellknown.TLSRouteGVK, gvr, controllerName,
 					func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1a2.TLSRoute {
 						return &gwv1a2.TLSRoute{ObjectMeta: om, Status: gwv1a2.TLSRouteStatus{RouteStatus: st}}
 					},
@@ -142,10 +144,12 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 	listenerSetReports := statussync.RegisterKindByObjectGVK(s.statusCollections, wellknown.ListenerSetGVK,
 		s.commonCols.RawListenerSets, s.statusContributions, contributionsByTarget,
 		krtopts.ToOptions("ListenerSetStatusReports")...)
-	s.statusWriters[wellknown.ListenerSetGVK] = listenerSetWriter(cl, f, s.commonCols.RawListenerSets, listenerSetReports)
+	registerStatusWriter(s.statusWriters, wellknown.ListenerSetGVK,
+		listenerSetWriter(cl, f, s.commonCols.RawListenerSets, listenerSetReports))
 	// ON_EXPERIMENTAL_PROMOTION : Remove this registration together with xlistenerset_status.go.
 	// Ref: https://github.com/kgateway-dev/kgateway/issues/12827
-	s.statusWriters[wellknown.XListenerSetGVK] = xListenerSetWriter(cl, s.commonCols.RawListenerSets, listenerSetReports)
+	registerStatusWriter(s.statusWriters, wellknown.XListenerSetGVK,
+		xListenerSetWriter(cl, s.commonCols.RawListenerSets, listenerSetReports))
 
 	backendPlugin, hasBackendPlugin := s.plugins.ContributesBackends[wellknown.BackendGVK.GroupKind()]
 	var backendReports krt.Collection[statussync.ResourceReports]
@@ -160,7 +164,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 		logger.Error("backend plugin is missing RawBackends; Backend status reconciliation is disabled",
 			"group_kind", wellknown.BackendGVK.GroupKind().String())
 	}
-	s.statusWriters[wellknown.BackendGVK] = statussync.Writer[*kgateway.Backend, kgateway.BackendStatus]{
+	registerStatusWriter(s.statusWriters, wellknown.BackendGVK, statussync.Writer[*kgateway.Backend, kgateway.BackendStatus]{
 		Name:    "backend",
 		Current: statussync.CollectionSource(backendPlugin.RawBackends),
 		Desired: func(res statussync.Resource, be *kgateway.Backend) (kgateway.BackendStatus, bool) {
@@ -181,7 +185,7 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 			}),
 		GetStatus: func(o *kgateway.Backend) kgateway.BackendStatus { return o.Status },
 		OnSync:    simpleStatusMetricsHook[*kgateway.Backend, kgateway.BackendStatus]("BackendStatusSyncer", wellknown.BackendGVK.Kind),
-	}
+	})
 
 	policyStatusInputs := plug.PolicyStatusInputs{
 		Collections:           s.statusCollections,
@@ -209,6 +213,11 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 // a second registration means two plugins both claim to persist that resource's status,
 // and whichever registered last would silently win. Keep the first and report the conflict
 // rather than letting registration order decide who writes status.
+//
+// Every registration goes through here, including the built-in kinds above. A guard that
+// half the entries bypass is worse than no guard: the built-in kinds are exactly the ones a
+// plugin is most likely to collide with, and assigning into the map directly is what made
+// that collision silent.
 func registerStatusWriter(
 	writers map[schema.GroupVersionKind]statussync.ResourceStatusSyncer,
 	gvk schema.GroupVersionKind,
@@ -254,7 +263,7 @@ func gatewayWriter(
 			}),
 		GetStatus: func(o *gwv1.Gateway) gwv1.GatewayStatus { return o.Status },
 		Merge:     mergeGatewayStatusAddresses,
-		OnSync:    gatewayStatusMetricsHook(),
+		OnSync:    gatewayStatusOnSync,
 	}
 }
 
@@ -264,22 +273,24 @@ func gatewayWriter(
 // R is the type the route collection holds and W the type its status is written back as.
 // They differ for TCP and TLS routes, whose collections are normalized to one Go type while
 // the write must go through the API version the object is actually served as.
+//
+// gvk is the identity this writer is registered under; the writer's log name and its metric
+// resource type are both derived from it rather than passed alongside it, so a caller cannot
+// spell the same kind three ways in one call.
 func routeWriter[R, W controllers.ComparableObject](
 	cl apiclient.Client,
 	f kclient.Filter,
 	routes krt.Collection[R],
 	reportCol krt.Collection[statussync.ResourceReports],
 	gvk schema.GroupVersionKind,
-	name string,
 	gvr schema.GroupVersionResource,
-	kind string,
 	controllerName string,
 	build func(om metav1.ObjectMeta, st gwv1.RouteStatus) W,
 	getStatus func(R) gwv1.RouteStatus,
 	parentRefs func(R) []gwv1.ParentReference,
 ) statussync.Writer[R, gwv1.RouteStatus] {
 	return statussync.Writer[R, gwv1.RouteStatus]{
-		Name:    name,
+		Name:    gvk.Kind,
 		Current: statussync.CollectionSource(routes),
 		UpdateStatus: statussync.ClientWriter(
 			kclient.NewFilteredDelayed[W](cl, gvr, f), build),
@@ -315,7 +326,7 @@ func routeWriter[R, W controllers.ComparableObject](
 			desired.Parents = statussync.MergeRouteParentStatuses(controllerName, getStatus(current).Parents, desired.Parents)
 			return desired
 		},
-		OnSync: routeStatusMetricsHook(kind, controllerName, parentRefs),
+		OnSync: routeStatusMetricsHook(gvk.Kind, controllerName, parentRefs),
 	}
 }
 
@@ -361,24 +372,24 @@ var (
 	}
 )
 
-// gatewayStatusMetricsHook records status sync metrics for Gateways, deriving an error
+// gatewayStatusOnSync records status sync metrics for Gateways, deriving an error
 // result from invalid Accepted/Programmed condition reasons like the previous syncer did.
-func gatewayStatusMetricsHook() func(res statussync.Resource, current *gwv1.Gateway, status gwv1.GatewayStatus, took time.Duration, err error) {
-	return func(res statussync.Resource, current *gwv1.Gateway, status gwv1.GatewayStatus, took time.Duration, err error) {
-		statusErr := statussync.ConditionError(err, status.Conditions,
-			gatewayConditionTypes, gatewayAcceptedReasons, "invalid gateway condition")
-		statussync.RecordStatusSync(statussync.SyncMetricLabels{
+func gatewayStatusOnSync(res statussync.Resource, _ *gwv1.Gateway, status gwv1.GatewayStatus, took time.Duration, err error) {
+	statusErr := statussync.ConditionError(err, status.Conditions,
+		gatewayConditionTypes, gatewayAcceptedReasons, "invalid gateway condition")
+	statussync.RecordStatusSyncOutcome(
+		statussync.SyncMetricLabels{
 			Name:      res.Name,
 			Namespace: res.Namespace,
 			Syncer:    "GatewayStatusSyncer",
-		}, took, statusErr)
-		statussync.EndResourceStatusSyncOnWriteSuccess(err, kmetrics.ResourceSyncDetails{
+		},
+		kmetrics.ResourceSyncDetails{
 			Namespace:    res.Namespace,
 			Gateway:      res.Name,
 			ResourceType: wellknown.GatewayKind,
 			ResourceName: res.Name,
-		})
-	}
+		},
+		took, err, statusErr)
 }
 
 // routeStatusMetricsHook records per-parent-gateway status sync metrics for routes,
@@ -428,17 +439,19 @@ func routeStatusMetricsHook[T controllers.ComparableObject](
 		}
 		for _, pr := range parentRefs(current) {
 			gwName := string(pr.Name)
-			statussync.RecordStatusSync(statussync.SyncMetricLabels{
-				Name:      gwName,
-				Namespace: res.Namespace,
-				Syncer:    "RouteStatusSyncer",
-			}, took, errors.Join(err, statusErrByGateway[gwName]))
-			statussync.EndResourceStatusSyncOnWriteSuccess(err, kmetrics.ResourceSyncDetails{
-				Namespace:    res.Namespace,
-				Gateway:      gwName,
-				ResourceType: kind,
-				ResourceName: res.Name,
-			})
+			statussync.RecordStatusSyncOutcome(
+				statussync.SyncMetricLabels{
+					Name:      gwName,
+					Namespace: res.Namespace,
+					Syncer:    "RouteStatusSyncer",
+				},
+				kmetrics.ResourceSyncDetails{
+					Namespace:    res.Namespace,
+					Gateway:      gwName,
+					ResourceType: kind,
+					ResourceName: res.Name,
+				},
+				took, err, errors.Join(err, statusErrByGateway[gwName]))
 		}
 	}
 }
@@ -446,18 +459,20 @@ func routeStatusMetricsHook[T controllers.ComparableObject](
 // simpleStatusMetricsHook records status sync metrics keyed by the resource itself
 // (used for kinds that are not parented by a Gateway).
 func simpleStatusMetricsHook[T controllers.ComparableObject, S any](syncer, kind string) func(res statussync.Resource, current T, status S, took time.Duration, err error) {
-	return func(res statussync.Resource, current T, status S, took time.Duration, err error) {
-		statussync.RecordStatusSync(statussync.SyncMetricLabels{
-			Name:      res.Name,
-			Namespace: res.Namespace,
-			Syncer:    syncer,
-		}, took, err)
-		statussync.EndResourceStatusSyncOnWriteSuccess(err, kmetrics.ResourceSyncDetails{
-			Namespace:    res.Namespace,
-			Gateway:      "",
-			ResourceType: kind,
-			ResourceName: res.Name,
-		})
+	return func(res statussync.Resource, _ T, _ S, took time.Duration, err error) {
+		statussync.RecordStatusSyncOutcome(
+			statussync.SyncMetricLabels{
+				Name:      res.Name,
+				Namespace: res.Namespace,
+				Syncer:    syncer,
+			},
+			kmetrics.ResourceSyncDetails{
+				Namespace:    res.Namespace,
+				Gateway:      "",
+				ResourceType: kind,
+				ResourceName: res.Name,
+			},
+			took, err, err)
 	}
 }
 
@@ -483,7 +498,7 @@ func listenerSetWriter(
 				return &gwv1.ListenerSet{ObjectMeta: om, Status: st}
 			}),
 		GetStatus: func(o *gwv1.ListenerSet) gwv1.ListenerSetStatus { return o.Status },
-		OnSync:    listenerSetStatusMetricsHook(),
+		OnSync:    listenerSetStatusOnSync,
 	}
 }
 
@@ -510,23 +525,23 @@ func listenerSetDesired(
 	}
 }
 
-// listenerSetStatusMetricsHook records status sync metrics for either ListenerSet flavor,
+// listenerSetStatusOnSync records status sync metrics for either ListenerSet flavor,
 // deriving an error result from invalid Accepted/Programmed condition reasons like the
 // previous syncer did.
-func listenerSetStatusMetricsHook() func(res statussync.Resource, current *gwv1.ListenerSet, status gwv1.ListenerSetStatus, took time.Duration, err error) {
-	return func(res statussync.Resource, current *gwv1.ListenerSet, status gwv1.ListenerSetStatus, took time.Duration, err error) {
-		statusErr := statussync.ConditionError(err, status.Conditions,
-			listenerSetConditionTypes, listenerSetAcceptedReasons, "invalid listener condition")
-		parentName := ""
-		if !controllers.IsNil(current) {
-			parentName = string(current.Spec.ParentRef.Name)
-		}
-		statussync.RecordStatusSync(statussync.SyncMetricLabels{
+func listenerSetStatusOnSync(res statussync.Resource, current *gwv1.ListenerSet, status gwv1.ListenerSetStatus, took time.Duration, err error) {
+	statusErr := statussync.ConditionError(err, status.Conditions,
+		listenerSetConditionTypes, listenerSetAcceptedReasons, "invalid listener condition")
+	parentName := ""
+	if !controllers.IsNil(current) {
+		parentName = string(current.Spec.ParentRef.Name)
+	}
+	statussync.RecordStatusSyncOutcome(
+		statussync.SyncMetricLabels{
 			Name:      parentName,
 			Namespace: res.Namespace,
 			Syncer:    "ListenerSetStatusSyncer",
-		}, took, statusErr)
-		statussync.EndResourceStatusSyncOnWriteSuccess(err, kmetrics.ResourceSyncDetails{
+		},
+		kmetrics.ResourceSyncDetails{
 			Namespace: res.Namespace,
 			Gateway:   parentName,
 			// Promoted ListenerSets and legacy XListenerSets are deliberately one metric
@@ -538,6 +553,6 @@ func listenerSetStatusMetricsHook() func(res statussync.Resource, current *gwv1.
 			// coordinated rename.
 			ResourceType: "XListenerSet",
 			ResourceName: res.Name,
-		})
-	}
+		},
+		took, err, statusErr)
 }

--- a/pkg/kgateway/proxy_syncer/status_contributions.go
+++ b/pkg/kgateway/proxy_syncer/status_contributions.go
@@ -13,12 +13,20 @@ import (
 	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
 )
 
+// gatewayStatusContributions unpacks the status half of each Gateway translation.
+//
+// It reads gatewayTranslationOutput directly rather than an intermediate collection of
+// GatewayStatusSnapshot. That collection was a pure projection, so its only effect was to run
+// GatewayStatusSnapshot.Equals -- a deep walk of every contribution of every route on the
+// Gateway -- a second time per translation, on top of the one gatewayTranslationOutput.Equals
+// already does. Contributions are still compared individually downstream, so status-only and
+// xDS-only changes stay as isolated from each other as before.
 func gatewayStatusContributions(
-	snapshots krt.Collection[GatewayStatusSnapshot],
+	outputs krt.Collection[gatewayTranslationOutput],
 	krtopts krtutil.KrtOptions,
 ) krt.Collection[reports.StatusContribution] {
-	return krt.NewManyCollection(snapshots, func(_ krt.HandlerContext, snapshot GatewayStatusSnapshot) []reports.StatusContribution {
-		return snapshot.Contributions
+	return krt.NewManyCollection(outputs, func(_ krt.HandlerContext, output gatewayTranslationOutput) []reports.StatusContribution {
+		return output.Status.Contributions
 	}, krtopts.ToOptions("GatewayStatusContributions")...)
 }
 

--- a/pkg/kgateway/proxy_syncer/status_cycle_test.go
+++ b/pkg/kgateway/proxy_syncer/status_cycle_test.go
@@ -292,7 +292,7 @@ func newStatusCycleFixture(t *testing.T) statusCycleFixture {
 		gatewayWriter:     gatewayWriter(c, f, gateways, gatewayReports),
 		listenerSetWriter: listenerSetWriter(c, f, listenerSets, listenerSetReports),
 		routeWriter: routeWriter[*gwv1.HTTPRoute, *gwv1.HTTPRoute](c, f, routes, routeReports,
-			wellknown.HTTPRouteGVK, "httpRoute", wellknown.HTTPRouteGVR, wellknown.HTTPRouteKind, cycleController,
+			wellknown.HTTPRouteGVK, wellknown.HTTPRouteGVR, cycleController,
 			func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.HTTPRoute {
 				return &gwv1.HTTPRoute{ObjectMeta: om, Status: gwv1.HTTPRouteStatus{RouteStatus: st}}
 			},

--- a/pkg/kgateway/proxy_syncer/status_cycle_test.go
+++ b/pkg/kgateway/proxy_syncer/status_cycle_test.go
@@ -474,27 +474,27 @@ func TestStatusWritersConvergeAfterOneWrite(t *testing.T) {
 func TestStatusWritersAreIdempotent(t *testing.T) {
 	f := newStatusCycleFixture(t)
 
-	require.True(t, statussync.WriterWouldWrite(f.gatewayWriter, f.liveGateway(t)),
+	require.True(t, statussync.WriterWouldWrite(f.gatewayWriter, gatewayResource(), f.liveGateway(t)),
 		"the seeded gateway status must actually be written, or the check below proves nothing")
-	require.NoError(t, statussync.CheckWriterIdempotent(f.gatewayWriter, f.liveGateway(t),
+	require.NoError(t, statussync.CheckWriterIdempotent(f.gatewayWriter, gatewayResource(), f.liveGateway(t),
 		func(current *gwv1.Gateway, status gwv1.GatewayStatus) *gwv1.Gateway {
 			next := current.DeepCopy()
 			next.Status = *status.DeepCopy()
 			return next
 		}))
 
-	require.True(t, statussync.WriterWouldWrite(f.routeWriter, f.liveRoute(t)),
+	require.True(t, statussync.WriterWouldWrite(f.routeWriter, routeResource(), f.liveRoute(t)),
 		"the seeded route status must actually be written, or the check below proves nothing")
-	require.NoError(t, statussync.CheckWriterIdempotent(f.routeWriter, f.liveRoute(t),
+	require.NoError(t, statussync.CheckWriterIdempotent(f.routeWriter, routeResource(), f.liveRoute(t),
 		func(current *gwv1.HTTPRoute, status gwv1.RouteStatus) *gwv1.HTTPRoute {
 			next := current.DeepCopy()
 			next.Status.RouteStatus = *status.DeepCopy()
 			return next
 		}))
 
-	require.True(t, statussync.WriterWouldWrite(f.listenerSetWriter, f.liveListenerSet(t)),
+	require.True(t, statussync.WriterWouldWrite(f.listenerSetWriter, listenerSetResource(), f.liveListenerSet(t)),
 		"the seeded listener set status must actually be written, or the check below proves nothing")
-	require.NoError(t, statussync.CheckWriterIdempotent(f.listenerSetWriter, f.liveListenerSet(t),
+	require.NoError(t, statussync.CheckWriterIdempotent(f.listenerSetWriter, listenerSetResource(), f.liveListenerSet(t),
 		func(current *gwv1.ListenerSet, status gwv1.ListenerSetStatus) *gwv1.ListenerSet {
 			next := current.DeepCopy()
 			next.Status = *status.DeepCopy()

--- a/pkg/kgateway/proxy_syncer/status_syncer.go
+++ b/pkg/kgateway/proxy_syncer/status_syncer.go
@@ -68,7 +68,7 @@ func NewStatusSyncer(cfg StatusSyncerConfig, opts ...StatusSyncerOption) *Status
 	// once. It re-reads its registration set on every call, so it already covers the reducers
 	// the registrations below add and must not be appended again here.
 	for _, register := range optCfg.statusRegistrations {
-		register(StatusRegistrationInputs{
+		register(statussync.RegistrationInputs{
 			Collections:           syncer.statusCollections,
 			StatusContributions:   cfg.StatusContributions,
 			ContributionsByTarget: cfg.StatusContributionsByTarget,

--- a/pkg/kgateway/proxy_syncer/xlistenerset_status.go
+++ b/pkg/kgateway/proxy_syncer/xlistenerset_status.go
@@ -44,7 +44,7 @@ func xListenerSetWriter(
 		Desired:      listenerSetDesired(reportCol),
 		UpdateStatus: patchXListenerSetStatus(cl, source),
 		GetStatus:    func(o *gwv1.ListenerSet) gwv1.ListenerSetStatus { return o.Status },
-		OnSync:       listenerSetStatusMetricsHook(),
+		OnSync:       listenerSetStatusOnSync,
 	}
 }
 

--- a/pkg/kgateway/proxy_syncer/xlistenerset_status.go
+++ b/pkg/kgateway/proxy_syncer/xlistenerset_status.go
@@ -23,45 +23,34 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 )
 
-// xListenerSetStatusSyncer is the status writer registered for the legacy experimental
-// XListenerSet GVK. Reads are identical to the promoted ListenerSet writer -- same
-// normalized collection, same report reducer, same builder -- and only the write differs:
-// the legacy CRD is served under its own GVR and its schema still requires a per-listener
-// port that gwv1.ListenerSetStatus no longer carries, so it goes out as a dynamic merge
-// patch rather than a typed UpdateStatus.
+// xListenerSetWriter is the status writer registered for the legacy experimental XListenerSet
+// GVK. Reads are identical to the promoted ListenerSet writer -- same normalized collection,
+// same report reducer, same builder -- and only the write differs: the legacy CRD is served
+// under its own GVR and its schema still requires a per-listener port that
+// gwv1.ListenerSetStatus no longer carries, so it goes out as a dynamic merge patch rather
+// than a typed UpdateStatus.
 //
-// It exists only to hold the context: the writer it delegates to is a plain
-// statussync.Writer, but Writer.UpdateStatus is handed an ObjectMeta and a status and
-// carries no context of its own, and the dynamic client needs one. Building the writer per
-// call is a handful of closures on a path that only runs for legacy objects.
-type xListenerSetStatusSyncer struct {
-	col     krt.Collection[*gwv1.ListenerSet]
-	client  apiclient.Client
-	reports krt.Collection[statussync.ResourceReports]
-}
-
-var _ statussync.ResourceStatusSyncer = &xListenerSetStatusSyncer{}
-
-func (s *xListenerSetStatusSyncer) ApplyStatus(ctx context.Context, res statussync.Resource) {
-	s.writer(ctx).ApplyStatus(ctx, res)
-}
-
-// writer is the legacy writer as the standard status pipeline sees it. Exposed as a method
-// so tests can assert the shared invariants on it -- CheckWriterIdempotent above all -- with
-// the same writer ApplyStatus runs.
-func (s *xListenerSetStatusSyncer) writer(ctx context.Context) statussync.Writer[*gwv1.ListenerSet, gwv1.ListenerSetStatus] {
+// That is the whole of the difference, so this is a plain statussync.Writer like every other
+// kind rather than a bespoke ResourceStatusSyncer.
+func xListenerSetWriter(
+	cl apiclient.Client,
+	listenerSets krt.Collection[*gwv1.ListenerSet],
+	reportCol krt.Collection[statussync.ResourceReports],
+) statussync.Writer[*gwv1.ListenerSet, gwv1.ListenerSetStatus] {
+	source := statussync.CollectionSource(listenerSets)
 	return statussync.Writer[*gwv1.ListenerSet, gwv1.ListenerSetStatus]{
 		Name:         "xListenerSet",
-		Current:      statussync.CollectionSource(s.col),
-		Desired:      listenerSetDesired(wellknown.XListenerSetGVK, s.reports),
-		UpdateStatus: s.patchStatus(ctx),
+		Current:      source,
+		Desired:      listenerSetDesired(reportCol),
+		UpdateStatus: patchXListenerSetStatus(cl, source),
 		GetStatus:    func(o *gwv1.ListenerSet) gwv1.ListenerSetStatus { return o.Status },
 		OnSync:       listenerSetStatusMetricsHook(),
 	}
 }
 
-// patchStatus merge-patches the status subresource of a legacy XListenerSet through the
-// dynamic client, injecting the per-listener port required by the legacy CRD schema.
+// patchXListenerSetStatus merge-patches the status subresource of a legacy XListenerSet
+// through the dynamic client, injecting the per-listener port required by the legacy CRD
+// schema.
 //
 // The patch body carries metadata.resourceVersion so the API server rejects the write when
 // the object has moved on, matching the optimistic concurrency the promoted path gets from
@@ -69,23 +58,31 @@ func (s *xListenerSetStatusSyncer) writer(ctx context.Context) statussync.Writer
 // stale read silently overwrites a newer one and nothing re-enqueues to correct it.
 //
 // The spec listeners the ports come from are re-read here rather than threaded through the
-// status, because there is no field of gwv1.ListenerSetStatus to thread them through. It is
-// the same collection Writer.Current reads, so the only way the read comes back empty is
-// that the object was deleted mid-write; the patch would then be rejected anyway, and
-// stamping every listener with the fallback port is a worse guess than not writing.
-func (s *xListenerSetStatusSyncer) patchStatus(ctx context.Context) func(metav1.ObjectMeta, gwv1.ListenerSetStatus) error {
-	return func(om metav1.ObjectMeta, desired gwv1.ListenerSetStatus) error {
-		current := s.col.GetKey(om.Namespace + "/" + om.Name)
-		if current == nil || *current == nil {
+// status, because there is no field of gwv1.ListenerSetStatus to thread them through. current
+// is the writer's own Writer.Current, so this cannot read a different collection than the
+// writer that drives it; the only way the read comes back empty is that the object was
+// deleted mid-write. The patch would then be rejected anyway, and stamping every listener
+// with the fallback port is a worse guess than not writing.
+func patchXListenerSetStatus(
+	cl apiclient.Client,
+	current func(statussync.Resource) *gwv1.ListenerSet,
+) func(context.Context, metav1.ObjectMeta, gwv1.ListenerSetStatus) error {
+	return func(ctx context.Context, om metav1.ObjectMeta, desired gwv1.ListenerSetStatus) error {
+		res := statussync.Resource{
+			GroupVersionKind: wellknown.XListenerSetGVK,
+			NamespacedName:   types.NamespacedName{Namespace: om.Namespace, Name: om.Name},
+		}
+		live := current(res)
+		if live == nil {
 			logger.Debug("legacy listener set no longer present, skipping status update",
-				"resource", om.Namespace+"/"+om.Name)
+				"namespace", om.Namespace, "name", om.Name)
 			return nil
 		}
 		statusMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&desired)
 		if err != nil {
 			return err
 		}
-		injectListenerPorts(statusMap, (*current).Spec.Listeners)
+		injectListenerPorts(statusMap, live.Spec.Listeners)
 		data, err := json.Marshal(map[string]any{
 			"metadata": map[string]any{"resourceVersion": om.ResourceVersion},
 			"status":   statusMap,
@@ -96,7 +93,7 @@ func (s *xListenerSetStatusSyncer) patchStatus(ctx context.Context) func(metav1.
 		// Conflicts and NotFound are not handled here: Writer.ApplyStatus recognizes both and
 		// skips the write, since the raw collection re-enqueues once the informer delivers the
 		// newer object.
-		_, err = s.client.Dynamic().Resource(wellknown.XListenerSetGVR).Namespace(om.Namespace).
+		_, err = cl.Dynamic().Resource(wellknown.XListenerSetGVR).Namespace(om.Namespace).
 			Patch(ctx, om.Name, types.MergePatchType, data, metav1.PatchOptions{}, "status")
 		return err
 	}

--- a/pkg/kgateway/proxy_syncer/xlistenerset_status_test.go
+++ b/pkg/kgateway/proxy_syncer/xlistenerset_status_test.go
@@ -57,7 +57,7 @@ func legacyListenerSet() *gwv1.ListenerSet {
 }
 
 type xListenerSetFixture struct {
-	syncer  *xListenerSetStatusSyncer
+	writer  statussync.Writer[*gwv1.ListenerSet, gwv1.ListenerSetStatus]
 	objects krt.StaticCollection[*gwv1.ListenerSet]
 	dynamic *dynamicfake.FakeDynamicClient
 	res     statussync.Resource
@@ -86,11 +86,7 @@ func newXListenerSetFixture(t *testing.T, ls *gwv1.ListenerSet) xListenerSetFixt
 
 	c := apifake.NewClient(t)
 	return xListenerSetFixture{
-		syncer: &xListenerSetStatusSyncer{
-			col:     objects,
-			client:  c,
-			reports: reportCol,
-		},
+		writer:  xListenerSetWriter(c, objects, reportCol),
 		objects: objects,
 		dynamic: c.Dynamic().(*dynamicfake.FakeDynamicClient),
 		res: statussync.Resource{
@@ -101,7 +97,7 @@ func newXListenerSetFixture(t *testing.T, ls *gwv1.ListenerSet) xListenerSetFixt
 }
 
 func (f xListenerSetFixture) apply() {
-	f.syncer.ApplyStatus(context.Background(), f.res)
+	f.writer.ApplyStatus(context.Background(), f.res)
 }
 
 // statusPatches returns the bodies of the status merge patches sent to the legacy GVR.
@@ -164,11 +160,9 @@ func TestXListenerSetStatusPatchPayload(t *testing.T) {
 func TestXListenerSetWriterIsIdempotent(t *testing.T) {
 	ls := legacyListenerSet()
 	f := newXListenerSetFixture(t, ls)
-	w := f.syncer.writer(context.Background())
-
-	require.True(t, statussync.WriterWouldWrite(w, ls),
+	require.True(t, statussync.WriterWouldWrite(f.writer, f.res, ls),
 		"the seeded legacy status must actually be written, or the check below proves nothing")
-	require.NoError(t, statussync.CheckWriterIdempotent(w, ls,
+	require.NoError(t, statussync.CheckWriterIdempotent(f.writer, f.res, ls,
 		func(current *gwv1.ListenerSet, status gwv1.ListenerSetStatus) *gwv1.ListenerSet {
 			next := current.DeepCopy()
 			next.Status = *status.DeepCopy()
@@ -187,7 +181,7 @@ func TestXListenerSetStatusSkipsNoOpPatch(t *testing.T) {
 	require.Len(t, f.statusPatches(), 1, "the stale status must be corrected in one patch")
 
 	// Echo our own write back into the collection the writer reads, as the informer would.
-	published, ok := f.syncer.writer(context.Background()).Desired(ls)
+	published, ok := f.writer.Desired(f.res, ls)
 	require.True(t, ok, "the writer must have a status for the seeded listener set")
 	echoed := ls.DeepCopy()
 	echoed.Status = published

--- a/pkg/pluginsdk/collections/route_version.go
+++ b/pkg/pluginsdk/collections/route_version.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/sleep"
 	"istio.io/istio/pkg/util/sets"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -18,9 +19,31 @@ import (
 	"k8s.io/client-go/discovery"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 )
 
 var logger = logging.New("pluginsdk/collections")
+
+// joinRouteCollections combines the per-version collections of one route kind into the single
+// normalized collection the rest of the control plane consumes.
+//
+// A kind with no served version we watch still gets a collection -- an empty one -- so every
+// consumer can be wired unconditionally rather than nil-checked. A single version is returned
+// as-is: a join over one member is pure indirection on every lookup.
+func joinRouteCollections[T any](
+	cols []krt.Collection[T],
+	krtOpts krtutil.KrtOptions,
+	name string,
+) krt.Collection[T] {
+	switch len(cols) {
+	case 0:
+		return krt.NewStaticCollection[T](nil, nil, krtOpts.ToOptions("disable/"+name)...)
+	case 1:
+		return cols[0]
+	default:
+		return krt.JoinCollection(cols, krtOpts.ToOptions(name)...)
+	}
+}
 
 const (
 	// crdLookupTimeout bounds a single read of the served versions.

--- a/pkg/pluginsdk/collections/setup.go
+++ b/pkg/pluginsdk/collections/setup.go
@@ -145,15 +145,7 @@ func (c *CommonCollections) InitCollections(
 		}
 	}
 
-	var tcproutes krt.Collection[*gwv1a2.TCPRoute]
-	switch len(tcpRouteCollections) {
-	case 0:
-		tcproutes = krt.NewStaticCollection[*gwv1a2.TCPRoute](nil, nil, c.KrtOpts.ToOptions("disable/TCPRoute")...)
-	case 1:
-		tcproutes = tcpRouteCollections[0]
-	default:
-		tcproutes = krt.JoinCollection(tcpRouteCollections, c.KrtOpts.ToOptions("TCPRoute")...)
-	}
+	tcproutes := joinRouteCollections(tcpRouteCollections, c.KrtOpts, "TCPRoute")
 
 	// As for TCPRoute above: one selection drives both the watches and the status writers.
 	// TLSRoute is standard as of Gateway API v1.5; pre-v1 versions stay behind the
@@ -217,15 +209,8 @@ func (c *CommonCollections) InitCollections(
 		}
 	}
 
-	var tlsRoutes krt.Collection[*gwv1a2.TLSRoute]
-	switch len(tlsRouteCollections) {
-	case 0:
-		tlsRoutes = krt.NewStaticCollection[*gwv1a2.TLSRoute](nil, nil, c.KrtOpts.ToOptions("disable/TLSRoute")...)
-	case 1:
-		tlsRoutes = tlsRouteCollections[0]
-	default:
-		tlsRoutes = krt.JoinCollection(tlsRouteCollections, c.KrtOpts.ToOptions("TLSRoute")...)
-	}
+	tlsRoutes := joinRouteCollections(tlsRouteCollections, c.KrtOpts, "TLSRoute")
+
 	metrics.RegisterEvents(tcproutes, kmetrics.GetResourceMetricEventHandler[*gwv1a2.TCPRoute]())
 	metrics.RegisterEvents(tlsRoutes, kmetrics.GetResourceMetricEventHandler[*gwv1a2.TLSRoute]())
 

--- a/pkg/pluginsdk/collections/tcproute_version.go
+++ b/pkg/pluginsdk/collections/tcproute_version.go
@@ -46,13 +46,28 @@ func convertTCPRouteV1ToV1Alpha2(in *gwv1.TCPRoute) *gwv1a2.TCPRoute {
 }
 
 func convertTCPRouteRulesV1ToV1Alpha2(in []gwv1.TCPRouteRule) []gwv1a2.TCPRouteRule {
+	return convertRouteSliceElems(in, func(r gwv1.TCPRouteRule) gwv1a2.TCPRouteRule {
+		return gwv1a2.TCPRouteRule(r)
+	})
+}
+
+// convertRouteSliceElems converts a slice of route spec elements to the identically-shaped
+// alpha type. Go has no conversion between slices of distinct element types, so every one of
+// these conversions is element-wise; this holds the part of that which is easy to get wrong.
+//
+// Empty input converts to nil, whether it arrived as nil or as a non-nil empty slice: the
+// two are canonicalized to one. That is what each of the per-kind helpers folded in here
+// already did, so it is preserved rather than chosen. It is also why this does not use
+// slices.Map, which returns a non-nil empty slice for empty input — switching would flip the
+// normalized Spec of every route that carries no rules or hostnames, which is a behavior
+// change unrelated to deduplicating these conversions.
+func convertRouteSliceElems[In, Out any](in []In, convert func(In) Out) []Out {
 	if len(in) == 0 {
 		return nil
 	}
-
-	out := make([]gwv1a2.TCPRouteRule, 0, len(in))
-	for _, rule := range in {
-		out = append(out, gwv1a2.TCPRouteRule(rule))
+	out := make([]Out, 0, len(in))
+	for _, e := range in {
+		out = append(out, convert(e))
 	}
 	return out
 }

--- a/pkg/pluginsdk/collections/tlsroute_version.go
+++ b/pkg/pluginsdk/collections/tlsroute_version.go
@@ -50,52 +50,29 @@ func convertTLSRouteV1ToV1Alpha2(in *gwv1.TLSRoute) *gwv1a2.TLSRoute {
 	}
 }
 
+// convertTLSRouteV1Alpha3ToV1Alpha2 normalizes a v1alpha3 TLSRoute. gwv1a3.TLSRoute is
+// declared as `type TLSRoute v1.TLSRoute`, so the two differ only in the API version they are
+// served under -- which is exactly the one field the conversion stamps. Spelling the field
+// copies out a second time would just be two Spec blocks to keep in sync.
 func convertTLSRouteV1Alpha3ToV1Alpha2(in *gwv1a3.TLSRoute) *gwv1a2.TLSRoute {
 	if in == nil {
 		return nil
 	}
 
-	return &gwv1a2.TLSRoute{
-		// See convertTLSRouteV1ToV1Alpha2: the served API version is preserved.
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: gwv1a3.GroupVersion.String(),
-			Kind:       wellknown.TLSRouteKind,
-		},
-		ObjectMeta: *in.ObjectMeta.DeepCopy(),
-		Spec: gwv1a2.TLSRouteSpec{
-			CommonRouteSpec: gwv1a2.CommonRouteSpec{
-				ParentRefs:         in.Spec.ParentRefs,
-				UseDefaultGateways: in.Spec.UseDefaultGateways,
-			},
-			Hostnames: convertTLSRouteHostnamesV1ToV1Alpha2(in.Spec.Hostnames),
-			Rules:     convertTLSRouteRulesV1ToV1Alpha2(in.Spec.Rules),
-		},
-		Status: gwv1a2.TLSRouteStatus{
-			RouteStatus: in.Status.RouteStatus,
-		},
-	}
+	out := convertTLSRouteV1ToV1Alpha2((*gwv1.TLSRoute)(in))
+	// See convertTLSRouteV1ToV1Alpha2: the served API version is preserved.
+	out.TypeMeta.APIVersion = gwv1a3.GroupVersion.String()
+	return out
 }
 
 func convertTLSRouteHostnamesV1ToV1Alpha2(in []gwv1.Hostname) []gwv1a2.Hostname {
-	if len(in) == 0 {
-		return nil
-	}
-
-	out := make([]gwv1a2.Hostname, 0, len(in))
-	for _, hostname := range in {
-		out = append(out, gwv1a2.Hostname(hostname))
-	}
-	return out
+	return convertRouteSliceElems(in, func(h gwv1.Hostname) gwv1a2.Hostname {
+		return gwv1a2.Hostname(h)
+	})
 }
 
 func convertTLSRouteRulesV1ToV1Alpha2(in []gwv1.TLSRouteRule) []gwv1a2.TLSRouteRule {
-	if len(in) == 0 {
-		return nil
-	}
-
-	out := make([]gwv1a2.TLSRouteRule, 0, len(in))
-	for _, rule := range in {
-		out = append(out, gwv1a2.TLSRouteRule(rule))
-	}
-	return out
+	return convertRouteSliceElems(in, func(r gwv1.TLSRouteRule) gwv1a2.TLSRouteRule {
+		return gwv1a2.TLSRouteRule(r)
+	})
 }

--- a/pkg/pluginsdk/statussync/collections.go
+++ b/pkg/pluginsdk/statussync/collections.go
@@ -12,7 +12,6 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/slices"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/logging"
 	"github.com/kgateway-dev/kgateway/v2/pkg/reports"
@@ -129,17 +128,20 @@ func NewResourceReports[I controllers.Object](
 // ReportFor looks up the current reduction for one status owner. Writers call it from
 // their Desired func to build status just in time from the latest KRT state.
 //
+// res is the identity Writer.Desired was handed, i.e. the one the resource was enqueued
+// under. Taking it whole rather than a separately-supplied GVK and name is what keeps a
+// writer from looking up a reduction filed under a different key than the queue dispatched on.
+//
 // The returned StatusReport contains pointers into KRT-owned retained state. Builders must
 // treat it as read-only, so later KRT equality checks continue to observe changes.
 func ReportFor(
 	col krt.Collection[ResourceReports],
-	gvk schema.GroupVersionKind,
-	nn types.NamespacedName,
+	res Resource,
 ) (reports.StatusReport, bool) {
 	if col == nil {
 		return reports.StatusReport{}, false
 	}
-	target := reports.StatusKey{GroupKind: gvk.GroupKind(), NamespacedName: nn}
+	target := reports.StatusKey{GroupKind: res.GroupKind(), NamespacedName: res.NamespacedName}
 	current := col.GetKey(target.String())
 	if current == nil {
 		return reports.StatusReport{}, false

--- a/pkg/pluginsdk/statussync/collections.go
+++ b/pkg/pluginsdk/statussync/collections.go
@@ -76,7 +76,7 @@ func RegisterKindByObjectGVK[I controllers.Object](
 ) krt.Collection[ResourceReports] {
 	return registerKind(s, objects, contributions, byTarget,
 		func(obj I) schema.GroupVersionKind { return objectGVKOrDefault(obj, fallback) },
-		func() { RegisterResourceByObjectGVK(s, fallback, objects) },
+		func() { registerResourceByObjectGVK(s, fallback, objects) },
 		opts...)
 }
 
@@ -215,9 +215,10 @@ func RegisterResource[I controllers.Object](
 	registerResource(s, col, func(I) schema.GroupVersionKind { return gvk })
 }
 
-// RegisterResourceByObjectGVK registers a normalized collection whose objects retain
+// registerResourceByObjectGVK registers a normalized collection whose objects retain
 // distinct source GVKs in TypeMeta, such as the combined ListenerSet/XListenerSet source.
-func RegisterResourceByObjectGVK[I controllers.Object](
+// Callers reach it through RegisterKindByObjectGVK, which wires the reducer alongside it.
+func registerResourceByObjectGVK[I controllers.Object](
 	s *StatusCollections,
 	fallback schema.GroupVersionKind,
 	col krt.Collection[I],

--- a/pkg/pluginsdk/statussync/collections_test.go
+++ b/pkg/pluginsdk/statussync/collections_test.go
@@ -97,7 +97,7 @@ func TestRegisterResourceByObjectGVKPreservesMixedSourceKinds(t *testing.T) {
 
 	sources := NewStatusCollections()
 	queue := &recordingQueue{}
-	RegisterResourceByObjectGVK(sources, fallback, col)
+	registerResourceByObjectGVK(sources, fallback, col)
 	sources.SetQueue(queue)
 
 	require.Equal(t, actual, queue.awaitResources(t, 1)[0].GroupVersionKind)

--- a/pkg/pluginsdk/statussync/idempotence.go
+++ b/pkg/pluginsdk/statussync/idempotence.go
@@ -16,11 +16,13 @@ type ApplyStatusFn[O controllers.ComparableObject, S any] func(current O, status
 // issuing one. CheckWriterIdempotent passes trivially for an object the writer declines to
 // write, so a test that means to exercise convergence should assert this first rather than
 // silently checking nothing.
-func WriterWouldWrite[O controllers.ComparableObject, S any](w Writer[O, S], current O) bool {
+// res must be the identity the writer is registered under, since that is what its Desired
+// keys its report lookup on.
+func WriterWouldWrite[O controllers.ComparableObject, S any](w Writer[O, S], res Resource, current O) bool {
 	if controllers.IsNil(current) {
 		return false
 	}
-	decision := w.decide(current)
+	decision := w.decide(res, current)
 	return decision.has && decision.write
 }
 
@@ -46,15 +48,18 @@ func WriterWouldWrite[O controllers.ComparableObject, S any](w Writer[O, S], cur
 // Every writer registered with the status pipeline should run this, including downstream
 // writers added via WithStatusRegistration — the invariant is a property of the pipeline,
 // not of the writers that shipped with it.
+// res must be the identity the writer is registered under, since that is what its Desired
+// keys its report lookup on.
 func CheckWriterIdempotent[O controllers.ComparableObject, S any](
 	w Writer[O, S],
+	res Resource,
 	current O,
 	apply ApplyStatusFn[O, S],
 ) error {
 	if controllers.IsNil(current) {
 		return fmt.Errorf("status writer %q: current object is nil, nothing to check", w.Name)
 	}
-	first := w.decide(current)
+	first := w.decide(res, current)
 	if !first.has || !first.write {
 		return nil
 	}
@@ -71,7 +76,7 @@ func CheckWriterIdempotent[O controllers.ComparableObject, S any](
 			w.Name, renderStatus(w.GetStatus(next)), renderStatus(first.status))
 	}
 
-	second := w.decide(next)
+	second := w.decide(res, next)
 	if !second.has || !second.write {
 		return nil
 	}

--- a/pkg/pluginsdk/statussync/idempotence_test.go
+++ b/pkg/pluginsdk/statussync/idempotence_test.go
@@ -8,8 +8,18 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+// testRoute is the identity the harness writers are notionally registered under. Their
+// Desired builders ignore it, but CheckWriterIdempotent needs the resource a real writer
+// would have been handed.
+var testRoute = Resource{
+	GroupVersionKind: schema.GroupVersionKind{Group: gwv1.GroupName, Version: "v1", Kind: "HTTPRoute"},
+	NamespacedName:   types.NamespacedName{Namespace: "default", Name: "route"},
+}
 
 // applyRouteStatus is the ApplyStatusFn for an HTTPRoute: it models what the API server
 // stores after a status write.
@@ -24,7 +34,7 @@ func applyRouteStatus(current *gwv1.HTTPRoute, status gwv1.RouteStatus) *gwv1.HT
 func routeWriterWithDesired(desired func(*gwv1.HTTPRoute) (gwv1.RouteStatus, bool)) Writer[*gwv1.HTTPRoute, gwv1.RouteStatus] {
 	return Writer[*gwv1.HTTPRoute, gwv1.RouteStatus]{
 		Name:      "httpRoute",
-		Desired:   desired,
+		Desired:   func(_ Resource, o *gwv1.HTTPRoute) (gwv1.RouteStatus, bool) { return desired(o) },
 		GetStatus: func(o *gwv1.HTTPRoute) gwv1.RouteStatus { return o.Status.RouteStatus },
 		Merge: func(current *gwv1.HTTPRoute, d gwv1.RouteStatus) gwv1.RouteStatus {
 			return gwv1.RouteStatus{Parents: MergeRouteParentStatuses(ourController, current.Status.Parents, d.Parents)}
@@ -74,7 +84,7 @@ func TestCheckWriterIdempotentAcceptsATimestampPreservingBuilder(t *testing.T) {
 	// once (the parent list is otherwise empty) and then settle.
 	current := routeWithParents()
 
-	require.NoError(t, CheckWriterIdempotent(writer, current, applyRouteStatus))
+	require.NoError(t, CheckWriterIdempotent(writer, testRoute, current, applyRouteStatus))
 }
 
 // The regression this harness exists for: a builder that stamps time.Now() unconditionally
@@ -89,7 +99,7 @@ func TestCheckWriterIdempotentRejectsRegeneratedTimestamps(t *testing.T) {
 		}}}, true
 	})
 
-	err := CheckWriterIdempotent(writer, routeWithParents(), applyRouteStatus)
+	err := CheckWriterIdempotent(writer, testRoute, routeWithParents(), applyRouteStatus)
 
 	require.ErrorContains(t, err, "not idempotent")
 }
@@ -100,7 +110,7 @@ func TestCheckWriterIdempotentRejectsRegeneratedTimestamps(t *testing.T) {
 func TestCheckWriterIdempotentRejectsUnstableForeignEntryOrder(t *testing.T) {
 	writer := Writer[*gwv1.HTTPRoute, gwv1.RouteStatus]{
 		Name: "httpRoute",
-		Desired: func(*gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
+		Desired: func(Resource, *gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
 			return gwv1.RouteStatus{Parents: []gwv1.RouteParentStatus{routeParent(ourController, "gw")}}, true
 		},
 		GetStatus: func(o *gwv1.HTTPRoute) gwv1.RouteStatus { return o.Status.RouteStatus },
@@ -117,7 +127,7 @@ func TestCheckWriterIdempotentRejectsUnstableForeignEntryOrder(t *testing.T) {
 		routeParent(otherController, "their-gw-b"),
 	)
 
-	err := CheckWriterIdempotent(writer, current, applyRouteStatus)
+	err := CheckWriterIdempotent(writer, testRoute, current, applyRouteStatus)
 
 	require.ErrorContains(t, err, "not idempotent")
 }
@@ -138,7 +148,7 @@ func TestCheckWriterIdempotentIgnoresWritersThatPublishNothing(t *testing.T) {
 	for name, writer := range tests {
 		t.Run(name, func(t *testing.T) {
 			current := routeWithParents(routeParent(ourController, "gw"))
-			require.NoError(t, CheckWriterIdempotent(writer, current, applyRouteStatus))
+			require.NoError(t, CheckWriterIdempotent(writer, testRoute, current, applyRouteStatus))
 		})
 	}
 }
@@ -150,7 +160,7 @@ func TestCheckWriterIdempotentRejectsAnApplyThatDropsTheStatus(t *testing.T) {
 		return gwv1.RouteStatus{Parents: []gwv1.RouteParentStatus{routeParent(ourController, "gw")}}, true
 	})
 
-	err := CheckWriterIdempotent(writer, routeWithParents(), func(current *gwv1.HTTPRoute, _ gwv1.RouteStatus) *gwv1.HTTPRoute {
+	err := CheckWriterIdempotent(writer, testRoute, routeWithParents(), func(current *gwv1.HTTPRoute, _ gwv1.RouteStatus) *gwv1.HTTPRoute {
 		return current
 	})
 

--- a/pkg/pluginsdk/statussync/metrics.go
+++ b/pkg/pluginsdk/statussync/metrics.go
@@ -80,6 +80,25 @@ func RecordStatusSync(labels SyncMetricLabels, took time.Duration, err error) {
 	statusSyncsTotal.Inc(append(l, metrics.Label{Name: resultLabel, Value: result})...)
 }
 
+// RecordStatusSyncOutcome reports one status write to both status-sync metrics. Every
+// Writer.OnSync ends in exactly this pair, and the pair is easy to get subtly wrong: the two
+// take different errors on purpose (see EndResourceStatusSyncOnWriteSuccess), so passing the
+// condition-derived error to both leaves a resource's sync open forever over a status that
+// was in fact persisted.
+//
+// writeErr is the error ApplyStatus reported. statusErr is that error joined with whatever
+// the caller derives from the conditions it published, or writeErr itself for a writer that
+// grades no conditions.
+func RecordStatusSyncOutcome(
+	labels SyncMetricLabels,
+	details kmetrics.ResourceSyncDetails,
+	took time.Duration,
+	writeErr, statusErr error,
+) {
+	RecordStatusSync(labels, took, statusErr)
+	EndResourceStatusSyncOnWriteSuccess(writeErr, details)
+}
+
 // ConditionError returns err joined with message when any condition whose type is in
 // watchedTypes carries a reason outside acceptedReasons. Gateways, ListenerSets and
 // policies all derive their status-sync error result this way, differing only in which

--- a/pkg/pluginsdk/statussync/status_cycle_test.go
+++ b/pkg/pluginsdk/statussync/status_cycle_test.go
@@ -56,7 +56,7 @@ func TestStatusCollectionEnqueueWriteNoopCycle(t *testing.T) {
 	reports.NewReporter(&routeReport).
 		Route(&gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"}}).
 		ParentRef(&gwv1.ParentReference{Name: "gw"})
-	buildDesired := func(current *gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
+	buildDesired := func(_ Resource, current *gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
 		status := reports.BuildRouteStatus(
 			routeReport.HTTPRoutes[types.NamespacedName{Namespace: "default", Name: "route"}],
 			current,
@@ -129,7 +129,7 @@ func TestStatusCollectionEnqueueWriteNoopCycle(t *testing.T) {
 	// the same check CheckWriterIdempotent exports for writers outside this package.
 	written := routesClient.Get("route", "default")
 	require.NotNil(t, written)
-	require.NoError(t, CheckWriterIdempotent(writer, written,
+	require.NoError(t, CheckWriterIdempotent(writer, testRoute, written,
 		func(current *gwv1.HTTPRoute, status gwv1.RouteStatus) *gwv1.HTTPRoute {
 			next := current.DeepCopy()
 			next.Status.RouteStatus = *status.DeepCopy()

--- a/pkg/pluginsdk/statussync/writer.go
+++ b/pkg/pluginsdk/statussync/writer.go
@@ -185,35 +185,45 @@ func (w Writer[O, S]) decide(res Resource, current O) writeDecision[S] {
 	return writeDecision[S]{status: merged, has: true, write: true}
 }
 
+// attemptOutcome is what the last write attempt saw, carried out of the retry closure for
+// OnSync. Keeping it in one value rather than three loose variables means the reader does not
+// have to work out which attempt last assigned each of them: they are always from the same one.
+type attemptOutcome[O controllers.ComparableObject, S any] struct {
+	current O
+	merged  S
+	has     bool
+}
+
 func (w Writer[O, S]) ApplyStatus(ctx context.Context, obj Resource) {
-	log := logger.With("kind", w.Name, "resource", obj.NamespacedName.String())
 	start := time.Now()
-	var lastCurrent O
-	var lastMerged S
-	hasDesired := false
+	// Log fields are passed inline rather than bound with logger.With: With clones the handler
+	// and preformats the attrs whatever the level, and the two dominant outcomes here are the
+	// debug-only "nothing to do" skips, on every informer event of every registered kind.
+	var last attemptOutcome[O, S]
 	err := retryStatusWrite(ctx, func() error {
-		hasDesired = false
+		last = attemptOutcome[O, S]{}
 		// Fetch the current object so we can preserve status written by other controllers or
 		// subsystems, and suppress writes that would be no-ops.
 		current := w.Current(obj)
 		if controllers.IsNil(current) {
 			// The resource was deleted between enqueue and write. Current reads the
 			// collection that enqueued it, so this cannot mean "not visible yet".
-			log.Debug("resource no longer present, skipping status update")
+			logger.Debug("resource no longer present, skipping status update",
+				"kind", w.Name, "namespace", obj.Namespace, "name", obj.Name)
 			return nil
 		}
-		lastCurrent = current
 
 		decision := w.decide(obj, current)
 		if !decision.has {
-			log.Debug("resource has no desired status, skipping status update")
+			logger.Debug("resource has no desired status, skipping status update",
+				"kind", w.Name, "namespace", obj.Namespace, "name", obj.Name)
 			return nil
 		}
-		hasDesired = true
-		lastMerged = decision.status
+		last = attemptOutcome[O, S]{current: current, merged: decision.status, has: true}
 
 		if !decision.write {
-			log.Debug("status already up to date, skipping status update")
+			logger.Debug("status already up to date, skipping status update",
+				"kind", w.Name, "namespace", obj.Namespace, "name", obj.Name)
 			return nil
 		}
 
@@ -228,25 +238,29 @@ func (w Writer[O, S]) ApplyStatus(ctx context.Context, obj Resource) {
 			if apierrors.IsConflict(err) {
 				// This is normal. The raw collection will re-enqueue the write once the
 				// informer delivers the newer object.
-				log.Debug("updating stale status, skipping", "error", err)
+				logger.Debug("updating stale status, skipping",
+					"kind", w.Name, "namespace", obj.Namespace, "name", obj.Name, "error", err)
 				return nil
 			}
 			if apierrors.IsNotFound(err) {
 				// ignore status write after resource was deleted.
-				log.Debug("resource not found, skipping status update", "error", err)
+				logger.Debug("resource not found, skipping status update",
+					"kind", w.Name, "namespace", obj.Namespace, "name", obj.Name, "error", err)
 				return nil
 			}
-			log.Error("error updating status", "error", err)
+			logger.Error("error updating status",
+				"kind", w.Name, "namespace", obj.Namespace, "name", obj.Name, "error", err)
 			return err
 		}
-		log.Debug("updated status")
+		logger.Debug("updated status", "kind", w.Name, "namespace", obj.Namespace, "name", obj.Name)
 		return nil
 	})
 	if err != nil {
-		log.Error("failed to sync status after retries", "error", err)
+		logger.Error("failed to sync status after retries",
+			"kind", w.Name, "namespace", obj.Namespace, "name", obj.Name, "error", err)
 	}
-	if hasDesired && w.OnSync != nil {
-		w.OnSync(obj, lastCurrent, lastMerged, time.Since(start), err)
+	if last.has && w.OnSync != nil {
+		w.OnSync(obj, last.current, last.merged, time.Since(start), err)
 	}
 }
 
@@ -354,6 +368,12 @@ func mergeOwnedStatusEntries[T any](
 
 	// Order ours deterministically before the cap, so which of them survives truncation does
 	// not depend on map/set iteration upstream.
+	//
+	// This is not redundant with the canonical sort below, and must not be made conditional on
+	// the cap: that sort is stable and keyed on ParentString, which collapses distinctions
+	// compareParentReference keeps (it canonicalizes nil Group/Kind to the Gateway API
+	// defaults, ParentString renders them empty). Entries that tie on ParentString therefore
+	// publish in whatever order they arrive in, and that order is what this pass fixes.
 	slices.SortFunc(ours, func(a, b T) int {
 		if c := cmp.Compare(controllerOf(a), controllerOf(b)); c != 0 {
 			return c

--- a/pkg/pluginsdk/statussync/writer.go
+++ b/pkg/pluginsdk/statussync/writer.go
@@ -136,14 +136,17 @@ func ClientWriter[W controllers.ComparableObject, S any](
 	}
 }
 
-// RetryStatusWrite runs attempt with the standard status-write retry policy: 5 attempts
-// with exponential backoff, aborted on ctx cancellation. attempt must re-read the current
-// object each time and swallow (return nil for) conflicts and NotFound, which self-heal
-// via re-enqueue; only transient errors (throttling, 5xx, network) should be returned.
-// Custom ResourceStatusSyncer implementations should wrap their write in this so transient
-// failures are not silently dropped: after a failed write nothing changes on the informer,
-// so no event is guaranteed to re-enqueue the resource.
-func RetryStatusWrite(ctx context.Context, attempt func() error) error {
+// retryStatusWrite runs attempt with the standard status-write retry policy: 5 attempts
+// with exponential backoff, aborted on ctx cancellation. attempt re-reads the current object
+// each time and swallows (returns nil for) conflicts and NotFound, which self-heal via
+// re-enqueue; only transient errors (throttling, 5xx, network) are returned.
+//
+// Retrying is a property of the pipeline rather than of each writer: after a failed write
+// nothing changes on the informer, so no event is guaranteed to re-enqueue the resource.
+// ApplyStatus is the single place it is applied, which is why this is unexported — a custom
+// ResourceStatusSyncer that forgot to wrap its own write would silently drop transient
+// failures.
+func retryStatusWrite(ctx context.Context, attempt func() error) error {
 	return retry.Do(attempt,
 		retry.Context(ctx),
 		retry.Attempts(maxRetryAttempts),
@@ -188,7 +191,7 @@ func (w Writer[O, S]) ApplyStatus(ctx context.Context, obj Resource) {
 	var lastCurrent O
 	var lastMerged S
 	hasDesired := false
-	err := RetryStatusWrite(ctx, func() error {
+	err := retryStatusWrite(ctx, func() error {
 		hasDesired = false
 		// Fetch the current object so we can preserve status written by other controllers or
 		// subsystems, and suppress writes that would be no-ops.

--- a/pkg/pluginsdk/statussync/writer.go
+++ b/pkg/pluginsdk/statussync/writer.go
@@ -71,14 +71,24 @@ type Writer[O controllers.ComparableObject, S any] struct {
 	// Desired builds the desired status from the latest object and report state. Returning
 	// false suppresses the write. It is invoked for every retry so neither the object nor
 	// report snapshot is retained in the work queue.
-	Desired func(current O) (S, bool)
+	//
+	// res is the identity the resource was enqueued under, and is what a builder must key its
+	// report lookup on — see ReportFor. Deriving the key from current instead recovers the
+	// name and namespace but not the GVK, so a writer for a normalized collection that serves
+	// several source kinds (ListenerSet/XListenerSet, the route versions) had to capture a
+	// GVK at construction that can disagree with the one the queue dispatched on.
+	Desired func(res Resource, current O) (S, bool)
 
 	// UpdateStatus persists s against the given ObjectMeta, which carries only the name,
 	// namespace and the resourceVersion the status was built from: the API server ignores
 	// spec on status writes, and the resourceVersion is what makes stale data rejected.
 	// It takes an ObjectMeta rather than an O so a normalized read type can be written back
 	// through the versioned client that actually serves it — see ClientWriter.
-	UpdateStatus func(om metav1.ObjectMeta, s S) error
+	//
+	// ctx is the one ApplyStatus was called with, so a writer that persists through a client
+	// needing a context (the dynamic client, for one) is a plain Writer like any other rather
+	// than a bespoke ResourceStatusSyncer built per call to capture one.
+	UpdateStatus func(ctx context.Context, om metav1.ObjectMeta, s S) error
 
 	// GetStatus extracts the live status from the current object. When set, a write is
 	// skipped if the (merged) desired status already matches the live status.
@@ -119,8 +129,8 @@ func CollectionSource[O controllers.ComparableObject](col krt.Collection[O]) fun
 func ClientWriter[W controllers.ComparableObject, S any](
 	cl kclient.Client[W],
 	build func(om metav1.ObjectMeta, s S) W,
-) func(metav1.ObjectMeta, S) error {
-	return func(om metav1.ObjectMeta, s S) error {
+) func(context.Context, metav1.ObjectMeta, S) error {
+	return func(_ context.Context, om metav1.ObjectMeta, s S) error {
 		_, err := cl.UpdateStatus(build(om, s))
 		return err
 	}
@@ -157,8 +167,8 @@ type writeDecision[S any] struct {
 }
 
 // decide runs the build/merge/compare sequence for one object.
-func (w Writer[O, S]) decide(current O) writeDecision[S] {
-	desired, ok := w.Desired(current)
+func (w Writer[O, S]) decide(res Resource, current O) writeDecision[S] {
+	desired, ok := w.Desired(res, current)
 	if !ok {
 		return writeDecision[S]{}
 	}
@@ -191,7 +201,7 @@ func (w Writer[O, S]) ApplyStatus(ctx context.Context, obj Resource) {
 		}
 		lastCurrent = current
 
-		decision := w.decide(current)
+		decision := w.decide(obj, current)
 		if !decision.has {
 			log.Debug("resource has no desired status, skipping status update")
 			return nil
@@ -206,7 +216,7 @@ func (w Writer[O, S]) ApplyStatus(ctx context.Context, obj Resource) {
 
 		// Write with the collection's current resourceVersion so stale data is rejected;
 		// conflicts are expected and self-heal via re-enqueue.
-		err := w.UpdateStatus(metav1.ObjectMeta{
+		err := w.UpdateStatus(ctx, metav1.ObjectMeta{
 			Name:            obj.Name,
 			Namespace:       obj.Namespace,
 			ResourceVersion: current.GetResourceVersion(),

--- a/pkg/pluginsdk/statussync/writer_apply_test.go
+++ b/pkg/pluginsdk/statussync/writer_apply_test.go
@@ -62,7 +62,7 @@ func newTestWriter(t *testing.T, createRoute bool) (Writer[*gwv1.HTTPRoute, gwv1
 		// The writer reads the collection that would have enqueued the route, never the
 		// client it writes through.
 		Current: CollectionSource(routes),
-		Desired: func(*gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
+		Desired: func(Resource, *gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
 			return gwv1.RouteStatus{Parents: []gwv1.RouteParentStatus{{
 				ParentRef:      gwv1.ParentReference{Name: "gw"},
 				ControllerName: ourController,
@@ -185,7 +185,7 @@ func TestApplyStatusReadsTheCollectionNotTheWriteClient(t *testing.T) {
 	writer := Writer[*gwv1.HTTPRoute, gwv1.RouteStatus]{
 		Name:    "httpRoute",
 		Current: CollectionSource(routes),
-		Desired: func(*gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
+		Desired: func(Resource, *gwv1.HTTPRoute) (gwv1.RouteStatus, bool) {
 			return gwv1.RouteStatus{Parents: []gwv1.RouteParentStatus{{
 				ParentRef:      gwv1.ParentReference{Name: "gw"},
 				ControllerName: ourController,

--- a/pkg/pluginsdk/statussync/writer_test.go
+++ b/pkg/pluginsdk/statussync/writer_test.go
@@ -189,7 +189,7 @@ func TestMergeRouteParentStatusesCapsAtGatewayAPILimit(t *testing.T) {
 
 func TestRetryStatusWriteRetriesTransientErrors(t *testing.T) {
 	attempts := 0
-	err := RetryStatusWrite(context.Background(), func() error {
+	err := retryStatusWrite(context.Background(), func() error {
 		attempts++
 		if attempts < 3 {
 			return errors.New("transient")
@@ -203,7 +203,7 @@ func TestRetryStatusWriteRetriesTransientErrors(t *testing.T) {
 func TestRetryStatusWriteStopsOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	attempts := 0
-	err := RetryStatusWrite(ctx, func() error {
+	err := retryStatusWrite(ctx, func() error {
 		attempts++
 		cancel()
 		return errors.New("transient")

--- a/pkg/pluginsdk/types.go
+++ b/pkg/pluginsdk/types.go
@@ -50,9 +50,6 @@ type PerClientProcessBackend func(
 // registers its raw collection, keyed report reducer, and just-in-time writer.
 type PolicyStatusInputs = statussync.RegistrationInputs
 
-// StatusCollections aliases the statussync type for plugin convenience.
-type StatusCollections = statussync.StatusCollections
-
 type PolicyPlugin struct {
 	Name                      string
 	NewGatewayTranslationPass func(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/conditions"
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/utils"
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 )
 
 // Status message constants
@@ -475,30 +474,11 @@ func (r *ReportMap) BuildRouteStatus(
 	return BuildRouteStatus(r.route(obj), obj, controller)
 }
 
-func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
-	obj client.Object,
-	controller string,
-	defaultParentRef bool,
-) *gwv1.RouteStatus {
-	return BuildRouteStatusWithParentRefDefaulting(r.route(obj), obj, controller, defaultParentRef)
-}
-
 // BuildRouteStatus builds a Route status directly from its typed report fragment.
 func BuildRouteStatus(
 	routeReport *RouteReport,
 	obj client.Object,
 	controller string,
-) *gwv1.RouteStatus {
-	return BuildRouteStatusWithParentRefDefaulting(routeReport, obj, controller, false)
-}
-
-// BuildRouteStatusWithParentRefDefaulting builds a Route status directly from its typed
-// report fragment and optionally defaults parent reference fields.
-func BuildRouteStatusWithParentRefDefaulting(
-	routeReport *RouteReport,
-	obj client.Object,
-	controller string,
-	defaultParentRef bool,
 ) *gwv1.RouteStatus {
 	if routeReport == nil {
 		logger.Info("missing route report", "type", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
@@ -550,10 +530,6 @@ func BuildRouteStatusWithParentRefDefaulting(
 	if len(parentRefs) == 0 {
 		parentRefs = append(parentRefs, routeReport.parentRefs()...)
 	}
-	if defaultParentRef {
-		parentRefs = ensureParentRefNamespaces(parentRefs, obj.GetNamespace())
-	}
-
 	newStatus := gwv1.RouteStatus{}
 	// Process the parent references to build the RouteParentStatus
 	for _, parentRef := range parentRefs {
@@ -621,22 +597,6 @@ func BuildRouteStatusWithParentRefDefaulting(
 	}
 
 	return &newStatus
-}
-
-func ensureParentRefNamespaces(parentRefs []gwv1.ParentReference, routeNamespace string) []gwv1.ParentReference {
-	return slices.Map(parentRefs, func(e gwv1.ParentReference) gwv1.ParentReference {
-		if e.Namespace == nil {
-			routeNs := gwv1.Namespace(routeNamespace)
-			e.Namespace = &routeNs
-		}
-		if e.Group == nil {
-			e.Group = new(gwv1.Group(wellknown.GatewayGVK.Group))
-		}
-		if e.Kind == nil {
-			e.Kind = new(gwv1.Kind(wellknown.GatewayGVK.Kind))
-		}
-		return e
-	})
 }
 
 // match istio/istio logic, see:


### PR DESCRIPTION
# Description

Follow-ups on #14519, split into three reviewable commits. The first closes a footgun in the writer contract, the second consolidates two things that were easy to get subtly wrong at each call site, and the third is an optimization plus dead-code removal. No change to the status any resource ends up with.

**1. Key writer reads on the enqueued resource**

`Writer.Desired` is handed the `statussync.Resource` the write was enqueued under instead of each writer capturing a GVK at construction, and `ReportFor` takes that `Resource` whole rather than a separately-supplied GVK and name.

The reducer and the queue are keyed by the same function, so a captured GVK and the dispatched one did agree — but only by convention, restated per writer. A writer over a normalized collection serving several source kinds (ListenerSet/XListenerSet, the route versions) is where that convention is easiest to get wrong, and nothing made a wrong one fail loudly: the lookup would just miss and the resource would silently carry no status. Taking the identity the queue dispatched on makes the disagreement unrepresentable.

`Writer.UpdateStatus` also gains the context `ApplyStatus` was called with. That was the only reason the legacy XListenerSet path was a bespoke `ResourceStatusSyncer` rebuilding its writer per call to capture one; it is now a plain `Writer` like every other kind.

**2. Pair the sync metrics, narrow the surface**

Every `Writer.OnSync` ends in `RecordStatusSync` plus `EndResourceStatusSyncOnWriteSuccess`. The pair is easy to get wrong because the two take different errors on purpose: passing the condition-derived error to both leaves a resource's sync open forever over a status that was in fact persisted. `RecordStatusSyncOutcome` takes both and becomes the only way to spell the pair.

Every writer registration now goes through `registerStatusWriter`. Half the entries assigned into the map directly, and the built-in kinds they registered are exactly the ones a plugin registration is most likely to collide with — so the duplicate-registration guard was bypassed precisely where it mattered. `routeWriter` derives its log name and metric resource type from the GVK it is registered under instead of taking them alongside it, so a caller cannot spell one kind three ways in one call.

Also unexports `retryStatusWrite` and `registerResourceByObjectGVK`, and drops the `pluginsdk.StatusCollections` and `proxy_syncer.StatusRegistrationInputs` aliases — `RegistrationInputs` is deliberately one struct shared by both entry points, and re-spelling it per package sends a reader who greps the local name to a type with no fields.

**3. Drop the redundant Gateway status projection and hot-path logging**

`GatewayStatusSnapshots` was a pure projection of `gatewayTranslationOutput`, so its only effect was to run `GatewayStatusSnapshot.Equals` — a deep walk of every contribution of every route on the Gateway — a second time per translation, on top of the one `gatewayTranslationOutput.Equals` already does. `gatewayStatusContributions` reads the translation output directly. Contributions are still compared individually downstream, so status-only and xDS-only changes stay as isolated from each other as before.

`Writer.ApplyStatus` passes its log fields inline rather than binding them with `logger.With`, which clones the handler and preformats the attrs whatever the level. Its two dominant outcomes are the debug-only "nothing to do" skips, on every informer event of every registered kind.

Also drops `BuildRouteStatusWithParentRefDefaulting` and `ensureParentRefNamespaces`, and folds the repeated per-version route collection joins and element-wise slice conversions into `joinRouteCollections` and `convertRouteSliceElems`.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Each commit builds and passes tests on its own, so the series bisects.

Two notes for reviewers:

- `pkg/reports.BuildRouteStatusWithParentRefDefaulting` is an exported symbol removal. It predates #14519 and has no callers on either side of that merge — it was reachable only through its own file.
- `convertRouteSliceElems` canonicalizes both nil and empty input to nil. That is inherited behavior — each of the per-kind helpers it replaces did the same — so folding them together preserves it rather than picking it. It is also why it does not use `slices.Map`, which returns a non-nil empty slice for empty input and would therefore change the normalized Spec of every route carrying no rules or hostnames.

Release note is NONE deliberately: all three commits refine code that landed in #14519 and has not shipped in a release, so there is no user-visible delta to describe on its own.
