### PR TITLE
[v2.3.x] fix: recover OAuth2 config when OIDC discovery fails at startup (#14508)

### DIFF
--- a/api/v1alpha1/kgateway/oauth2.go
+++ b/api/v1alpha1/kgateway/oauth2.go
@@ -90,8 +90,10 @@ type OAuth2Provider struct {
 	// It discovers the authorizationEndpoint, tokenEndpoint, endSessionEndpoint, and jwksURI if specified in the discovery response.
 	// Explicit configuration of these options will take precedence over the discovered values.
 	// Refer to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig for more details.
-	// Note that the OpenID provider configuration is cached and only refreshed periodically when the GatewayExtension object
-	// is reprocessed.
+	// Note that the OpenID provider configuration is cached. It is refreshed periodically in the background, and a failed
+	// discovery is retried, so a provider that is unreachable when the configuration is first discovered is picked up once
+	// it becomes reachable. Discovery stops once authorizationEndpoint, tokenEndpoint, endSessionEndpoint, and jwksURI
+	// (when JWT parsing is configured) are all set explicitly, since none of the discovered values are then used.
 	// +optional
 	//
 	// +kubebuilder:validation:Pattern=`^https://([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(:[0-9]{1,5})?(/[a-zA-Z0-9\-._~!$&'()*+,;=:@%]*)*/?$`

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
@@ -1399,8 +1399,10 @@ spec:
                       It discovers the authorizationEndpoint, tokenEndpoint, endSessionEndpoint, and jwksURI if specified in the discovery response.
                       Explicit configuration of these options will take precedence over the discovered values.
                       Refer to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig for more details.
-                      Note that the OpenID provider configuration is cached and only refreshed periodically when the GatewayExtension object
-                      is reprocessed.
+                      Note that the OpenID provider configuration is cached. It is refreshed periodically in the background, and a failed
+                      discovery is retried, so a provider that is unreachable when the configuration is first discovered is picked up once
+                      it becomes reachable. Discovery stops once authorizationEndpoint, tokenEndpoint, endSessionEndpoint, and jwksURI
+                      (when JWT parsing is configured) are all set explicitly, since none of the discovered values are then used.
                     pattern: ^https://([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(:[0-9]{1,5})?(/[a-zA-Z0-9\-._~!$&'()*+,;=:@%]*)*/?$
                     type: string
                   jwt:

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -116,9 +116,22 @@ func TranslateGatewayExtensionBuilder(
 	ctx context.Context,
 	commoncol *collections.CommonCollections,
 ) func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {
-	oidcDiscoverer := newOIDCProviderConfigDiscoverer()
-	go oidcDiscoverer.refresh(ctx)
+	oidcDiscoverer := newOIDCProviderConfigDiscoverer(
+		func() []string { return oidcIssuerURIs(commoncol.GatewayExtensions.List()) },
+		commoncol.KrtOpts.ToOptions("OIDCDiscoveryTrigger")...,
+	)
+	go oidcDiscoverer.run(ctx)
 
+	return gatewayExtensionBuilder(ctx, commoncol, oidcDiscoverer)
+}
+
+// gatewayExtensionBuilder is split out of TranslateGatewayExtensionBuilder so that tests can
+// supply a discoverer with shorter refresh intervals than the production defaults.
+func gatewayExtensionBuilder(
+	ctx context.Context,
+	commoncol *collections.CommonCollections,
+	oidcDiscoverer *oidcProviderConfigDiscoverer,
+) func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {
 	return func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {
 		p := &TrafficPolicyGatewayExtensionIR{
 			Name:             krt.Named{Name: gExt.Name, Namespace: gExt.Namespace}.ResourceName(),
@@ -214,7 +227,7 @@ func TranslateGatewayExtensionBuilder(
 			p.Jwt = buildCompositeJwtFilter(jwtConfig)
 
 		case gExt.OAuth2 != nil:
-			out, err := buildOAuth2ProviderConfig(krtctx, &gExt, commoncol.BackendIndex, commoncol.Secrets, oidcDiscoverer)
+			out, err := buildOAuth2ProviderConfig(ctx, krtctx, &gExt, commoncol.BackendIndex, commoncol.Secrets, oidcDiscoverer)
 			if err != nil {
 				p.Err = fmt.Errorf("error building OAuth2 config: %w", err)
 				return p

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/oauth2.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/oauth2.go
@@ -1,6 +1,7 @@
 package trafficpolicy
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -122,6 +123,7 @@ func constructOAuth2(
 }
 
 func buildOAuth2ProviderConfig(
+	ctx context.Context,
 	krtctx krt.HandlerContext,
 	ext *ir.GatewayExtension,
 	backends *krtcollections.BackendIndex,
@@ -138,25 +140,30 @@ func buildOAuth2ProviderConfig(
 		jwksURI = ptr.Deref(in.JWT.JWKSURI, "").String()
 	}
 
-	if in.IssuerURI != nil {
-		// only discover config if we need to, i.e., when either tokenEndpoint, authorizationEndpoint, or endSessionEndpoint is not provided
-		if in.TokenEndpoint == nil || in.AuthorizationEndpoint == nil || in.EndSessionEndpoint == nil || (in.JWT != nil && in.JWT.JWKSURI == nil) {
-			openidCfg, err := discoverer.get(*in.IssuerURI)
-			if err != nil {
-				return nil, err
-			}
-			if tokenEndpoint == "" {
-				tokenEndpoint = openidCfg.TokenEndpoint
-			}
-			if authorizationEndpoint == "" {
-				authorizationEndpoint = openidCfg.AuthorizationEndpoint
-			}
-			if endSessionEndpoint == "" {
-				endSessionEndpoint = ptr.Deref(openidCfg.EndSessionEndpoint, "")
-			}
-			if jwksURI == "" {
-				jwksURI = openidCfg.JWKSURI
-			}
+	// Only discover if we need to, i.e. when the issuer is set and at least one endpoint is
+	// left for the well-known document to supply.
+	if oidcDiscoveryRequired(in) {
+		// Register a dependency on the discovery cache before fetching, so this extension
+		// is re-translated when the discovered config changes. This is what un-latches a
+		// discovery failure: the provider is not a Kubernetes resource, so without it a
+		// provider that was down at startup would keep this extension (and every
+		// TrafficPolicy referencing it) rejected until the control plane restarted.
+		discoverer.markDependant(krtctx)
+		openidCfg, err := discoverer.get(ctx, *in.IssuerURI)
+		if err != nil {
+			return nil, err
+		}
+		if tokenEndpoint == "" {
+			tokenEndpoint = openidCfg.TokenEndpoint
+		}
+		if authorizationEndpoint == "" {
+			authorizationEndpoint = openidCfg.AuthorizationEndpoint
+		}
+		if endSessionEndpoint == "" {
+			endSessionEndpoint = ptr.Deref(openidCfg.EndSessionEndpoint, "")
+		}
+		if jwksURI == "" {
+			jwksURI = openidCfg.JWKSURI
 		}
 	}
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc.go
@@ -6,27 +6,56 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+
+	kgwv1a1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
 const (
 	wellKnownOpenIDConfPath = "/.well-known/openid-configuration"
 	userAgent               = "kgateway/oidc-discovery"
 	oidcAcceptedContentType = "application/json"
-)
 
-type oidcProviderConfigDiscoverer struct {
-	// caches oidcProviderConfig per issuer URI
-	cache                sync.Map
-	cacheRefreshInterval time.Duration
-	// discoverGroup deduplicates concurrent discover() calls for the same issuer URI,
-	// preventing redundant HTTP requests when the cache is cleared.
-	discoverGroup singleflight.Group
-}
+	// defaultOIDCCacheRefreshInterval is how long a successful discovery is served from the
+	// cache before it is re-discovered. The OpenID provider configuration is not expected to
+	// change frequently, so caching it for a longer duration prevents excessive network calls.
+	// It also caps the backoff applied to repeated failures.
+	defaultOIDCCacheRefreshInterval = 5 * time.Minute
+
+	// defaultOIDCFailureRetryInterval is the base interval after which a failed discovery is
+	// retried. It is much shorter than the success interval so that a provider which was
+	// unreachable when kgateway started, or which was down during a provider outage, is picked
+	// up quickly rather than leaving the policy broken until restart. Consecutive failures back
+	// off exponentially from here, capped at defaultOIDCCacheRefreshInterval.
+	defaultOIDCFailureRetryInterval = 30 * time.Second
+
+	// oidcDiscoveryHTTPTimeout bounds a single discovery request.
+	oidcDiscoveryHTTPTimeout = 30 * time.Second
+
+	// foregroundDiscoveryTimeout bounds discovery performed from a krt transform, which blocks
+	// the event loop and therefore translation of everything downstream of GatewayExtensions.
+	// It is deliberately tight: the background refresh loop retries, so giving up quickly costs
+	// only a short-lived error on the policy rather than a lost configuration.
+	foregroundDiscoveryTimeout = 10 * time.Second
+
+	// backgroundDiscoveryTimeout bounds discovery performed by the refresh loop. It can afford
+	// to be more generous than the foreground budget because it runs off the event loop.
+	backgroundDiscoveryTimeout = 30 * time.Second
+
+	// backgroundDiscoveryConcurrency bounds how many issuers the refresh loop re-discovers at
+	// once, so recovery latency does not scale with the number of unreachable providers.
+	backgroundDiscoveryConcurrency = 4
+)
 
 // oidcProviderConfig maps the OpenID provider config response.
 // Refer to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse for more details.
@@ -37,78 +66,368 @@ type oidcProviderConfig struct {
 	JWKSURI               string  `json:"jwks_uri"`
 }
 
-// newOIDCProviderConfigDiscoverer returns a oidcProviderConfigDiscoverer instance that is responsible
-// for periodically refreshing the OpenID provider configuration cache
-func newOIDCProviderConfigDiscoverer() *oidcProviderConfigDiscoverer {
+// equals reports whether two provider configs would produce the same Envoy configuration.
+// EndSessionEndpoint is compared by dereferenced value because an unset and an empty
+// end_session_endpoint are treated identically by buildOAuth2ProviderConfig.
+func (c *oidcProviderConfig) equals(other *oidcProviderConfig) bool {
+	if c == nil || other == nil {
+		return c == nil && other == nil
+	}
+	return c.TokenEndpoint == other.TokenEndpoint &&
+		c.AuthorizationEndpoint == other.AuthorizationEndpoint &&
+		ptr.Deref(c.EndSessionEndpoint, "") == ptr.Deref(other.EndSessionEndpoint, "") &&
+		c.JWKSURI == other.JWKSURI
+}
+
+// oidcDiscoveryResult is a cached discovery outcome. Failures are cached alongside successes
+// so that a GatewayExtension re-translated for an unrelated reason does not block the krt
+// event loop re-contacting a provider that is already known to be unreachable.
+//
+// err is only ever set for an issuer that has never been discovered successfully: once there is
+// a config to serve, rediscover keeps serving it through failures rather than withdrawing it.
+// So a non-zero failures with a non-nil cfg means "stale, still being retried".
+type oidcDiscoveryResult struct {
+	cfg *oidcProviderConfig
+	err error
+	// expiry is when the refresh loop becomes eligible to re-discover this entry.
+	expiry time.Time
+	// failures counts consecutive failed discoveries, and drives the retry backoff.
+	failures int
+}
+
+// sameOutcome reports whether two results translate to the same GatewayExtension IR.
+// Errors are compared by message, matching how TrafficPolicyGatewayExtensionIR compares its
+// Err field, so a retry that keeps failing the same way does not churn krt.
+func (r oidcDiscoveryResult) sameOutcome(other oidcDiscoveryResult) bool {
+	if (r.err == nil) != (other.err == nil) {
+		return false
+	}
+	if r.err != nil {
+		return r.err.Error() == other.err.Error()
+	}
+	return r.cfg.equals(other.cfg)
+}
+
+type oidcProviderConfigDiscoverer struct {
+	// trigger re-runs the GatewayExtension transform when a cached discovery result changes.
+	// The OpenID provider is not a Kubernetes resource, so krt has no dependency of its own
+	// to track here: without this trigger a discovery failure stays latched in the
+	// GatewayExtension IR (and the TrafficPolicies referencing it stay rejected) until the
+	// control plane is restarted.
+	trigger *krt.RecomputeTrigger
+
+	// liveIssuerURIs returns the issuer URIs some GatewayExtension currently discovers from,
+	// per oidcDiscoveryRequired. The refresh loop intersects this with the cache so it stops
+	// polling an issuer as soon as nothing reads its discovered config.
+	liveIssuerURIs func() []string
+
+	cacheRefreshInterval time.Duration
+	failureRetryInterval time.Duration
+
+	// mu guards cache. The cache is authoritative for get(): expiry is acted on only by the
+	// refresh loop, so a translation never blocks on discovery for an issuer already known.
+	mu    sync.RWMutex
+	cache map[string]oidcDiscoveryResult
+
+	// discoverGroup deduplicates concurrent discover() calls for the same issuer URI,
+	// preventing redundant HTTP requests when several extensions share an issuer.
+	discoverGroup singleflight.Group
+}
+
+// newOIDCProviderConfigDiscoverer returns an oidcProviderConfigDiscoverer that caches OpenID
+// provider configurations. liveIssuerURIs must report the issuer URIs still referenced by
+// GatewayExtensions so the refresh loop can prune entries it no longer needs to poll.
+// Callers must start run() for cached entries to be refreshed and retried.
+func newOIDCProviderConfigDiscoverer(liveIssuerURIs func() []string, opts ...krt.CollectionOption) *oidcProviderConfigDiscoverer {
 	return &oidcProviderConfigDiscoverer{
-		cacheRefreshInterval: 5 * time.Minute,
+		// Start synced: get() discovers synchronously on first use, so dependent collections
+		// must not block waiting for the refresh loop to publish an initial state.
+		trigger:              krt.NewRecomputeTrigger(true, opts...),
+		liveIssuerURIs:       liveIssuerURIs,
+		cacheRefreshInterval: defaultOIDCCacheRefreshInterval,
+		failureRetryInterval: defaultOIDCFailureRetryInterval,
+		cache:                map[string]oidcDiscoveryResult{},
 	}
 }
 
-// refresh periodically clears the cache to allow re-discovery of OpenID provider configurations.
-// The OpenID provider configuration is not expected to change frequently, so caching it for a longer duration
-// is desirable to prevent excessive network calls. However, to accommodate potential changes in the provider configuration,
-// the cache is cleared at regular intervals, prompting re-discovery on subsequent requests.
-func (o *oidcProviderConfigDiscoverer) refresh(ctx context.Context) {
+// oidcDiscoveryRequired reports whether an extension relies on OpenID discovery: it names an
+// issuer and leaves at least one endpoint for the well-known document to supply.
+//
+// This is the single definition of "this extension will call discoverer.get()". It is shared by
+// buildOAuth2ProviderConfig and by the refresh loop's live set so the two cannot drift: a live
+// set wider than this polls issuers nobody reads, and one narrower prunes entries that are still
+// needed, which would re-latch a discovery failure with nothing left to retry it.
+func oidcDiscoveryRequired(in *kgwv1a1.OAuth2Provider) bool {
+	if in == nil || in.IssuerURI == nil {
+		return false
+	}
+	return in.TokenEndpoint == nil ||
+		in.AuthorizationEndpoint == nil ||
+		in.EndSessionEndpoint == nil ||
+		(in.JWT != nil && in.JWT.JWKSURI == nil)
+}
+
+// oidcIssuerURIs collects the issuer URIs of the given extensions that rely on discovery. It
+// feeds the discovery refresh loop, so that an issuer stops being polled once no extension
+// discovers from it any more: because its GatewayExtension was deleted, was re-pointed at a
+// different provider, or had every endpoint filled in explicitly.
+func oidcIssuerURIs(exts []ir.GatewayExtension) []string {
+	issuerURIs := make([]string, 0, len(exts))
+	for _, ext := range exts {
+		if !oidcDiscoveryRequired(ext.OAuth2) {
+			continue
+		}
+		issuerURIs = append(issuerURIs, *ext.OAuth2.IssuerURI)
+	}
+	return issuerURIs
+}
+
+// markDependant registers the calling krt transform as depending on discovery results.
+// It must be called before get(), including when get() goes on to fail, so that the transform
+// is re-run once discovery starts succeeding.
+func (o *oidcProviderConfigDiscoverer) markDependant(krtctx krt.HandlerContext) {
+	o.trigger.MarkDependant(krtctx)
+}
+
+// run periodically re-discovers the provider configuration for every cached issuer that is
+// still referenced by a GatewayExtension, and triggers a krt recomputation whenever an
+// outcome changes. Successful entries are refreshed on cacheRefreshInterval; failed entries
+// are retried on failureRetryInterval, backing off on consecutive failures.
+func (o *oidcProviderConfigDiscoverer) run(ctx context.Context) {
+	// Tick at half the retry interval so an entry expiring just after a tick is not delayed by
+	// a full extra period. time.NewTicker panics on a non-positive interval, so clamp.
+	interval := o.failureRetryInterval / 2
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(o.cacheRefreshInterval):
-			// refresh the cache every 5 minutes; next get() will re-discover the config
-			o.cache.Clear()
+		case <-ticker.C:
+			// Guard against the race where both ctx.Done() and ticker.C are
+			// ready simultaneously and the scheduler picks ticker.C first.
+			if ctx.Err() != nil {
+				return
+			}
+			o.refreshOnce(ctx)
 		}
 	}
 }
 
-func (o *oidcProviderConfigDiscoverer) get(issuerURI string) (*oidcProviderConfig, error) {
-	v, ok := o.cache.Load(issuerURI)
-	if ok {
-		return v.(*oidcProviderConfig), nil
+// refreshOnce prunes issuers no longer referenced by any GatewayExtension, re-discovers the
+// expired ones, and triggers a single recomputation if any outcome changed.
+func (o *oidcProviderConfigDiscoverer) refreshOnce(ctx context.Context) {
+	// Resolve the live set outside the lock: it calls into krt, which must not be done while
+	// holding o.mu.
+	live := sets.New(o.liveIssuerURIs()...)
+
+	// Only refresh issuers that are both still discovered-from and already cached. Entries are
+	// only ever added by get(), so a config no extension has ever asked for is never
+	// discovered here; the live set additionally drops entries cached earlier that are no
+	// longer needed.
+	var pruned, expired []string
+	now := time.Now()
+	o.mu.RLock()
+	for issuerURI, result := range o.cache {
+		switch {
+		case !live.Has(issuerURI):
+			pruned = append(pruned, issuerURI)
+		case now.After(result.expiry):
+			expired = append(expired, issuerURI)
+		}
+	}
+	o.mu.RUnlock()
+
+	if len(pruned) > 0 {
+		o.mu.Lock()
+		for _, issuerURI := range pruned {
+			delete(o.cache, issuerURI)
+		}
+		o.mu.Unlock()
 	}
 
-	// Use singleflight to deduplicate concurrent discovery calls for the same issuer.
-	// After a cache.Clear(), multiple goroutines may call get() simultaneously;
-	// singleflight ensures only one discover() HTTP request is made per issuer URI.
-	result, err, _ := o.discoverGroup.Do(issuerURI, func() (any, error) {
-		// Re-check the cache inside the singleflight function, as another caller
-		// may have populated it between our initial Load and entering the group.
-		if v, ok := o.cache.Load(issuerURI); ok {
-			return v, nil
-		}
-		cfg, err := o.discover(issuerURI)
-		if err != nil {
-			return nil, err
-		}
-		o.cache.Store(issuerURI, cfg)
-		return cfg, nil
-	})
+	if len(expired) == 0 {
+		return
+	}
+
+	// Re-discover concurrently, with a bound, so that recovery latency for one issuer does not
+	// scale with the number of other unreachable issuers.
+	changed := make([]bool, len(expired))
+	var g errgroup.Group
+	g.SetLimit(backgroundDiscoveryConcurrency)
+	for i, issuerURI := range expired {
+		g.Go(func() error {
+			changed[i] = o.rediscover(ctx, issuerURI)
+			return nil
+		})
+	}
+	_ = g.Wait() // rediscover never returns an error; failures are recorded in the cache
+
+	// Trigger once for the whole pass, outside o.mu: the trigger synchronously drives the
+	// dependent transform, which calls back into load().
+	if slices.Contains(changed, true) {
+		logger.Debug("openid provider config changed, triggering recomputation")
+		o.trigger.TriggerRecomputation()
+	}
+}
+
+// rediscover re-runs discovery for issuerURI and replaces the cached entry, reporting whether
+// the new outcome differs from the cached one.
+func (o *oidcProviderConfigDiscoverer) rediscover(parent context.Context, issuerURI string) bool {
+	// Never let shutdown look like a provider failure. A refresh pass can be cancelled part
+	// way through, and overwriting a healthy cached config with "context canceled" would
+	// report a change, trigger a recomputation, and set Err on every OAuth2 extension on the
+	// way out.
+	if parent.Err() != nil {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(parent, backgroundDiscoveryTimeout)
+	defer cancel()
+
+	discoveryURL, err := oidcDiscoveryURL(issuerURI)
+	if err != nil {
+		// Not reachable in practice: the entry could only have been cached by a get() that
+		// parsed the same URI successfully.
+		logger.Warn("error refreshing OpenID provider config", "issuer_uri", issuerURI, "error", err)
+		return false
+	}
+
+	cfg, err := o.discover(ctx, discoveryURL)
+	// Check the parent, not ctx: a genuinely slow provider hits our own
+	// backgroundDiscoveryTimeout and should be cached as the failure it is, whereas a
+	// cancelled parent means we are shutting down and learned nothing about the provider.
+	if err != nil && parent.Err() != nil {
+		return false
+	}
+
+	o.mu.Lock()
+	prev, ok := o.cache[issuerURI]
+	if !ok {
+		// The entry was pruned while we were discovering, because its GatewayExtension went
+		// away. Don't resurrect it.
+		o.mu.Unlock()
+		return false
+	}
+	next := o.newResult(cfg, err, prev.failures)
+	// A refresh failure must not withdraw a configuration that was already discovered
+	// successfully. The provider document rarely changes, the proxies are running with the one
+	// we have, and caching the error instead would set Err on the GatewayExtension, which
+	// rejects every TrafficPolicy referencing it: a provider blip alone would take down
+	// authentication on routes that were working. Serve the last known good config and let the
+	// backed-off retry that newResult stamped on next.expiry pick up any change once the
+	// provider is reachable again.
+	servingLastKnownGood := err != nil && prev.err == nil
+	if servingLastKnownGood {
+		next.cfg, next.err = prev.cfg, nil
+	}
+	o.cache[issuerURI] = next
+	o.mu.Unlock()
+
+	if err != nil {
+		logger.Warn("error refreshing OpenID provider config", "issuer_uri", issuerURI,
+			"serving_last_known_good", servingLastKnownGood, "consecutive_failures", next.failures,
+			"error", err)
+	}
+	return !prev.sameOutcome(next)
+}
+
+// get returns the OpenID provider config for issuerURI, discovering it if it is not already
+// cached. Both successes and failures are cached; run() owns re-discovering them and
+// triggering a recomputation when the outcome changes, so callers must have registered with
+// markDependant to observe that change.
+func (o *oidcProviderConfigDiscoverer) get(ctx context.Context, issuerURI string) (*oidcProviderConfig, error) {
+	if result, ok := o.load(issuerURI); ok {
+		return result.cfg, result.err
+	}
+
+	// A malformed issuer URI is deliberately not cached. It can only be corrected by editing
+	// the GatewayExtension, which is a tracked krt input that re-runs this transform on its
+	// own, so there is nothing for the refresh loop to usefully retry: caching it would just
+	// log a warning every pass, forever.
+	discoveryURL, err := oidcDiscoveryURL(issuerURI)
 	if err != nil {
 		return nil, err
 	}
-	return result.(*oidcProviderConfig), nil
+
+	// Bound the time spent blocking the krt event loop; run() retries in the background.
+	ctx, cancel := context.WithTimeout(ctx, foregroundDiscoveryTimeout)
+	defer cancel()
+
+	// Use singleflight to deduplicate concurrent discovery calls for the same issuer;
+	// several transforms may call get() for the same issuer at once.
+	v, _, _ := o.discoverGroup.Do(issuerURI, func() (any, error) {
+		// Re-check the cache inside the singleflight function, as another caller
+		// may have populated it between our initial load and entering the group.
+		if result, ok := o.load(issuerURI); ok {
+			return result, nil
+		}
+		cfg, err := o.discover(ctx, discoveryURL)
+		result := o.newResult(cfg, err, 0)
+		o.mu.Lock()
+		o.cache[issuerURI] = result
+		o.mu.Unlock()
+		return result, nil
+	})
+	// The discovery error is carried inside the result rather than returned from the
+	// singleflight function, so that every waiter observes the same cached outcome.
+	result := v.(oidcDiscoveryResult)
+	return result.cfg, result.err
 }
 
-func (o *oidcProviderConfigDiscoverer) discover(issuerURI string) (*oidcProviderConfig, error) {
-	discoveryURL, err := url.Parse(issuerURI + wellKnownOpenIDConfPath)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing discovery URL: %w", err)
+func (o *oidcProviderConfigDiscoverer) load(issuerURI string) (oidcDiscoveryResult, bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	result, ok := o.cache[issuerURI]
+	return result, ok
+}
+
+// newResult stamps a discovery outcome with the expiry after which run() may retry it.
+// priorFailures is the consecutive-failure count of the entry being replaced (0 for a first
+// discovery), so that a provider which stays down is polled with an exponential backoff rather
+// than at a fixed interval for the whole outage.
+func (o *oidcProviderConfigDiscoverer) newResult(cfg *oidcProviderConfig, err error, priorFailures int) oidcDiscoveryResult {
+	if err == nil {
+		return oidcDiscoveryResult{cfg: cfg, expiry: time.Now().Add(o.cacheRefreshInterval)}
 	}
 
+	failures := priorFailures + 1
+	ttl := o.failureRetryInterval
+	// Cap the shift before it can overflow, then cap the interval itself.
+	if shift := min(failures-1, 16); shift > 0 {
+		ttl <<= shift
+	}
+	if ttl > o.cacheRefreshInterval {
+		ttl = o.cacheRefreshInterval
+	}
+	return oidcDiscoveryResult{err: err, expiry: time.Now().Add(ttl), failures: failures}
+}
+
+// oidcDiscoveryURL builds the well-known discovery URL for an issuer.
+func oidcDiscoveryURL(issuerURI string) (string, error) {
+	u, err := url.Parse(issuerURI + wellKnownOpenIDConfPath)
+	if err != nil {
+		return "", fmt.Errorf("error parsing discovery URL: %w", err)
+	}
+	return u.String(), nil
+}
+
+func (o *oidcProviderConfigDiscoverer) discover(ctx context.Context, discoveryURL string) (*oidcProviderConfig, error) {
 	cfg := &oidcProviderConfig{}
-	err = retry.Do(func() error {
+	client := &http.Client{Timeout: oidcDiscoveryHTTPTimeout}
+	err := retry.Do(func() error {
 		// TODO: allow using custom certs for HTTPS Issuer URI
-		req, err := http.NewRequest(http.MethodGet, discoveryURL.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create request: %w", err)
 		}
 
 		req.Header.Set("Accept", oidcAcceptedContentType)
 		req.Header.Set("User-Agent", userAgent)
-
-		client := &http.Client{
-			Timeout: 30 * time.Second,
-		}
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -130,7 +449,7 @@ func (o *oidcProviderConfigDiscoverer) discover(issuerURI string) (*oidcProvider
 			return retry.Unrecoverable(fmt.Errorf("error discovering OpenID provider config; unexpected status code %d", resp.StatusCode))
 		}
 		return nil
-	}, retry.Attempts(5), retry.Delay(100*time.Millisecond), retry.MaxDelay(5*time.Second), retry.DelayType(retry.BackOffDelay))
+	}, retry.Attempts(5), retry.Delay(100*time.Millisecond), retry.MaxDelay(5*time.Second), retry.DelayType(retry.BackOffDelay), retry.Context(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc_recompute_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc_recompute_test.go
@@ -1,0 +1,321 @@
+package trafficpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	apifake "github.com/kgateway-dev/kgateway/v2/pkg/apiclient/fake"
+	k8splugin "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/plugins/kubernetes"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// TestGatewayExtensionRecoversFromOIDCDiscoveryFailure is the regression test for
+// https://github.com/kgateway-dev/kgateway/issues/14497. It drives the real krt collection
+// built from TranslateGatewayExtensionBuilder, so it covers the mechanism the fix depends on
+// end to end: the transform registering as a dependant of the discovery trigger (including on
+// the error path), the background loop re-discovering, and the resulting recomputation clearing
+// TrafficPolicyGatewayExtensionIR.Err.
+//
+// Unlike the discoverer-level tests, this fails if markDependant is dropped from
+// buildOAuth2ProviderConfig or moved after the get() error return.
+func TestGatewayExtensionRecoversFromOIDCDiscoveryFailure(t *testing.T) {
+	ctx := t.Context()
+
+	// Serve the 521 from the issue report until the test marks the provider healthy, mirroring
+	// an IdP that is still starting up while the control plane translates.
+	var healthy atomic.Bool
+	var requestCount int64
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		if !healthy.Load() {
+			w.WriteHeader(521)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oidcProviderConfig{
+			TokenEndpoint:         "https://idp.example.com/token",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+		})
+	}))
+	defer idp.Close()
+
+	gwExt := &kgateway.GatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{Name: "dex-auth", Namespace: "default"},
+		Spec: kgateway.GatewayExtensionSpec{
+			Type: new(kgateway.GatewayExtensionTypeOAuth2),
+			OAuth2: &kgateway.OAuth2Provider{
+				IssuerURI:  new(idp.URL),
+				LogoutPath: "/logout",
+				BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Kind: new(gwv1.Kind("Service")),
+						Name: "dex",
+						Port: new(gwv1.PortNumber(80)),
+					},
+				},
+				Credentials: kgateway.OAuth2Credentials{
+					ClientID:        "kgateway",
+					ClientSecretRef: corev1.LocalObjectReference{Name: "dex-client-secret"},
+				},
+			},
+		},
+	}
+
+	fakeClient := apifake.NewClient(t,
+		gwExt,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "dex", Namespace: "default"},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(80)}},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "dex-client-secret", Namespace: "default"},
+			Data:       map[string][]byte{clientSecretKey: []byte("shhh")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      wellknown.OAuth2HMACSecret.Name,
+				Namespace: wellknown.OAuth2HMACSecret.Namespace,
+			},
+			Data: map[string][]byte{wellknown.OAuth2HMACSecretKey: []byte("hmac")},
+		},
+	)
+
+	// EnableEnvoy gates the GatewayExtensions collection this test builds on.
+	settings := apisettings.Settings{EnableEnvoy: true}
+	krtopts := krtutil.NewKrtOptions(ctx.Done(), nil)
+	commoncol, err := collections.NewCommonCollections(
+		ctx, krtopts, fakeClient, wellknown.DefaultGatewayControllerName, settings,
+	)
+	require.NoError(t, err)
+	// The kubernetes plugin contributes Service-backed Backends, which the OAuth2 backendRef
+	// above resolves against.
+	commoncol.InitPlugins(ctx, k8splugin.NewPlugin(ctx, commoncol), settings)
+
+	// Build the discoverer exactly as TranslateGatewayExtensionBuilder does, but with short
+	// intervals so the test does not wait out the production 30s retry floor.
+	discoverer := newOIDCProviderConfigDiscoverer(
+		func() []string { return oidcIssuerURIs(commoncol.GatewayExtensions.List()) },
+	)
+	discoverer.cacheRefreshInterval = 200 * time.Millisecond
+	discoverer.failureRetryInterval = 20 * time.Millisecond
+	go discoverer.run(ctx)
+
+	extensions := krt.NewCollection(commoncol.GatewayExtensions, gatewayExtensionBuilder(ctx, commoncol, discoverer))
+
+	fakeClient.RunAndWait(ctx.Done())
+	require.Eventually(t, func() bool {
+		return commoncol.HasSynced() && commoncol.BackendIndex.HasSynced() && extensions.HasSynced()
+	}, 10*time.Second, 50*time.Millisecond, "collections should sync")
+
+	extName := krt.Named{Name: gwExt.Name, Namespace: gwExt.Namespace}.ResourceName()
+	getIR := func() *TrafficPolicyGatewayExtensionIR {
+		return extensions.GetKey(extName)
+	}
+
+	// While the provider is down, the extension carries the discovery failure. This is the
+	// state the issue reports as permanent.
+	require.Eventually(t, func() bool {
+		out := getIR()
+		return out != nil && out.Err != nil
+	}, 10*time.Second, 50*time.Millisecond, "extension should report the discovery failure")
+	require.ErrorContains(t, getIR().Err, "unexpected status code 521")
+	require.Nil(t, getIR().OAuth2, "no OAuth2 config should be produced while discovery fails")
+
+	// The provider comes back. Nothing about the Kubernetes objects changes, so only the
+	// discovery recompute trigger can drive the extension out of its failed state.
+	healthy.Store(true)
+
+	require.Eventually(t, func() bool {
+		out := getIR()
+		return out != nil && out.Err == nil && out.OAuth2 != nil
+	}, 10*time.Second, 20*time.Millisecond,
+		"extension should recover once the provider is reachable, without a control plane restart")
+
+	// The recovered config uses the discovered endpoints.
+	cfg := getIR().OAuth2.cfg.GetConfig()
+	require.Equal(t, "https://idp.example.com/token", cfg.GetTokenEndpoint().GetUri())
+	require.Equal(t, "https://idp.example.com/auth", cfg.GetAuthorizationEndpoint())
+	require.Greater(t, atomic.LoadInt64(&requestCount), int64(1), "discovery should have been retried")
+}
+
+// TestOIDCDiscovererRunStopsOnContextCancel replaces the coverage lost with the old
+// refresh() test: run() must exit and stop polling once its context is cancelled.
+func TestOIDCDiscovererRunStopsOnContextCancel(t *testing.T) {
+	r := require.New(t)
+
+	var requestCount int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oidcProviderConfig{
+			TokenEndpoint:         "https://example.com/token",
+			AuthorizationEndpoint: "https://example.com/auth",
+		})
+	}))
+	defer server.Close()
+
+	issuer := server.URL
+	o := newTestDiscoverer(issuer)
+	// Expire immediately so every pass re-discovers, making a still-running loop obvious.
+	o.cacheRefreshInterval = 0
+	o.failureRetryInterval = 5 * time.Millisecond
+
+	_, err := o.get(t.Context(), issuer)
+	r.NoError(err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		o.run(ctx)
+	}()
+
+	// Wait until the loop is demonstrably polling.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&requestCount) > 2
+	}, 5*time.Second, 5*time.Millisecond, "refresh loop should be polling")
+
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() did not return after context cancellation")
+	}
+
+	// No further polling once the loop has exited.
+	countAfterStop := atomic.LoadInt64(&requestCount)
+	time.Sleep(50 * time.Millisecond)
+	r.Equal(countAfterStop, atomic.LoadInt64(&requestCount), "no polling should happen after cancellation")
+}
+
+// TestProviderBlipDoesNotBreakHealthyExtension is the same scenario driven through the real
+// krt collection, using the same harness as
+// TestGatewayExtensionRecoversFromOIDCDiscoveryFailure. It asserts a working extension is not
+// knocked into an error state -- which rejects every TrafficPolicy referencing it -- by a
+// provider blip alone, with no Kubernetes object changing.
+func TestProviderBlipDoesNotBreakHealthyExtension(t *testing.T) {
+	ctx := t.Context()
+
+	var healthy atomic.Bool
+	healthy.Store(true)
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !healthy.Load() {
+			w.WriteHeader(521)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oidcProviderConfig{
+			TokenEndpoint:         "https://idp.example.com/token",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+		})
+	}))
+	defer idp.Close()
+
+	gwExt := &kgateway.GatewayExtension{
+		ObjectMeta: metav1.ObjectMeta{Name: "dex-auth", Namespace: "default"},
+		Spec: kgateway.GatewayExtensionSpec{
+			Type: new(kgateway.GatewayExtensionTypeOAuth2),
+			OAuth2: &kgateway.OAuth2Provider{
+				IssuerURI:  new(idp.URL),
+				LogoutPath: "/logout",
+				BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Kind: new(gwv1.Kind("Service")),
+						Name: "dex",
+						Port: new(gwv1.PortNumber(80)),
+					},
+				},
+				Credentials: kgateway.OAuth2Credentials{
+					ClientID:        "kgateway",
+					ClientSecretRef: corev1.LocalObjectReference{Name: "dex-client-secret"},
+				},
+			},
+		},
+	}
+
+	fakeClient := apifake.NewClient(t,
+		gwExt,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "dex", Namespace: "default"},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(80)}},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "dex-client-secret", Namespace: "default"},
+			Data:       map[string][]byte{clientSecretKey: []byte("shhh")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      wellknown.OAuth2HMACSecret.Name,
+				Namespace: wellknown.OAuth2HMACSecret.Namespace,
+			},
+			Data: map[string][]byte{wellknown.OAuth2HMACSecretKey: []byte("hmac")},
+		},
+	)
+
+	// EnableEnvoy gates the GatewayExtensions collection this test builds on.
+	settings := apisettings.Settings{EnableEnvoy: true}
+	krtopts := krtutil.NewKrtOptions(ctx.Done(), nil)
+	commoncol, err := collections.NewCommonCollections(
+		ctx, krtopts, fakeClient, wellknown.DefaultGatewayControllerName, settings,
+	)
+	require.NoError(t, err)
+	commoncol.InitPlugins(ctx, k8splugin.NewPlugin(ctx, commoncol), settings)
+
+	discoverer := newOIDCProviderConfigDiscoverer(
+		func() []string { return oidcIssuerURIs(commoncol.GatewayExtensions.List()) },
+	)
+	discoverer.cacheRefreshInterval = 100 * time.Millisecond
+	discoverer.failureRetryInterval = 100 * time.Millisecond
+	go discoverer.run(ctx)
+
+	extensions := krt.NewCollection(commoncol.GatewayExtensions, gatewayExtensionBuilder(ctx, commoncol, discoverer))
+
+	fakeClient.RunAndWait(ctx.Done())
+	require.Eventually(t, func() bool {
+		return commoncol.HasSynced() && commoncol.BackendIndex.HasSynced() && extensions.HasSynced()
+	}, 10*time.Second, 50*time.Millisecond, "collections should sync")
+
+	extName := krt.Named{Name: gwExt.Name, Namespace: gwExt.Namespace}.ResourceName()
+	getIR := func() *TrafficPolicyGatewayExtensionIR { return extensions.GetKey(extName) }
+
+	// Steady state: healthy extension serving a real OAuth2 config.
+	require.Eventually(t, func() bool {
+		out := getIR()
+		return out != nil && out.Err == nil && out.OAuth2 != nil
+	}, 10*time.Second, 50*time.Millisecond, "extension should be healthy to begin with")
+
+	// The IdP blips. Nothing about the Kubernetes objects changes.
+	healthy.Store(false)
+
+	// Give the refresh loop several passes to do damage, then assert it did not.
+	time.Sleep(time.Second)
+
+	out := getIR()
+	require.NotNil(t, out)
+	if out.Err != nil {
+		t.Logf("extension was knocked into an error state by the blip:\n%v", out.Err)
+	}
+	require.NoError(t, out.Err, "a provider blip must not break a working OAuth2 extension")
+	require.NotNil(t, out.OAuth2, "the discovered OAuth2 config must be retained through a blip")
+}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/oidc_test.go
@@ -3,6 +3,7 @@ package trafficpolicy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,7 +12,20 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	kgwv1a1 "github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
+
+// newTestDiscoverer returns a discoverer whose refresh loop considers the given issuer URIs
+// live, with short intervals so refresh behavior is observable in tests.
+func newTestDiscoverer(issuerURIs ...string) *oidcProviderConfigDiscoverer {
+	o := newOIDCProviderConfigDiscoverer(func() []string { return issuerURIs })
+	o.cacheRefreshInterval = 50 * time.Millisecond
+	o.failureRetryInterval = 20 * time.Millisecond
+	return o
+}
 
 func TestOIDCConfigDiscovery(t *testing.T) {
 	tests := []struct {
@@ -121,10 +135,10 @@ func TestOIDCConfigDiscovery(t *testing.T) {
 			issuer := issuerURL.String()
 
 			// Create new OIDC config discovery instance for each test
-			o := newOIDCProviderConfigDiscoverer()
+			o := newTestDiscoverer(issuer)
 
 			// Test the discovery
-			config, err := o.get(issuer)
+			config, err := o.get(context.Background(), issuer)
 
 			if tt.expectError {
 				r.Error(err)
@@ -166,17 +180,17 @@ func TestOIDCConfigDiscoveryCache(t *testing.T) {
 	}))
 	defer server.Close()
 
-	o := newOIDCProviderConfigDiscoverer()
 	issuer := server.URL
+	o := newTestDiscoverer(issuer)
 
 	// First call should make HTTP request
-	config1, err := o.get(issuer)
+	config1, err := o.get(context.Background(), issuer)
 	r.NoError(err)
 	r.NotNil(config1)
 	r.Equal(1, requestCount)
 
 	// Second call should use cache
-	config2, err := o.get(issuer)
+	config2, err := o.get(context.Background(), issuer)
 	r.NoError(err)
 	r.NotNil(config2)
 	r.Equal(1, requestCount) // Should still be 1, no new request
@@ -184,6 +198,34 @@ func TestOIDCConfigDiscoveryCache(t *testing.T) {
 	// Verify configs are the same
 	r.Equal(config1.TokenEndpoint, config2.TokenEndpoint)
 	r.Equal(config1.AuthorizationEndpoint, config2.AuthorizationEndpoint)
+}
+
+// TestOIDCConfigDiscoveryFailureIsCached asserts that a discovery failure is served from the
+// cache, so a GatewayExtension re-translated for an unrelated reason does not re-block the krt
+// event loop contacting a provider already known to be unreachable.
+func TestOIDCConfigDiscoveryFailureIsCached(t *testing.T) {
+	r := require.New(t)
+
+	var requestCount int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	issuer := server.URL
+	o := newTestDiscoverer(issuer)
+
+	cfg, err := o.get(context.Background(), issuer)
+	r.Error(err)
+	r.Nil(cfg)
+	// 404 is unrecoverable, so exactly one request is made.
+	r.Equal(int64(1), atomic.LoadInt64(&requestCount))
+
+	cfg, err = o.get(context.Background(), issuer)
+	r.Error(err)
+	r.Nil(cfg)
+	r.Equal(int64(1), atomic.LoadInt64(&requestCount), "failed discovery should be served from cache")
 }
 
 func TestOIDCConfigDiscoveryConcurrentDedup(t *testing.T) {
@@ -204,8 +246,8 @@ func TestOIDCConfigDiscoveryConcurrentDedup(t *testing.T) {
 	}))
 	defer server.Close()
 
-	o := newOIDCProviderConfigDiscoverer()
 	issuer := server.URL
+	o := newTestDiscoverer(issuer)
 
 	// Launch many concurrent get() calls for the same issuer.
 	const goroutines = 10
@@ -213,7 +255,7 @@ func TestOIDCConfigDiscoveryConcurrentDedup(t *testing.T) {
 	configs := make(chan *oidcProviderConfig, goroutines)
 	for range goroutines {
 		go func() {
-			cfg, err := o.get(issuer)
+			cfg, err := o.get(context.Background(), issuer)
 			errs <- err
 			configs <- cfg
 		}()
@@ -235,101 +277,558 @@ func TestOIDCConfigDiscoveryConcurrentDedup(t *testing.T) {
 func TestOIDCConfigDiscoveryInvalidIssuerURL(t *testing.T) {
 	r := require.New(t)
 
-	o := newOIDCProviderConfigDiscoverer()
-
 	// Test with invalid URL that would cause url.Parse to fail
 	invalidIssuer := "://invalid-url"
+	o := newTestDiscoverer(invalidIssuer)
 
-	config, err := o.get(invalidIssuer)
+	config, err := o.get(context.Background(), invalidIssuer)
 	r.Error(err)
 	r.Nil(config)
 	r.Contains(err.Error(), "error parsing discovery URL")
+
+	// A malformed issuer URI is not cached: it can only be fixed by editing the
+	// GatewayExtension, which re-runs the transform on its own, so there is nothing for the
+	// refresh loop to retry and it must not be polled (or warned about) every pass forever.
+	_, cached := o.load(invalidIssuer)
+	r.False(cached, "malformed issuer URI should not be cached")
+
+	o.refreshOnce(context.Background())
+	_, cached = o.load(invalidIssuer)
+	r.False(cached, "refresh should not resurrect a malformed issuer URI")
 }
 
-func TestOIDCProviderConfigDiscovererRun(t *testing.T) {
+// TestOIDCConfigDiscoveryFailureBacksOff asserts consecutive failures are retried with an
+// exponential backoff capped at cacheRefreshInterval, so a multi-hour provider outage is not
+// polled at the base interval for its whole duration.
+func TestOIDCConfigDiscoveryFailureBacksOff(t *testing.T) {
 	r := require.New(t)
 
-	// Track the number of requests made to the server
-	var requestCount int64
+	o := newOIDCProviderConfigDiscoverer(func() []string { return nil })
+	o.failureRetryInterval = time.Second
+	o.cacheRefreshInterval = 4 * time.Second
+	discoveryErr := errors.New("boom")
 
+	// failures=1 -> 1s, 2 -> 2s, 3 -> 4s, then capped at cacheRefreshInterval.
+	for _, tc := range []struct {
+		priorFailures int
+		wantTTL       time.Duration
+	}{
+		{priorFailures: 0, wantTTL: time.Second},
+		{priorFailures: 1, wantTTL: 2 * time.Second},
+		{priorFailures: 2, wantTTL: 4 * time.Second},
+		{priorFailures: 3, wantTTL: 4 * time.Second},
+		{priorFailures: 40, wantTTL: 4 * time.Second}, // no overflow at high failure counts
+	} {
+		before := time.Now()
+		result := o.newResult(nil, discoveryErr, tc.priorFailures)
+		r.Equal(tc.priorFailures+1, result.failures)
+		ttl := result.expiry.Sub(before)
+		r.GreaterOrEqual(ttl, tc.wantTTL, "ttl for %d prior failures", tc.priorFailures)
+		r.Less(ttl, tc.wantTTL+time.Second, "ttl for %d prior failures", tc.priorFailures)
+	}
+
+	// A success resets to the full refresh interval.
+	success := o.newResult(&oidcProviderConfig{}, nil, 9)
+	r.Equal(0, success.failures)
+	r.Greater(time.Until(success.expiry), 3*time.Second)
+}
+
+// TestOIDCConfigDiscoveryShutdownDoesNotClobberCache asserts a refresh pass interrupted by
+// shutdown leaves cached configs alone. Overwriting a healthy entry with "context canceled"
+// would report a change, trigger a recomputation, and set Err on every OAuth2 extension on the
+// way out.
+func TestOIDCConfigDiscoveryShutdownDoesNotClobberCache(t *testing.T) {
+	r := require.New(t)
+
+	// Block the handler until the test releases it, so cancellation can land mid-flight.
+	release := make(chan struct{})
+	var serving atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		atomic.AddInt64(&requestCount, 1)
+		if serving.Load() {
+			serving.Store(false)
+			<-release
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oidcProviderConfig{
+			TokenEndpoint:         "https://example.com/token",
+			AuthorizationEndpoint: "https://example.com/auth",
+		})
+	}))
+	defer server.Close()
+	defer close(release)
 
+	issuer := server.URL
+	o := newTestDiscoverer(issuer)
+
+	// Populate a healthy entry.
+	cfg, err := o.get(context.Background(), issuer)
+	r.NoError(err)
+	r.NotNil(cfg)
+
+	assertCacheIntact := func(when string) {
+		got, ok := o.load(issuer)
+		r.True(ok, "entry should still be cached %s", when)
+		r.NoError(got.err, "cached config should survive %s", when)
+		r.NotNil(got.cfg, "cached config should survive %s", when)
+		r.Equal("https://example.com/token", got.cfg.TokenEndpoint)
+	}
+
+	// Cancelled before the pass starts.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r.False(o.rediscover(ctx, issuer), "a cancelled pass should not report a change")
+	assertCacheIntact("cancellation before the pass")
+
+	// Cancelled while the request is in flight.
+	serving.Store(true)
+	inflightCtx, cancelInflight := context.WithCancel(context.Background())
+	done := make(chan bool, 1)
+	go func() { done <- o.rediscover(inflightCtx, issuer) }()
+	require.Eventually(t, func() bool { return !serving.Load() }, 5*time.Second, 10*time.Millisecond,
+		"handler should have been entered")
+	cancelInflight()
+
+	select {
+	case changed := <-done:
+		r.False(changed, "a pass cancelled in flight should not report a change")
+	case <-time.After(5 * time.Second):
+		t.Fatal("rediscover did not return after cancellation")
+	}
+	assertCacheIntact("cancellation in flight")
+}
+
+// TestOIDCDiscovererRunClampsNonPositiveInterval guards against time.NewTicker panicking when a
+// discoverer is built with a zero interval, as the pruning test does.
+func TestOIDCDiscovererRunClampsNonPositiveInterval(t *testing.T) {
+	o := newOIDCProviderConfigDiscoverer(func() []string { return nil })
+	o.failureRetryInterval = 0
+	o.cacheRefreshInterval = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		o.run(ctx) // must not panic
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() did not return after context cancellation")
+	}
+}
+
+// TestOIDCConfigDiscoveryRetriesFailureAndRecovers covers the regression in
+// https://github.com/kgateway-dev/kgateway/issues/14497: an issuer that is unreachable when
+// the config is first discovered must be re-discovered by the refresh loop, and the recovery
+// must trigger a krt recomputation so the GatewayExtension stops reporting the error.
+func TestOIDCConfigDiscoveryRetriesFailureAndRecovers(t *testing.T) {
+	r := require.New(t)
+
+	// Serve the 521 from the issue report until the test flips the switch, mirroring a
+	// provider that is still starting up while the control plane translates.
+	var healthy atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !healthy.Load() {
+			w.WriteHeader(521)
+			return
+		}
 		config := oidcProviderConfig{
 			TokenEndpoint:         "https://example.com/token",
 			AuthorizationEndpoint: "https://example.com/auth",
-			EndSessionEndpoint:    new("https://example.com/logout"),
+			JWKSURI:               "https://example.com/keys",
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(config)
 	}))
 	defer server.Close()
 
-	// Create discoverer with very short refresh interval for testing
-	o := &oidcProviderConfigDiscoverer{
-		cacheRefreshInterval: 50 * time.Millisecond,
+	issuer := server.URL
+	o := newTestDiscoverer(issuer)
+
+	// Initial translation fails, exactly as reported in the issue.
+	cfg, err := o.get(context.Background(), issuer)
+	r.Error(err)
+	r.Nil(cfg)
+	r.Contains(err.Error(), "unexpected status code 521")
+
+	// While the provider is still down, refreshing must not report a change: the error is
+	// identical, so krt should not be churned.
+	r.False(o.rediscover(context.Background(), issuer), "unchanged failure should not trigger recomputation")
+
+	// The provider comes back.
+	healthy.Store(true)
+
+	// The refresh loop re-discovers and reports the changed outcome.
+	r.True(o.rediscover(context.Background(), issuer), "recovery should trigger recomputation")
+
+	// A subsequent translation now sees the discovered config instead of the latched error.
+	cfg, err = o.get(context.Background(), issuer)
+	r.NoError(err)
+	r.NotNil(cfg)
+	r.Equal("https://example.com/token", cfg.TokenEndpoint)
+	r.Equal("https://example.com/keys", cfg.JWKSURI)
+}
+
+// TestProviderBlipKeepsCachedConfig is the mirror image of
+// TestOIDCConfigDiscoveryRetriesFailureAndRecovers: the provider starts healthy and then blips.
+// A refresh failure must not withdraw a configuration that was discovered successfully -- it
+// should keep serving the last known good config and just retry.
+func TestProviderBlipKeepsCachedConfig(t *testing.T) {
+	r := require.New(t)
+
+	var healthy atomic.Bool
+	healthy.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !healthy.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oidcProviderConfig{
+			TokenEndpoint:         "https://example.com/token",
+			AuthorizationEndpoint: "https://example.com/auth",
+		})
+	}))
+	defer server.Close()
+
+	issuer := server.URL
+	o := newTestDiscoverer(issuer)
+
+	// Steady state: discovery succeeded, translation is serving a real config.
+	cfg, err := o.get(context.Background(), issuer)
+	r.NoError(err)
+	r.Equal("https://example.com/token", cfg.TokenEndpoint)
+
+	// The provider blips and a refresh pass lands in the window.
+	healthy.Store(false)
+	r.False(o.rediscover(context.Background(), issuer), "a transient refresh failure should not trigger a recomputation")
+
+	// What the next translation sees.
+	cfg, err = o.get(context.Background(), issuer)
+	r.NoError(err, "the last known good config should still be served during a blip")
+	r.NotNil(cfg, "the last known good config should still be served during a blip")
+	r.Equal("https://example.com/token", cfg.TokenEndpoint)
+}
+
+// TestProviderBlipBacksOffAndPicksUpChanges guards the two things retaining a config through a
+// failure must not cost us: the retry must still back off while the provider is down, and the
+// entry must not be latched -- once the provider returns with a *different* document, the change
+// has to propagate.
+func TestProviderBlipBacksOffAndPicksUpChanges(t *testing.T) {
+	r := require.New(t)
+
+	var token atomic.Value
+	token.Store("https://example.com/token")
+	var healthy atomic.Bool
+	healthy.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !healthy.Load() {
+			w.WriteHeader(http.StatusNotFound) // unrecoverable, so the blip resolves fast
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oidcProviderConfig{
+			TokenEndpoint:         token.Load().(string),
+			AuthorizationEndpoint: "https://example.com/auth",
+		})
+	}))
+	defer server.Close()
+
+	issuer := server.URL
+	o := newTestDiscoverer(issuer)
+	o.failureRetryInterval = time.Second
+	o.cacheRefreshInterval = 4 * time.Second
+
+	_, err := o.get(context.Background(), issuer)
+	r.NoError(err)
+
+	// Two failed refresh passes while stale-serving: the retry backs off 1s -> 2s rather than
+	// hammering the provider for the length of the outage.
+	healthy.Store(false)
+	for _, want := range []time.Duration{time.Second, 2 * time.Second} {
+		before := time.Now()
+		r.False(o.rediscover(context.Background(), issuer))
+
+		result, ok := o.load(issuer)
+		r.True(ok)
+		r.NotNil(result.cfg, "the last known good config must be retained across every failure")
+		r.NoError(result.err)
+		ttl := result.expiry.Sub(before)
+		r.GreaterOrEqual(ttl, want)
+		r.Less(ttl, want+time.Second)
 	}
+
+	// The provider comes back, with a different token endpoint than we cached.
+	token.Store("https://example.com/token/v2")
+	healthy.Store(true)
+
+	r.True(o.rediscover(context.Background(), issuer), "a changed config must trigger a recomputation")
+	cfg, err := o.get(context.Background(), issuer)
+	r.NoError(err)
+	r.Equal("https://example.com/token/v2", cfg.TokenEndpoint)
+
+	result, ok := o.load(issuer)
+	r.True(ok)
+	r.Equal(0, result.failures, "a successful refresh resets the backoff")
+}
+
+// TestOIDCConfigDiscoveryRefreshLoopRecovers exercises the same recovery through the running
+// refresh loop rather than by calling rediscover() directly.
+func TestOIDCConfigDiscoveryRefreshLoopRecovers(t *testing.T) {
+	r := require.New(t)
+
+	var healthy atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !healthy.Load() {
+			w.WriteHeader(http.StatusNotFound) // unrecoverable, so no retry backoff
+			return
+		}
+		config := oidcProviderConfig{
+			TokenEndpoint:         "https://example.com/token",
+			AuthorizationEndpoint: "https://example.com/auth",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(config)
+	}))
+	defer server.Close()
+
+	issuer := server.URL
+	o := newTestDiscoverer(issuer)
+
+	_, err := o.get(context.Background(), issuer)
+	r.Error(err)
+
+	ctx := t.Context()
+	go o.run(ctx)
+
+	healthy.Store(true)
+
+	require.Eventually(t, func() bool {
+		cfg, err := o.get(context.Background(), issuer)
+		return err == nil && cfg != nil && cfg.TokenEndpoint == "https://example.com/token"
+	}, 5*time.Second, 10*time.Millisecond, "refresh loop should re-discover the recovered provider")
+}
+
+// TestOIDCConfigDiscoveryPrunesDeletedIssuers asserts the refresh loop stops polling an issuer
+// once no GatewayExtension references it, so a deleted or re-pointed extension does not leave
+// kgateway contacting a dead endpoint forever.
+func TestOIDCConfigDiscoveryPrunesDeletedIssuers(t *testing.T) {
+	r := require.New(t)
+
+	var requestCount int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		config := oidcProviderConfig{
+			TokenEndpoint:         "https://example.com/token",
+			AuthorizationEndpoint: "https://example.com/auth",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(config)
+	}))
+	defer server.Close()
 
 	issuer := server.URL
 
-	// Initial request to populate cache
-	config1, err := o.get(issuer)
+	var live atomic.Bool
+	live.Store(true)
+	o := newOIDCProviderConfigDiscoverer(func() []string {
+		if !live.Load() {
+			return nil
+		}
+		return []string{issuer}
+	})
+	// Expire immediately so every refresh pass re-discovers a live issuer.
+	o.cacheRefreshInterval = 0
+	o.failureRetryInterval = 0
+
+	_, err := o.get(context.Background(), issuer)
 	r.NoError(err)
-	r.NotNil(config1)
-	r.Equal("https://example.com/token", config1.TokenEndpoint)
-	r.Equal(int64(1), atomic.LoadInt64(&requestCount)) // First request
+	r.Equal(int64(1), atomic.LoadInt64(&requestCount))
 
-	// Second get should use cache (no new request)
-	config2, err := o.get(issuer)
+	// While referenced, a refresh pass re-discovers.
+	o.refreshOnce(context.Background())
+	r.Equal(int64(2), atomic.LoadInt64(&requestCount))
+	_, cached := o.load(issuer)
+	r.True(cached)
+
+	// Once the GatewayExtension is gone, the entry is pruned and no longer polled.
+	live.Store(false)
+	o.refreshOnce(context.Background())
+	_, cached = o.load(issuer)
+	r.False(cached, "issuer with no referencing GatewayExtension should be pruned")
+
+	countAfterPrune := atomic.LoadInt64(&requestCount)
+	o.refreshOnce(context.Background())
+	r.Equal(countAfterPrune, atomic.LoadInt64(&requestCount), "pruned issuer should not be polled")
+}
+
+// TestOIDCDiscoveryRequired pins the predicate that defines "this extension will call
+// discoverer.get()". buildOAuth2ProviderConfig and the refresh loop's live set both use it, so a
+// change here silently changes which issuers are polled: widening it polls issuers nobody reads,
+// narrowing it prunes entries that are still needed and re-latches discovery failures.
+func TestOIDCDiscoveryRequired(t *testing.T) {
+	const uri = kgwv1a1.HttpsUri("https://idp.example.com/x")
+	issuer := "https://idp.example.com"
+
+	// allExplicit is the only shape that does not need discovery while still naming an issuer.
+	allExplicit := func() *kgwv1a1.OAuth2Provider {
+		return &kgwv1a1.OAuth2Provider{
+			IssuerURI:             &issuer,
+			TokenEndpoint:         ptr.To(uri),
+			AuthorizationEndpoint: ptr.To(uri),
+			EndSessionEndpoint:    ptr.To(uri),
+		}
+	}
+
+	tests := []struct {
+		name string
+		in   *kgwv1a1.OAuth2Provider
+		want bool
+	}{
+		{name: "nil provider", in: nil, want: false},
+		{name: "no issuer at all", in: &kgwv1a1.OAuth2Provider{}, want: false},
+		{
+			name: "no issuer, endpoints explicit",
+			in:   &kgwv1a1.OAuth2Provider{TokenEndpoint: ptr.To(uri), AuthorizationEndpoint: ptr.To(uri)},
+			want: false,
+		},
+		{name: "issuer only", in: &kgwv1a1.OAuth2Provider{IssuerURI: &issuer}, want: true},
+		{name: "issuer and every endpoint explicit", in: allExplicit(), want: false},
+		{
+			name: "issuer, token endpoint missing",
+			in: func() *kgwv1a1.OAuth2Provider {
+				p := allExplicit()
+				p.TokenEndpoint = nil
+				return p
+			}(),
+			want: true,
+		},
+		{
+			name: "issuer, authorization endpoint missing",
+			in: func() *kgwv1a1.OAuth2Provider {
+				p := allExplicit()
+				p.AuthorizationEndpoint = nil
+				return p
+			}(),
+			want: true,
+		},
+		{
+			name: "issuer, end session endpoint missing",
+			in: func() *kgwv1a1.OAuth2Provider {
+				p := allExplicit()
+				p.EndSessionEndpoint = nil
+				return p
+			}(),
+			want: true,
+		},
+		{
+			name: "issuer, endpoints explicit, JWT without jwksURI",
+			in: func() *kgwv1a1.OAuth2Provider {
+				p := allExplicit()
+				p.JWT = &kgwv1a1.OAuth2JWTConfig{}
+				return p
+			}(),
+			want: true,
+		},
+		{
+			name: "issuer, endpoints explicit, JWT with jwksURI",
+			in: func() *kgwv1a1.OAuth2Provider {
+				p := allExplicit()
+				p.JWT = &kgwv1a1.OAuth2JWTConfig{JWKSURI: ptr.To(uri)}
+				return p
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, oidcDiscoveryRequired(tt.in))
+
+			// oidcIssuerURIs must agree: it lists exactly the issuers that will be discovered.
+			got := oidcIssuerURIs([]ir.GatewayExtension{{OAuth2: tt.in}})
+			if tt.want {
+				require.Equal(t, []string{issuer}, got)
+			} else {
+				require.Empty(t, got)
+			}
+		})
+	}
+}
+
+// TestOIDCIssuerURIsSharedIssuer asserts an issuer stays live while any one extension still
+// discovers from it, even if another has every endpoint configured explicitly.
+func TestOIDCIssuerURIsSharedIssuer(t *testing.T) {
+	issuer := "https://idp.example.com"
+	uri := kgwv1a1.HttpsUri("https://idp.example.com/x")
+
+	needsDiscovery := &kgwv1a1.OAuth2Provider{IssuerURI: &issuer}
+	fullyExplicit := &kgwv1a1.OAuth2Provider{
+		IssuerURI:             &issuer,
+		TokenEndpoint:         new(uri),
+		AuthorizationEndpoint: new(uri),
+		EndSessionEndpoint:    new(uri),
+	}
+
+	require.Equal(t, []string{issuer}, oidcIssuerURIs([]ir.GatewayExtension{
+		{OAuth2: fullyExplicit}, {OAuth2: needsDiscovery},
+	}), "issuer should stay live while any extension still discovers from it")
+}
+
+// TestOIDCConfigDiscoveryPrunesIssuerNoLongerDiscovered covers the transition the deletion-based
+// prune test does not: the GatewayExtension still exists and still names the issuer, but every
+// endpoint is now configured explicitly, so nothing reads the discovered config any more.
+func TestOIDCConfigDiscoveryPrunesIssuerNoLongerDiscovered(t *testing.T) {
+	r := require.New(t)
+
+	var requestCount int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oidcProviderConfig{
+			TokenEndpoint:         "https://example.com/token",
+			AuthorizationEndpoint: "https://example.com/auth",
+		})
+	}))
+	defer server.Close()
+
+	issuer := server.URL
+	uri := kgwv1a1.HttpsUri("https://example.com/x")
+
+	// The extension starts out relying on discovery, then is edited to spell out every endpoint
+	// while keeping issuerURI.
+	ext := &kgwv1a1.OAuth2Provider{IssuerURI: &issuer}
+	o := newOIDCProviderConfigDiscoverer(func() []string {
+		return oidcIssuerURIs([]ir.GatewayExtension{{OAuth2: ext}})
+	})
+	// Expire immediately so every pass re-discovers whatever is still live.
+	o.cacheRefreshInterval = 0
+	o.failureRetryInterval = 0
+
+	_, err := o.get(context.Background(), issuer)
 	r.NoError(err)
-	r.NotNil(config2)
-	r.Equal("https://example.com/token", config2.TokenEndpoint)
-	r.Equal(int64(1), atomic.LoadInt64(&requestCount)) // Still only 1 request (from cache)
+	r.Equal(int64(1), atomic.LoadInt64(&requestCount))
 
-	// Start the background cache clearing
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// While discovery is still required, the entry is refreshed.
+	o.refreshOnce(context.Background())
+	r.Equal(int64(2), atomic.LoadInt64(&requestCount))
+	_, cached := o.load(issuer)
+	r.True(cached)
 
-	go o.refresh(ctx)
+	// The user fills in every endpoint. buildOAuth2ProviderConfig will no longer call get() for
+	// this extension, so the cached entry must be dropped rather than polled forever.
+	ext.TokenEndpoint = new(uri)
+	ext.AuthorizationEndpoint = new(uri)
+	ext.EndSessionEndpoint = new(uri)
 
-	// Wait for cache to be cleared (refresh interval is 50ms)
-	time.Sleep(75 * time.Millisecond)
+	o.refreshOnce(context.Background())
+	_, cached = o.load(issuer)
+	r.False(cached, "issuer should be pruned once no extension discovers from it")
 
-	// Now get should make a new request because cache was cleared
-	config3, err := o.get(issuer)
-	r.NoError(err)
-	r.NotNil(config3)
-	r.Equal("https://example.com/token", config3.TokenEndpoint)
-	r.Equal(int64(2), atomic.LoadInt64(&requestCount)) // Second request after cache clear
-
-	// Verify cache is working again (no new request)
-	config4, err := o.get(issuer)
-	r.NoError(err)
-	r.NotNil(config4)
-	r.Equal("https://example.com/token", config4.TokenEndpoint)
-	r.Equal(int64(2), atomic.LoadInt64(&requestCount)) // Still 2 requests (from cache)
-
-	// Wait for another cache clear cycle
-	time.Sleep(75 * time.Millisecond)
-
-	// Another get should make a third request because cache was cleared again
-	config5, err := o.get(issuer)
-	r.NoError(err)
-	r.NotNil(config5)
-	r.Equal("https://example.com/token", config5.TokenEndpoint)
-	r.Equal(int64(3), atomic.LoadInt64(&requestCount)) // Third request after second cache clear
-
-	// Cancel context and verify no more cache clearing
-	cancel()
-	requestCountBeforeCancel := atomic.LoadInt64(&requestCount)
-
-	// Wait longer than the refresh interval
-	time.Sleep(100 * time.Millisecond)
-
-	// Get should still use cache since run() stopped
-	config6, err := o.get(issuer)
-	r.NoError(err)
-	r.NotNil(config6)
-	r.Equal("https://example.com/token", config6.TokenEndpoint)
-	r.Equal(requestCountBeforeCancel, atomic.LoadInt64(&requestCount)) // No new requests after cancel
+	countAfterPrune := atomic.LoadInt64(&requestCount)
+	o.refreshOnce(context.Background())
+	r.Equal(countAfterPrune, atomic.LoadInt64(&requestCount), "pruned issuer should not be polled")
 }


### PR DESCRIPTION
# Description

Backport of #14508 to `v2.3.x`. Also fixes #14047, which reports the same latched failure reached from a transient IdP outage rather than a control-plane restart, on a release branch that does not have this fix. The `v2.4.x` backport is #14576.

OIDC discovery is an HTTP call made inside a KRT transformation (`TranslateGatewayExtensionBuilder` -> `buildOAuth2ProviderConfig` -> `discoverer.get`), but the OpenID provider is not a Kubernetes resource, so KRT has no dependency it can track on it. A provider that is unreachable while the control plane translates leaves the failure baked into `TrafficPolicyGatewayExtensionIR.Err`, and nothing ever re-runs the transform to clear it: every `TrafficPolicy` referencing the extension stays rejected and its routes are replaced with a direct response until the control plane is restarted. The existing 5 minute `refresh()` loop only called `cache.Clear()`, which affects the *next* `get()` that never comes.

The discoverer now owns a `krt.RecomputeTrigger`, retries failed discovery in the background with backoff, and triggers a recomputation when an outcome actually changes. Full rationale is in #14508.

## Backport notes

Cherry-picked from f7aea07289623a6b0a5e69dd8129dd1cbed191cc. Three adjustments, all mechanical:

- `oidc.go` and `oidc_test.go` conflicted because this branch never took #13985 (hoist the `http.Client` out of the retry loop) or #14022 (ticker-based refresh loop, and the test change that goes with it). Both are superseded by this change, which hoists the same client and replaces `refresh()` with the ticker-driven `run()`, so the conflicts were resolved in favour of the incoming version. The resolved `oidc.go`, `oidc_test.go` and `oidc_recompute_test.go` are byte-identical to main's apart from the last point below.
- Dropped the `errors` import main added when it enabled the error linters (#14534), which is not on this branch; the two error returns it touched still use `fmt.Errorf` here.
- `TestGatewayExtensionRecoversFromOIDCDiscoveryFailure` sets `EnableEnvoy` on its `Settings`. This branch only builds the `GatewayExtensions` collection when Envoy is enabled, and the test drives that collection; without it, `krt.NewCollection` panics on a nil parent.

# Change Type

/kind fix

# Changelog

```release-note
Fixed an issue where a TrafficPolicy using OAuth2 would stay permanently broken if the OpenID provider was unreachable the first time kgateway discovered its configuration, for example when both were restarting together. The discovery failure was latched until the control plane was restarted. kgateway now retries discovery in the background and re-translates affected policies once the provider becomes reachable. Retries start 30 seconds after a failure and back off exponentially, so recovery from a prolonged provider outage can take up to a few minutes.
```

# Additional Notes

Verified on this branch: `make go-generate-apis` leaves no diff, `make analyze` reports 0 issues, and `go test -race ./pkg/kgateway/extensions2/plugins/trafficpolicy/...` passes, including `TestGatewayExtensionRecoversFromOIDCDiscoveryFailure`, which drives the real KRT collection and asserts the extension IR's `Err` goes non-nil -> nil once the provider recovers.
