### PR TITLE
perf: avoid fmt.Sprintf on translation hot paths

### DIFF
--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -729,11 +730,11 @@ func (h *httpRouteConfigurationTranslator) initRoutes(
 	out := &envoyroutev3.Route{
 		Match: translateMatcher(in.Match),
 	}
-	name := in.Name
-	if name != "" {
-		out.Name = fmt.Sprintf("%s-%s-matcher-%d", generatedName, name, in.MatchIndex)
+	matchIdx := strconv.Itoa(in.MatchIndex)
+	if name := in.Name; name != "" {
+		out.Name = generatedName + "-" + name + "-matcher-" + matchIdx
 	} else {
-		out.Name = fmt.Sprintf("%s-matcher-%d", generatedName, in.MatchIndex)
+		out.Name = generatedName + "-matcher-" + matchIdx
 	}
 
 	return out

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -48,7 +48,7 @@ type NotFoundError struct {
 }
 
 func (n *NotFoundError) Error() string {
-	return fmt.Sprintf("%s %s/%s not found", n.NotFoundObj.Kind, n.NotFoundObj.Namespace, n.NotFoundObj.Name)
+	return n.NotFoundObj.Kind + " " + n.NotFoundObj.Namespace + "/" + n.NotFoundObj.Name + " not found"
 }
 
 type BackendPortNotAllowedError struct {
@@ -642,7 +642,7 @@ type TargetRefIndexKey struct {
 }
 
 func (k TargetRefIndexKey) String() string {
-	return fmt.Sprintf("%s/%s/%s/%s/%s", k.Group, k.Kind, k.Name, k.Namespace, k.SectionName)
+	return k.Group + "/" + k.Kind + "/" + k.Name + "/" + k.Namespace + "/" + k.SectionName
 }
 
 // HTTPRouteSelector is used to lookup HttpRouteIR using one of the following ways:


### PR DESCRIPTION
# Description

**Motivation:** three `fmt.Sprintf` calls sit on paths that run per-route or per-KRT-comparison, where the reflection and `[]any` boxing are pure overhead. All three build simple, fixed-shape strings that plain concatenation produces identically.

**What changed:**

- `NotFoundError.Error()` (`pkg/krtcollections/policy.go`) — the IR `Equals()` implementations compare errors by message (`pkg/pluginsdk/ir/backend.go`, `iface.go`, `routes.go`, `gw.go`), so this is re-formatted on every KRT change-detection pass over a route or backend carrying an error. Construction was already lazy; the cost is in the repeated `Error()` calls.
- `TargetRefIndexKey.String()` (`pkg/krtcollections/policy.go`) — `Stringer` used for KRT debug dumps and `%v` logging. Note that the key is already struct-typed: every call site passes it straight to `krt.FilterIndex`/`UnnamedIndex`, which uses it as a comparable map key without stringifying, so this method is off the lookup path entirely.
- `initRoutes()` (`pkg/kgateway/translator/irtranslator/route.go`) — runs once per route match, so it scales with route count. The match index is now converted with `strconv.Itoa` once, before the branch, instead of by two `%d` verbs.

All three produce byte-identical output; the existing unit tests in both packages pass unchanged.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

No behavior change and no golden-file churn — the generated route names and error messages are the same strings as before. `make verify` and `make analyze` are both clean.
