### PR TITLE
fix(backendconfigpolicy): validate TLS cipher suites and ECDH curves

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/tls.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/tls.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	eiutils "github.com/kgateway-dev/kgateway/v2/internal/envoyinit/pkg/utils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/pluginutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/sslutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
@@ -246,9 +247,19 @@ func parseTLSParameters(tlsParameters *kgateway.TLSParameters) (*envoytlsv3.TlsP
 		return nil, err
 	}
 
+	cipherSuites, err := sslutils.ValidateTlsStrings(tlsParameters.CipherSuites, sslutils.SupportedCipherSuites, "cipher suite")
+	if err != nil {
+		return nil, err
+	}
+
+	ecdhCurves, err := sslutils.ValidateTlsStrings(tlsParameters.EcdhCurves, sslutils.SupportedEcdhCurves, "ECDH curve")
+	if err != nil {
+		return nil, err
+	}
+
 	return &envoytlsv3.TlsParameters{
-		CipherSuites:              tlsParameters.CipherSuites,
-		EcdhCurves:                tlsParameters.EcdhCurves,
+		CipherSuites:              cipherSuites,
+		EcdhCurves:                ecdhCurves,
 		SignatureAlgorithms:       tlsParameters.SignatureAlgorithms,
 		TlsMinimumProtocolVersion: tlsMinVersion,
 		TlsMaximumProtocolVersion: tlsMaxVersion,

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/tls_test.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/tls_test.go
@@ -253,6 +253,30 @@ func TestTranslateTLSConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid TLS config - unsupported cipher suite",
+			tlsConfig: &kgateway.TLS{
+				Files: &kgateway.TLSFiles{
+					RootCA: new(CACert),
+				},
+				Parameters: &kgateway.TLSParameters{
+					CipherSuites: []string{"BOGUS_CIPHER_SUITE_1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid TLS config - unsupported ECDH curve",
+			tlsConfig: &kgateway.TLS{
+				Files: &kgateway.TLSFiles{
+					RootCA: new(CACert),
+				},
+				Parameters: &kgateway.TLSParameters{
+					EcdhCurves: []string{"hello"},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "should not error with only rootca",
 			tlsConfig: &kgateway.TLS{
 				Files: &kgateway.TLSFiles{

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -1,33 +1,9 @@
 Clusters:
-- commonLbConfig:
-    localityWeightedLbConfig: {}
-  connectTimeout: 5s
-  edsClusterConfig:
-    edsConfig:
-      ads: {}
-      resourceApiVersion: V3
-  ignoreHealthOnHostRemoval: true
+- loadAssignment:
+    clusterName: kube_gwtest_example-svc_80
+  metadata: {}
   name: kube_gwtest_example-svc_80
-  transportSocket:
-    name: envoy.transport_sockets.tls
-    typedConfig:
-      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-      commonTlsContext:
-        tlsParams:
-          cipherSuites:
-          - BOGUS_CIPHER_SUITE_1
-          - INVALID_AES_256_GCM_SHA384
-          - FAKE_ECDHE_RSA_WITH_AES_128_CBC_SHA
-          ecdhCurves:
-          - invalid-curve-p256
-          - bogus-secp384r1
-          - fake-x25519
-          signatureAlgorithms:
-          - rsa_unknown_algo
-          - ecdsa_bogus
-          tlsMaximumProtocolVersion: TLSv1_3
-          tlsMinimumProtocolVersion: TLSv1_2
-  type: EDS
+  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:
@@ -159,13 +135,14 @@ Statuses:
           namespace: gwtest
         conditions:
         - lastTransitionTime: null
-          message: Policy accepted
-          reason: Valid
-          status: "True"
+          message: 'unsupported cipher suite: "BOGUS_CIPHER_SUITE_1" (ensure you are
+            using a BoringSSL-supported name)'
+          reason: Invalid
+          status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Attached to all targets
-          reason: Attached
-          status: "True"
+          message: ""
+          reason: Pending
+          status: "False"
           type: Attached
         controllerName: kgateway.dev/kgateway

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -135,10 +135,8 @@ Statuses:
           namespace: gwtest
         conditions:
         - lastTransitionTime: null
-          message: 'invalid xds configuration: error initializing configuration ''/dev/fd/0'':
-            Failed to initialize cipher suites BOGUS_CIPHER_SUITE_1:INVALID_AES_256_GCM_SHA384:FAKE_ECDHE_RSA_WITH_AES_128_CBC_SHA.
-            The following ciphers were rejected when tried individually: BOGUS_CIPHER_SUITE_1,
-            INVALID_AES_256_GCM_SHA384, FAKE_ECDHE_RSA_WITH_AES_128_CBC_SHA'
+          message: 'unsupported cipher suite: "BOGUS_CIPHER_SUITE_1" (ensure you are
+            using a BoringSSL-supported name)'
           reason: Invalid
           status: "False"
           type: Accepted

--- a/pkg/kgateway/translator/sslutils/tls_params.go
+++ b/pkg/kgateway/translator/sslutils/tls_params.go
@@ -93,8 +93,11 @@ func ValidateTlsStrings(input []string, supported map[string]struct{}, fieldName
 
 	seen := make(map[string]struct{}, len(input))
 	cleaned := make([]string, 0, len(input))
-	for _, val := range input {
+	for i, val := range input {
 		trimmed := strings.TrimSpace(val)
+		if trimmed == "" {
+			return nil, fmt.Errorf("empty %s entry at index %d", fieldName, i)
+		}
 		if _, ok := supported[trimmed]; !ok {
 			return nil, fmt.Errorf("unsupported %s: %q (ensure you are using a BoringSSL-supported name)", fieldName, trimmed)
 		}

--- a/pkg/kgateway/translator/sslutils/tls_params.go
+++ b/pkg/kgateway/translator/sslutils/tls_params.go
@@ -1,0 +1,108 @@
+package sslutils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SupportedCipherSuites is the set of cipher suite names accepted by
+// BoringSSL/Envoy for BackendConfigPolicy TLS parameters. Both the IANA names
+// (e.g. "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256") and the OpenSSL short names
+// (e.g. "ECDHE-ECDSA-AES128-GCM-SHA256") are recognized by BoringSSL, so both
+// conventions are accepted here.
+//
+// This list is intentionally permissive: omitting a value BoringSSL supports
+// would reject otherwise-valid configuration, so prefer accepting a name that
+// may later be rejected by Envoy over rejecting a name Envoy would accept.
+var SupportedCipherSuites = map[string]struct{}{
+	// TLS 1.3 AEAD suites.
+	"TLS_AES_128_GCM_SHA256":       {},
+	"TLS_AES_256_GCM_SHA384":       {},
+	"TLS_CHACHA20_POLY1305_SHA256": {},
+
+	// TLS 1.2 ECDHE AEAD suites (IANA names).
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       {},
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       {},
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         {},
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         {},
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": {},
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   {},
+	"TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256":   {},
+	"TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256":         {},
+	"TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384":         {},
+
+	// TLS 1.2 ECDHE CBC suites (IANA names).
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    {},
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    {},
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      {},
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      {},
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": {},
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384": {},
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   {},
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384":   {},
+
+	// TLS 1.2 AEAD suites (OpenSSL short names).
+	"ECDHE-ECDSA-AES128-GCM-SHA256": {},
+	"ECDHE-ECDSA-AES256-GCM-SHA384": {},
+	"ECDHE-RSA-AES128-GCM-SHA256":   {},
+	"ECDHE-RSA-AES256-GCM-SHA384":   {},
+	"ECDHE-ECDSA-CHACHA20-POLY1305": {},
+	"ECDHE-RSA-CHACHA20-POLY1305":   {},
+	"ECDHE-PSK-CHACHA20-POLY1305":   {},
+	"ECDHE-PSK-AES128-GCM-SHA256":   {},
+	"ECDHE-PSK-AES256-GCM-SHA384":   {},
+
+	// TLS 1.2 CBC suites (OpenSSL short names).
+	"ECDHE-ECDSA-AES128-SHA":    {},
+	"ECDHE-ECDSA-AES256-SHA":    {},
+	"ECDHE-RSA-AES128-SHA":      {},
+	"ECDHE-RSA-AES256-SHA":      {},
+	"ECDHE-ECDSA-AES128-SHA256": {},
+	"ECDHE-ECDSA-AES256-SHA384": {},
+	"ECDHE-RSA-AES128-SHA256":   {},
+	"ECDHE-RSA-AES256-SHA384":   {},
+
+	// Non-ECDHE suites (OpenSSL short names).
+	"AES128-GCM-SHA256": {},
+	"AES256-GCM-SHA384": {},
+	"AES128-SHA":        {},
+	"AES256-SHA":        {},
+	"AES128-SHA256":     {},
+	"AES256-SHA256":     {},
+}
+
+// SupportedEcdhCurves is the set of ECDH curve names accepted by
+// BoringSSL/Envoy for BackendConfigPolicy TLS parameters.
+var SupportedEcdhCurves = map[string]struct{}{
+	"X25519":                {},
+	"X25519MLKEM768":        {},
+	"X25519Kyber768Draft00": {},
+	"P-256":                 {},
+	"P-384":                 {},
+	"P-521":                 {},
+}
+
+// ValidateTlsStrings validates and normalizes a user-provided list of TLS
+// parameter values (cipher suites or ECDH curves). It trims each entry,
+// rejects values not present in supported, and removes duplicates. An empty
+// input is valid and returns a nil slice.
+func ValidateTlsStrings(input []string, supported map[string]struct{}, fieldName string) ([]string, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{}, len(input))
+	cleaned := make([]string, 0, len(input))
+	for _, val := range input {
+		trimmed := strings.TrimSpace(val)
+		if _, ok := supported[trimmed]; !ok {
+			return nil, fmt.Errorf("unsupported %s: %q (ensure you are using a BoringSSL-supported name)", fieldName, trimmed)
+		}
+		if _, dup := seen[trimmed]; dup {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		cleaned = append(cleaned, trimmed)
+	}
+	return cleaned, nil
+}

--- a/pkg/kgateway/translator/sslutils/tls_params_test.go
+++ b/pkg/kgateway/translator/sslutils/tls_params_test.go
@@ -1,0 +1,80 @@
+package sslutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTlsStrings(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     []string
+		supported map[string]struct{}
+		want      []string
+		wantErr   bool
+	}{
+		{
+			name:      "empty input is valid",
+			input:     nil,
+			supported: SupportedEcdhCurves,
+			want:      nil,
+			wantErr:   false,
+		},
+		{
+			name:      "valid curves",
+			input:     []string{"X25519", "P-256"},
+			supported: SupportedEcdhCurves,
+			want:      []string{"X25519", "P-256"},
+			wantErr:   false,
+		},
+		{
+			name:      "valid cipher suites in both naming conventions",
+			input:     []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "ECDHE-RSA-AES128-GCM-SHA256"},
+			supported: SupportedCipherSuites,
+			want:      []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "ECDHE-RSA-AES128-GCM-SHA256"},
+			wantErr:   false,
+		},
+		{
+			name:      "unsupported value",
+			input:     []string{"hello"},
+			supported: SupportedEcdhCurves,
+			want:      nil,
+			wantErr:   true,
+		},
+		{
+			name:      "unsupported cipher suite",
+			input:     []string{"BOGUS_CIPHER_SUITE_1"},
+			supported: SupportedCipherSuites,
+			want:      nil,
+			wantErr:   true,
+		},
+		{
+			name:      "duplicates are deduplicated",
+			input:     []string{"P-256", "P-256", "X25519"},
+			supported: SupportedEcdhCurves,
+			want:      []string{"P-256", "X25519"},
+			wantErr:   false,
+		},
+		{
+			name:      "values are trimmed",
+			input:     []string{"  X25519  ", "P-256"},
+			supported: SupportedEcdhCurves,
+			want:      []string{"X25519", "P-256"},
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ValidateTlsStrings(tc.input, tc.supported, "test")
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Fixes #11983

BackendConfigPolicy `tls.parameters` values (`cipherSuites` and `ecdhCurves`) were passed through to Envoy without validation. Invalid values — a misspelled curve (`hello`) or a bogus cipher suite — were accepted by the control plane but rejected by Envoy as an xDS NACK, leaving the policy silently broken and Envoy retrying the update in a tight loop.

This change validates the values during translation against the BoringSSL-supported sets and rejects unknown or empty entries with a clear error surfaced on the policy status.

## What changed

- Added `SupportedCipherSuites` and `SupportedEcdhCurves` sets plus `ValidateTlsStrings` to `pkg/kgateway/translator/sslutils` (centralized, as discussed on the issue).
- Wired validation into `parseTLSParameters` in the BackendConfigPolicy plugin.
- Accepted cipher suite names use both the IANA names (`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`) and the OpenSSL short names (`ECDHE-ECDSA-AES128-GCM-SHA256`) since BoringSSL recognizes both; duplicates are dropped.
- Added unit tests and regenerated the `invalid-cipher-suites` translator golden outputs (standard + strict).

## Notes for reviewers

- The cipher suite list is intentionally permissive. Omitting a BoringSSL-supported value would reject valid configs; accepting a name BoringSSL later rejects is no worse than the status quo (Envoy NACKs). Happy to trim/extend the list.
- Envoy on arm64 vs amd64 can differ in supported curves (e.g. `X25519MLKEM768` / `X25519Kyber768Draft00`), per the discussion on the issue. If a full "escape hatch" (bypass for custom Envoy images) is desired, that can be a follow-up — please advise.

# Change Type

/kind fix

# Changelog

```release-note
Validate BackendConfigPolicy TLS cipher suites and ECDH curves during translation to prevent Envoy NACK loops and surface a clear error on the policy status.
```

# Additional Notes

- `go test ./pkg/kgateway/translator/sslutils/... ./pkg/kgateway/extensions2/plugins/backendconfigpolicy/...` passes.
- The strict-mode golden output was regenerated manually (the strict translator test requires a Docker daemon, which isn't available locally); the standard-mode golden was regenerated and verified via `go test`.