### PR TITLE
fix: Buffer filter location

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
@@ -3,7 +3,9 @@ package trafficpolicy
 import (
 	"testing"
 
+	envoymatchingv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/common/matching/v3"
 	bufferv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/buffer/v3"
+	faulthttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -65,7 +67,10 @@ func TestBufferIREquals(t *testing.T) {
 	}
 }
 
-func TestBufferFilterRunsImmediatelyBeforeRustformation(t *testing.T) {
+// TestBufferFilterRunsFirst asserts the Buffer filter sorts ahead of every filter that reads or
+// holds the request body. Staged after one of them, its per-route max_request_bytes renders in the
+// Envoy config but never takes effect.
+func TestBufferFilterRunsFirst(t *testing.T) {
 	const filterChainName = "test-filter-chain"
 
 	plugin := &trafficPolicyPluginGwPass{
@@ -77,6 +82,22 @@ func TestBufferFilterRunsImmediatelyBeforeRustformation(t *testing.T) {
 				MaxRequestBytes: &wrapperspb.UInt32Value{Value: 1024},
 			},
 		},
+		faultInChain: map[string]*faulthttpv3.HTTPFault{
+			filterChainName: {},
+		},
+		extProcPerProvider: ProviderNeededMap{
+			Providers: map[string][]Provider{
+				filterChainName: {{
+					Name: "ext-proc",
+					Extension: &TrafficPolicyGatewayExtensionIR{
+						Name:    "ext-proc",
+						ExtProc: &envoymatchingv3.ExtensionWithMatcher{},
+					},
+					// the earliest stage a GatewayExtension can ask for
+					FilterStage: filters.BeforeStage(filters.FaultStage),
+				}},
+			},
+		},
 	}
 
 	httpFilters, err := plugin.HttpFilters(
@@ -84,13 +105,17 @@ func TestBufferFilterRunsImmediatelyBeforeRustformation(t *testing.T) {
 		ir.FilterChainCommon{FilterChainName: filterChainName},
 	)
 	require.NoError(t, err)
-	require.Len(t, httpFilters, 2)
 
 	sortedFilters := filters.StagedHttpFilterList(httpFilters)
 	sortedFilters.Sort()
 
-	assert.Equal(t, bufferFilterName, sortedFilters[0].Filter.GetName())
-	assert.Equal(t, filters.RelativeToStage(filters.AcceptedStage, -2), sortedFilters[0].Stage)
-	assert.Equal(t, rustformationFilterNamePrefix, sortedFilters[1].Filter.GetName())
-	assert.Equal(t, filters.BeforeStage(filters.AcceptedStage), sortedFilters[1].Stage)
+	names := make([]string, 0, len(sortedFilters))
+	for _, f := range sortedFilters {
+		names = append(names, f.Filter.GetName())
+	}
+
+	require.Equal(t, bufferFilterName, names[0], "buffer must sort first, got %v", names)
+	assert.Equal(t, filters.RelativeToStage(filters.FaultStage, -2), sortedFilters[0].Stage)
+	assert.Contains(t, names, rustformationFilterNamePrefix)
+	assert.Contains(t, names, extProcFilterName("ext-proc"))
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
@@ -69,10 +69,13 @@ func TestBufferIREquals(t *testing.T) {
 	}
 }
 
-// TestBufferFilterRunsAfterDecompressionAndBeforeBodyReaders asserts the Buffer filter sorts
-// behind request decompression - so max_request_bytes is measured against decompressed bytes - and
-// ahead of every filter that reads or holds the request body. Staged after one of those, its
-// per-route limit renders in the Envoy config but never takes effect.
+// TestBufferFilterRunsAfterDecompressionAndBeforeBodyReaders asserts the chain invariant
+// request decompression -> Buffer -> every body-reading filter, with the ext_proc provider at
+// BeforeStage(FaultStage), the earliest position a GatewayExtension can ask for.
+//
+// Staged after a filter that reads the body, Buffer's per-route max_request_bytes renders in the
+// Envoy config but never takes effect; staged ahead of decompression, it measures the request
+// against its compressed size and a small compressed body expands past the limit.
 func TestBufferFilterRunsAfterDecompressionAndBeforeBodyReaders(t *testing.T) {
 	const filterChainName = "test-filter-chain"
 
@@ -102,7 +105,8 @@ func TestBufferFilterRunsAfterDecompressionAndBeforeBodyReaders(t *testing.T) {
 						Name:    "ext-proc",
 						ExtProc: &envoymatchingv3.ExtensionWithMatcher{},
 					},
-					FilterStage: defaultExtProcFilterStage,
+					// the earliest stage a GatewayExtension can ask for
+					FilterStage: filters.BeforeStage(filters.FaultStage),
 				}},
 			},
 		},
@@ -122,16 +126,19 @@ func TestBufferFilterRunsAfterDecompressionAndBeforeBodyReaders(t *testing.T) {
 		names = append(names, f.Filter.GetName())
 	}
 
-	assert.Equal(t, []string{
-		extProcGlobalDisableFilterName,
-		faultFilterName,
-		decompressorFilterNameFor(kgateway.CompressionGzip),
-		bufferFilterName,
-		extProcFilterName("ext-proc"),
-		rustformationFilterNamePrefix,
-	}, names)
+	require.Equal(t, decompressorFilterNameFor(kgateway.CompressionGzip), names[0], "got %v", names)
+	require.Equal(t, bufferFilterName, names[1], "got %v", names)
+	assert.Equal(t, filters.RelativeToStage(filters.FaultStage, -3), sortedFilters[0].Stage)
+	assert.Equal(t, filters.RelativeToStage(filters.FaultStage, -2), sortedFilters[1].Stage)
 
-	bufferIdx := slices.Index(names, bufferFilterName)
-	require.NotEqual(t, -1, bufferIdx)
-	assert.Equal(t, filters.RelativeToStage(filters.WafStage, -2), sortedFilters[bufferIdx].Stage)
+	// everything that reads or holds the request body sorts behind Buffer
+	for _, name := range []string{
+		extProcFilterName("ext-proc"),
+		faultFilterName,
+		rustformationFilterNamePrefix,
+	} {
+		idx := slices.Index(names, name)
+		require.NotEqual(t, -1, idx, "%s missing from %v", name, names)
+		assert.Greater(t, idx, 1, "%s must sort behind Buffer, got %v", name, names)
+	}
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/buffer_test.go
@@ -1,10 +1,12 @@
 package trafficpolicy
 
 import (
+	"slices"
 	"testing"
 
 	envoymatchingv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/common/matching/v3"
 	bufferv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/buffer/v3"
+	decompressorv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/decompressor/v3"
 	faulthttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,10 +69,11 @@ func TestBufferIREquals(t *testing.T) {
 	}
 }
 
-// TestBufferFilterRunsFirst asserts the Buffer filter sorts ahead of every filter that reads or
-// holds the request body. Staged after one of them, its per-route max_request_bytes renders in the
-// Envoy config but never takes effect.
-func TestBufferFilterRunsFirst(t *testing.T) {
+// TestBufferFilterRunsAfterDecompressionAndBeforeBodyReaders asserts the Buffer filter sorts
+// behind request decompression - so max_request_bytes is measured against decompressed bytes - and
+// ahead of every filter that reads or holds the request body. Staged after one of those, its
+// per-route limit renders in the Envoy config but never takes effect.
+func TestBufferFilterRunsAfterDecompressionAndBeforeBodyReaders(t *testing.T) {
 	const filterChainName = "test-filter-chain"
 
 	plugin := &trafficPolicyPluginGwPass{
@@ -85,6 +88,12 @@ func TestBufferFilterRunsFirst(t *testing.T) {
 		faultInChain: map[string]*faulthttpv3.HTTPFault{
 			filterChainName: {},
 		},
+		decompressorInChain: map[string][]decompressorEntry{
+			filterChainName: {{
+				filterName:   decompressorFilterNameFor(kgateway.CompressionGzip),
+				decompressor: &decompressorv3.Decompressor{},
+			}},
+		},
 		extProcPerProvider: ProviderNeededMap{
 			Providers: map[string][]Provider{
 				filterChainName: {{
@@ -93,8 +102,7 @@ func TestBufferFilterRunsFirst(t *testing.T) {
 						Name:    "ext-proc",
 						ExtProc: &envoymatchingv3.ExtensionWithMatcher{},
 					},
-					// the earliest stage a GatewayExtension can ask for
-					FilterStage: filters.BeforeStage(filters.FaultStage),
+					FilterStage: defaultExtProcFilterStage,
 				}},
 			},
 		},
@@ -114,8 +122,16 @@ func TestBufferFilterRunsFirst(t *testing.T) {
 		names = append(names, f.Filter.GetName())
 	}
 
-	require.Equal(t, bufferFilterName, names[0], "buffer must sort first, got %v", names)
-	assert.Equal(t, filters.RelativeToStage(filters.FaultStage, -2), sortedFilters[0].Stage)
-	assert.Contains(t, names, rustformationFilterNamePrefix)
-	assert.Contains(t, names, extProcFilterName("ext-proc"))
+	assert.Equal(t, []string{
+		extProcGlobalDisableFilterName,
+		faultFilterName,
+		decompressorFilterNameFor(kgateway.CompressionGzip),
+		bufferFilterName,
+		extProcFilterName("ext-proc"),
+		rustformationFilterNamePrefix,
+	}, names)
+
+	bufferIdx := slices.Index(names, bufferFilterName)
+	require.NotEqual(t, -1, bufferIdx)
+	assert.Equal(t, filters.RelativeToStage(filters.WafStage, -2), sortedFilters[bufferIdx].Stage)
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/compression.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/compression.go
@@ -346,13 +346,18 @@ func addCompressionFiltersIfNeeded(staged []filters.StagedHttpFilter, p *traffic
 		filter.Filter.Disabled = true
 		staged = append(staged, filter)
 	}
-	// One disabled-by-default decompressor filter per codec. Order is not significant (Envoy
-	// selects by Content-Encoding), and same-stage filters sort deterministically by name.
+	// One disabled-by-default decompressor filter per codec. Order among the codecs is not
+	// significant (Envoy selects by Content-Encoding), and same-stage filters sort
+	// deterministically by name.
+	//
+	// They run at the head of the chain, ahead of Buffer at FaultStage-2: Envoy requires request
+	// decompression to happen before Buffer, so that a per-route max_request_bytes is measured
+	// against the decompressed body rather than the encoded bytes.
 	for _, entry := range p.decompressorInChain[fcn] {
 		filter := filters.MustNewStagedFilter(
 			entry.filterName,
 			entry.decompressor,
-			filters.AfterStage(filters.WellKnownFilterStage(filters.CorsStage)),
+			filters.RelativeToStage(filters.FaultStage, -3),
 		)
 		filter.Filter.Disabled = true
 		staged = append(staged, filter)

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -667,30 +667,31 @@ func (p *trafficPolicyPluginGwPass) HttpFilters(_ ir.HttpFiltersContext, fcc ir.
 		stagedFilters = append(stagedFilters, filter)
 	}
 
-	// Register Buffer after request decompression and before every filter that reads the request
-	// body.
+	// Register Buffer between request decompression and every filter that reads the request body,
+	// establishing the invariant: decompression (FaultStage-3) -> Buffer (FaultStage-2) -> the
+	// earliest body-reading filter (BeforeStage(FaultStage), the earliest position reachable
+	// through GatewayExtension.filterStage).
 	//
-	// The filter enforces max_request_bytes only while it is the filter accumulating the body: it
-	// sets the limit with setDecoderBufferLimit in decodeHeaders, and Envoy emits the 413 when the
+	// Buffer enforces max_request_bytes only while it is the filter accumulating the body: it sets
+	// the limit with setDecoderBufferLimit in decodeHeaders, and Envoy emits the 413 when the
 	// buffered request data crosses that watermark. A filter ahead of it that holds or parses the
 	// body first therefore makes the limit inert in both directions - a limit smaller than the
 	// per-stream default stops rejecting oversized bodies, and a larger one never raises the
 	// default. ext_proc does this whenever it waits on its server, and body transformations do it
 	// by construction.
 	//
-	// It has to stay behind the decompressors (AfterStage(CorsStage)) though: buffering the
-	// encoded bytes would measure the request against the compressed size, letting a small
-	// compressed body expand past the limit. WafStage-2 is after every Cors-stage filter and ahead
-	// of the earliest body-reading filter in the chain.
+	// Buffer stays behind the decompressors because Envoy requires request decompression to run
+	// first: buffering the encoded bytes would measure the request against its compressed size,
+	// letting a small compressed body expand past the limit.
 	//
-	// Filters explicitly staged before decompression - reachable through
-	// GatewayExtension.filterStage - still see the body first and are not covered; honoring the
-	// configured limit against decompressed bytes takes precedence.
+	// Both filters are disabled by default and enabled per route, so mixed listeners behave: a
+	// decompression-only route leaves Buffer disabled, a buffer-only route leaves the
+	// decompressors disabled, and with both enabled Buffer limits the decompressed body.
 	if f := p.bufferInChain[fcc.FilterChainName]; f != nil {
 		filter := filters.MustNewStagedFilter(
 			bufferFilterName,
 			f,
-			filters.RelativeToStage(filters.WafStage, -2),
+			filters.RelativeToStage(filters.FaultStage, -2),
 		)
 		filter.Filter.Disabled = true
 		stagedFilters = append(stagedFilters, filter)

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -667,13 +667,24 @@ func (p *trafficPolicyPluginGwPass) HttpFilters(_ ir.HttpFiltersContext, fcc ir.
 		stagedFilters = append(stagedFilters, filter)
 	}
 
-	// Register Buffer immediately before Rustformation so its per-route request
-	// limit is established before a body-parsing transformation buffers data.
+	// Register Buffer at the front of the chain so its per-route request limit is established
+	// before any filter reads the request body.
+	//
+	// The filter enforces max_request_bytes only while it is the filter accumulating the body: it
+	// sets the limit with setDecoderBufferLimit in decodeHeaders, and Envoy emits the 413 when the
+	// buffered request data crosses that watermark. A filter ahead of it that holds or parses the
+	// body first therefore makes the limit inert in both directions - a limit smaller than the
+	// per-stream default stops rejecting oversized bodies, and a larger one never raises the
+	// default. ext_proc does this whenever it waits on its server, and body transformations do it
+	// by construction.
+	//
+	// FaultStage-2 keeps Buffer ahead of the earliest stage reachable through
+	// GatewayExtension.filterStage, which is BeforeStage(FaultStage).
 	if f := p.bufferInChain[fcc.FilterChainName]; f != nil {
 		filter := filters.MustNewStagedFilter(
 			bufferFilterName,
 			f,
-			filters.RelativeToStage(filters.AcceptedStage, -2),
+			filters.RelativeToStage(filters.FaultStage, -2),
 		)
 		filter.Filter.Disabled = true
 		stagedFilters = append(stagedFilters, filter)

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/traffic_policy_plugin.go
@@ -667,8 +667,8 @@ func (p *trafficPolicyPluginGwPass) HttpFilters(_ ir.HttpFiltersContext, fcc ir.
 		stagedFilters = append(stagedFilters, filter)
 	}
 
-	// Register Buffer at the front of the chain so its per-route request limit is established
-	// before any filter reads the request body.
+	// Register Buffer after request decompression and before every filter that reads the request
+	// body.
 	//
 	// The filter enforces max_request_bytes only while it is the filter accumulating the body: it
 	// sets the limit with setDecoderBufferLimit in decodeHeaders, and Envoy emits the 413 when the
@@ -678,13 +678,19 @@ func (p *trafficPolicyPluginGwPass) HttpFilters(_ ir.HttpFiltersContext, fcc ir.
 	// default. ext_proc does this whenever it waits on its server, and body transformations do it
 	// by construction.
 	//
-	// FaultStage-2 keeps Buffer ahead of the earliest stage reachable through
-	// GatewayExtension.filterStage, which is BeforeStage(FaultStage).
+	// It has to stay behind the decompressors (AfterStage(CorsStage)) though: buffering the
+	// encoded bytes would measure the request against the compressed size, letting a small
+	// compressed body expand past the limit. WafStage-2 is after every Cors-stage filter and ahead
+	// of the earliest body-reading filter in the chain.
+	//
+	// Filters explicitly staged before decompression - reachable through
+	// GatewayExtension.filterStage - still see the body first and are not covered; honoring the
+	// configured limit against decompressed bytes takes precedence.
 	if f := p.bufferInChain[fcc.FilterChainName]; f != nil {
 		filter := filters.MustNewStagedFilter(
 			bufferFilterName,
 			f,
-			filters.RelativeToStage(filters.FaultStage, -2),
+			filters.RelativeToStage(filters.WafStage, -2),
 		)
 		filter.Filter.Disabled = true
 		stagedFilters = append(stagedFilters, filter)

--- a/test/e2e/features/compression/suite.go
+++ b/test/e2e/features/compression/suite.go
@@ -3,6 +3,8 @@
 package compression
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -228,6 +230,48 @@ func (s *testingSuite) TestRequestDecompression() {
 	)
 
 	s.assertDecompressorMetric(".decompressor.gzip.request.decompressed")
+}
+
+// TestBufferLimitAppliesToDecompressedRequestBody verifies that a route's buffer.maxRequestSize is
+// enforced against the decompressed request body. The Buffer filter has to run behind the
+// decompressor for that: ahead of it, it would accumulate the encoded bytes, so a body that is
+// small compressed and large decompressed would satisfy the limit and expand past it upstream.
+func (s *testingSuite) TestBufferLimitAppliesToDecompressedRequestBody() {
+	// 8 KiB compresses to a few dozen bytes, well under the 1Ki limit, but exceeds it decompressed
+	s.postGzipped(8*1024, http.StatusRequestEntityTooLarge)
+
+	// under the limit once decompressed, so it is forwarded
+	s.postGzipped(256, http.StatusOK)
+}
+
+// postGzipped posts size bytes of gzip-compressed body to the buffer + decompression route and
+// asserts the response status.
+func (s *testingSuite) postGzipped(size int, expectedStatus int) {
+	s.T().Helper()
+
+	var compressed bytes.Buffer
+	w := gzip.NewWriter(&compressed)
+	_, err := w.Write([]byte(strings.Repeat("a", size)))
+	s.Require().NoError(err)
+	s.Require().NoError(w.Close())
+	s.Require().Less(compressed.Len(), 1024, "compressed body must fit under the configured limit")
+
+	common.BaseGateway.Send(
+		s.T(),
+		&testmatchers.HttpResponse{
+			StatusCode: expectedStatus,
+		},
+		curl.WithPort(80),
+		curl.WithPath("/post"),
+		curl.WithHostHeader("buffer-decompress.example.com"),
+		curl.WithMethod(http.MethodPost),
+		curl.WithBody(compressed.String()),
+		curl.WithHeaders(map[string]string{
+			"Content-Encoding": "gzip",
+			"Content-Type":     "text/plain",
+		}),
+		curl.WithIgnoreBody(),
+	)
 }
 
 // assertDecompressorMetric verifies the decompressor filter emitted a metric ending in

--- a/test/e2e/features/compression/testdata/tp-route-buffer-decompression.yaml
+++ b/test/e2e/features/compression/testdata/tp-route-buffer-decompression.yaml
@@ -1,0 +1,39 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-route-buffer-decompress
+  namespace: kgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: kgateway-base
+  hostnames:
+    - "buffer-decompress.example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: httpbin
+          port: 8000
+---
+# A request size limit alongside request decompression. The limit has to be measured against the
+# decompressed body, which only holds while the Buffer filter runs behind the decompressor: a body
+# that is small compressed and large decompressed must still be rejected.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: route-buffer-decompress
+  namespace: kgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httpbin-route-buffer-decompress
+  buffer:
+    maxRequestSize: 1Ki
+  compression:
+    requestDecompression:
+      libraries:
+        - Gzip

--- a/test/e2e/features/compression/types.go
+++ b/test/e2e/features/compression/types.go
@@ -13,14 +13,15 @@ import (
 
 var (
 	// manifests
-	serviceManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata", "service.yaml")
-	httpRoutesManifest         = filepath.Join(fsutils.MustGetThisDir(), "testdata", "httproutes.yaml")
-	routeCompressionManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-compression.yaml")
-	routeBrotliManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-brotli.yaml")
-	routeZstdManifest          = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-zstd.yaml")
-	routeNegotiationManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-negotiation.yaml")
-	routeDecompressionManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-decompression.yaml")
-	routeReqDecompressManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-request-decompression.yaml")
+	serviceManifest               = filepath.Join(fsutils.MustGetThisDir(), "testdata", "service.yaml")
+	httpRoutesManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata", "httproutes.yaml")
+	routeCompressionManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-compression.yaml")
+	routeBrotliManifest           = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-brotli.yaml")
+	routeZstdManifest             = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-zstd.yaml")
+	routeNegotiationManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-negotiation.yaml")
+	routeDecompressionManifest    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-decompression.yaml")
+	routeReqDecompressManifest    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-request-decompression.yaml")
+	routeBufferDecompressManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "tp-route-buffer-decompression.yaml")
 
 	// proxy object meta for the shared gateway
 	proxyObjectMeta = metav1.ObjectMeta{
@@ -56,6 +57,9 @@ var (
 		},
 		"TestZstdRequestDecompression": {
 			Manifests: []string{routeReqDecompressManifest},
+		},
+		"TestBufferLimitAppliesToDecompressedRequestBody": {
+			Manifests: []string{routeBufferDecompressManifest},
 		},
 	}
 )


### PR DESCRIPTION
# Description

**Motivation:** `buffer.maxRequestSize` does not enforce when any filter ahead of the buffer filter reads the request body. Envoy's buffer filter establishes the limit with `setDecoderBufferLimit` in `decodeHeaders` and relies on the filter manager emitting the 413 when the buffered request data crosses that watermark — so it only enforces while it is the filter doing the accumulating. When something upstream of it holds the body first, the body is already complete by the time the buffer filter runs, no watermark is crossed, and the limit is inert in both directions:

- a limit *below* Envoy's default per-stream limit stops rejecting oversized bodies (silent fail open on a request-size control), and
- a limit *above* it never raises the default, so bodies between the default and the configured limit are rejected with a 413.

#14479 fixed this for Rustformation by staging Buffer at `AcceptedStage-2`, immediately ahead of it. That leaves ext_proc broken: ext_proc holds body data whenever it is waiting on its server (regardless of body mode) and buffers it outright in `BUFFERED` mode, and its default stage `AfterStage(AuthZStage)` still sorts before `AcceptedStage-2`. A `TrafficPolicy` carrying both `buffer` and an ext_proc policy on the same route therefore renders the limit into the Envoy config while oversized requests pass through.

**What changed:** establish the invariant *request decompression → Buffer → every body-reading filter*:

```
envoy.filters.http.decompressor   FaultStage-3
envoy.filters.http.buffer         FaultStage-2
ext_proc earliest                 FaultStage-1  (BeforeStage(FaultStage))
envoy.filters.http.fault          FaultStage
...
dynamic_modules/simple_mutations  BeforeStage(AcceptedStage)
```

Buffer stays behind decompression because Envoy requires it: buffering the encoded bytes would measure the request against its compressed size, letting a small gzip/brotli/zstd body satisfy `maxRequestSize` and expand past it upstream. Decompression moves to the head of the chain so Buffer can still precede the earliest stage reachable through `GatewayExtension.filterStage`. `newDecompressor` disables response-direction decompression, so these filters only touch requests and the response path is unaffected.

Both filters are disabled at chain level and enabled per route, so mixed listeners behave: a decompression-only route leaves Buffer disabled, a buffer-only route leaves the decompressors disabled, and with both enabled Buffer limits the decompressed body.

E2E, in the existing compression suite (`test/e2e/features/compression`): a route with `buffer.maxRequestSize: 1Ki` and gzip request decompression, where an 8 KiB body that compresses to a few dozen bytes must be rejected with a 413 and a body under the limit once decompressed must be forwarded. With Buffer ahead of the decompressor the oversized request satisfies the limit against its encoded size and reaches the upstream, so this pins at runtime what the unit test asserts at the config level.

**Follow-up:** the `-3`/`-2` weights are not self-explanatory. Naming them (e.g. `RequestNormalizationStage`, `RequestBufferStage`) is worth doing separately, since inserting stages shifts every `WellKnownFilterStage` value and reaches downstream consumers.

# Change Type

/kind fix

# Changelog

```release-note
Honor configured request buffer limits when any filter reads the request body, including ext_proc.
```

# Additional Notes

Ordering tradeoffs this introduces. Both filters are disabled at chain level and enabled per route, so routes that use neither are unaffected, as are header-only requests (Buffer continues immediately when there is no body):

- A route with a buffer policy buffers the request body — bounded by the configured `maxRequestSize` — before fault injection and the auth and rate-limit filters see the request. Buffer previously sat at `AcceptedStage-2`, so authn, authz and rate limiting could reject an oversized upload before anything was buffered; now they cannot. That is the cost of a limit that enforces at all. (CORS also now runs after buffering, but nothing changes in practice: preflights carry no body, and the CORS filter does not reject bodied requests.)
- A route with request decompression decompresses before those same filters, so a body is expanded even if fault injection or auth would go on to reject the request. Where the route also carries a buffer policy the decompressed size is bounded by `maxRequestSize`; on a decompression-only route the exposure is what it is today, since the filter streams.

**Compatibility change worth calling out:** on a decompression-enabled route, a filter staged before the decompressor's old position at `AfterStage(CorsStage)` now sees the decompressed body instead of the encoded bytes, with `Content-Encoding` removed and `Content-Length` adjusted. That covers every Fault-relative stage an ext_proc can be given through `GatewayExtension.filterStage` — `(Fault, -1)`, `(Fault, 0)`, `(Fault, +1)`. For body inspection this is the intended direction (inspecting a gzip blob is not useful), but a filter deliberately staged early to see the wire form — an HMAC over the encoded payload, or a size check on transferred bytes — would now receive different input. On a route that also enables a buffer policy, such a filter additionally receives the body only once Buffer has accumulated it in full, which changes what an ext_proc in `STREAMED` body mode observes.

#14479 deferred having Rustformation configure its own bounded buffering. Extending that idea — each body-reading filter bounding its own buffering — would supersede this ordering and is the better long-term shape, at which point Buffer would not need to lead the chain.