### PR TITLE
chore: forbid reading through the controller-runtime manager

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -86,6 +86,16 @@ linters:
           msg: use kclient.NewFilteredDelayed for CRDs and kclient.NewFiltered for core types, with discovery namespace ObjectFilter instead
         - pattern: ^client.Client$
           msg: use apiclient.Client instead of controller-runtime's client.Client
+        # The ^client.Client$ rule above only catches naming the type, so it misses an
+        # inline mgr.GetClient().List(...). Nothing reads through the controller-runtime
+        # manager any more: status syncing and translation both use the istio kclient/krt
+        # caches, which is why the manager currently holds no informers. Its cache starts
+        # one lazily on first read, so a single call here would silently add a second
+        # informer for every watched type, with nothing else in CI to catch it.
+        - pattern: \.GetClient$
+          msg: use apiclient.Client instead of the controller-runtime manager's client; mgr.GetClient() reads through the manager cache, which starts a duplicate informer per type
+        - pattern: \.GetCache$
+          msg: read through the krt collections instead of the controller-runtime manager's cache; mgr.GetCache() starts a duplicate informer per type
         - pattern: (\bt|\bT\(\))\.Cleanup
           msg: require testutils.Cleanup in e2e tests (test/e2e/)
         - pattern: ^slog\.(Debug|DebugContext|Info|InfoContext|Warn|WarnContext|Error|ErrorContext|Log|LogAttrs)$

--- a/pkg/kgateway/controller/controller_test.go
+++ b/pkg/kgateway/controller/controller_test.go
@@ -713,7 +713,7 @@ func (s *ControllerSuite) startController(
 		return err
 	}
 
-	if err := mgr.GetClient().Create(ctx, &kgateway.GatewayParameters{
+	if err := s.client.Create(ctx, &kgateway.GatewayParameters{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      selfManagedGatewayClassName,
 			Namespace: "default",
@@ -788,7 +788,7 @@ func (s *ControllerSuite) startController(
 	// This ensures the controller is fully started before tests run
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		var gcList gwv1.GatewayClassList
-		err := mgr.GetClient().List(ctx, &gcList)
+		err := s.client.List(ctx, &gcList)
 		assert.NoError(c, err, assert.NoError)
 	}, defaultPollTimeout, 250*time.Millisecond, "timed out waiting for Manager to be ready")
 	select {


### PR DESCRIPTION
# Description

**Motivation:** nothing in the runtime path reads `mgr.GetClient()` or `mgr.GetCache()` any more — status syncing and translation both go through `apiclient.Client` and the istio kclient/krt informer caches. That is why the controller-runtime manager currently holds no informers, and `pkg/kgateway/proxy_syncer` has a comment saying so:

```go
// Note: the controller-runtime manager cache is deliberately not waited on here.
// Nothing reads through it anymore (status syncing uses the istio/krt cache), so
// it holds no informers.
```

But that is a property of nobody calling it, not a guarantee. A controller-runtime cache starts an informer lazily on first read, so one stray `mgr.GetClient().List()` in a future PR would silently stand up a second informer for that type alongside the krt one — duplicating the memory the status refactor removed, with nothing in CI to catch it.

**What changed:** the existing `^client.Client$` forbidigo rule only catches naming the type, so it misses an inline call through the manager. This adds patterns for `.GetClient` and `.GetCache`, so the manager cannot be used as a Kubernetes client without the linter saying so.

The only two call sites were in the controller envtest suite, which already holds an uncached client of its own (`s.client`, built straight from the test `rest.Config`) and uses it everywhere else in the file; those two now use it too. Being uncached, it starts no informers, so it is the right client for a test to reach the API server with.

Verified the rules fire by temporarily reintroducing both calls:

```
controller_test.go:716:6: use of `mgr.GetCache` forbidden because "read through the krt collections instead of ..." (forbidigo)
controller_test.go:717:12: use of `mgr.GetClient` forbidden because "use apiclient.Client instead of ..." (forbidigo)
```

`make analyze` is clean on the branch as committed, and `go test ./pkg/kgateway/controller/` passes.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

The patterns match on method name rather than receiver type. Enabling forbidigo's `analyze-types` would let them be qualified as `manager.Manager.GetClient`, but that flag is global and would change the match text for the existing `(\bt|\bT\(\))\.Cleanup` rule to `testing.T.Cleanup`, silently disabling the e2e `testutils.Cleanup` check. Not worth that trade here: `GetClient`/`GetCache` have no other implementations in the tree today, and if something else grows one, the message says what to use instead.

This is the cheap half of a larger idea. Removing the manager outright — its remaining jobs are leader election, runnable lifecycle, and the health-probe/metrics/pprof servers — is a much bigger change with no measurable resource win, since the manager's cache is already empty. It is worth doing only as a prerequisite for graceful leader failover, so that a lease blip stops costing a full pod restart and a cold krt cache rebuild. That is a separate discussion; this PR just closes the hole in the meantime.
