### PR TITLE
docs: clarify BackendConfigPolicy maxHeadersCount scope

### DIFF
--- a/api/v1alpha1/kgateway/backend_config_policy_types.go
+++ b/api/v1alpha1/kgateway/backend_config_policy_types.go
@@ -224,9 +224,10 @@ type CommonHttpProtocolOptions struct {
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	IdleTimeout *metav1.Duration `json:"idleTimeout,omitempty"`
 
-	// Specifies the maximum number of headers that the connection will accept.
-	// If not specified, the default of 100 is used. Requests that exceed this limit will receive
-	// a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
+	// Specifies the maximum number of response headers that the upstream connection will accept
+	// from the backend. If not specified, the default of 100 is used.
+	// To configure the maximum number of headers accepted in downstream requests, use
+	// ListenerPolicy.spec.default.httpSettings.maxHeadersCount.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	MaxHeadersCount *int32 `json:"maxHeadersCount,omitempty"`

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_backendconfigpolicies.yaml
@@ -123,9 +123,10 @@ spec:
                       rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                   maxHeadersCount:
                     description: |-
-                      Specifies the maximum number of headers that the connection will accept.
-                      If not specified, the default of 100 is used. Requests that exceed this limit will receive
-                      a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
+                      Specifies the maximum number of response headers that the upstream connection will accept
+                      from the backend. If not specified, the default of 100 is used.
+                      To configure the maximum number of headers accepted in downstream requests, use
+                      ListenerPolicy.spec.default.httpSettings.maxHeadersCount.
                     format: int32
                     minimum: 0
                     type: integer


### PR DESCRIPTION
# Description

Clarify that `BackendConfigPolicy.spec.commonHttpProtocolOptions.maxHeadersCount` limits response headers received from an upstream backend, not request headers received by the gateway.

The previous API description used downstream-oriented language about HTTP 431 responses. This made it appear that the setting addressed the behavior reported in #14373, even though downstream request limits are configured with `ListenerPolicy.spec.default.httpSettings.maxHeadersCount`.

This change updates the API comment and regenerates the BackendConfigPolicy CRD description. There is no runtime behavior change.

Related to #14373.

# Change Type

/kind documentation

# Changelog

```release-note
NONE
```

# Additional Notes

The reported 431 occurs during downstream protocol decoding before route or backend selection. Version 2.3.5 already supports the corresponding downstream setting through ListenerPolicy.
