### PR TITLE
perf: precompute per-client cluster/endpoint KRT resource names

### DIFF
--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -2,7 +2,6 @@ package proxy_syncer
 
 import (
 	"context"
-	"fmt"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"istio.io/istio/pkg/kube/krt"
@@ -29,10 +28,23 @@ type uccWithCluster struct {
 	BackendSource ir.ObjectSource
 	// BackendGeneration is the observed generation of the source Backend.
 	BackendGeneration int64
+	// resourceName caches the KRT identity key, which KRT recomputes for every row on
+	// every event. Rows are per-client x per-backend, so computing it on each call is a
+	// per-call allocation multiplied by both dimensions.
+	// +noKrtEquals derived from Client and Name; a difference makes it a different KRT row
+	resourceName string
 }
 
 func (c uccWithCluster) ResourceName() string {
-	return fmt.Sprintf("%s/%s", c.Client.ResourceName(), c.Name)
+	// Fall back for rows built as bare struct literals (tests) that skip the cache.
+	if c.resourceName == "" {
+		return uccClusterResourceName(c.Client, c.Name)
+	}
+	return c.resourceName
+}
+
+func uccClusterResourceName(client ir.UniquelyConnectedClient, name string) string {
+	return client.ResourceName() + "/" + name
 }
 
 func (c uccWithCluster) Equals(in uccWithCluster) bool {
@@ -91,6 +103,7 @@ func NewPerClientEnvoyClusters(
 				ClusterVersion:    utils.HashProto(c),
 				BackendSource:     backendObj.GetObjectSource(),
 				BackendGeneration: backendGeneration,
+				resourceName:      uccClusterResourceName(ucc, c.GetName()),
 			})
 		}
 		return uccWithClusterRet

--- a/pkg/kgateway/proxy_syncer/cla.go
+++ b/pkg/kgateway/proxy_syncer/cla.go
@@ -1,8 +1,6 @@
 package proxy_syncer
 
 import (
-	"fmt"
-
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"istio.io/istio/pkg/kube/krt"
 
@@ -17,10 +15,23 @@ type UccWithEndpoints struct {
 	Endpoints     *envoyendpointv3.ClusterLoadAssignment
 	EndpointsHash uint64
 	endpointsName string
+	// resourceName caches the KRT identity key, which KRT recomputes for every row on
+	// every event. Rows are per-client x per-backend, so computing it on each call is a
+	// per-call allocation multiplied by both dimensions.
+	// +noKrtEquals derived from Client and endpointsName, both of which are compared
+	resourceName string
 }
 
 func (c UccWithEndpoints) ResourceName() string {
-	return fmt.Sprintf("%s/%s", c.Client.ResourceName(), c.endpointsName)
+	// Fall back for rows built as bare struct literals (tests) that skip the cache.
+	if c.resourceName == "" {
+		return uccEndpointsResourceName(c.Client, c.endpointsName)
+	}
+	return c.resourceName
+}
+
+func uccEndpointsResourceName(client ir.UniquelyConnectedClient, endpointsName string) string {
+	return client.ResourceName() + "/" + endpointsName
 }
 
 func (c UccWithEndpoints) Equals(in UccWithEndpoints) bool {
@@ -49,11 +60,13 @@ func NewPerClientEnvoyEndpoints(
 		uccWithEndpointsRet := make([]UccWithEndpoints, 0, len(uccs))
 		for _, ucc := range uccs {
 			cla, additionalHash := translateEndpoints(kctx, ucc, ep)
+			epName := ep.ResourceName()
 			u := UccWithEndpoints{
 				Client:        ucc,
 				Endpoints:     cla,
 				EndpointsHash: ep.LbEpsEqualityHash ^ additionalHash,
-				endpointsName: ep.ResourceName(),
+				endpointsName: epName,
+				resourceName:  uccEndpointsResourceName(ucc, epName),
 			}
 			uccWithEndpointsRet = append(uccWithEndpointsRet, u)
 		}

--- a/pkg/kgateway/proxy_syncer/local_cluster.go
+++ b/pkg/kgateway/proxy_syncer/local_cluster.go
@@ -67,6 +67,7 @@ func NewPerClientLocalClusterEndpoints(
 			Endpoints:     cla,
 			EndpointsHash: hashLocalClusterLoadAssignment(cla),
 			endpointsName: localClusterName,
+			resourceName:  uccEndpointsResourceName(ucc, localClusterName),
 		}
 	}, krtopts.ToOptions("LocalClusterEndpoints")...)
 


### PR DESCRIPTION
# Description

related: https://github.com/kgateway-dev/kgateway/pull/14092

**Motivation:** `uccWithCluster.ResourceName()` and `UccWithEndpoints.ResourceName()` built their KRT identity key with `fmt.Sprintf("%s/%s", ...)` on every call. Both types are rows of a `krt.NewManyCollection` fanned out per connected client, so row count is `|clients| x |backends|`, and KRT calls `ResourceName()` on every row on every recompute (`slices.GroupUnique` over the transformation output in `manycollection`) plus again on the event path. That makes the format-string parse, varargs slice, and two interface boxes a cost multiplied by both dimensions.

**What changed:** cache the key in an unexported `resourceName` field set at construction, matching the existing `BackendObjectIR.clusterName` pattern.

This costs no retained memory. KRT already keeps the key string as a map key in `collectionState.mappings` / `outputs`, so computing on the fly just means allocating fresh on each call and retaining one of them anyway; caching makes the struct field and the map keys share a single allocation. Each row also already retains a full `*Cluster` / `*ClusterLoadAssignment` proto, which dwarfs a string header.

`ResourceName()` falls back to plain concatenation when the cache is unset, so the rows built as bare struct literals in tests stay correct without touching those call sites.

Microbenchmark on representative key shapes (client key + cluster name):

```
fmt.Sprintf    52.97 ns/op   144 B/op   3 allocs/op
concatenation  20.41 ns/op   112 B/op   1 allocs/op
precomputed     0.33 ns/op     0 B/op   0 allocs/op
```

Files touched:
- `pkg/kgateway/proxy_syncer/backends.go` — cached field on `uccWithCluster`, populated in `NewPerClientEnvoyClusters`.
- `pkg/kgateway/proxy_syncer/cla.go` — same for `UccWithEndpoints`, populated in `NewPerClientEnvoyEndpoints`; `ep.ResourceName()` is hoisted into a local so it's called once per row instead of twice.
- `pkg/kgateway/proxy_syncer/local_cluster.go` — the other `UccWithEndpoints` construction site (local-cluster CLA) sets the cache too.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

The new fields are annotated `+noKrtEquals` for the `krtequals` analyzer: both are derived from fields the `Equals` methods already handle. For `UccWithEndpoints`, `Client` and `endpointsName` are both compared. For `uccWithCluster`, `Client` is compared and a differing `Name` yields a different KRT identity key, i.e. a different row rather than an update.
