### PR TITLE
test: fix TestOIDCDiscovererRunStopsOnContextCancel flake

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc_recompute_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc_recompute_test.go
@@ -200,8 +200,21 @@ func TestOIDCDiscovererRunStopsOnContextCancel(t *testing.T) {
 		t.Fatal("run() did not return after context cancellation")
 	}
 
-	// No further polling once the loop has exited.
-	countAfterStop := atomic.LoadInt64(&requestCount)
+	// A poll the loop had already put on the wire when cancel() landed still reaches the test
+	// server's handler, even though client.Do returns "context canceled" without waiting for the
+	// response, so requestCount can tick up once more after run() has returned. Wait for it to
+	// settle rather than assuming that trailing request has already been counted. This cannot
+	// mask a loop that is still running: such a loop polls every failureRetryInterval/2, so it
+	// would never produce two equal samples a settle period apart.
+	var countAfterStop int64
+	require.Eventually(t, func() bool {
+		count := atomic.LoadInt64(&requestCount)
+		settled := count == countAfterStop
+		countAfterStop = count
+		return settled
+	}, 5*time.Second, 50*time.Millisecond, "polling should stop after cancellation")
+
+	// And it stays stopped.
 	time.Sleep(50 * time.Millisecond)
 	r.Equal(countAfterStop, atomic.LoadInt64(&requestCount), "no polling should happen after cancellation")
 }


### PR DESCRIPTION
# Description

**Motivation:** `TestOIDCDiscovererRunStopsOnContextCancel` is flaky, failing with `expected: 4, actual: 5` / `no polling should happen after cancellation`. Seen on an unrelated dep-bump PR ([run](https://github.com/kgateway-dev/kgateway/actions/runs/31709292162/job/94480917411)), where it passed on re-run. The flake is in the test only — the discoverer is correct.

**What changed:** the test sampled the server-side request counter immediately after `run()` returned:

```go
countAfterStop := atomic.LoadInt64(&requestCount)
time.Sleep(50 * time.Millisecond)
r.Equal(countAfterStop, atomic.LoadInt64(&requestCount))
```

The refresh loop ticks every `failureRetryInterval/2`, which the test sets to 2.5ms, so `cancel()` frequently lands while a discovery request is already on the wire. `client.Do` returns `context canceled` without waiting for the response, `refreshOnce` unwinds and `run()` returns — but the `httptest` server still dispatches that already-transmitted request, so the handler increments `requestCount` *after* `<-stopped`. The baseline was then one too low, and the 50ms window caught the trailing increment.

The fix waits for the counter to settle before sampling it, then keeps the existing quiet-window assertion. This cannot mask the regression the test guards against: a loop that is still running polls every 2.5ms, so it can never produce two equal samples a settle period apart.

No production code changed. `refreshOnce` is called synchronously from the loop and `g.Wait()`s its errgroup, so no poller outlives `run()`.

# Change Type

/kind flake

# Changelog

```release-note
NONE
```

# Additional Notes

Verification:

- Reproduced deterministically with `GOMAXPROCS=1` (contended CI runners hit the same window) — same `4` vs `5`, same 0.06s duration as CI. A temporary probe confirmed the mechanism: `count moved 4 -> 5; handlers that started after run() returned: 1`.
- With the fix, 300 runs at `GOMAXPROCS=1` pass; full package passes with `-race -count=2`.
- Teeth check: mutated `run()` to leak a live poller goroutine on cancel — the test fails with `polling should stop after cancellation`.

Unrelated, for whoever is looking at CI: that same run also fails `api/tests TestCRDs` on the `backendconfigpolicies` CEL cost budget (`exceeds budget by factor of 1.331825x`). It fails on all three attempts, so it is a real failure rather than a flake, and it is independent of this change.
