### PR TITLE
translator: isolate per-client endpoint mutations

### DIFF
--- a/design/14184-shared-base-per-client-cluster-overlays.md
+++ b/design/14184-shared-base-per-client-cluster-overlays.md
@@ -1,0 +1,542 @@
+# EP-14184: Shared Base Clusters with Per-Client Overlays
+
+- Issue: [#14184](https://github.com/kgateway-dev/kgateway/issues/14184)
+- Originating PR: [#14343](https://github.com/kgateway-dev/kgateway/pull/14343) (superseded by the 7-PR stack in [Delivery](#delivery))
+- Predecessors: [#14104](https://github.com/kgateway-dev/kgateway/pull/14104), [#14317](https://github.com/kgateway-dev/kgateway/pull/14317)
+- Related: [#13586](https://github.com/kgateway-dev/kgateway/issues/13586) (the *backends* axis of the same scaling problem)
+
+## Background
+
+kgateway serves a distinct xDS snapshot to every *uniquely connected client* (UCC). A UCC is
+a bucket of Envoy streams that share a role, namespace, locality, augmented pod labels, and
+local-cluster capability — the inputs that can legitimately change what config a proxy should
+receive. Any Envoy whose locality or labels differ gets its own UCC.
+
+Before this EP, the cluster half of that per-client pipeline forked the **entire** backend
+translation for every `(backend, client)` pair:
+
+```go
+// pkg/kgateway/proxy_syncer/backends.go, before
+for _, ucc := range krt.Fetch(kctx, uccs) {
+    c, err := translator.TranslateBackend(ctx, kctx, ucc, backendObj) // full translation
+    ...                                                              // one KRT row per pair
+}
+```
+
+`TranslateBackend` builds the cluster from scratch: `initializeCluster`, the backend plugin's
+`InitEnvoyBackend`, DNS lookup family, every `ProcessBackend` policy hook, the Gateway backend
+client certificate, and — in strict mode — a full Envoy bootstrap validation. Almost none of
+that depends on the client. The parts that genuinely do are small and rare:
+
+- a destination rule whose `workloadSelector` matches this proxy's labels (outlier detection,
+  locality LB, TCP keepalive);
+- the ambient waypoint ingress redirect, which rewrites an EDS cluster into a STATIC one; and
+- an inline `ClusterLoadAssignment`, whose endpoint priorities are computed from the client's
+  locality by `PrioritizeEndpoints`.
+
+With `N` connected client shapes and `M` backends, the control plane therefore performed
+`O(N*M)` full translations and retained `O(N*M)` KRT rows, each holding an independently
+allocated `Cluster` proto, and recomputed all of it whenever a client connected or
+disconnected. #14184 is the incident that made this visible: a fleet with 15 UCCs multiplied
+every backend's translation by 15, and the resulting CPU and GC pressure interacted badly with
+the per-client readiness gates that were later reverted in #14380.
+
+`gatewayScopedBackend` (the Gateway-backend-client-certificate variant collection) shows what
+the right shape looks like: a rare, structurally-required fork expressed as a *separate row*
+rather than as a multiplier on every row. This EP applies the same idea to per-client
+translation.
+
+## Motivation
+
+Per-client cluster state is the dominant term in kgateway's control-plane footprint on large
+clusters, and it grows in the one dimension operators cannot control: how many distinct Envoy
+shapes are connected. Two operational consequences follow.
+
+**Cost.** Translation cost and retained memory both scale with `N*M` even though the
+per-client *difference* is usually empty. Duplicate `Cluster` protos dominate the KRT store,
+and each is re-marshalled for hashing on every recompute.
+
+**Blast radius.** Because every `(client, backend)` pair is one row in one flat collection,
+one client's churn invalidates the whole collection, and any consumer that waits for
+coherence waits on the whole fleet. That coupling is the structural reason the #13868
+readiness gates could deadlock (#14184, #14352): a barrier expressed over a fleet-wide
+collection cannot distinguish "this client is not ready" from "some other client is not
+ready".
+
+## Goals
+
+- Translate each backend's client-invariant cluster **once**, and share the resulting proto
+  read-only across every client that targets it.
+- Store per-client clusters **sparsely**: a row materializes only for the `(client, backend)`
+  pairs whose cluster genuinely differs, so retained state is `O(M) + O(N*K)` with
+  `K << M` in typical workloads.
+- Keep the merge of shared base and sparse overlay **coherent** across independently updated
+  KRT collections, without turning one client's unresolved state into a fleet-wide barrier.
+- Make the new aliasing **enforceable**: a mutation of a shared proto must fail loudly in CI
+  rather than silently corrupt sibling clients' snapshots.
+- Give endpoint plugins a mutation surface that cannot reach KRT-owned or cross-client state.
+- Preserve observable xDS output and Backend status for every existing configuration.
+
+## Non-Goals
+
+- Reducing the *set* of backends discovered. Scoping CDS/EDS to route-referenced Services is
+  the separate backends axis tracked in #13586.
+- Reducing the recompute fan-out on client churn. A UCC event still re-runs the delta
+  transform for every backend; only the per-pair cost and the retained state shrink. See
+  [Open Questions](#open-questions).
+- Reintroducing per-client readiness gates. The first-connect grace period from #14380 remains
+  the mechanism that hides the convergence window from a client's first watch.
+- Changing UCC bucketing, `DISABLE_POD_LOCALITY_XDS`, or the local-cluster EDS resource.
+
+## Implementation Details
+
+### Overview
+
+```mermaid
+flowchart LR
+    FB["finalBackends<br/>(krt.Collection[*BackendObjectIR])"]
+    FB --> B["BaseEnvoyClusters<br/>one row per backend<br/>TranslateBackendBase()"]
+    FB --> D["PerClientEnvoyClusterDeltas<br/>one row per backend<br/>sparse map[ucc]delta<br/>ApplyPerClient()"]
+    UCC["UniquelyConnectedClients"] --> D
+    B -->|"FetchOne by cluster name"| D
+    B --> M["FetchClustersForClient(ucc)<br/>fence, then delta-wins"]
+    D -->|"krt.PartialFetch(forClient)"| M
+    UCC --> M
+    M --> S["snapshotPerClient<br/>CDS payload"]
+    B --> ST["StatusClusters()<br/>base rows + errored deltas"]
+    D --> ST
+    ST --> BS["Backend status"]
+```
+
+### Translator and Proxy Syncer
+
+`BackendTranslator.TranslateBackend` is replaced by two functions with an explicit ownership
+contract (`pkg/kgateway/translator/irtranslator/backend.go`).
+
+**`TranslateBackendBase(ctx, backend) *BaseCluster`** performs every UCC-invariant step and
+returns a proto that is shared read-only across all clients. `BaseCluster` also carries the
+non-proto state the per-client phase needs:
+
+| Field | Purpose |
+| --- | --- |
+| `Cluster` | the shared cluster proto |
+| `EndpointInputs` | inline endpoints from `InitEnvoyBackend`, if any |
+| `SupportsInlineCLA` | cluster type accepts an inline CLA (STATIC / STRICT_DNS / LOGICAL_DNS / `envoy.clusters.dns`) |
+| `DefaultedLocalityConfig` | `defaultLocalityConfig` — not a policy — chose the locality mode |
+| `Error` | translation failed; `Cluster` is the blackhole |
+
+`NeedsInlineCLA()` is the derived predicate that ties the two phases together: it is true when
+the cluster type takes an inline CLA, the backend produced inline endpoints, and no plugin
+already set a `LoadAssignment`. Such a base is **deliberately not validated and never
+publishable on its own** — Envoy rejects some CLA-less clusters outright (logical-DNS requires
+exactly one endpoint), so validating the base would blackhole a valid ServiceEntry for every
+client.
+
+**`ApplyPerClient(kctx, ctx, ucc, backend, base) (*Cluster, error)`** returns `nil, nil` — the
+dominant case — when the pair needs no per-client cluster. Otherwise it clones the base and
+applies, in order:
+
+1. every applicable `ClusterOverlay`, sorted by `GroupKind` so the mutated proto is
+   byte-stable across recomputes (`ContributedPolicies` is a map);
+2. `undoDefaultedLocalityConfig`, if the base defaulted the locality mode and an overlay has
+   since replaced the EDS cluster with a plugin-provided inline one (the waypoint redirect
+   does exactly this — see [Ordering changes](#ordering-and-semantic-changes));
+3. the inline CLA, built through `ResolveEndpointInputs` + `PrioritizeEndpoints`, only if the
+   base needs one and no overlay supplied one; and
+4. strict-mode validation of the **complete** per-client cluster. Overlay output was never
+   validated before this EP.
+
+On validation failure it returns `(blackhole, err)`, so a per-client failure has the same
+shape as a base failure and the snapshot consumer's errored-cluster tracking is unchanged.
+
+### Sparse CDS storage
+
+`PerClientEnvoyClusters` (`pkg/kgateway/proxy_syncer/backends.go`) becomes three collections
+instead of one flat per-pair collection:
+
+- **`base`** — `krt.Collection[baseEnvoyCluster]`, keyed by cluster name, one row per backend.
+- **`deltas`** — `krt.Collection[backendClusterDeltaSet]`, also one row per backend, holding
+  `map[uccResourceName]uccClusterDelta` with entries only for clients that differ. The row
+  exists even when the map is empty; that is what records "evaluated, no overlay applies".
+- **`clients`** — the UCC collection, so a read can confirm the requesting client is still
+  connected without depending on the rest of the fleet.
+
+`deltas` is driven off `finalBackends` (not off `uccs`) and fetches the already-computed base
+by key. Driving it off backends is what makes a backend *metadata-only* change — a Service
+label an overlay reads, with an unchanged base proto — still recompute deltas.
+
+#### Cross-collection coherence
+
+Base and deltas are separate collections with no shared transaction, so a reader can observe
+one ahead of the other. Four fences make the merge safe; `FetchClustersForClient` validates the
+whole generation before exposing any row, because a partial base/delta mix would let
+`snapshotPerClient` publish an incoherent CDS payload.
+
+| Fence | Mechanism | What it prevents |
+| --- | --- | --- |
+| Base generation | `baseClusterFingerprint{ClusterVersion}` stored on the delta set and compared against the live base | publishing deltas cloned from a superseded base |
+| Sparse absence | `clientInputSnapshot.ContainsCurrent(ucc)` — the exact immutable UCC snapshot the deltas were computed against | reading "no delta" as "no overlay applies" when the client was never evaluated |
+| Inline CLA | `baseEnvoyCluster.NeedsInlineCLA` forces a materialized delta | publishing a host-less STRICT_DNS/STATIC cluster to a newly connected client |
+| Client identity | `krt.FetchOne(clients, FilterKey(ucc))` plus `Equals` | serving a client whose `KnowsLocalCluster` or labels have moved |
+
+Two of those deserve emphasis.
+
+`baseClusterVersion` folds the inline endpoints hash **and** the attached-policy hash into the
+base proto hash when `SupportsInlineCLA` is true. The per-client CLA is built from
+`BaseCluster.EndpointInputs`, which is not part of the base proto; KRT keeps the *old* stored
+object when `Equals` returns true, so without this fold an endpoint or policy change would
+leave clients pinned to a stale `LoadAssignment` forever. It mirrors what
+`newFinalBackendEndpoints` already does for the EDS path. It is gated on `SupportsInlineCLA`
+so EDS clusters — whose endpoints flow through the separate EDS pipeline — do not churn.
+
+Readiness is scoped **per requesting client**, not fleet-wide. `FetchClustersForClient` uses
+`krt.PartialFetch` with a projection to `clientBackendDeltaView`, so another client's delta
+changing does not retrigger this client's CDS assembly; and it consults the resolution
+snapshot only when interpreting an *absent* sparse entry. A materialized delta carries the
+exact UCC it was computed for, which is proof enough on its own. This is the property that
+prevents the sparse design from reintroducing the fleet-wide barrier of #13868/#14352:
+unrelated client churn can never withhold an established client's CDS.
+
+#### Interning and immutability
+
+Two levels of sharing sit on top of the sparse representation:
+
+- **Per-client cluster deltas** are interned within each backend transform by their
+  already-computed content version. Inline-CLA backends materialize a delta for *every*
+  client, but clients that share the relevant inputs produce byte-identical clusters.
+- **CLAs** are interned across clients in `NewPerClientEnvoyEndpoints`, keyed by
+  `combineEndpointHash(resolvedEndpointHash, pluginHash, loadBalancingHash)`.
+
+Sharing a proto across snapshots means a post-creation mutation corrupts every sibling client
+*and* the copy KRT stores — and is invisible to KRT equality, because version hashes are
+computed at store time. The new `sharedproto` package makes that unrepresentable rather than
+merely forbidden: `Shared[M]` holds the proto in an unexported field, so the only exits are
+`Clone()` (the one legitimate mutation path) and `ResourceWithTTL()` (the one legitimate sink,
+the envoycache snapshot). When `ASSERT_SHARED_PROTO_IMMUTABILITY` is set, `Wrap` captures the
+content hash and `ResourceWithTTL` re-hashes and panics on drift, naming the resource. It is
+off by default because the re-hash is exactly the marshal cost the interning exists to avoid.
+
+### Plugin
+
+Two SDK hooks change; both keep the old hook working through a compatibility adapter, so no
+downstream plugin is forced to migrate in this EP.
+
+**`PerClientClusterOverlay`** replaces `PerClientProcessBackend`:
+
+```go
+type PerClientClusterOverlay func(krt.HandlerContext, context.Context,
+    ir.UniquelyConnectedClient, ir.BackendObjectIR) *ClusterOverlay
+
+type ClusterOverlay struct{ Mutate func(out *envoyclusterv3.Cluster) }
+```
+
+Returning `nil` means "this pair needs no per-client cluster changes". Self-gating is what
+keeps the delta collection sparse, so the plugin — not the framework — owns the cheap
+applicability check. `Mutate` is invoked exactly once with a fresh clone and must not retain
+its argument. `PerClientProcessBackend` is retained as deprecated and adapted as an
+always-applicable overlay, since a legacy hook cannot report a no-op cheaply.
+
+Both in-tree users were migrated with their cheap filters ordered before their expensive
+fetches: destrule returns `nil` unless a matching destination rule has outlier detection;
+waypoint returns `nil` unless the client carries `ambient.istio.io/redirection=enabled` and
+the backend opts into ingress-use-waypoint, before the Gateway `FetchOne`.
+
+**`EndpointEditorPlugin`** replaces the raw `*EndpointsInputs` hook. `EndpointInputsEditor`
+(`pkg/kgateway/endpoints/editor.go`) exposes reads plus explicit setters, and a
+copy-on-write `EndpointSetBuilder` for plugins that need to replace endpoints:
+
+```go
+type EndpointInputsEditor interface {
+    BackendLabels() map[string]string
+    Hostname() string
+    Port() uint32
+    PoliciesFor(schema.GroupKind) []ir.PolicyAtt
+
+    SetPriorityInfo(*PriorityInfo)
+    SetTrafficDistribution(wellknown.TrafficDistribution)
+
+    ForEachEndpoint(func(ir.PodLocality, EndpointView) bool)
+    NewEndpointSet() *EndpointSetBuilder
+    ReplaceEndpoints(*EndpointSetBuilder)
+}
+```
+
+A shallow copy of `EndpointsInputs` still aliases nested slices, maps, and protos, so before
+this change a plugin evaluating one client could change the endpoints another client
+subsequently observed. `EndpointView` is read-only with an explicit `Clone`; untouched
+endpoints are structurally shared through `AddUnchanged`. The deprecated hook is preserved
+behind `LegacyMutableInputs()`, which deep-copies the whole input graph at most once per
+client no matter how many legacy plugins run.
+
+Both `PerClientProcessEndpoints` and `PerClientEditEndpoints` return a hash that is now
+**load-bearing**: it keys CLA interning across clients, so it must capture every per-client
+effect the plugin has that is not already reflected by the resolved endpoint hash or the
+load-balancing-context hash. An under-captured mutation aliases one client's load assignment
+onto another.
+
+### Endpoints
+
+`TranslateEndpoints` is split so that CLA *construction* can be deduplicated separately from
+endpoint *resolution*:
+
+- `ResolveEndpoints(kctx, ucc, ep) ResolvedEndpoints` runs the ordered endpoint plugins and
+  returns the resolved inputs plus `AdditionalHash` (plugin contributions) and
+  `LoadBalancingHash`.
+- `BuildClusterLoadAssignment(ucc, resolved)` is pure given its arguments, which is what makes
+  interning sound.
+
+`endpoints.LoadBalancingContextHash` is the new third component. It hashes exactly the
+UCC-dependent inputs `PrioritizeEndpoints` consumes, mirroring its branches: when
+`FailoverPriority` is set only the *resolved* priority-label values matter and locality is
+ignored; otherwise only `PodLocality` matters; when there is no `PriorityInfo` at all the
+output is UCC-independent and the hash is `0`. It replaces the previous
+`LbEpsEqualityHash ^ additionalHash` key, which omitted the load-balancing context entirely,
+so clients differing only in locality or priority labels could collide.
+
+The hash is deliberately **conservative in one direction only**: equal hash must imply
+proto-equal CLA; the converse is not asserted (single-group locality failover renormalizes
+every priority to 0, so clients in different localities can hash differently yet build
+identical CLAs). Over-discrimination costs a missed dedup; under-discrimination misroutes.
+`TestLoadBalancingContextHashSoundness` locks that direction.
+
+Both the EDS path and the inline-CLA path now go through the same `ResolveEndpointInputs`
+helper, so their ownership and plugin-composition semantics cannot diverge. Backend and
+local-cluster EDS resources are wrapped in the same `sharedproto.Shared` boundary.
+
+### Reporting
+
+Backend status previously read the flat per-pair collection, so one Backend's status depended
+on rows for every connected client. `StatusClusters(krtopts)` now projects exactly what
+`GenerateBackendStatusReport` consumes: one row per base cluster carrying the source Backend
+identity and any UCC-invariant error, plus one row per **errored** per-client delta. Non-errored
+deltas contribute nothing. It is a collection rather than a `Fetch` helper so
+`backendStatusContributions` can index it by Backend: one client's cluster error then
+recomputes only its owning Backend's status.
+
+Status uses the same base-generation fence but, unlike CDS, **skips** a stale delta set instead
+of treating it as a barrier. Status has no cross-backend coherence requirement, and withholding
+every row mid-propagation would clear `Accepted` conditions that are still true. At worst a
+departed client's error lingers for one propagation.
+
+One observable output change follows from carrying base and per-client errors separately:
+errored clusters are omitted from emitted CDS, so seven gateway translation fixtures no longer
+contain a synthetic blackhole cluster entry. Route output and policy status are unchanged.
+
+### Ordering and semantic changes
+
+The split necessarily reorders translation. These are intentional and the only behavioral
+deltas identified:
+
+| Before | After | Rationale / compensation |
+| --- | --- | --- |
+| `ProcessBackend` and `PerClientProcessBackend` interleaved in `ContributedPolicies` map order | all `ProcessBackend` in the base, then overlays in `GroupKind` order | map order was nondeterministic; overlay output now feeds a content hash that drives KRT equality and interning, so it must be stable |
+| `defaultLocalityConfig` ran *after* per-client hooks and saw the final cluster shape | runs on the base, before overlays | `undoDefaultedLocalityConfig` re-evaluates the EDS guard and reverts the default when an overlay has replaced the EDS cluster with an inline one, including dropping a `CommonLbConfig` it allocated itself |
+| `clusterSupportsInlineCLA` evaluated on the final cluster | evaluated on the base | an overlay that inlines a CLA sets `LoadAssignment`, which the `out.GetLoadAssignment() == nil` re-check already respects |
+| Strict-mode validation ran once, on the final per-client cluster | base validated unless `NeedsInlineCLA`; per-client cluster always validated | CLA-less inline-CLA bases would fail validation spuriously; overlay output was previously never validated at all |
+| Endpoint plugin hashes discarded on the inline-CLA path | combined via `ResolveEndpointInputs` for both paths | unifies the two paths |
+
+### Configuration
+
+No CRD or user-facing API change. One new environment variable:
+
+- `ASSERT_SHARED_PROTO_IMMUTABILITY` — arms the shared-proto mutation tripwire. Off by
+  default in production; a trip surfaces as a controller panic, so the message is in the
+  previous container's logs (`kubectl logs --previous`). Set in CI three ways: the
+  `proxy_syncer` package tests force it on in-process via `TestMain`, the e2e suites set it on
+  the deployed controller through `common-recommendations.yaml`, and the conformance action
+  sets it on both of its helm install branches.
+
+### Measured results
+
+`BenchmarkPerClientClusters` (`backend_bench_test.go`) reconstructs the pre-refactor per-pair
+translation body and compares it against base + overlay, swept across whether a per-client
+overlay plugin is registered (`istio`) and how expensive the client-invariant base translation
+is (`heavy`). 200 backends x 20 clients, with a destination rule matching 1 client in 10;
+Apple M4 Max, `-benchtime=20x`:
+
+| Case | Old ns/op | New ns/op | Old allocs | New allocs | Old B/op | New B/op |
+| --- | --- | --- | --- | --- | --- | --- |
+| istio=false heavy=false | 849,946 | 88,610 | 28,000 | 2,201 | 3.44 MB | 214 KB |
+| istio=false heavy=true | 1,378,042 | 138,875 | 52,000 | 3,401 | 4.94 MB | 289 KB |
+| istio=true heavy=false | 1,085,748 | 584,398 | 28,800 | 7,401 | 3.56 MB | 756 KB |
+| istio=true heavy=true | 1,689,979 | 703,883 | 52,800 | 10,201 | 5.06 MB | 911 KB |
+
+Roughly 10x on the no-overlay path and 2x with a sparsely-matching destination rule, with
+allocation counts down 5-13x. The benchmark measures the translator only; see
+[Open Questions](#open-questions) for a collection-level cost it does not model.
+
+### Delivery
+
+The work landed as a 7-PR stack rather than as #14343, so that the translator contract, the
+KRT topology change, and the allocation optimizations can be reviewed and reverted
+independently.
+
+| # | PR | Scope | Topology change |
+| --- | --- | --- | --- |
+| 1 | #14599 | endpoint mutation boundary (`EndpointInputsEditor`) | no |
+| 2 | #14600 | `TranslateBackendBase` / `ApplyPerClient` / `ClusterOverlay`, dense storage retained | no |
+| 3 | #14601 | gateway translation fixtures for the errored-cluster output change | no |
+| 4 | #14602 | sparse CDS storage, fencing, `sharedproto` | **yes** |
+| 5 | #14603 | intern equivalent per-client cluster deltas | no |
+| 6 | #14604 | intern equivalent per-client CLAs, `LoadBalancingContextHash` | no |
+| 7 | #14605 | arm the immutability tripwire in e2e and conformance CI | no |
+
+PRs 1-3 are shippable before the topology change. PR 2 deliberately keeps dense storage and
+an independently owned proto per row so reviewers can validate the translation contract
+without also reasoning about cross-collection synchronization.
+
+## Test Plan
+
+**Unit.**
+- `backends_test.go` — `baseClusterVersion`: reflects inline-CLA endpoint and policy changes,
+  stays stable for EDS endpoint changes, zero for errored bases.
+- `backends_merge_test.go` — every fence, individually: delta-wins, delta error over base
+  error, client filtering, matching delta needs no resolution proof, inline-CLA base withheld
+  until its delta arrives, stale delta rejected after a base update, waits for the current
+  client set, waits for the current local-cluster capability, and unrelated client churn is
+  *not* a readiness barrier.
+- `backend_overlay_test.go`, `backend_validation_test.go` — overlay gathering, deterministic
+  ordering, locality-default undo, strict-mode validation of overlay output.
+- `editor_test.go` — structural sharing, legacy isolation, plugin ordering, allocations.
+- `sharedproto_test.go` — tripwire fires on mutation, skips uncaptured protos, respects the
+  flag; `Clone` independence; identity helpers.
+
+**Property.** `TestLoadBalancingContextHashSoundness` asserts `equal hash => proto.Equal(CLA)`
+over a diverse client set across three priority configurations, with a vacuity guard requiring
+the discriminating scenarios to produce more than one hash.
+
+**KRT integration.** `backends_integration_test.go` (sparse overlay wiring; backend
+metadata-only update recomputes deltas), `cla_intern_test.go` (equivalent clients share a CLA;
+distinct clients must not alias), `backends_disabled_pod_locality_test.go`
+(`DISABLE_POD_LOCALITY_XDS` shared-capability buckets without global withholding),
+`perclient_clusters_stress_test.go` (sustained trigger-driven churn never strands a stable
+client).
+
+**Golden.** `test/translator` selects the same base-or-per-client cluster the production
+sparse collection publishes, so gateway translation fixtures continue to assert real output.
+
+**Benchmarks.** `BenchmarkPerClientClusters` (translator), `BenchmarkEndpointInputsResolver`
+(scalar edit vs replacement builder vs legacy deep copy, at 10/100/1000 endpoints).
+
+**CI enforcement.** `ASSERT_SHARED_PROTO_IMMUTABILITY` on the deployed controller in every
+e2e suite and both conformance install paths, so a mutation after sharing surfaces as a
+controller panic instead of a silent cross-client leak.
+
+## Alternatives
+
+**Keep dense storage, share only the base translation.** This is exactly PR 2 of the stack,
+and it captures most of the CPU win with none of the synchronization risk. It was rejected as
+an endpoint because it retains `O(N*M)` rows and `O(N*M)` cluster protos — the memory half of
+the problem — and leaves one flat collection whose invalidation is fleet-wide.
+
+**Defer the whole publish until every delta is computed.** Simple and obviously coherent, but
+it is the #13868 design: a barrier that can stay unsatisfied indefinitely, stranding warm
+clients on stale endpoints and starving new pods (#14184, #14352). Rejected in favor of
+per-client fences plus the #14380 first-connect grace period.
+
+**A per-UCC "computed" marker instead of a retained client snapshot.** Would close the
+remaining waypoint propagation beat (below) exactly rather than by proof-of-membership. It
+needs a second write path per client per backend, and the retained snapshot is shared by
+reference across all backends, so the snapshot approach is cheaper. Worth revisiting if the
+beat proves user-visible.
+
+**A KRT collection between UCC events and delta recomputation** (rather than the
+`clientInputSnapshotInterner`). Cleaner dependency graph, but it adds a propagation hop
+between a client connecting and its deltas existing — which is precisely the window the
+inline-CLA withholding rule has to cover.
+
+**Hash-free equality (`proto.Equal` on stored clusters).** Correct by construction, but
+`Equals` runs on every recompute for every row; a content hash computed once at store time is
+the established pattern in this codebase, and `sharedproto` exists to protect the assumption
+that makes it sound.
+
+## Open Questions
+
+**`PrioritizeEndpoints` output is not byte-stable, which the delta version and the interning
+both assume.** `prioritizeWithLbInfo` ranges over the `LbEps` locality map and appends to
+`cla.Endpoints` in map order, so identical inputs produce different `Endpoints` orderings
+across calls. A probe over 200 identical calls with 5 localities produced 5 distinct
+`utils.HashProto` values. Consequences: `uccClusterDelta.ClusterVersion` for inline-CLA
+backends churns spuriously, and the PR 5 interning of byte-identical per-client clusters
+degrades to probabilistic. Multi-locality inline-CLA backends are reachable today — a STATIC
+or DNS `ServiceEntry` whose inline endpoints carry `locality:` fields lands in
+`endpointsFromWorkloads` as `eps.Add(workload.Locality, ep)`. The version churn is
+pre-existing (main also hashed the whole cluster including the CLA); the interning dependency
+is new. Sorting the locality keys in `prioritizeWithLbInfo` — or sorting `cla.Endpoints` before
+returning — would fix both, and would let the existing property test drop its `normalizeCLA`
+helper.
+
+**The base clone is unconditional.** `NewPerClientEnvoyClusters` does
+`perClientBase.Cluster = b.Cluster.Clone()` once per backend per recompute, before knowing
+whether any client will materialize a delta — and `ApplyPerClient` clones again from that copy
+when it does materialize. For 200 light backends the wasted clone measures 126 us / 202 KB /
+2000 allocs, against 80 us / 214 KB / 2201 allocs for the entire new translation path: it
+roughly doubles the cost and allocation count of the dominant no-overlay case, and it is not
+modelled by `BenchmarkPerClientClusters`. `ApplyPerClient` decides applicability before it
+touches `base.Cluster`, so passing a `func() *Cluster` (or the `Shared` wrapper) instead of a
+materialized clone would make it lazy and remove the double clone.
+
+**`EndpointsForBackend.EmptyCopy()` drops the folded policy hash.** It resets
+`LbEpsEqualityHash` to `upstreamHash`, discarding the contribution
+`newFinalBackendEndpoints` folded in. Any endpoint plugin that uses the new
+`NewEndpointSet()` / `ReplaceEndpoints()` path therefore returns a resolved hash that no
+longer distinguishes policy states, weakening both the CLA interning key and
+`UccWithEndpoints.Equals`. No in-tree plugin takes that path yet, so this is a latent trap in
+a newly public API rather than an active bug; either `EmptyCopy` should carry the folded hash
+or the editor should document the requirement.
+
+**A `fingerprintClients` collision withholds a client permanently.** `ClientsFingerprint`
+participates in `backendClusterDeltaSet.Equals`, so if two different client sets hashed equal,
+KRT would keep the old row, its `ResolvedClients` would not contain the current client, and
+`FetchClustersForClient` would withhold that client's CDS with no event able to recover it.
+The fingerprint covers every field `UniquelyConnectedClient.Equals` compares, so this needs a
+64-bit FNV collision — but the failure mode is permanent rather than transient. Worth deciding
+whether the delta set should fall back to a membership comparison when the fingerprint matches
+but `matches()` does not.
+
+**The base name is an undocumented hard invariant.** The delta transform locates its base with
+`FetchOne(base, FilterKey(backendObj.ClusterName()))`. Every current path names the cluster
+from `BackendObjectIR.ClusterName()` (`initializeCluster` and `buildBlackholeCluster` both do,
+and no plugin reassigns `Cluster.Name`), but if a future `InitEnvoyBackend` or `ProcessBackend`
+renamed it, the base row would exist with no delta row and `FetchClustersForClient` would
+withhold that client's entire CDS forever. Cheap to make loud with a log or a defensive
+fallback.
+
+**A newly connected ambient client can see the un-overlaid base for one KRT propagation
+beat** before its waypoint delta is computed: in a sparse design, absence of a delta is
+indistinguishable from not-yet-computed. The deterministic half — 503s from CLA-less inline
+clusters — is closed by the `NeedsInlineCLA` withholding rule. Closing the waypoint beat needs
+a per-UCC computed marker, and naive whole-publish deferral is riskier than the beat. Needs a
+follow-up issue.
+
+**The recompute fan-out on client churn is unchanged.** The delta transform `Fetch`es the whole
+UCC collection, so any connect or disconnect re-runs it for every backend, and each run loops
+over every client calling `ApplyPerClient` and re-hashes the client set. Per-pair cost is now
+small and retained state is sparse, but the `O(N*M)` event fan-out remains — the same as
+before this EP. Narrowing it is a separate change.
+
+**PR 2 of the stack is red on its own.** #14600 changes which clusters the golden helper emits
+but leaves the seven affected fixtures for #14601, so `pkg/kgateway/translator/gateway` fails
+on #14600 (`TestBasic/Priority_groups_backend_with_non-static_member_reports_error`,
+`TestBasic/Backend_TLS_Policy_with_terminated_TLSRoute_invalid_CA`, and five
+`TestValidation/*/backendconfigpolicy/*` cases). Either the fixtures move into #14600 or the
+two PRs must merge as a unit; as stacked, `main` is briefly broken and bisect is poisoned.
+
+**`ASSERT_SHARED_PROTO_IMMUTABILITY` is unconditional in conformance CI.** The tripwire adds a
+full deterministic marshal per resource per snapshot rebuild in every conformance and e2e run.
+The suites are green today, but unlike `ordered-ads` there is no action input to turn it off,
+which makes bisecting a timing-sensitive flake awkward.
+
+**`StatusClusters` constructs a KRT collection per call.** It is called once, but a second call
+would silently build a duplicate collection. Constructing it inside
+`NewPerClientEnvoyClusters` and returning it as a field would remove the hazard.
+
+**`UccWithEndpoints.Endpoints` still carries `+krtEqualsTodo`.** The marker predates this EP,
+but PR 6 changes the field's type and gives its equality a real justification
+(`EndpointsHash` is a content hash over the same CLA). It should become `+noKrtEquals` with
+that reason rather than remaining on the legacy-gap list.
+
+**Deep-cloning in `PoliciesFor`.** The editor deep-copies attachment metadata (`PolicyRef`,
+`Errors`, `MergeOrigins`) on every call, on a path that runs per client per backend, for
+consumers that only read. A documented read-only contract, or a view type, would avoid the
+allocation.

--- a/design/14184-shared-base-per-client-cluster-overlays.md
+++ b/design/14184-shared-base-per-client-cluster-overlays.md
@@ -303,6 +303,30 @@ Both the EDS path and the inline-CLA path now go through the same `ResolveEndpoi
 helper, so their ownership and plugin-composition semantics cannot diverge. Backend and
 local-cluster EDS resources are wrapped in the same `sharedproto.Shared` boundary.
 
+#### Deterministic CLA construction
+
+Interning and content-hash versioning both require that identical inputs produce identical
+*bytes*, which `prioritizeWithLbInfo` did not: it ranged `ep.LbEps` — a map — and appended each
+locality's groups to `cla.Endpoints` in map order. Locality order carries no meaning to Envoy,
+but the CLA's serialized form versions per-client xDS and keys the interning, so map order made
+identical inputs hash differently on every recompute. `sortedLocalities` now orders localities
+by `(region, zone, subzone)` before the loop. The renormalization in `applyLocalityFailover`
+depends only on the *set* of distinct priority values and each group's own priority, not on
+slice order, so the assigned priorities are unchanged.
+
+This was a pre-existing bug — `main` also hashed the whole cluster including its inline CLA, so
+the version churn predates this EP — but the interning added here is the first thing whose
+*correctness of purpose* depends on byte-stability. Measured on a 5-locality inline-CLA backend:
+
+| | Before | After |
+| --- | --- | --- |
+| Distinct CLA content hashes over 200 identical `PrioritizeEndpoints` calls | 5 | 1 |
+| Distinct interning keys across 20 clients sharing one load-balancing context | 5 | 1 |
+
+`TestPrioritizeEndpointsIsByteStable` locks byte-stability across all three priority modes and
+pins the canonical order, so a later change that is stable but no longer sorted has to be
+deliberate.
+
 ### Reporting
 
 Backend status previously read the flat per-pair collection, so one Backend's status depended
@@ -367,23 +391,24 @@ allocation counts down 5-13x. The benchmark measures the translator only; see
 
 ### Delivery
 
-The work landed as a 7-PR stack rather than as #14343, so that the translator contract, the
+The work landed as a 6-PR stack rather than as #14343, so that the translator contract, the
 KRT topology change, and the allocation optimizations can be reviewed and reverted
 independently.
 
 | # | PR | Scope | Topology change |
 | --- | --- | --- | --- |
-| 1 | #14599 | endpoint mutation boundary (`EndpointInputsEditor`) | no |
-| 2 | #14600 | `TranslateBackendBase` / `ApplyPerClient` / `ClusterOverlay`, dense storage retained | no |
-| 3 | #14601 | gateway translation fixtures for the errored-cluster output change | no |
-| 4 | #14602 | sparse CDS storage, fencing, `sharedproto` | **yes** |
-| 5 | #14603 | intern equivalent per-client cluster deltas | no |
-| 6 | #14604 | intern equivalent per-client CLAs, `LoadBalancingContextHash` | no |
-| 7 | #14605 | arm the immutability tripwire in e2e and conformance CI | no |
+| 1 | #14599 | endpoint mutation boundary (`EndpointInputsEditor`), deterministic CLA construction | no |
+| 2 | #14600 | `TranslateBackendBase` / `ApplyPerClient` / `ClusterOverlay`, dense storage retained, gateway fixtures for the errored-cluster output change | no |
+| 3 | #14602 | sparse CDS storage, fencing, `sharedproto` | **yes** |
+| 4 | #14603 | intern equivalent per-client cluster deltas | no |
+| 5 | #14604 | intern equivalent per-client CLAs, `LoadBalancingContextHash` | no |
+| 6 | #14605 | arm the immutability tripwire in e2e and conformance CI | no |
 
-PRs 1-3 are shippable before the topology change. PR 2 deliberately keeps dense storage and
+PRs 1-2 are shippable before the topology change. PR 2 deliberately keeps dense storage and
 an independently owned proto per row so reviewers can validate the translation contract
-without also reasoning about cross-collection synchronization.
+without also reasoning about cross-collection synchronization. Its output change — errored
+clusters omitted from CDS — is carried with its own fixture updates so the tree is green at
+every point in the stack.
 
 ## Test Plan
 
@@ -397,6 +422,8 @@ without also reasoning about cross-collection synchronization.
   *not* a readiness barrier.
 - `backend_overlay_test.go`, `backend_validation_test.go` — overlay gathering, deterministic
   ordering, locality-default undo, strict-mode validation of overlay output.
+- `prioritize_test.go` — the CLA is byte-stable across repeated calls in all three priority
+  modes, and localities are emitted in `(region, zone, subzone)` order.
 - `editor_test.go` — structural sharing, legacy isolation, plugin ordering, allocations.
 - `sharedproto_test.go` — tripwire fires on mutation, skips uncaptured protos, respects the
   flag; `Clone` independence; identity helpers.
@@ -452,20 +479,6 @@ that makes it sound.
 
 ## Open Questions
 
-**`PrioritizeEndpoints` output is not byte-stable, which the delta version and the interning
-both assume.** `prioritizeWithLbInfo` ranges over the `LbEps` locality map and appends to
-`cla.Endpoints` in map order, so identical inputs produce different `Endpoints` orderings
-across calls. A probe over 200 identical calls with 5 localities produced 5 distinct
-`utils.HashProto` values. Consequences: `uccClusterDelta.ClusterVersion` for inline-CLA
-backends churns spuriously, and the PR 5 interning of byte-identical per-client clusters
-degrades to probabilistic. Multi-locality inline-CLA backends are reachable today — a STATIC
-or DNS `ServiceEntry` whose inline endpoints carry `locality:` fields lands in
-`endpointsFromWorkloads` as `eps.Add(workload.Locality, ep)`. The version churn is
-pre-existing (main also hashed the whole cluster including the CLA); the interning dependency
-is new. Sorting the locality keys in `prioritizeWithLbInfo` — or sorting `cla.Endpoints` before
-returning — would fix both, and would let the existing property test drop its `normalizeCLA`
-helper.
-
 **The base clone is unconditional.** `NewPerClientEnvoyClusters` does
 `perClientBase.Cluster = b.Cluster.Clone()` once per backend per recompute, before knowing
 whether any client will materialize a delta — and `ApplyPerClient` clones again from that copy
@@ -515,13 +528,6 @@ over every client calling `ApplyPerClient` and re-hashes the client set. Per-pai
 small and retained state is sparse, but the `O(N*M)` event fan-out remains — the same as
 before this EP. Narrowing it is a separate change.
 
-**PR 2 of the stack is red on its own.** #14600 changes which clusters the golden helper emits
-but leaves the seven affected fixtures for #14601, so `pkg/kgateway/translator/gateway` fails
-on #14600 (`TestBasic/Priority_groups_backend_with_non-static_member_reports_error`,
-`TestBasic/Backend_TLS_Policy_with_terminated_TLSRoute_invalid_CA`, and five
-`TestValidation/*/backendconfigpolicy/*` cases). Either the fixtures move into #14600 or the
-two PRs must merge as a unit; as stacked, `main` is briefly broken and bisect is poisoned.
-
 **`ASSERT_SHARED_PROTO_IMMUTABILITY` is unconditional in conformance CI.** The tripwire adds a
 full deterministic marshal per resource per snapshot rebuild in every conformance and e2e run.
 The suites are green today, but unlike `ordered-ads` there is no action input to turn it off,
@@ -535,6 +541,12 @@ would silently build a duplicate collection. Constructing it inside
 but PR 6 changes the field's type and gives its equality a real justification
 (`EndpointsHash` is a content hash over the same CLA). It should become `+noKrtEquals` with
 that reason rather than remaining on the legacy-gap list.
+
+**`normalizeCLA` in the property test is now redundant.** It exists to sort
+`ClusterLoadAssignment.Endpoints` before `proto.Equal` because
+`PrioritizeEndpoints` used to emit them in map order. Now that the order is canonical, it and
+its `localityKey` helper can go, and the comment explaining why they are needed is no longer
+true.
 
 **Deep-cloning in `PoliciesFor`.** The editor deep-copies attachment metadata (`PolicyRef`,
 `Errors`, `MergeOrigins`) on every call, on a path that runs per client per backend, for

--- a/design/14184-shared-base-per-client-cluster-overlays.md
+++ b/design/14184-shared-base-per-client-cluster-overlays.md
@@ -430,7 +430,10 @@ every point in the stack.
 
 **Property.** `TestLoadBalancingContextHashSoundness` asserts `equal hash => proto.Equal(CLA)`
 over a diverse client set across three priority configurations, with a vacuity guard requiring
-the discriminating scenarios to produce more than one hash.
+the discriminating scenarios to produce more than one hash. It compares the CLAs exactly as
+built — canonical locality ordering makes normalization unnecessary — so it also fails if that
+ordering regresses; its failure message names both causes and points at the byte-stability test
+first.
 
 **KRT integration.** `backends_integration_test.go` (sparse overlay wiring; backend
 metadata-only update recomputes deltas), `cla_intern_test.go` (equivalent clients share a CLA;
@@ -541,12 +544,6 @@ would silently build a duplicate collection. Constructing it inside
 but PR 6 changes the field's type and gives its equality a real justification
 (`EndpointsHash` is a content hash over the same CLA). It should become `+noKrtEquals` with
 that reason rather than remaining on the legacy-gap list.
-
-**`normalizeCLA` in the property test is now redundant.** It exists to sort
-`ClusterLoadAssignment.Endpoints` before `proto.Equal` because
-`PrioritizeEndpoints` used to emit them in map order. Now that the order is canonical, it and
-its `localityKey` helper can go, and the comment explaining why they are needed is no longer
-true.
 
 **Deep-cloning in `PoliciesFor`.** The editor deep-copies attachment metadata (`PolicyRef`,
 `Errors`, `MergeOrigins`) on every call, on a path that runs per client per backend, for

--- a/design/14184-shared-base-per-client-cluster-overlays.md
+++ b/design/14184-shared-base-per-client-cluster-overlays.md
@@ -276,6 +276,13 @@ Exposing the legacy mutable graph invalidates reuse for the rest of that plugin 
 later editor safely rehashes rather than trusting a cache a legacy mutation may have made
 stale.
 
+Replacement builders are owner-bound and single-use. `ReplaceEndpoints` consumes shared
+builder state, so even a builder value copied before installation cannot mutate the installed
+endpoint map afterwards; nil, cross-resolver, repeated, and post-install uses panic as SDK
+contract violations. Endpoint-content hashes and folded semantic-version contributions are
+stored separately, allowing `EmptyCopy` to preserve the latter and preventing a subsequent
+`Add` from erasing policy versioning.
+
 Both `PerClientProcessEndpoints` and `PerClientEditEndpoints` return a hash that is now
 **load-bearing**: it keys CLA interning across clients, so it must capture every per-client
 effect the plugin has that is not already reflected by the resolved endpoint hash or the

--- a/design/14184-shared-base-per-client-cluster-overlays.md
+++ b/design/14184-shared-base-per-client-cluster-overlays.md
@@ -287,7 +287,9 @@ Both `PerClientProcessEndpoints` and `PerClientEditEndpoints` return a hash that
 **load-bearing**: it keys CLA interning across clients, so it must capture every per-client
 effect the plugin has that is not already reflected by the resolved endpoint hash or the
 load-balancing-context hash. An under-captured mutation aliases one client's load assignment
-onto another.
+onto another. Nonzero contributions are combined sequentially in deterministic plugin order
+and mixed with the plugin's group, kind, and name. Zero remains a no-op, while equal nonzero
+values from two plugins cannot cancel as they did under XOR.
 
 ### Endpoints
 
@@ -320,27 +322,29 @@ local-cluster EDS resources are wrapped in the same `sharedproto.Shared` boundar
 
 #### Deterministic CLA construction
 
-Interning and content-hash versioning both require that identical inputs produce identical
-*bytes*, which `prioritizeWithLbInfo` did not: it ranged `ep.LbEps` — a map — and appended each
-locality's groups to `cla.Endpoints` in map order. Locality order carries no meaning to Envoy,
-but the CLA's serialized form versions per-client xDS and keys the interning, so map order made
-identical inputs hash differently on every recompute. `sortedLocalities` now orders localities
-by `(region, zone, subzone)` before the loop. The renormalization in `applyLocalityFailover`
-depends only on the *set* of distinct priority values and each group's own priority, not on
-slice order, so the assigned priorities are unchanged.
+`prioritizeWithLbInfo` ranged `ep.LbEps` — a map — and appended each locality's groups to
+`cla.Endpoints` in map order. Locality order carries no meaning to Envoy, but inline-CLA
+backends embed those bytes in the cluster. `uccWithCluster.ClusterVersion` hashes the full
+cluster, KRT equality compares that field, and the aggregate CDS version folds it in. Random
+map order therefore produced a fresh CDS version on an unchanged recompute and re-warmed the
+cluster. EDS KRT equality instead uses `EndpointsForBackend.LbEpsEqualityHash`, a structural
+hash, so locality map order never affected EDS change detection.
 
-This was a pre-existing bug — `main` also hashed the whole cluster including its inline CLA, so
-the version churn predates this EP — but the interning added here is the first thing whose
-*correctness of purpose* depends on byte-stability. Measured on a 5-locality inline-CLA backend:
+`sortedLocalities` now orders localities by `(region, zone, subzone)` before the loop. The
+renormalization in `applyLocalityFailover` depends only on the *set* of distinct priority
+values and each group's own priority, not on slice order, so the assigned priorities are
+unchanged. Stable CLA bytes also keep content-addressed interning effective for equivalent
+clients. This is an independently user-visible fix for a pre-existing CDS churn bug, not only
+support for interning. Measured on a 5-locality inline-CLA backend:
 
 | | Before | After |
 | --- | --- | --- |
-| Distinct CLA content hashes over 200 identical `PrioritizeEndpoints` calls | 5 | 1 |
+| Distinct inline-cluster versions over 200 identical `PrioritizeEndpoints` calls | 5 | 1 |
 | Distinct interning keys across 20 clients sharing one load-balancing context | 5 | 1 |
 
-`TestPrioritizeEndpointsIsByteStable` locks byte-stability across all three priority modes and
-pins the canonical order, so a later change that is stable but no longer sorted has to be
-deliberate.
+`TestPrioritizeEndpointsIsByteStable` locks the inline-cluster version across all three
+priority modes and pins the canonical order, so a later change that is stable but no longer
+sorted has to be deliberate.
 
 ### Reporting
 

--- a/design/14184-shared-base-per-client-cluster-overlays.md
+++ b/design/14184-shared-base-per-client-cluster-overlays.md
@@ -268,6 +268,14 @@ endpoints are structurally shared through `AddUnchanged`. The deprecated hook is
 behind `LegacyMutableInputs()`, which deep-copies the whole input graph at most once per
 client no matter how many legacy plugins run.
 
+`EndpointsForBackend.Add` retains each endpoint's already-computed hash contribution as
+unexported derived state. `AddUnchanged` reuses that contribution when the endpoint stays in
+the same locality, avoiding the per-client proto marshal that #14489 removed from the shared
+derived collections; cloned or relocated endpoints still go through `Add` and are rehashed.
+Exposing the legacy mutable graph invalidates reuse for the rest of that plugin chain, so a
+later editor safely rehashes rather than trusting a cache a legacy mutation may have made
+stale.
+
 Both `PerClientProcessEndpoints` and `PerClientEditEndpoints` return a hash that is now
 **load-bearing**: it keys CLA interning across clients, so it must capture every per-client
 effect the plugin has that is not already reflected by the resolved endpoint hash or the

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -234,4 +234,3 @@ func clonePriorityInfo(in *PriorityInfo) *PriorityInfo {
 	}
 	return &out
 }
-

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -25,7 +25,7 @@ type EndpointInputsEditor interface {
 	BackendLabels() map[string]string
 	Hostname() string
 	Port() uint32
-	PoliciesFor(schema.GroupKind) []ir.PolicyAtt
+	PoliciesFor(schema.GroupKind) []PolicyView
 
 	SetPriorityInfo(*PriorityInfo)
 	SetTrafficDistribution(wellknown.TrafficDistribution)
@@ -78,10 +78,20 @@ func (e *EndpointInputsResolver) Port() uint32 {
 	return e.inputs.EndpointsForBackend.Port
 }
 
-// PoliciesFor returns a copy of the attachments so plugins cannot mutate shared
-// attachment metadata. PolicyIR values are immutable KRT IR and remain shared.
-func (e *EndpointInputsResolver) PoliciesFor(groupKind schema.GroupKind) []ir.PolicyAtt {
-	return clonePolicyAttachments(e.inputs.EndpointsForBackend.AttachedPolicies.Policies[groupKind])
+// PoliciesFor returns read-only views of the policies of one kind attached to
+// this backend. A view cannot reach the attachment's mutable metadata, so no
+// copy of it is made: this runs per client per backend, and the callers only
+// read.
+func (e *EndpointInputsResolver) PoliciesFor(groupKind schema.GroupKind) []PolicyView {
+	attachments := e.inputs.EndpointsForBackend.AttachedPolicies.Policies[groupKind]
+	if len(attachments) == 0 {
+		return nil
+	}
+	views := make([]PolicyView, len(attachments))
+	for i, attachment := range attachments {
+		views[i] = PolicyView{attachment: attachment}
+	}
+	return views
 }
 
 func (e *EndpointInputsResolver) SetPriorityInfo(priorityInfo *PriorityInfo) {
@@ -113,7 +123,52 @@ func (e *EndpointInputsResolver) ReplaceEndpoints(replacement *EndpointSetBuilde
 	if replacement == nil {
 		return
 	}
+	// The builder started from EmptyCopy, which reseeds the equality hash from
+	// backend identity, so it carries no trace of anything the row's owner
+	// folded in after construction — newFinalBackendEndpoints folds the
+	// attached-policy hash, which changes what the endpoints translate into
+	// without changing the endpoints. Fold the source row's hash back in: the
+	// resolved hash keys CLA interning and the KRT equality of the resolved
+	// row, so dropping it would serve one policy state's load assignment for
+	// another's. This over-discriminates (the result now varies with the source
+	// endpoints too, costing a missed dedup at worst) which is the safe
+	// direction.
+	replacement.endpoints.FoldVersion(e.inputs.EndpointsForBackend.LbEpsEqualityHash)
 	e.inputs.EndpointsForBackend = replacement.endpoints
+}
+
+// PolicyView is an immutable view of one policy attachment. It exposes what
+// endpoint plugins actually need — the policy IR, whether the attachment failed
+// IR construction, and the identity a plugin folds into its version hash —
+// while keeping PolicyRef, Errors, and MergeOrigins out of reach. That is what
+// lets [EndpointInputsResolver.PoliciesFor] hand out attachments without
+// deep-copying metadata that no caller writes.
+type PolicyView struct {
+	attachment ir.PolicyAtt
+}
+
+// PolicyIR returns the attached policy's IR, which is immutable KRT state and
+// therefore safe to share across clients.
+func (p PolicyView) PolicyIR() ir.PolicyIR {
+	return p.attachment.PolicyIr
+}
+
+// HasErrors reports whether this attachment failed IR construction, in which
+// case its PolicyIR must not be applied.
+func (p PolicyView) HasErrors() bool {
+	return len(p.attachment.Errors) > 0
+}
+
+// RefString identifies the attached policy object. Plugins hash it to version
+// their contribution; see [EndpointEditorPlugin] on why that hash is
+// load-bearing.
+func (p PolicyView) RefString() string {
+	return ir.PolicyRefString(p.attachment.PolicyRef)
+}
+
+// Generation is the observed generation of the attached policy object.
+func (p PolicyView) Generation() int64 {
+	return p.attachment.Generation
 }
 
 // EndpointView is an immutable view of one endpoint from shared input state.

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -78,11 +78,10 @@ func (e *EndpointInputsResolver) Port() uint32 {
 	return e.inputs.EndpointsForBackend.Port
 }
 
-// PoliciesFor returns a copy of the attachment slice so plugins cannot reorder
-// or replace entries in the shared attachment container. PolicyIR values are
-// immutable KRT IR and remain shared.
+// PoliciesFor returns a copy of the attachments so plugins cannot mutate shared
+// attachment metadata. PolicyIR values are immutable KRT IR and remain shared.
 func (e *EndpointInputsResolver) PoliciesFor(groupKind schema.GroupKind) []ir.PolicyAtt {
-	return slices.Clone(e.inputs.EndpointsForBackend.AttachedPolicies.Policies[groupKind])
+	return clonePolicyAttachments(e.inputs.EndpointsForBackend.AttachedPolicies.Policies[groupKind])
 }
 
 func (e *EndpointInputsResolver) SetPriorityInfo(priorityInfo *PriorityInfo) {
@@ -195,22 +194,25 @@ func cloneAttachedPolicies(in ir.AttachedPolicies) ir.AttachedPolicies {
 	}
 	out := ir.AttachedPolicies{Policies: make(map[schema.GroupKind][]ir.PolicyAtt, len(in.Policies))}
 	for groupKind, attachments := range in.Policies {
-		cloned := make([]ir.PolicyAtt, len(attachments))
-		for i, attachment := range attachments {
-			cloned[i] = attachment
-			if attachment.PolicyRef != nil {
-				policyRef := *attachment.PolicyRef
-				cloned[i].PolicyRef = &policyRef
-			}
-			cloned[i].Errors = slices.Clone(attachment.Errors)
-			if attachment.MergeOrigins != nil {
-				cloned[i].MergeOrigins = make(ir.MergeOrigins, len(attachment.MergeOrigins))
-				for field, origins := range attachment.MergeOrigins {
-					cloned[i].MergeOrigins[field] = origins.Clone()
-				}
+		out.Policies[groupKind] = clonePolicyAttachments(attachments)
+	}
+	return out
+}
+
+func clonePolicyAttachments(in []ir.PolicyAtt) []ir.PolicyAtt {
+	out := slices.Clone(in)
+	for i := range out {
+		if out[i].PolicyRef != nil {
+			policyRef := *out[i].PolicyRef
+			out[i].PolicyRef = &policyRef
+		}
+		out[i].Errors = slices.Clone(out[i].Errors)
+		if out[i].MergeOrigins != nil {
+			out[i].MergeOrigins = make(ir.MergeOrigins, len(out[i].MergeOrigins))
+			for field, origins := range in[i].MergeOrigins {
+				out[i].MergeOrigins[field] = origins.Clone()
 			}
 		}
-		out.Policies[groupKind] = cloned
 	}
 	return out
 }

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -1,0 +1,237 @@
+package endpoints
+
+import (
+	"maps"
+	"slices"
+
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"google.golang.org/protobuf/proto"
+	"istio.io/api/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+// EndpointInputsEditor is the mutation surface exposed to per-client endpoint
+// plugins. The shared endpoint inputs are only available through read accessors;
+// plugins express output changes through setters or by installing a replacement
+// endpoint set built with [EndpointSetBuilder].
+//
+// This prevents plugins from accidentally mutating KRT-owned maps, slices, or
+// protobufs shared by other clients. Plugins that still use the legacy raw-input
+// hook are isolated by a defensive deep copy in the translation framework.
+type EndpointInputsEditor interface {
+	BackendLabels() map[string]string
+	Hostname() string
+	Port() uint32
+	PoliciesFor(schema.GroupKind) []ir.PolicyAtt
+
+	SetPriorityInfo(*PriorityInfo)
+	SetTrafficDistribution(wellknown.TrafficDistribution)
+
+	ForEachEndpoint(func(ir.PodLocality, EndpointView) bool)
+	NewEndpointSet() *EndpointSetBuilder
+	ReplaceEndpoints(*EndpointSetBuilder)
+}
+
+// EndpointInputsResolver owns one client's working endpoint inputs. Translation
+// code retains the concrete resolver to retrieve the result; plugins receive only
+// the restricted [EndpointInputsEditor] interface.
+type EndpointInputsResolver struct {
+	inputs         EndpointsInputs
+	legacyIsolated bool
+}
+
+// NewEndpointInputsResolver creates a per-client working view over shared
+// endpoint inputs. The shared nested state remains immutable until a plugin
+// explicitly builds a replacement or requests the legacy mutable view.
+func NewEndpointInputsResolver(inputs EndpointsInputs) *EndpointInputsResolver {
+	return &EndpointInputsResolver{inputs: inputs}
+}
+
+// Inputs returns the resolved per-client inputs after all plugins have run.
+func (e *EndpointInputsResolver) Inputs() EndpointsInputs {
+	return e.inputs
+}
+
+// LegacyMutableInputs returns a transitively isolated input graph for the legacy
+// raw mutation hook. The copy is made at most once per client even when multiple
+// legacy plugins run.
+func (e *EndpointInputsResolver) LegacyMutableInputs() *EndpointsInputs {
+	if !e.legacyIsolated {
+		e.inputs = cloneEndpointsInputs(e.inputs)
+		e.legacyIsolated = true
+	}
+	return &e.inputs
+}
+
+func (e *EndpointInputsResolver) BackendLabels() map[string]string {
+	return maps.Clone(e.inputs.EndpointsForBackend.BackendLabels)
+}
+
+func (e *EndpointInputsResolver) Hostname() string {
+	return e.inputs.EndpointsForBackend.Hostname
+}
+
+func (e *EndpointInputsResolver) Port() uint32 {
+	return e.inputs.EndpointsForBackend.Port
+}
+
+// PoliciesFor returns a copy of the attachment slice so plugins cannot reorder
+// or replace entries in the shared attachment container. PolicyIR values are
+// immutable KRT IR and remain shared.
+func (e *EndpointInputsResolver) PoliciesFor(groupKind schema.GroupKind) []ir.PolicyAtt {
+	return slices.Clone(e.inputs.EndpointsForBackend.AttachedPolicies.Policies[groupKind])
+}
+
+func (e *EndpointInputsResolver) SetPriorityInfo(priorityInfo *PriorityInfo) {
+	e.inputs.PriorityInfo = priorityInfo
+}
+
+func (e *EndpointInputsResolver) SetTrafficDistribution(distribution wellknown.TrafficDistribution) {
+	e.inputs.EndpointsForBackend.TrafficDistribution = distribution
+}
+
+// ForEachEndpoint visits the immutable source endpoint set. Returning false
+// stops iteration. EndpointView exposes scalar reads and an explicit Clone method
+// for plugins that need to modify an endpoint.
+func (e *EndpointInputsResolver) ForEachEndpoint(fn func(ir.PodLocality, EndpointView) bool) {
+	for locality, localityEndpoints := range e.inputs.EndpointsForBackend.LbEps {
+		for _, endpoint := range localityEndpoints {
+			if !fn(locality, EndpointView{endpoint: endpoint}) {
+				return
+			}
+		}
+	}
+}
+
+func (e *EndpointInputsResolver) NewEndpointSet() *EndpointSetBuilder {
+	return &EndpointSetBuilder{endpoints: e.inputs.EndpointsForBackend.EmptyCopy()}
+}
+
+func (e *EndpointInputsResolver) ReplaceEndpoints(replacement *EndpointSetBuilder) {
+	if replacement == nil {
+		return
+	}
+	e.inputs.EndpointsForBackend = replacement.endpoints
+}
+
+// EndpointView is an immutable view of one endpoint from shared input state.
+// Clone must be called before changing any endpoint proto or metadata label.
+type EndpointView struct {
+	endpoint ir.EndpointWithMd
+}
+
+func (e EndpointView) Label(name string) string {
+	return e.endpoint.EndpointMd.Labels[name]
+}
+
+// SocketAddress returns the socket address and whether the endpoint uses a
+// socket address. An empty address with ok=true is distinct from a non-socket
+// endpoint.
+func (e EndpointView) SocketAddress() (address string, ok bool) {
+	socketAddress := e.endpoint.GetEndpoint().GetAddress().GetSocketAddress()
+	if socketAddress == nil {
+		return "", false
+	}
+	return socketAddress.GetAddress(), true
+}
+
+func (e EndpointView) LoadBalancingWeight() uint32 {
+	return e.endpoint.GetLoadBalancingWeight().GetValue()
+}
+
+// Clone returns a mutable, transitively isolated endpoint value.
+func (e EndpointView) Clone() ir.EndpointWithMd {
+	out := e.endpoint
+	if e.endpoint.LbEndpoint != nil {
+		out.LbEndpoint = proto.Clone(e.endpoint.LbEndpoint).(*envoyendpointv3.LbEndpoint)
+	}
+	out.EndpointMd.Labels = maps.Clone(e.endpoint.EndpointMd.Labels)
+	return out
+}
+
+// EndpointSetBuilder constructs a replacement EndpointsForBackend while
+// preserving its identity and precomputed hash semantics. Unchanged endpoints
+// may be structurally shared; modified endpoints must be added after Clone.
+type EndpointSetBuilder struct {
+	endpoints ir.EndpointsForBackend
+}
+
+func (b *EndpointSetBuilder) AddUnchanged(locality ir.PodLocality, endpoint EndpointView) {
+	b.endpoints.Add(locality, endpoint.endpoint)
+}
+
+func (b *EndpointSetBuilder) Add(locality ir.PodLocality, endpoint ir.EndpointWithMd) {
+	b.endpoints.Add(locality, endpoint)
+}
+
+func cloneEndpointsInputs(in EndpointsInputs) EndpointsInputs {
+	out := in
+	out.EndpointsForBackend = cloneEndpointsForBackend(in.EndpointsForBackend)
+	out.PriorityInfo = clonePriorityInfo(in.PriorityInfo)
+	return out
+}
+
+func cloneEndpointsForBackend(in ir.EndpointsForBackend) ir.EndpointsForBackend {
+	out := in
+	out.BackendLabels = maps.Clone(in.BackendLabels)
+	out.AttachedPolicies = cloneAttachedPolicies(in.AttachedPolicies)
+	out.LbEps = make(ir.LocalityLbMap, len(in.LbEps))
+	for locality, localityEndpoints := range in.LbEps {
+		cloned := make([]ir.EndpointWithMd, len(localityEndpoints))
+		for i, endpoint := range localityEndpoints {
+			cloned[i] = EndpointView{endpoint: endpoint}.Clone()
+		}
+		out.LbEps[locality] = cloned
+	}
+	return out
+}
+
+func cloneAttachedPolicies(in ir.AttachedPolicies) ir.AttachedPolicies {
+	if in.Policies == nil {
+		return ir.AttachedPolicies{}
+	}
+	out := ir.AttachedPolicies{Policies: make(map[schema.GroupKind][]ir.PolicyAtt, len(in.Policies))}
+	for groupKind, attachments := range in.Policies {
+		cloned := make([]ir.PolicyAtt, len(attachments))
+		for i, attachment := range attachments {
+			cloned[i] = attachment
+			if attachment.PolicyRef != nil {
+				policyRef := *attachment.PolicyRef
+				cloned[i].PolicyRef = &policyRef
+			}
+			cloned[i].Errors = slices.Clone(attachment.Errors)
+			if attachment.MergeOrigins != nil {
+				cloned[i].MergeOrigins = make(ir.MergeOrigins, len(attachment.MergeOrigins))
+				for field, origins := range attachment.MergeOrigins {
+					cloned[i].MergeOrigins[field] = origins.Clone()
+				}
+			}
+		}
+		out.Policies[groupKind] = cloned
+	}
+	return out
+}
+
+func clonePriorityInfo(in *PriorityInfo) *PriorityInfo {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.FailoverPriority != nil {
+		prioritizer := *in.FailoverPriority
+		prioritizer.priorityLabels = slices.Clone(in.FailoverPriority.priorityLabels)
+		prioritizer.priorityLabelOverrides = maps.Clone(in.FailoverPriority.priorityLabelOverrides)
+		out.FailoverPriority = &prioritizer
+	}
+	out.Failover = make([]*v1alpha3.LocalityLoadBalancerSetting_Failover, len(in.Failover))
+	for i, failover := range in.Failover {
+		if failover != nil {
+			out.Failover[i] = proto.Clone(failover).(*v1alpha3.LocalityLoadBalancerSetting_Failover)
+		}
+	}
+	return &out
+}
+

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -100,7 +100,10 @@ func (e *EndpointInputsResolver) PoliciesFor(groupKind schema.GroupKind) []Polic
 }
 
 func (e *EndpointInputsResolver) SetPriorityInfo(priorityInfo *PriorityInfo) {
-	e.inputs.PriorityInfo = priorityInfo
+	// A plugin owns the value it passes in and may reuse or mutate it after this
+	// call. Snapshot the transitive graph so later writes cannot mutate resolved
+	// inputs behind the editor boundary.
+	e.inputs.PriorityInfo = clonePriorityInfo(priorityInfo)
 }
 
 func (e *EndpointInputsResolver) SetTrafficDistribution(distribution wellknown.TrafficDistribution) {

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -125,25 +125,30 @@ func (e *EndpointInputsResolver) ForEachEndpoint(fn func(ir.PodLocality, Endpoin
 }
 
 func (e *EndpointInputsResolver) NewEndpointSet() *EndpointSetBuilder {
-	return &EndpointSetBuilder{endpoints: e.inputs.EndpointsForBackend.EmptyCopy()}
+	return &EndpointSetBuilder{state: &endpointSetBuilderState{
+		endpoints: e.inputs.EndpointsForBackend.EmptyCopy(),
+		owner:     e,
+	}}
 }
 
 func (e *EndpointInputsResolver) ReplaceEndpoints(replacement *EndpointSetBuilder) {
 	if replacement == nil {
-		return
+		panic("endpoint replacement builder is nil")
 	}
-	// The builder started from EmptyCopy, which reseeds the equality hash from
-	// backend identity, so it carries no trace of anything the row's owner
-	// folded in after construction — newFinalBackendEndpoints folds the
-	// attached-policy hash, which changes what the endpoints translate into
-	// without changing the endpoints. Fold the source row's hash back in: the
-	// resolved hash keys CLA interning and the KRT equality of the resolved
-	// row, so dropping it would serve one policy state's load assignment for
-	// another's. This over-discriminates (the result now varies with the source
-	// endpoints too, costing a missed dedup at worst) which is the safe
-	// direction.
-	replacement.endpoints.FoldVersion(e.inputs.EndpointsForBackend.LbEpsEqualityHash)
-	e.inputs.EndpointsForBackend = replacement.endpoints
+	state := replacement.mutableState()
+	if state.owner != e {
+		panic("endpoint replacement builder belongs to a different resolver")
+	}
+
+	// Consume the shared state rather than only this particular builder value:
+	// copying an EndpointSetBuilder before installation must not create another
+	// live handle to the installed map.
+	installed := state.endpoints
+	state.endpoints = ir.EndpointsForBackend{}
+	state.owner = nil
+	state.consumed = true
+
+	e.inputs.EndpointsForBackend = installed
 	e.endpointHashesReusable = true
 }
 
@@ -220,28 +225,48 @@ func (e EndpointView) Clone() ir.EndpointWithMd {
 
 // EndpointSetBuilder constructs a replacement EndpointsForBackend while
 // preserving its identity and precomputed hash semantics. Unchanged endpoints
-// may be structurally shared; modified endpoints must be added after Clone.
+// may be structurally shared; modified endpoints must be added after Clone. A
+// builder belongs to the resolver that created it and is consumed by
+// ReplaceEndpoints. Any later use panics, including through a copied builder
+// value.
 type EndpointSetBuilder struct {
+	state *endpointSetBuilderState
+}
+
+type endpointSetBuilderState struct {
 	endpoints ir.EndpointsForBackend
+	owner     *EndpointInputsResolver
+	consumed  bool
+}
+
+func (b *EndpointSetBuilder) mutableState() *endpointSetBuilderState {
+	if b == nil || b.state == nil {
+		panic("endpoint replacement builder is uninitialized")
+	}
+	if b.state.consumed {
+		panic("endpoint replacement builder has already been consumed")
+	}
+	return b.state
 }
 
 // AddUnchanged structurally shares an immutable endpoint and reuses its
 // precomputed contribution hash. Moving it to another locality, or using a view
 // exposed after a legacy mutable hook, safely falls back to a fresh hash.
 func (b *EndpointSetBuilder) AddUnchanged(locality ir.PodLocality, endpoint EndpointView) {
+	state := b.mutableState()
 	if locality != endpoint.locality || !endpoint.hashReusable {
 		// Locality participates in the endpoint contribution hash, so moving an
 		// otherwise unchanged endpoint still requires a fresh hash. A legacy
 		// plugin may also have mutated the endpoint behind the view, invalidating
 		// the cached contribution.
-		b.endpoints.Add(locality, endpoint.endpoint)
+		state.endpoints.Add(locality, endpoint.endpoint)
 		return
 	}
-	b.endpoints.ReuseEndpoint(locality, endpoint.endpoint)
+	state.endpoints.ReuseEndpoint(locality, endpoint.endpoint)
 }
 
 func (b *EndpointSetBuilder) Add(locality ir.PodLocality, endpoint ir.EndpointWithMd) {
-	b.endpoints.Add(locality, endpoint)
+	b.mutableState().endpoints.Add(locality, endpoint)
 }
 
 func cloneEndpointsInputs(in EndpointsInputs) EndpointsInputs {

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -39,15 +39,16 @@ type EndpointInputsEditor interface {
 // code retains the concrete resolver to retrieve the result; plugins receive only
 // the restricted [EndpointInputsEditor] interface.
 type EndpointInputsResolver struct {
-	inputs         EndpointsInputs
-	legacyIsolated bool
+	inputs                 EndpointsInputs
+	legacyIsolated         bool
+	endpointHashesReusable bool
 }
 
 // NewEndpointInputsResolver creates a per-client working view over shared
 // endpoint inputs. The shared nested state remains immutable until a plugin
 // explicitly builds a replacement or requests the legacy mutable view.
 func NewEndpointInputsResolver(inputs EndpointsInputs) *EndpointInputsResolver {
-	return &EndpointInputsResolver{inputs: inputs}
+	return &EndpointInputsResolver{inputs: inputs, endpointHashesReusable: true}
 }
 
 // Inputs returns the resolved per-client inputs after all plugins have run.
@@ -63,6 +64,10 @@ func (e *EndpointInputsResolver) LegacyMutableInputs() *EndpointsInputs {
 		e.inputs = cloneEndpointsInputs(e.inputs)
 		e.legacyIsolated = true
 	}
+	// A legacy plugin can mutate endpoint protos or metadata without going
+	// through EndpointsForBackend.Add, so their cached contribution hashes can
+	// no longer be trusted by a later editor plugin.
+	e.endpointHashesReusable = false
 	return &e.inputs
 }
 
@@ -108,7 +113,11 @@ func (e *EndpointInputsResolver) SetTrafficDistribution(distribution wellknown.T
 func (e *EndpointInputsResolver) ForEachEndpoint(fn func(ir.PodLocality, EndpointView) bool) {
 	for locality, localityEndpoints := range e.inputs.EndpointsForBackend.LbEps {
 		for _, endpoint := range localityEndpoints {
-			if !fn(locality, EndpointView{endpoint: endpoint}) {
+			if !fn(locality, EndpointView{
+				locality:     locality,
+				endpoint:     endpoint,
+				hashReusable: e.endpointHashesReusable,
+			}) {
 				return
 			}
 		}
@@ -135,6 +144,7 @@ func (e *EndpointInputsResolver) ReplaceEndpoints(replacement *EndpointSetBuilde
 	// direction.
 	replacement.endpoints.FoldVersion(e.inputs.EndpointsForBackend.LbEpsEqualityHash)
 	e.inputs.EndpointsForBackend = replacement.endpoints
+	e.endpointHashesReusable = true
 }
 
 // PolicyView is an immutable view of one policy attachment. It exposes what
@@ -174,7 +184,9 @@ func (p PolicyView) Generation() int64 {
 // EndpointView is an immutable view of one endpoint from shared input state.
 // Clone must be called before changing any endpoint proto or metadata label.
 type EndpointView struct {
-	endpoint ir.EndpointWithMd
+	locality     ir.PodLocality
+	endpoint     ir.EndpointWithMd
+	hashReusable bool
 }
 
 func (e EndpointView) Label(name string) string {
@@ -213,8 +225,19 @@ type EndpointSetBuilder struct {
 	endpoints ir.EndpointsForBackend
 }
 
+// AddUnchanged structurally shares an immutable endpoint and reuses its
+// precomputed contribution hash. Moving it to another locality, or using a view
+// exposed after a legacy mutable hook, safely falls back to a fresh hash.
 func (b *EndpointSetBuilder) AddUnchanged(locality ir.PodLocality, endpoint EndpointView) {
-	b.endpoints.Add(locality, endpoint.endpoint)
+	if locality != endpoint.locality || !endpoint.hashReusable {
+		// Locality participates in the endpoint contribution hash, so moving an
+		// otherwise unchanged endpoint still requires a fresh hash. A legacy
+		// plugin may also have mutated the endpoint behind the view, invalidating
+		// the cached contribution.
+		b.endpoints.Add(locality, endpoint.endpoint)
+		return
+	}
+	b.endpoints.ReuseEndpoint(locality, endpoint.endpoint)
 }
 
 func (b *EndpointSetBuilder) Add(locality ir.PodLocality, endpoint ir.EndpointWithMd) {

--- a/pkg/kgateway/endpoints/editor.go
+++ b/pkg/kgateway/endpoints/editor.go
@@ -4,7 +4,6 @@ import (
 	"maps"
 	"slices"
 
-	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"google.golang.org/protobuf/proto"
 	"istio.io/api/networking/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -151,7 +150,14 @@ func (e *EndpointInputsResolver) ReplaceEndpoints(replacement *EndpointSetBuilde
 	state.owner = nil
 	state.consumed = true
 
-	e.inputs.EndpointsForBackend = installed
+	// Take only what the builder owns — the endpoint set and its content hash.
+	// A builder is seeded from the inputs as they stood when it was created, so
+	// installing its whole EndpointsForBackend would roll back every setter
+	// called while the replacement was being populated. SetTrafficDistribution
+	// between NewEndpointSet and ReplaceEndpoints is exactly that shape, and it
+	// would fail silently: the resolved hash faithfully versions the reverted
+	// state.
+	e.inputs.EndpointsForBackend.AdoptEndpointsFrom(&installed)
 	e.endpointHashesReusable = true
 }
 
@@ -216,22 +222,29 @@ func (e EndpointView) LoadBalancingWeight() uint32 {
 	return e.endpoint.GetLoadBalancingWeight().GetValue()
 }
 
-// Clone returns a mutable, transitively isolated endpoint value.
+// Clone returns a mutable, transitively isolated endpoint value the caller
+// owns. Prefer [EndpointSetBuilder.AddModified] when the clone is only being
+// made in order to contribute a changed endpoint: it clones once where this
+// plus Add clones twice.
 func (e EndpointView) Clone() ir.EndpointWithMd {
-	out := e.endpoint
-	if e.endpoint.LbEndpoint != nil {
-		out.LbEndpoint = proto.Clone(e.endpoint.LbEndpoint).(*envoyendpointv3.LbEndpoint)
-	}
-	out.EndpointMd.Labels = maps.Clone(e.endpoint.EndpointMd.Labels)
-	return out
+	return e.endpoint.Clone()
 }
 
-// EndpointSetBuilder constructs a replacement EndpointsForBackend while
-// preserving its identity and precomputed hash semantics. Unchanged endpoints
-// may be structurally shared; modified endpoints must be added after Clone. A
-// builder belongs to the resolver that created it and is consumed by
+// EndpointSetBuilder accumulates a replacement endpoint set. Unchanged
+// endpoints are structurally shared with the immutable source and keep their
+// precomputed contribution hash; changed and synthesized ones are isolated by
+// the builder itself, so nothing a plugin holds stays reachable from the
+// resolved set.
+//
+// A builder belongs to the resolver that created it and is consumed by
 // ReplaceEndpoints. Any later use panics, including through a copied builder
-// value.
+// value. Only the endpoint set and its hash are installed: the identity fields
+// it is seeded with are inert.
+//
+// Those panics are deliberate and uncontained. A nil, foreign, or consumed
+// builder is a deterministic bug that a plugin's own tests hit on the first
+// run, and silently dropping the contribution instead would ship a client
+// whose endpoints nobody asked for.
 type EndpointSetBuilder struct {
 	state *endpointSetBuilderState
 }
@@ -255,6 +268,10 @@ func (b *EndpointSetBuilder) mutableState() *endpointSetBuilderState {
 // AddUnchanged structurally shares an immutable endpoint and reuses its
 // precomputed contribution hash. Moving it to another locality, or using a view
 // exposed after a legacy mutable hook, safely falls back to a fresh hash.
+//
+// This is the one path that installs an endpoint without copying it, and it can
+// be: a view only ever names source state the plugin has no way to write to.
+// Add and AddModified take values the plugin does own, so they copy.
 func (b *EndpointSetBuilder) AddUnchanged(locality ir.PodLocality, endpoint EndpointView) {
 	state := b.mutableState()
 	if locality != endpoint.locality || !endpoint.hashReusable {
@@ -268,8 +285,37 @@ func (b *EndpointSetBuilder) AddUnchanged(locality ir.PodLocality, endpoint Endp
 	state.endpoints.ReuseEndpoint(locality, endpoint.endpoint)
 }
 
+// AddModified contributes a changed version of an existing endpoint. The
+// builder clones base, hands the clone to modify, and hashes the result once
+// modify returns.
+//
+// This is the shape to reach for. The plugin never names the value it is
+// contributing, so it cannot accidentally retain it and mutate it after the
+// hash is taken or into a later client's pass, and the endpoint is cloned once
+// where [EndpointView.Clone] followed by Add clones twice. A plugin that
+// deliberately captures the pointer out of modify escapes that, which no Go
+// signature can prevent; use Add if you want the copy made unconditionally.
+func (b *EndpointSetBuilder) AddModified(locality ir.PodLocality, base EndpointView, modify func(*ir.EndpointWithMd)) {
+	state := b.mutableState()
+	if modify == nil {
+		panic("endpoint modifier is nil")
+	}
+	endpoint := base.endpoint.Clone()
+	modify(&endpoint)
+	state.endpoints.Add(locality, endpoint)
+}
+
+// Add contributes an endpoint the plugin synthesized itself. The value is deep
+// copied on the way in, so the caller keeps ownership of what it passed and may
+// go on mutating or reusing it. Without that copy a plugin that builds one
+// endpoint and adds it for every client would put a single proto pointer into
+// every client's resolved set, and a later write would reach back into clients
+// already resolved.
+//
+// Use [EndpointSetBuilder.AddModified] for endpoints derived from an existing
+// one; it avoids the second clone.
 func (b *EndpointSetBuilder) Add(locality ir.PodLocality, endpoint ir.EndpointWithMd) {
-	b.mutableState().endpoints.Add(locality, endpoint)
+	b.mutableState().endpoints.Add(locality, endpoint.Clone())
 }
 
 func cloneEndpointsInputs(in EndpointsInputs) EndpointsInputs {
@@ -287,7 +333,7 @@ func cloneEndpointsForBackend(in ir.EndpointsForBackend) ir.EndpointsForBackend 
 	for locality, localityEndpoints := range in.LbEps {
 		cloned := make([]ir.EndpointWithMd, len(localityEndpoints))
 		for i, endpoint := range localityEndpoints {
-			cloned[i] = EndpointView{endpoint: endpoint}.Clone()
+			cloned[i] = endpoint.Clone()
 		}
 		out.LbEps[locality] = cloned
 	}

--- a/pkg/kgateway/endpoints/editor_bench_test.go
+++ b/pkg/kgateway/endpoints/editor_bench_test.go
@@ -1,0 +1,59 @@
+package endpoints
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+var endpointEditorBenchSink EndpointsInputs
+
+func BenchmarkEndpointInputsResolver(b *testing.B) {
+	for _, endpointCount := range []int{10, 100, 1000} {
+		base := benchmarkEndpointInputs(endpointCount)
+		b.Run(fmt.Sprintf("endpoints=%d/scalar-edit", endpointCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				resolver := NewEndpointInputsResolver(base)
+				resolver.SetTrafficDistribution(wellknown.TrafficDistributionAny)
+				endpointEditorBenchSink = resolver.Inputs()
+			}
+		})
+		b.Run(fmt.Sprintf("endpoints=%d/replacement-builder", endpointCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				resolver := NewEndpointInputsResolver(base)
+				replacement := resolver.NewEndpointSet()
+				resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+					replacement.AddUnchanged(locality, endpoint)
+					return true
+				})
+				resolver.ReplaceEndpoints(replacement)
+				endpointEditorBenchSink = resolver.Inputs()
+			}
+		})
+		b.Run(fmt.Sprintf("endpoints=%d/legacy-deep-copy", endpointCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				resolver := NewEndpointInputsResolver(base)
+				resolver.LegacyMutableInputs()
+				endpointEditorBenchSink = resolver.Inputs()
+			}
+		})
+	}
+}
+
+func benchmarkEndpointInputs(endpointCount int) EndpointsInputs {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	backendEndpoints := ir.NewEndpointsForBackend(backend)
+	for i := range endpointCount {
+		backendEndpoints.Add(ir.PodLocality{Region: "r", Zone: fmt.Sprintf("z%d", i%3)}, editorTestEndpoint(
+			fmt.Sprintf("10.0.%d.%d", i/255, i%255),
+			fmt.Sprintf("endpoint-%d", i),
+		))
+	}
+	return EndpointsInputs{EndpointsForBackend: *backendEndpoints}
+}
+

--- a/pkg/kgateway/endpoints/editor_bench_test.go
+++ b/pkg/kgateway/endpoints/editor_bench_test.go
@@ -56,4 +56,3 @@ func benchmarkEndpointInputs(endpointCount int) EndpointsInputs {
 	}
 	return EndpointsInputs{EndpointsForBackend: *backendEndpoints}
 }
-

--- a/pkg/kgateway/endpoints/editor_bench_test.go
+++ b/pkg/kgateway/endpoints/editor_bench_test.go
@@ -63,9 +63,9 @@ func benchmarkReplacement(base EndpointsInputs, modifyEvery int) {
 			replacement.AddUnchanged(locality, endpoint)
 			return true
 		}
-		cloned := endpoint.Clone()
-		cloned.GetEndpoint().GetAddress().GetSocketAddress().Address = "127.167.0.1"
-		replacement.Add(locality, cloned)
+		replacement.AddModified(locality, endpoint, func(ep *ir.EndpointWithMd) {
+			ep.GetEndpoint().GetAddress().GetSocketAddress().Address = "127.167.0.1"
+		})
 		return true
 	})
 	resolver.ReplaceEndpoints(replacement)

--- a/pkg/kgateway/endpoints/editor_bench_test.go
+++ b/pkg/kgateway/endpoints/editor_bench_test.go
@@ -21,17 +21,22 @@ func BenchmarkEndpointInputsResolver(b *testing.B) {
 				endpointEditorBenchSink = resolver.Inputs()
 			}
 		})
-		b.Run(fmt.Sprintf("endpoints=%d/replacement-builder", endpointCount), func(b *testing.B) {
+		b.Run(fmt.Sprintf("endpoints=%d/replacement-all-unchanged", endpointCount), func(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
-				resolver := NewEndpointInputsResolver(base)
-				replacement := resolver.NewEndpointSet()
-				resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
-					replacement.AddUnchanged(locality, endpoint)
-					return true
-				})
-				resolver.ReplaceEndpoints(replacement)
-				endpointEditorBenchSink = resolver.Inputs()
+				benchmarkReplacement(base, 0)
+			}
+		})
+		b.Run(fmt.Sprintf("endpoints=%d/replacement-90pct-unchanged", endpointCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				benchmarkReplacement(base, 10)
+			}
+		})
+		b.Run(fmt.Sprintf("endpoints=%d/replacement-50pct-unchanged", endpointCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				benchmarkReplacement(base, 2)
 			}
 		})
 		b.Run(fmt.Sprintf("endpoints=%d/legacy-deep-copy", endpointCount), func(b *testing.B) {
@@ -43,6 +48,28 @@ func BenchmarkEndpointInputsResolver(b *testing.B) {
 			}
 		})
 	}
+}
+
+// benchmarkReplacement models the peering endpoint editor: most endpoints are
+// structurally shared while every modifyEvery-th endpoint is cloned and
+// rewritten. A zero modifyEvery keeps every endpoint unchanged.
+func benchmarkReplacement(base EndpointsInputs, modifyEvery int) {
+	resolver := NewEndpointInputsResolver(base)
+	replacement := resolver.NewEndpointSet()
+	index := 0
+	resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+		index++
+		if modifyEvery == 0 || index%modifyEvery != 0 {
+			replacement.AddUnchanged(locality, endpoint)
+			return true
+		}
+		cloned := endpoint.Clone()
+		cloned.GetEndpoint().GetAddress().GetSocketAddress().Address = "127.167.0.1"
+		replacement.Add(locality, cloned)
+		return true
+	})
+	resolver.ReplaceEndpoints(replacement)
+	endpointEditorBenchSink = resolver.Inputs()
 }
 
 func benchmarkEndpointInputs(endpointCount int) EndpointsInputs {

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -1,0 +1,116 @@
+package endpoints
+
+import (
+	"errors"
+	"testing"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+func TestEndpointInputsResolverBuildsReplacementWithStructuralSharing(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	backend.Obj = &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"scope": "peered"}}}
+	baseEndpoints := ir.NewEndpointsForBackend(backend)
+	locality := ir.PodLocality{Region: "r", Zone: "z"}
+	baseEndpoints.Add(locality, editorTestEndpoint("10.0.0.1", "unchanged"))
+	baseEndpoints.Add(locality, editorTestEndpoint("10.0.0.2", "changed"))
+
+	base := EndpointsInputs{EndpointsForBackend: *baseEndpoints}
+	resolver := NewEndpointInputsResolver(base)
+	labels := resolver.BackendLabels()
+	labels["scope"] = "mutated"
+	require.Equal(t, "peered", base.EndpointsForBackend.BackendLabels["scope"], "read access must not expose the shared label map")
+
+	replacement := resolver.NewEndpointSet()
+	resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+		if endpoint.Label("id") == "unchanged" {
+			replacement.AddUnchanged(locality, endpoint)
+			return true
+		}
+		cloned := endpoint.Clone()
+		cloned.EndpointMd.Labels["id"] = "modified"
+		cloned.GetEndpoint().GetAddress().GetSocketAddress().Address = "127.0.0.1"
+		replacement.Add(locality, cloned)
+		return true
+	})
+	resolver.ReplaceEndpoints(replacement)
+
+	resolved := resolver.Inputs()
+	require.Len(t, resolved.EndpointsForBackend.LbEps[locality], 2)
+	unchanged := resolved.EndpointsForBackend.LbEps[locality][0]
+	modified := resolved.EndpointsForBackend.LbEps[locality][1]
+	require.Same(t, base.EndpointsForBackend.LbEps[locality][0].LbEndpoint, unchanged.LbEndpoint,
+		"unchanged endpoints should retain their immutable shared proto")
+	require.NotSame(t, base.EndpointsForBackend.LbEps[locality][1].LbEndpoint, modified.LbEndpoint,
+		"modified endpoints must use an isolated clone")
+	assert.Equal(t, "changed", base.EndpointsForBackend.LbEps[locality][1].EndpointMd.Labels["id"])
+	assert.Equal(t, "10.0.0.2", base.EndpointsForBackend.LbEps[locality][1].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+	assert.Equal(t, "modified", modified.EndpointMd.Labels["id"])
+	assert.Equal(t, "127.0.0.1", modified.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+	assert.NotEqual(t, base.EndpointsForBackend.LbEpsEqualityHash, resolved.EndpointsForBackend.LbEpsEqualityHash,
+		"the replacement builder must hash its resolved endpoint content")
+}
+
+func TestEndpointInputsResolverDeepCopiesLegacyMutableInputs(t *testing.T) {
+	groupKind := schema.GroupKind{Group: "example.io", Kind: "Policy"}
+	policyRef := &ir.AttachedPolicyRef{Name: "policy", Namespace: "ns"}
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	backend.Obj = &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"scope": "peered"}}}
+	backend.AttachedPolicies = ir.AttachedPolicies{Policies: map[schema.GroupKind][]ir.PolicyAtt{
+		groupKind: {{
+			PolicyRef:    policyRef,
+			Errors:       []error{errors.New("base")},
+			MergeOrigins: ir.MergeOrigins{"field": sets.New("origin")},
+		}},
+	}}
+	baseEndpoints := ir.NewEndpointsForBackend(backend)
+	locality := ir.PodLocality{Region: "r", Zone: "z"}
+	baseEndpoints.Add(locality, editorTestEndpoint("10.0.0.1", "base"))
+	base := EndpointsInputs{
+		EndpointsForBackend: *baseEndpoints,
+		PriorityInfo: &PriorityInfo{
+			FailoverPriority: NewPriorities([]string{"topology.kubernetes.io/zone"}),
+		},
+	}
+
+	resolver := NewEndpointInputsResolver(base)
+	legacy := resolver.LegacyMutableInputs()
+	legacy.EndpointsForBackend.BackendLabels["scope"] = "mutated"
+	legacy.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0].PolicyRef.Name = "mutated"
+	legacy.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0].Errors[0] = errors.New("mutated")
+	legacy.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0].MergeOrigins["field"].Insert("mutated")
+	legacy.EndpointsForBackend.LbEps[locality][0].EndpointMd.Labels["id"] = "mutated"
+	legacy.EndpointsForBackend.LbEps[locality][0].GetEndpoint().GetAddress().GetSocketAddress().Address = "127.0.0.1"
+	legacy.PriorityInfo.FailoverPriority.priorityLabels[0] = "mutated"
+
+	assert.Equal(t, "peered", base.EndpointsForBackend.BackendLabels["scope"])
+	assert.Equal(t, "policy", base.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0].PolicyRef.Name)
+	assert.EqualError(t, base.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0].Errors[0], "base")
+	assert.False(t, base.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0].MergeOrigins["field"].Has("mutated"))
+	assert.Equal(t, "base", base.EndpointsForBackend.LbEps[locality][0].EndpointMd.Labels["id"])
+	assert.Equal(t, "10.0.0.1", base.EndpointsForBackend.LbEps[locality][0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+	assert.Equal(t, "topology.kubernetes.io/zone", base.PriorityInfo.FailoverPriority.priorityLabels[0])
+	require.Same(t, legacy, resolver.LegacyMutableInputs(), "legacy inputs should be cloned only once per client")
+}
+
+func editorTestEndpoint(address, id string) ir.EndpointWithMd {
+	return ir.EndpointWithMd{
+		LbEndpoint: &envoyendpointv3.LbEndpoint{
+			HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{Endpoint: &envoyendpointv3.Endpoint{
+				Address: &envoycorev3.Address{Address: &envoycorev3.Address_SocketAddress{SocketAddress: &envoycorev3.SocketAddress{
+					Address: address,
+				}}},
+			}},
+		},
+		EndpointMd: ir.EndpointMetadata{Labels: map[string]string{"id": id}},
+	}
+}
+

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -113,4 +113,3 @@ func editorTestEndpoint(address, id string) ir.EndpointWithMd {
 		EndpointMd: ir.EndpointMetadata{Labels: map[string]string{"id": id}},
 	}
 }
-

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -101,6 +101,30 @@ func TestEndpointInputsResolverDeepCopiesLegacyMutableInputs(t *testing.T) {
 	require.Same(t, legacy, resolver.LegacyMutableInputs(), "legacy inputs should be cloned only once per client")
 }
 
+func TestEndpointInputsResolverPoliciesForDoesNotExposeMutableMetadata(t *testing.T) {
+	groupKind := schema.GroupKind{Group: "example.io", Kind: "Policy"}
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	backend.AttachedPolicies = ir.AttachedPolicies{Policies: map[schema.GroupKind][]ir.PolicyAtt{
+		groupKind: {{
+			PolicyRef:    &ir.AttachedPolicyRef{Name: "policy", Namespace: "ns"},
+			Errors:       []error{errors.New("base")},
+			MergeOrigins: ir.MergeOrigins{"field": sets.New("origin")},
+		}},
+	}}
+	base := EndpointsInputs{EndpointsForBackend: *ir.NewEndpointsForBackend(backend)}
+
+	policies := NewEndpointInputsResolver(base).PoliciesFor(groupKind)
+	require.Len(t, policies, 1)
+	policies[0].PolicyRef.Name = "mutated"
+	policies[0].Errors[0] = errors.New("mutated")
+	policies[0].MergeOrigins["field"].Insert("mutated")
+
+	basePolicy := base.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0]
+	assert.Equal(t, "policy", basePolicy.PolicyRef.Name)
+	assert.EqualError(t, basePolicy.Errors[0], "base")
+	assert.False(t, basePolicy.MergeOrigins["field"].Has("mutated"))
+}
+
 func editorTestEndpoint(address, id string) ir.EndpointWithMd {
 	return ir.EndpointWithMd{
 		LbEndpoint: &envoyendpointv3.LbEndpoint{

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -101,28 +101,75 @@ func TestEndpointInputsResolverDeepCopiesLegacyMutableInputs(t *testing.T) {
 	require.Same(t, legacy, resolver.LegacyMutableInputs(), "legacy inputs should be cloned only once per client")
 }
 
-func TestEndpointInputsResolverPoliciesForDoesNotExposeMutableMetadata(t *testing.T) {
+// PoliciesFor hands out views rather than copies, so the mutable attachment
+// metadata is unreachable by construction instead of defensively cloned on a
+// per-client-per-backend path. What the views must still do is answer every
+// question the endpoint plugins ask, including for an attachment that failed IR
+// construction.
+func TestEndpointInputsResolverPoliciesForExposesReadsOnly(t *testing.T) {
 	groupKind := schema.GroupKind{Group: "example.io", Kind: "Policy"}
 	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
 	backend.AttachedPolicies = ir.AttachedPolicies{Policies: map[schema.GroupKind][]ir.PolicyAtt{
-		groupKind: {{
-			PolicyRef:    &ir.AttachedPolicyRef{Name: "policy", Namespace: "ns"},
-			Errors:       []error{errors.New("base")},
-			MergeOrigins: ir.MergeOrigins{"field": sets.New("origin")},
-		}},
+		groupKind: {
+			{
+				PolicyRef:  &ir.AttachedPolicyRef{Group: "example.io", Kind: "Policy", Name: "good", Namespace: "ns"},
+				Generation: 7,
+			},
+			{
+				PolicyRef:    &ir.AttachedPolicyRef{Group: "example.io", Kind: "Policy", Name: "broken", Namespace: "ns"},
+				Errors:       []error{errors.New("bad config")},
+				MergeOrigins: ir.MergeOrigins{"field": sets.New("origin")},
+			},
+		},
 	}}
 	base := EndpointsInputs{EndpointsForBackend: *ir.NewEndpointsForBackend(backend)}
 
 	policies := NewEndpointInputsResolver(base).PoliciesFor(groupKind)
-	require.Len(t, policies, 1)
-	policies[0].PolicyRef.Name = "mutated"
-	policies[0].Errors[0] = errors.New("mutated")
-	policies[0].MergeOrigins["field"].Insert("mutated")
+	require.Len(t, policies, 2)
 
-	basePolicy := base.EndpointsForBackend.AttachedPolicies.Policies[groupKind][0]
-	assert.Equal(t, "policy", basePolicy.PolicyRef.Name)
-	assert.EqualError(t, basePolicy.Errors[0], "base")
-	assert.False(t, basePolicy.MergeOrigins["field"].Has("mutated"))
+	assert.False(t, policies[0].HasErrors())
+	assert.Equal(t, "example.io/Policy/ns/good/", policies[0].RefString())
+	assert.Equal(t, int64(7), policies[0].Generation())
+
+	assert.True(t, policies[1].HasErrors(), "an attachment that failed IR construction must report it")
+	assert.Equal(t, "example.io/Policy/ns/broken/", policies[1].RefString())
+
+	assert.Nil(t, NewEndpointInputsResolver(base).PoliciesFor(schema.GroupKind{Kind: "Absent"}),
+		"a kind with no attachments should allocate nothing")
+}
+
+// TestReplaceEndpointsKeepsFoldedVersion covers the trap in building a
+// replacement endpoint set: EmptyCopy reseeds the equality hash from backend
+// identity, so anything the row's owner folded in afterwards — the
+// attached-policy hash, in production — would vanish and stop distinguishing
+// the states it was folded in to distinguish. The resolved hash keys CLA
+// interning, so two policy states must not resolve alike.
+func TestReplaceEndpointsKeepsFoldedVersion(t *testing.T) {
+	locality := ir.PodLocality{Region: "r", Zone: "z"}
+
+	resolvedHashFor := func(policyVersion uint64) uint64 {
+		backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+		source := ir.NewEndpointsForBackend(backend)
+		source.Add(locality, editorTestEndpoint("10.0.0.1", "ep"))
+		// Mirrors newFinalBackendEndpoints folding the attached-policy hash into
+		// the row it publishes.
+		source.FoldVersion(policyVersion)
+
+		resolver := NewEndpointInputsResolver(EndpointsInputs{EndpointsForBackend: *source})
+		// A plugin that rebuilds the set without changing any endpoint.
+		replacement := resolver.NewEndpointSet()
+		resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+			replacement.AddUnchanged(locality, endpoint)
+			return true
+		})
+		resolver.ReplaceEndpoints(replacement)
+		return resolver.Inputs().EndpointsForBackend.LbEpsEqualityHash
+	}
+
+	assert.NotEqual(t, resolvedHashFor(1), resolvedHashFor(2),
+		"a policy-only change must survive the replacement path")
+	assert.Equal(t, resolvedHashFor(1), resolvedHashFor(1),
+		"the replacement path must stay deterministic for equal inputs")
 }
 
 func editorTestEndpoint(address, id string) ir.EndpointWithMd {

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
@@ -36,10 +37,10 @@ func TestEndpointInputsResolverBuildsReplacementWithStructuralSharing(t *testing
 			replacement.AddUnchanged(locality, endpoint)
 			return true
 		}
-		cloned := endpoint.Clone()
-		cloned.EndpointMd.Labels["id"] = "modified"
-		cloned.GetEndpoint().GetAddress().GetSocketAddress().Address = "127.0.0.1"
-		replacement.Add(locality, cloned)
+		replacement.AddModified(locality, endpoint, func(ep *ir.EndpointWithMd) {
+			ep.EndpointMd.Labels["id"] = "modified"
+			ep.GetEndpoint().GetAddress().GetSocketAddress().Address = "127.0.0.1"
+		})
 		return true
 	})
 	resolver.ReplaceEndpoints(replacement)
@@ -286,6 +287,145 @@ func TestReplaceEndpointsKeepsFoldedVersion(t *testing.T) {
 		"a policy-only change must survive the replacement path")
 	assert.Equal(t, resolvedHashFor(1), resolvedHashFor(1),
 		"the replacement path must stay deterministic for equal inputs")
+}
+
+// A plugin that rebuilds the endpoint set without changing anything must land
+// on the source hash exactly, not merely on a stable one. The resolved hash is
+// this client's EDS resource version, so anything else republishes an identical
+// CLA to every connected Envoy on every recompute.
+func TestNoOpRebuildReproducesTheSourceHash(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	backend.Obj = &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"scope": "peered"}}}
+	source := ir.NewEndpointsForBackend(backend)
+	source.Add(ir.PodLocality{Region: "r", Zone: "z1"}, editorTestEndpoint("10.0.0.1", "ep-1"))
+	source.Add(ir.PodLocality{Region: "r", Zone: "z2"}, editorTestEndpoint("10.0.0.2", "ep-2"))
+	source.Add(ir.PodLocality{}, editorTestEndpoint("10.0.0.3", "ep-3"))
+	source.FoldVersion(7)
+
+	resolver := NewEndpointInputsResolver(EndpointsInputs{EndpointsForBackend: *source})
+	replacement := resolver.NewEndpointSet()
+	resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+		replacement.AddUnchanged(locality, endpoint)
+		return true
+	})
+	resolver.ReplaceEndpoints(replacement)
+
+	assert.Equal(t, source.LbEpsEqualityHash, resolver.Inputs().EndpointsForBackend.LbEpsEqualityHash,
+		"a no-op rebuild must not bump the EDS version")
+	assert.True(t, source.Equals(resolver.Inputs().EndpointsForBackend),
+		"a no-op rebuild must be indistinguishable from its source to KRT")
+}
+
+// Add is the one entry point that takes a caller-owned mutable graph, so it is
+// the one that has to take ownership of it. A plugin that keeps the value it
+// contributed must not be able to reach into the resolved set — either to
+// change content the version hash was already taken over, or to reach a client
+// that has already been resolved.
+func TestEndpointSetBuilderAddCopiesCallerOwnedEndpoint(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	base := EndpointsInputs{EndpointsForBackend: *ir.NewEndpointsForBackend(backend)}
+	locality := ir.PodLocality{Region: "r", Zone: "z"}
+	retained := editorTestEndpoint("10.0.0.1", "original")
+
+	first := NewEndpointInputsResolver(base)
+	firstBuilder := first.NewEndpointSet()
+	firstBuilder.Add(locality, retained)
+	first.ReplaceEndpoints(firstBuilder)
+	firstResolved := first.Inputs().EndpointsForBackend
+	firstHash := firstResolved.LbEpsEqualityHash
+
+	// The plugin reuses the same endpoint value for the next client, mutating it
+	// on the way.
+	second := NewEndpointInputsResolver(base)
+	secondBuilder := second.NewEndpointSet()
+	retained.GetEndpoint().GetAddress().GetSocketAddress().Address = "10.0.0.2"
+	retained.EndpointMd.Labels["id"] = "reused"
+	secondBuilder.Add(locality, retained)
+	second.ReplaceEndpoints(secondBuilder)
+	secondResolved := second.Inputs().EndpointsForBackend
+
+	firstInstalled := firstResolved.LbEps[locality][0]
+	assert.Equal(t, "10.0.0.1", firstInstalled.GetEndpoint().GetAddress().GetSocketAddress().GetAddress(),
+		"a later client's pass must not reach an already resolved client")
+	assert.Equal(t, "original", firstInstalled.EndpointMd.Labels["id"])
+	require.NotSame(t, firstInstalled.LbEndpoint, secondResolved.LbEps[locality][0].LbEndpoint,
+		"two clients must not share one endpoint proto")
+	assert.Equal(t, firstHash, firstResolved.LbEpsEqualityHash)
+	assert.NotEqual(t, firstHash, secondResolved.LbEpsEqualityHash,
+		"different resolved content must resolve to different versions")
+
+	// The same aliasing within one client shows up as a version that no longer
+	// describes the installed content.
+	third := NewEndpointInputsResolver(base)
+	thirdBuilder := third.NewEndpointSet()
+	own := editorTestEndpoint("10.0.0.3", "own")
+	thirdBuilder.Add(locality, own)
+	own.GetEndpoint().GetAddress().GetSocketAddress().Address = "10.0.0.4"
+	third.ReplaceEndpoints(thirdBuilder)
+	assert.Equal(t, "10.0.0.3", third.Inputs().EndpointsForBackend.LbEps[locality][0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress(),
+		"mutating after Add must not change installed content the hash was taken over")
+}
+
+func TestEndpointSetBuilderAddModifiedClonesAndRehashes(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	locality := ir.PodLocality{Region: "r", Zone: "z"}
+	source := ir.NewEndpointsForBackend(backend)
+	source.Add(locality, editorTestEndpoint("10.0.0.1", "source"))
+	base := EndpointsInputs{EndpointsForBackend: *source}
+
+	resolver := NewEndpointInputsResolver(base)
+	builder := resolver.NewEndpointSet()
+	resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+		builder.AddModified(locality, endpoint, func(ep *ir.EndpointWithMd) {
+			ep.EndpointMd.Labels["id"] = "derived"
+			ep.GetEndpoint().GetAddress().GetSocketAddress().Address = "10.0.0.9"
+		})
+		return true
+	})
+	resolver.ReplaceEndpoints(builder)
+
+	resolved := resolver.Inputs().EndpointsForBackend.LbEps[locality][0]
+	assert.Equal(t, "derived", resolved.EndpointMd.Labels["id"])
+	assert.Equal(t, "10.0.0.9", resolved.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+	assert.Equal(t, "source", base.EndpointsForBackend.LbEps[locality][0].EndpointMd.Labels["id"],
+		"the immutable source must be untouched")
+	assert.Equal(t, "10.0.0.1", base.EndpointsForBackend.LbEps[locality][0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+	require.NotSame(t, base.EndpointsForBackend.LbEps[locality][0].LbEndpoint, resolved.LbEndpoint)
+
+	want := ir.NewEndpointsForBackend(backend)
+	want.Add(locality, resolved)
+	assert.Equal(t, want.LbEpsEqualityHash, resolver.Inputs().EndpointsForBackend.LbEpsEqualityHash,
+		"the modified endpoint must be hashed as it was installed")
+
+	assert.PanicsWithValue(t, "endpoint modifier is nil", func() {
+		other := NewEndpointInputsResolver(base)
+		otherBuilder := other.NewEndpointSet()
+		other.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+			otherBuilder.AddModified(locality, endpoint, nil)
+			return true
+		})
+	})
+}
+
+// A builder is seeded from the inputs as they stood when it was created, so
+// installing it wholesale would roll back anything a setter wrote while it was
+// being populated. That failure is silent: the resolved hash faithfully
+// versions the reverted state, so nothing downstream notices.
+func TestReplaceEndpointsKeepsSettersWrittenWhileBuilding(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	locality := ir.PodLocality{Region: "r", Zone: "z"}
+	resolver := NewEndpointInputsResolver(EndpointsInputs{EndpointsForBackend: *ir.NewEndpointsForBackend(backend)})
+
+	builder := resolver.NewEndpointSet()
+	// BackendConfigPolicy's zone-aware hook writes exactly this, and a plugin
+	// that also rewrote endpoints would build the replacement around it.
+	resolver.SetTrafficDistribution(wellknown.TrafficDistributionPreferSameZone)
+	builder.Add(locality, editorTestEndpoint("10.0.0.1", "ep"))
+	resolver.ReplaceEndpoints(builder)
+
+	assert.Equal(t, wellknown.TrafficDistributionPreferSameZone, resolver.Inputs().EndpointsForBackend.TrafficDistribution,
+		"installing a replacement must not revert the resolver's own fields")
+	assert.Len(t, resolver.Inputs().EndpointsForBackend.LbEps[locality], 1)
 }
 
 func editorTestEndpoint(address, id string) ir.EndpointWithMd {

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -8,6 +8,7 @@ import (
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"istio.io/api/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -131,6 +132,36 @@ func TestEndpointInputsResolverDeepCopiesLegacyMutableInputs(t *testing.T) {
 	want.Add(locality, legacy.EndpointsForBackend.LbEps[locality][0])
 	assert.Equal(t, want.LbEpsEqualityHash, replacement.state.endpoints.LbEpsEqualityHash,
 		"legacy mutation must invalidate the cached endpoint contribution")
+}
+
+func TestEndpointInputsResolverSetPriorityInfoClonesInput(t *testing.T) {
+	resolver := NewEndpointInputsResolver(EndpointsInputs{})
+	priorityInfo := &PriorityInfo{
+		FailoverPriority: NewPriorities([]string{"region=west", "zone"}),
+		Failover: []*v1alpha3.LocalityLoadBalancerSetting_Failover{
+			{From: "west", To: "east"},
+			nil,
+		},
+	}
+
+	resolver.SetPriorityInfo(priorityInfo)
+	installed := resolver.Inputs().PriorityInfo
+	require.NotSame(t, priorityInfo, installed)
+	require.NotSame(t, priorityInfo.FailoverPriority, installed.FailoverPriority)
+	require.NotSame(t, priorityInfo.Failover[0], installed.Failover[0])
+
+	priorityInfo.FailoverPriority.priorityLabels[0] = "mutated"
+	priorityInfo.FailoverPriority.priorityLabelOverrides["region"] = "mutated"
+	priorityInfo.Failover[0].From = "mutated"
+	priorityInfo.Failover = nil
+	priorityInfo.FailoverPriority = nil
+
+	assert.Equal(t, []string{"region", "zone"}, installed.FailoverPriority.priorityLabels)
+	assert.Equal(t, map[string]string{"region": "west"}, installed.FailoverPriority.priorityLabelOverrides)
+	require.Len(t, installed.Failover, 2)
+	assert.Equal(t, "west", installed.Failover[0].GetFrom())
+	assert.Equal(t, "east", installed.Failover[0].GetTo())
+	assert.Nil(t, installed.Failover[1])
 }
 
 func TestEndpointSetBuilderIsConsumedByReplace(t *testing.T) {

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -75,7 +75,7 @@ func TestEndpointSetBuilderRehashesWhenLocalityChanges(t *testing.T) {
 
 	want := ir.NewEndpointsForBackend(backend)
 	want.Add(targetLocality, source.LbEps[sourceLocality][0])
-	assert.Equal(t, want.LbEpsEqualityHash, replacement.endpoints.LbEpsEqualityHash,
+	assert.Equal(t, want.LbEpsEqualityHash, replacement.state.endpoints.LbEpsEqualityHash,
 		"moving an endpoint must hash its new locality")
 }
 
@@ -129,8 +129,61 @@ func TestEndpointInputsResolverDeepCopiesLegacyMutableInputs(t *testing.T) {
 	})
 	want := ir.NewEndpointsForBackend(backend)
 	want.Add(locality, legacy.EndpointsForBackend.LbEps[locality][0])
-	assert.Equal(t, want.LbEpsEqualityHash, replacement.endpoints.LbEpsEqualityHash,
+	assert.Equal(t, want.LbEpsEqualityHash, replacement.state.endpoints.LbEpsEqualityHash,
 		"legacy mutation must invalidate the cached endpoint contribution")
+}
+
+func TestEndpointSetBuilderIsConsumedByReplace(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	resolver := NewEndpointInputsResolver(EndpointsInputs{EndpointsForBackend: *ir.NewEndpointsForBackend(backend)})
+	builder := resolver.NewEndpointSet()
+	builderCopy := *builder
+	builder.Add(ir.PodLocality{}, editorTestEndpoint("10.0.0.1", "installed"))
+
+	resolver.ReplaceEndpoints(builder)
+	installed := resolver.Inputs().EndpointsForBackend
+	installedHash := installed.LbEpsEqualityHash
+
+	for name, candidate := range map[string]*EndpointSetBuilder{
+		"original":     builder,
+		"copied value": &builderCopy,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.PanicsWithValue(t, "endpoint replacement builder has already been consumed", func() {
+				candidate.Add(ir.PodLocality{}, editorTestEndpoint("10.0.0.2", "late"))
+			})
+		})
+	}
+	assert.PanicsWithValue(t, "endpoint replacement builder has already been consumed", func() {
+		resolver.ReplaceEndpoints(builder)
+	})
+
+	got := resolver.Inputs().EndpointsForBackend
+	assert.Equal(t, installedHash, got.LbEpsEqualityHash, "rejected writes must not skew the installed hash")
+	assert.Len(t, got.LbEps[ir.PodLocality{}], 1, "rejected writes must not mutate installed endpoint content")
+}
+
+func TestEndpointSetBuilderRejectsWrongOwnerAndNil(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	inputs := EndpointsInputs{EndpointsForBackend: *ir.NewEndpointsForBackend(backend)}
+	owner := NewEndpointInputsResolver(inputs)
+	other := NewEndpointInputsResolver(inputs)
+	builder := owner.NewEndpointSet()
+
+	assert.PanicsWithValue(t, "endpoint replacement builder belongs to a different resolver", func() {
+		other.ReplaceEndpoints(builder)
+	})
+	// Rejection by the wrong owner does not consume the builder; its owner can
+	// still finish and install it.
+	builder.Add(ir.PodLocality{}, editorTestEndpoint("10.0.0.1", "owned"))
+	owner.ReplaceEndpoints(builder)
+
+	assert.PanicsWithValue(t, "endpoint replacement builder is nil", func() {
+		other.ReplaceEndpoints(nil)
+	})
+	assert.PanicsWithValue(t, "endpoint replacement builder is uninitialized", func() {
+		new(EndpointSetBuilder).Add(ir.PodLocality{}, editorTestEndpoint("10.0.0.2", "uninitialized"))
+	})
 }
 
 // PoliciesFor hands out views rather than copies, so the mutable attachment

--- a/pkg/kgateway/endpoints/editor_test.go
+++ b/pkg/kgateway/endpoints/editor_test.go
@@ -59,6 +59,26 @@ func TestEndpointInputsResolverBuildsReplacementWithStructuralSharing(t *testing
 		"the replacement builder must hash its resolved endpoint content")
 }
 
+func TestEndpointSetBuilderRehashesWhenLocalityChanges(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "svc"}, 8080, "", "")
+	sourceLocality := ir.PodLocality{Region: "r1", Zone: "z1"}
+	targetLocality := ir.PodLocality{Region: "r2", Zone: "z2"}
+	source := ir.NewEndpointsForBackend(backend)
+	source.Add(sourceLocality, editorTestEndpoint("10.0.0.1", "moved"))
+
+	resolver := NewEndpointInputsResolver(EndpointsInputs{EndpointsForBackend: *source})
+	replacement := resolver.NewEndpointSet()
+	resolver.ForEachEndpoint(func(_ ir.PodLocality, endpoint EndpointView) bool {
+		replacement.AddUnchanged(targetLocality, endpoint)
+		return true
+	})
+
+	want := ir.NewEndpointsForBackend(backend)
+	want.Add(targetLocality, source.LbEps[sourceLocality][0])
+	assert.Equal(t, want.LbEpsEqualityHash, replacement.endpoints.LbEpsEqualityHash,
+		"moving an endpoint must hash its new locality")
+}
+
 func TestEndpointInputsResolverDeepCopiesLegacyMutableInputs(t *testing.T) {
 	groupKind := schema.GroupKind{Group: "example.io", Kind: "Policy"}
 	policyRef := &ir.AttachedPolicyRef{Name: "policy", Namespace: "ns"}
@@ -99,6 +119,18 @@ func TestEndpointInputsResolverDeepCopiesLegacyMutableInputs(t *testing.T) {
 	assert.Equal(t, "10.0.0.1", base.EndpointsForBackend.LbEps[locality][0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
 	assert.Equal(t, "topology.kubernetes.io/zone", base.PriorityInfo.FailoverPriority.priorityLabels[0])
 	require.Same(t, legacy, resolver.LegacyMutableInputs(), "legacy inputs should be cloned only once per client")
+
+	// A later editor plugin must not reuse the contribution cached before the
+	// legacy mutation. AddUnchanged falls back to hashing the now-mutated proto.
+	replacement := resolver.NewEndpointSet()
+	resolver.ForEachEndpoint(func(locality ir.PodLocality, endpoint EndpointView) bool {
+		replacement.AddUnchanged(locality, endpoint)
+		return true
+	})
+	want := ir.NewEndpointsForBackend(backend)
+	want.Add(locality, legacy.EndpointsForBackend.LbEps[locality][0])
+	assert.Equal(t, want.LbEpsEqualityHash, replacement.endpoints.LbEpsEqualityHash,
+		"legacy mutation must invalidate the cached endpoint contribution")
 }
 
 // PoliciesFor hands out views rather than copies, so the mutable attachment

--- a/pkg/kgateway/endpoints/prioritize.go
+++ b/pkg/kgateway/endpoints/prioritize.go
@@ -111,12 +111,39 @@ func priorityLabelOverrides(labels []string) ([]string, map[string]string) {
 	return priorityLabels, overriddenValueByLabel
 }
 
+// sortedLocalities orders an endpoint map's localities by (region, zone, subzone).
+//
+// LbEps is a map, so ranging it directly would emit the CLA's LocalityLbEndpoints
+// in a different order on every call. Locality order carries no meaning to Envoy,
+// but the CLA's serialized bytes do: the content hash of the CLA (and of any
+// cluster carrying it inline) versions per-client xDS for KRT change detection and
+// keys the interning that shares one proto across equivalent clients. Map order
+// would make identical inputs hash differently on every recompute, republishing
+// unchanged config and defeating the interning.
+func sortedLocalities(lbEps ir.LocalityLbMap) []ir.PodLocality {
+	out := make([]ir.PodLocality, 0, len(lbEps))
+	for loc := range lbEps {
+		out = append(out, loc)
+	}
+	slices.SortFunc(out, func(a, b ir.PodLocality) int {
+		if c := strings.Compare(a.Region, b.Region); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Zone, b.Zone); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Subzone, b.Subzone)
+	})
+	return out
+}
+
 func prioritizeWithLbInfo(logger *slog.Logger, ep ir.EndpointsForBackend, lbInfo LoadBalancingInfo) *envoyendpointv3.ClusterLoadAssignment {
 	cla := &envoyendpointv3.ClusterLoadAssignment{
 		ClusterName: ep.ClusterName,
 	}
 	totalEndpoints := 0
-	for loc, eps := range ep.LbEps {
+	for _, loc := range sortedLocalities(ep.LbEps) {
+		eps := ep.LbEps[loc]
 		var l *envoycorev3.Locality
 		if loc != (ir.PodLocality{}) {
 			l = &envoycorev3.Locality{

--- a/pkg/kgateway/endpoints/prioritize.go
+++ b/pkg/kgateway/endpoints/prioritize.go
@@ -115,11 +115,12 @@ func priorityLabelOverrides(labels []string) ([]string, map[string]string) {
 //
 // LbEps is a map, so ranging it directly would emit the CLA's LocalityLbEndpoints
 // in a different order on every call. Locality order carries no meaning to Envoy,
-// but the CLA's serialized bytes do: the content hash of the CLA (and of any
-// cluster carrying it inline) versions per-client xDS for KRT change detection and
-// keys the interning that shares one proto across equivalent clients. Map order
-// would make identical inputs hash differently on every recompute, republishing
-// unchanged config and defeating the interning.
+// but an inline CLA is part of the serialized cluster. The full cluster content
+// hash is its KRT equality version and contributes to the CDS version, so random
+// locality order would republish and re-warm an unchanged inline cluster on each
+// recompute. EDS rows are versioned from the structural endpoint hash instead;
+// their KRT change detection does not depend on CLA byte order. Stable bytes also
+// make content-addressed sharing of equivalent CLAs effective.
 func sortedLocalities(lbEps ir.LocalityLbMap) []ir.PodLocality {
 	out := make([]ir.PodLocality, 0, len(lbEps))
 	for loc := range lbEps {

--- a/pkg/kgateway/endpoints/prioritize_test.go
+++ b/pkg/kgateway/endpoints/prioritize_test.go
@@ -1,0 +1,100 @@
+package endpoints
+
+import (
+	"strconv"
+	"testing"
+
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+// TestPrioritizeEndpointsIsByteStable pins the determinism that per-client xDS
+// versioning and interning depend on. The CLA this builds is hashed by content:
+// utils.HashProto versions inline-CLA clusters for KRT change detection and keys
+// the sharing of one proto across clients that resolve identically. Ranging
+// LbEps directly would emit LocalityLbEndpoints in a fresh order on every call,
+// so identical inputs would hash differently, republishing unchanged config and
+// silently defeating the interning.
+//
+// Every priority mode is covered because each takes a different path through
+// getEndpoints and applyLocalityFailover.
+func TestPrioritizeEndpointsIsByteStable(t *testing.T) {
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group: "networking.istio.io", Kind: "ServiceEntry", Namespace: "ns", Name: "se",
+	}, 80, "", "")
+	backendEndpoints := ir.NewEndpointsForBackend(backend)
+	// Enough localities that map ordering is overwhelmingly unlikely to be
+	// stable by chance, plus the zero locality, which is emitted with a nil
+	// Locality and so sorts ahead of everything else.
+	localities := []ir.PodLocality{
+		{},
+		{Region: "r1", Zone: "z1"},
+		{Region: "r1", Zone: "z2"},
+		{Region: "r2", Zone: "z3"},
+		{Region: "r3", Zone: "z4"},
+	}
+	for i, locality := range localities {
+		backendEndpoints.Add(locality, prioritizeTestEndpoint(locality, i))
+	}
+
+	client := ir.NewUniquelyConnectedClient("role", "ns", map[string]string{
+		corev1.LabelTopologyRegion: "r1",
+		corev1.LabelTopologyZone:   "z1",
+	}, ir.PodLocality{Region: "r1", Zone: "z1"})
+
+	priorityModes := map[string]*PriorityInfo{
+		// UCC-independent: no prioritization is applied at all.
+		"noPriorityInfo": nil,
+		// Groups endpoints by how well their topology labels match the client's.
+		"failoverPriority": {
+			FailoverPriority: NewPriorities([]string{corev1.LabelTopologyRegion, corev1.LabelTopologyZone}),
+		},
+		// Renormalizes priorities from the client's locality instead.
+		"localityFailover": {},
+	}
+
+	for name, priorityInfo := range priorityModes {
+		t.Run(name, func(t *testing.T) {
+			inputs := EndpointsInputs{EndpointsForBackend: *backendEndpoints, PriorityInfo: priorityInfo}
+
+			hashes := map[uint64]struct{}{}
+			for range 200 {
+				hashes[utils.HashProto(PrioritizeEndpoints(nil, client, inputs))] = struct{}{}
+			}
+			require.Len(t, hashes, 1,
+				"identical inputs must hash to one value; %d distinct hashes means the CLA is not byte-stable", len(hashes))
+
+			// Pin the canonical order too, so a change that is stable but no
+			// longer sorted is a deliberate decision rather than a silent one.
+			// Failover priority splits one locality into several groups, so
+			// equal neighbors are expected.
+			cla := PrioritizeEndpoints(nil, client, inputs)
+			require.NotEmpty(t, cla.GetEndpoints())
+			for i := 1; i < len(cla.GetEndpoints()); i++ {
+				assert.LessOrEqual(t, localityOrderKey(cla.GetEndpoints()[i-1]), localityOrderKey(cla.GetEndpoints()[i]),
+					"localities must be emitted in ascending (region, zone, subzone) order")
+			}
+		})
+	}
+}
+
+// localityOrderKey renders a locality group's locality for ordering assertions. A
+// nil Locality (the zero PodLocality) yields the empty key, which sorts first.
+func localityOrderKey(group *envoyendpointv3.LocalityLbEndpoints) string {
+	locality := group.GetLocality()
+	return locality.GetRegion() + "/" + locality.GetZone() + "/" + locality.GetSubZone()
+}
+
+func prioritizeTestEndpoint(locality ir.PodLocality, index int) ir.EndpointWithMd {
+	endpoint := editorTestEndpoint("10.0.0."+strconv.Itoa(index+1), "ep")
+	endpoint.EndpointMd.Labels = map[string]string{
+		corev1.LabelTopologyRegion: locality.Region,
+		corev1.LabelTopologyZone:   locality.Zone,
+	}
+	return endpoint
+}

--- a/pkg/kgateway/endpoints/prioritize_test.go
+++ b/pkg/kgateway/endpoints/prioritize_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,13 +14,12 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
-// TestPrioritizeEndpointsIsByteStable pins the determinism that per-client xDS
-// versioning and interning depend on. The CLA this builds is hashed by content:
-// utils.HashProto versions inline-CLA clusters for KRT change detection and keys
-// the sharing of one proto across clients that resolve identically. Ranging
-// LbEps directly would emit LocalityLbEndpoints in a fresh order on every call,
-// so identical inputs would hash differently, republishing unchanged config and
-// silently defeating the interning.
+// TestPrioritizeEndpointsIsByteStable pins the determinism of inline-CLA cluster
+// versions. The proxy syncer hashes the full cluster into ClusterVersion, which
+// contributes to the CDS version. Ranging LbEps directly would put the same CLA
+// localities in a fresh order, spuriously changing CDS and re-warming the cluster.
+// EDS KRT equality uses the structural endpoint hash and does not depend on these
+// serialized bytes.
 //
 // Every priority mode is covered because each takes a different path through
 // getEndpoints and applyLocalityFailover.
@@ -62,12 +62,16 @@ func TestPrioritizeEndpointsIsByteStable(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			inputs := EndpointsInputs{EndpointsForBackend: *backendEndpoints, PriorityInfo: priorityInfo}
 
-			hashes := map[uint64]struct{}{}
+			clusterVersions := map[uint64]struct{}{}
 			for range 200 {
-				hashes[utils.HashProto(PrioritizeEndpoints(nil, client, inputs))] = struct{}{}
+				cluster := &envoyclusterv3.Cluster{
+					Name:           "inline-cluster",
+					LoadAssignment: PrioritizeEndpoints(nil, client, inputs),
+				}
+				clusterVersions[utils.HashProto(cluster)] = struct{}{}
 			}
-			require.Len(t, hashes, 1,
-				"identical inputs must hash to one value; %d distinct hashes means the CLA is not byte-stable", len(hashes))
+			require.Len(t, clusterVersions, 1,
+				"identical inputs must produce one inline-cluster version; got %d", len(clusterVersions))
 
 			// Pin the canonical order too, so a change that is stable but no
 			// longer sorted is a deliberate decision rather than a silent one.

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
@@ -527,18 +527,18 @@ func (p *backendConfigEndpointPlugin) processEndpoints(
 	out.SetTrafficDistribution(wellknown.TrafficDistributionAny)
 
 	hasher := fnv.New64()
-	hasher.Write([]byte(ir.PolicyRefString(pol.PolicyRef)))
-	hasher.Write(fmt.Appendf(nil, "%v", pol.Generation))
+	hasher.Write([]byte(pol.RefString()))
+	hasher.Write(fmt.Appendf(nil, "%v", pol.Generation()))
 	return hasher.Sum64()
 }
 
-func selectZoneAwareBackendConfigPolicy(policies []ir.PolicyAtt) (ir.PolicyAtt, *BackendConfigPolicyIR) {
+func selectZoneAwareBackendConfigPolicy(policies []endpoints.PolicyView) (endpoints.PolicyView, *BackendConfigPolicyIR) {
 	for _, pol := range policies {
-		bcpIR, ok := pol.PolicyIr.(*BackendConfigPolicyIR)
-		if !ok || len(pol.Errors) > 0 || bcpIR.loadBalancerConfig == nil || !bcpIR.loadBalancerConfig.hasZoneAware {
+		bcpIR, ok := pol.PolicyIR().(*BackendConfigPolicyIR)
+		if !ok || pol.HasErrors() || bcpIR.loadBalancerConfig == nil || !bcpIR.loadBalancerConfig.hasZoneAware {
 			continue
 		}
 		return pol, bcpIR
 	}
-	return ir.PolicyAtt{}, nil
+	return endpoints.PolicyView{}, nil
 }

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin.go
@@ -178,10 +178,10 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections, v 
 	return sdk.Plugin{
 		ContributesPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
 			wellknown.BackendConfigPolicyGVK.GroupKind(): {
-				Name:                      "BackendConfigPolicy",
-				Policies:                  backendConfigPolicyCol,
-				ProcessBackend:            processBackend,
-				PerClientProcessEndpoints: endpointPlugin.processEndpoints,
+				Name:                   "BackendConfigPolicy",
+				Policies:               backendConfigPolicyCol,
+				ProcessBackend:         processBackend,
+				PerClientEditEndpoints: endpointPlugin.processEndpoints,
 				MergePolicies: func(pols []ir.PolicyAtt) ir.PolicyAtt {
 					return policy.MergePolicies(sortForMerge(pols), mergeBackendConfigPolicies, "")
 				},
@@ -510,21 +510,21 @@ func TranslateTCPKeepalive(tcpKeepalive *kgateway.TCPKeepalive) *envoycorev3.Tcp
 // zone-aware routing using the backend's already resolved policy attachments.
 type backendConfigEndpointPlugin struct{}
 
-// processEndpoints implements sdk.EndpointPlugin for zone-aware routing.
+// processEndpoints implements sdk.EndpointEditorPlugin for zone-aware routing.
 // BackendConfigPolicy takes precedence over Kubernetes Service traffic distribution.
 func (p *backendConfigEndpointPlugin) processEndpoints(
 	kctx krt.HandlerContext,
 	ctx context.Context,
 	ucc ir.UniquelyConnectedClient,
-	out *endpoints.EndpointsInputs,
+	out endpoints.EndpointInputsEditor,
 ) uint64 {
-	pol, bcpIR := selectZoneAwareBackendConfigPolicy(out.EndpointsForBackend.AttachedPolicies)
+	pol, bcpIR := selectZoneAwareBackendConfigPolicy(out.PoliciesFor(wellknown.BackendConfigPolicyGVK.GroupKind()))
 	if bcpIR == nil {
 		return 0
 	}
 	// BackendConfigPolicy zoneAware settings take precedence over Service trafficDistribution
 	// settings for the same backend.
-	out.EndpointsForBackend.TrafficDistribution = wellknown.TrafficDistributionAny
+	out.SetTrafficDistribution(wellknown.TrafficDistributionAny)
 
 	hasher := fnv.New64()
 	hasher.Write([]byte(ir.PolicyRefString(pol.PolicyRef)))
@@ -532,8 +532,7 @@ func (p *backendConfigEndpointPlugin) processEndpoints(
 	return hasher.Sum64()
 }
 
-func selectZoneAwareBackendConfigPolicy(attachedPolicies ir.AttachedPolicies) (ir.PolicyAtt, *BackendConfigPolicyIR) {
-	policies := attachedPolicies.Policies[wellknown.BackendConfigPolicyGVK.GroupKind()]
+func selectZoneAwareBackendConfigPolicy(policies []ir.PolicyAtt) (ir.PolicyAtt, *BackendConfigPolicyIR) {
 	for _, pol := range policies {
 		bcpIR, ok := pol.PolicyIr.(*BackendConfigPolicyIR)
 		if !ok || len(pol.Errors) > 0 || bcpIR.loadBalancerConfig == nil || !bcpIR.loadBalancerConfig.hasZoneAware {

--- a/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/backendconfigpolicy/plugin_test.go
@@ -747,12 +747,18 @@ func TestProcessEndpointsZoneAwarePolicy(t *testing.T) {
 		}
 		return inputs
 	}
+	runPlugin := func(plugin backendConfigEndpointPlugin, ucc ir.UniquelyConnectedClient, inputs *endpoints.EndpointsInputs) uint64 {
+		resolver := endpoints.NewEndpointInputsResolver(*inputs)
+		hash := plugin.processEndpoints(krt.TestingDummyContext{}, context.Background(), ucc, resolver)
+		*inputs = resolver.Inputs()
+		return hash
+	}
 
 	t.Run("ignores policies without zoneAware", func(t *testing.T) {
 		inputs := withPolicies(newInputs(), newPolicy(false, nil, servicePolicyRef))
 		plugin := backendConfigEndpointPlugin{}
 
-		hash := plugin.processEndpoints(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{}, inputs)
+		hash := runPlugin(plugin, ir.UniquelyConnectedClient{}, inputs)
 
 		assert.Zero(t, hash)
 		assert.Equal(t, wellknown.TrafficDistributionPreferSameZone, inputs.EndpointsForBackend.TrafficDistribution)
@@ -763,7 +769,7 @@ func TestProcessEndpointsZoneAwarePolicy(t *testing.T) {
 		inputs := withPolicies(newInputs(), newPolicy(true, nil, servicePolicyRef))
 		plugin := backendConfigEndpointPlugin{}
 
-		hash := plugin.processEndpoints(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{}, inputs)
+		hash := runPlugin(plugin, ir.UniquelyConnectedClient{}, inputs)
 
 		assert.NotZero(t, hash)
 		assert.Equal(t, wellknown.TrafficDistributionAny, inputs.EndpointsForBackend.TrafficDistribution)
@@ -774,7 +780,7 @@ func TestProcessEndpointsZoneAwarePolicy(t *testing.T) {
 		inputs := withPolicies(newInputs(), newPolicy(true, new(uint32(2)), servicePolicyRef))
 		plugin := backendConfigEndpointPlugin{}
 
-		hash := plugin.processEndpoints(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{Locality: ir.PodLocality{Zone: "zone-a"}}, inputs)
+		hash := runPlugin(plugin, ir.UniquelyConnectedClient{Locality: ir.PodLocality{Zone: "zone-a"}}, inputs)
 
 		assert.NotZero(t, hash)
 		assert.Equal(t, wellknown.TrafficDistributionAny, inputs.EndpointsForBackend.TrafficDistribution)
@@ -789,7 +795,7 @@ func TestProcessEndpointsZoneAwarePolicy(t *testing.T) {
 		inputs.PriorityInfo = priorityInfo
 		plugin := backendConfigEndpointPlugin{}
 
-		hash := plugin.processEndpoints(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{Locality: ir.PodLocality{Zone: "zone-a"}}, inputs)
+		hash := runPlugin(plugin, ir.UniquelyConnectedClient{Locality: ir.PodLocality{Zone: "zone-a"}}, inputs)
 
 		assert.NotZero(t, hash)
 		assert.Equal(t, wellknown.TrafficDistributionAny, inputs.EndpointsForBackend.TrafficDistribution)
@@ -810,7 +816,7 @@ func TestProcessEndpointsZoneAwarePolicy(t *testing.T) {
 		inputs = withPolicies(inputs, newPolicy(true, new(uint32(1)), hostnamePolicyRef))
 		plugin := backendConfigEndpointPlugin{}
 
-		hash := plugin.processEndpoints(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{Locality: ir.PodLocality{Zone: "zone-a"}}, inputs)
+		hash := runPlugin(plugin, ir.UniquelyConnectedClient{Locality: ir.PodLocality{Zone: "zone-a"}}, inputs)
 
 		assert.NotZero(t, hash)
 		assert.Equal(t, wellknown.TrafficDistributionAny, inputs.EndpointsForBackend.TrafficDistribution)

--- a/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
@@ -41,9 +41,9 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 	return sdk.Plugin{
 		ContributesPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
 			gk: {
-				Name:                      "destrule",
-				PerClientProcessBackend:   d.processBackend,
-				PerClientProcessEndpoints: d.processEndpoints,
+				Name:                    "destrule",
+				PerClientProcessBackend: d.processBackend,
+				PerClientEditEndpoints:  d.processEndpoints,
 			},
 		},
 	}
@@ -59,20 +59,20 @@ func (d *destrulePlugin) processEndpoints(
 	kctx krt.HandlerContext,
 	ctx context.Context,
 	ucc ir.UniquelyConnectedClient,
-	out *endpoints.EndpointsInputs,
+	out endpoints.EndpointInputsEditor,
 ) uint64 {
-	destrule := d.destinationRulesIndex.FetchDestRulesFor(kctx, ucc.Namespace, out.EndpointsForBackend.Hostname, ucc.Labels)
+	destrule := d.destinationRulesIndex.FetchDestRulesFor(kctx, ucc.Namespace, out.Hostname(), ucc.Labels)
 	if destrule == nil {
 		return 0
 	}
 
-	trafficPolicy := getTrafficPolicy(destrule, out.EndpointsForBackend.Port)
+	trafficPolicy := getTrafficPolicy(destrule, out.Port())
 	localityLb := getLocalityLbSetting(trafficPolicy)
 	if localityLb == nil {
 		return 0
 	}
 
-	out.PriorityInfo = getPriorityInfoFromDestrule(localityLb)
+	out.SetPriorityInfo(getPriorityInfoFromDestrule(localityLb))
 	hasher := fnv.New64()
 	hasher.Write([]byte(destrule.UID))
 	hasher.Write(fmt.Appendf(nil, "%v", destrule.Generation))

--- a/pkg/kgateway/proxy_syncer/cla.go
+++ b/pkg/kgateway/proxy_syncer/cla.go
@@ -53,18 +53,18 @@ func NewPerClientEnvoyEndpoints(
 	krtopts krtutil.KrtOptions,
 	uccs krt.Collection[ir.UniquelyConnectedClient],
 	kgatewayEndpoints krt.Collection[ir.EndpointsForBackend],
-	translateEndpoints func(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) (*envoyendpointv3.ClusterLoadAssignment, uint64),
+	translateEndpoints func(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) (*envoyendpointv3.ClusterLoadAssignment, uint64, uint64),
 ) PerClientEnvoyEndpoints {
 	eps := krt.NewManyCollection(kgatewayEndpoints, func(kctx krt.HandlerContext, ep ir.EndpointsForBackend) []UccWithEndpoints {
 		uccs := krt.Fetch(kctx, uccs)
 		uccWithEndpointsRet := make([]UccWithEndpoints, 0, len(uccs))
 		for _, ucc := range uccs {
-			cla, additionalHash := translateEndpoints(kctx, ucc, ep)
+			cla, resolvedEndpointsHash, additionalHash := translateEndpoints(kctx, ucc, ep)
 			epName := ep.ResourceName()
 			u := UccWithEndpoints{
 				Client:        ucc,
 				Endpoints:     cla,
-				EndpointsHash: ep.LbEpsEqualityHash ^ additionalHash,
+				EndpointsHash: resolvedEndpointsHash ^ additionalHash,
 				endpointsName: epName,
 				resourceName:  uccEndpointsResourceName(ucc, epName),
 			}

--- a/pkg/kgateway/proxy_syncer/effective_endpoints.go
+++ b/pkg/kgateway/proxy_syncer/effective_endpoints.go
@@ -38,7 +38,7 @@ func newFinalBackendEndpoints(
 		// A same-named EDS cluster can still re-warm when policy changes CDS.
 		// Bump only the endpoint version so Envoy receives a fresh CLA response.
 		if policyHash := backendEndpointVersionHash(backend); policyHash != 0 {
-			final.LbEpsEqualityHash = combineEndpointHashes(final.LbEpsEqualityHash, policyHash)
+			final.FoldVersion(policyHash)
 		}
 		return &final
 	}, krtopts.ToOptions("FinalBackendEndpoints")...)
@@ -83,12 +83,5 @@ func backendEndpointVersionHash(backend *ir.BackendObjectIR) uint64 {
 		}
 	}
 
-	return hasher.Sum64()
-}
-
-func combineEndpointHashes(endpointHash, policyHash uint64) uint64 {
-	hasher := fnv.New64a()
-	utils.HashUint64(hasher, endpointHash)
-	utils.HashUint64(hasher, policyHash)
 	return hasher.Sum64()
 }

--- a/pkg/kgateway/proxy_syncer/perclient_test.go
+++ b/pkg/kgateway/proxy_syncer/perclient_test.go
@@ -1,11 +1,13 @@
 package proxy_syncer
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -13,14 +15,92 @@ import (
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/onsi/gomega"
 	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/endpoints"
+	kgtranslator "github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/xds"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
 	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
 )
+
+func TestPerClientEnvoyEndpointsUsesResolvedReplacementHash(t *testing.T) {
+	g := gomega.NewWithT(t)
+	krtopts := krtutil.NewKrtOptions(t.Context().Done(), nil)
+	pluginGK := schema.GroupKind{Group: "test.example.io", Kind: "EndpointReplacement"}
+
+	translator := kgtranslator.NewCombinedTranslator(t.Context(), sdk.Plugin{
+		ContributesPolicies: sdk.ContributesPolicies{
+			pluginGK: {
+				PerClientEditEndpoints: func(_ krt.HandlerContext, _ context.Context, _ ir.UniquelyConnectedClient, out endpoints.EndpointInputsEditor) uint64 {
+					replacement := out.NewEndpointSet()
+					replacement.Add(ir.PodLocality{}, ir.EndpointWithMd{LbEndpoint: &envoyendpointv3.LbEndpoint{
+						HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{Endpoint: &envoyendpointv3.Endpoint{
+							Address: &envoycorev3.Address{Address: &envoycorev3.Address_Pipe{Pipe: &envoycorev3.Pipe{Path: out.Hostname()}}},
+						}},
+					}})
+					out.ReplaceEndpoints(replacement)
+					return 0 // Replacement content is already reflected by LbEpsEqualityHash.
+				},
+			},
+		},
+	}, nil, nil)
+
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Kind: "Service", Namespace: "ns", Name: "backend"}, 80, "", "")
+	source := ir.NewEndpointsForBackend(backend)
+	source.Hostname = "replacement-a"
+	source.Add(ir.PodLocality{}, ir.EndpointWithMd{LbEndpoint: &envoyendpointv3.LbEndpoint{
+		HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{Endpoint: &envoyendpointv3.Endpoint{
+			Address: &envoycorev3.Address{Address: &envoycorev3.Address_Pipe{Pipe: &envoycorev3.Pipe{Path: "source"}}},
+		}},
+	}})
+	sourceHash := source.LbEpsEqualityHash
+	ucc := ir.NewUniquelyConnectedClient("client", "ns", nil, ir.PodLocality{})
+	uccs := krt.NewStaticCollection(nil, []ir.UniquelyConnectedClient{ucc}, krtopts.ToOptions("ReplacementHashClients")...)
+	sources := krt.NewStaticCollection(nil, []ir.EndpointsForBackend{*source}, krtopts.ToOptions("ReplacementHashEndpoints")...)
+	perClient := NewPerClientEnvoyEndpoints(krtopts, uccs, sources, translator.TranslateEndpoints)
+
+	var initialHash uint64
+	g.Eventually(func() string {
+		rows := perClient.FetchEndpointsForClient(krt.TestingDummyContext{}, ucc)
+		if len(rows) != 1 {
+			return ""
+		}
+		initialHash = rows[0].EndpointsHash
+		return endpointPipePath(rows[0].Endpoints)
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal("replacement-a"))
+	g.Expect(initialHash).ToNot(gomega.Equal(sourceHash),
+		"the row key must use the replacement set's resolved hash, not the source hash")
+
+	updated := *source
+	updated.Hostname = "replacement-b"
+	g.Expect(updated.LbEpsEqualityHash).To(gomega.Equal(sourceHash),
+		"precondition: only the plugin's replacement output changes the endpoint hash")
+	sources.UpdateObject(updated)
+
+	var updatedHash uint64
+	g.Eventually(func() string {
+		rows := perClient.FetchEndpointsForClient(krt.TestingDummyContext{}, ucc)
+		if len(rows) != 1 {
+			return ""
+		}
+		updatedHash = rows[0].EndpointsHash
+		return endpointPipePath(rows[0].Endpoints)
+	}, time.Second, 20*time.Millisecond).Should(gomega.Equal("replacement-b"),
+		"a replacement-only update must not be suppressed by stale KRT equality")
+	g.Expect(updatedHash).ToNot(gomega.Equal(initialHash))
+}
+
+func endpointPipePath(cla *envoyendpointv3.ClusterLoadAssignment) string {
+	if len(cla.GetEndpoints()) == 0 || len(cla.GetEndpoints()[0].GetLbEndpoints()) == 0 {
+		return ""
+	}
+	return cla.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetPipe().GetPath()
+}
 
 func TestFilterEndpointResourcesForStaticClusters_FiltersStaticClusterCLAs(t *testing.T) {
 	// Clusters: one STATIC ("static-cluster"), one EDS ("eds-cluster").

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -40,7 +40,7 @@ const (
 type BackendTranslator struct {
 	ContributedBackends map[schema.GroupKind]ir.BackendInit
 	ContributedPolicies map[schema.GroupKind]sdk.PolicyPlugin
-	EndpointPlugins     []sdk.EndpointPlugin
+	EndpointPlugins     []EndpointPlugin
 	CommonCols          *collections.CommonCollections
 	Validator           validator.Validator
 	Mode                apisettings.ValidationMode
@@ -180,9 +180,8 @@ func (t *BackendTranslator) runPolicies(
 	}
 
 	if endpointInputs != nil {
-		for _, processEndpoints := range t.orderedEndpointPlugins() {
-			processEndpoints(kctx, ctx, ucc, endpointInputs)
-		}
+		resolved, _ := ResolveEndpointInputs(kctx, ctx, ucc, *endpointInputs, t.orderedEndpointPlugins())
+		endpointInputs = &resolved
 	}
 
 	// for clusters that want a CLA _and_ initialized with inlineEps, build the CLA.
@@ -198,7 +197,7 @@ func (t *BackendTranslator) runPolicies(
 	return errors.Join(errs...)
 }
 
-func (t *BackendTranslator) orderedEndpointPlugins() []sdk.EndpointPlugin {
+func (t *BackendTranslator) orderedEndpointPlugins() []EndpointPlugin {
 	if t.EndpointPlugins != nil {
 		return t.EndpointPlugins
 	}

--- a/pkg/kgateway/translator/irtranslator/endpoint_plugins.go
+++ b/pkg/kgateway/translator/irtranslator/endpoint_plugins.go
@@ -2,29 +2,55 @@ package irtranslator
 
 import (
 	"cmp"
+	"context"
 	"slices"
 
+	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/endpoints"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
+
+// EndpointPlugin is the normalized internal endpoint hook. Editor plugins use
+// the resolver's restricted copy-on-write surface. Legacy plugins are adapted
+// by requesting a one-time deep-cloned mutable input graph from the resolver.
+type EndpointPlugin func(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniquelyConnectedClient,
+	out *endpoints.EndpointInputsResolver,
+) uint64
 
 type endpointPluginEntry struct {
 	groupKind schema.GroupKind
 	name      string
-	plugin    sdk.EndpointPlugin
+	plugin    EndpointPlugin
 }
 
-func OrderedEndpointPlugins(policies sdk.ContributesPolicies) []sdk.EndpointPlugin {
+func OrderedEndpointPlugins(policies sdk.ContributesPolicies) []EndpointPlugin {
 	entries := make([]endpointPluginEntry, 0, len(policies))
-	for groupKind, plugin := range policies {
-		if plugin.PerClientProcessEndpoints == nil {
+	for groupKind, policyPlugin := range policies {
+		var plugin EndpointPlugin
+		switch {
+		case policyPlugin.PerClientEditEndpoints != nil:
+			edit := policyPlugin.PerClientEditEndpoints
+			plugin = func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, out *endpoints.EndpointInputsResolver) uint64 {
+				return edit(kctx, ctx, ucc, out)
+			}
+		case policyPlugin.PerClientProcessEndpoints != nil: //nolint:staticcheck // compatibility boundary for legacy plugins
+			legacy := policyPlugin.PerClientProcessEndpoints //nolint:staticcheck // isolated below through LegacyMutableInputs
+			plugin = func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, out *endpoints.EndpointInputsResolver) uint64 {
+				return legacy(kctx, ctx, ucc, out.LegacyMutableInputs())
+			}
+		default:
 			continue
 		}
 		entries = append(entries, endpointPluginEntry{
 			groupKind: groupKind,
-			name:      plugin.Name,
-			plugin:    plugin.PerClientProcessEndpoints,
+			name:      policyPlugin.Name,
+			plugin:    plugin,
 		})
 	}
 
@@ -38,9 +64,28 @@ func OrderedEndpointPlugins(policies sdk.ContributesPolicies) []sdk.EndpointPlug
 		return cmp.Compare(a.name, b.name)
 	})
 
-	endpointPlugins := make([]sdk.EndpointPlugin, 0, len(entries))
+	endpointPlugins := make([]EndpointPlugin, 0, len(entries))
 	for _, entry := range entries {
 		endpointPlugins = append(endpointPlugins, entry.plugin)
 	}
 	return endpointPlugins
+}
+
+// ResolveEndpointInputs applies the ordered endpoint hooks to one client's
+// working view and returns the isolated result plus the combined plugin hash.
+// Both inline-CLA and EDS translation use this helper so their ownership and
+// composition semantics cannot diverge.
+func ResolveEndpointInputs(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniquelyConnectedClient,
+	inputs endpoints.EndpointsInputs,
+	plugins []EndpointPlugin,
+) (endpoints.EndpointsInputs, uint64) {
+	resolver := endpoints.NewEndpointInputsResolver(inputs)
+	var hash uint64
+	for _, plugin := range plugins {
+		hash ^= plugin(kctx, ctx, ucc, resolver)
+	}
+	return resolver.Inputs(), hash
 }

--- a/pkg/kgateway/translator/irtranslator/endpoint_plugins.go
+++ b/pkg/kgateway/translator/irtranslator/endpoint_plugins.go
@@ -3,36 +3,45 @@ package irtranslator
 import (
 	"cmp"
 	"context"
+	"hash/fnv"
 	"slices"
 
 	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/endpoints"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
-// EndpointPlugin is the normalized internal endpoint hook. Editor plugins use
-// the resolver's restricted copy-on-write surface. Legacy plugins are adapted
-// by requesting a one-time deep-cloned mutable input graph from the resolver.
-type EndpointPlugin func(
+type endpointPluginFunc func(
 	kctx krt.HandlerContext,
 	ctx context.Context,
 	ucc ir.UniquelyConnectedClient,
 	out *endpoints.EndpointInputsResolver,
 ) uint64
 
+// EndpointPlugin is a normalized internal endpoint hook together with its
+// stable policy identity. Editor plugins use the resolver's restricted
+// copy-on-write surface. Legacy plugins are adapted by requesting a one-time
+// deep-cloned mutable input graph from the resolver.
+type EndpointPlugin struct {
+	groupKind schema.GroupKind
+	name      string
+	process   endpointPluginFunc
+}
+
 type endpointPluginEntry struct {
 	groupKind schema.GroupKind
 	name      string
-	plugin    EndpointPlugin
+	plugin    endpointPluginFunc
 }
 
 func OrderedEndpointPlugins(policies sdk.ContributesPolicies) []EndpointPlugin {
 	entries := make([]endpointPluginEntry, 0, len(policies))
 	for groupKind, policyPlugin := range policies {
-		var plugin EndpointPlugin
+		var plugin endpointPluginFunc
 		switch {
 		case policyPlugin.PerClientEditEndpoints != nil:
 			edit := policyPlugin.PerClientEditEndpoints
@@ -66,7 +75,11 @@ func OrderedEndpointPlugins(policies sdk.ContributesPolicies) []EndpointPlugin {
 
 	endpointPlugins := make([]EndpointPlugin, 0, len(entries))
 	for _, entry := range entries {
-		endpointPlugins = append(endpointPlugins, entry.plugin)
+		endpointPlugins = append(endpointPlugins, EndpointPlugin{
+			groupKind: entry.groupKind,
+			name:      entry.name,
+			process:   entry.plugin,
+		})
 	}
 	return endpointPlugins
 }
@@ -83,9 +96,21 @@ func ResolveEndpointInputs(
 	plugins []EndpointPlugin,
 ) (endpoints.EndpointsInputs, uint64) {
 	resolver := endpoints.NewEndpointInputsResolver(inputs)
-	var hash uint64
+	hasher := fnv.New64a()
+	hasContribution := false
 	for _, plugin := range plugins {
-		hash ^= plugin(kctx, ctx, ucc, resolver)
+		contribution := plugin.process(kctx, ctx, ucc, resolver)
+		if contribution == 0 {
+			continue
+		}
+		hasContribution = true
+		utils.HashStringField(hasher, plugin.groupKind.Group)
+		utils.HashStringField(hasher, plugin.groupKind.Kind)
+		utils.HashStringField(hasher, plugin.name)
+		utils.HashUint64(hasher, contribution)
 	}
-	return resolver.Inputs(), hash
+	if !hasContribution {
+		return resolver.Inputs(), 0
+	}
+	return resolver.Inputs(), hasher.Sum64()
 }

--- a/pkg/kgateway/translator/irtranslator/endpoint_plugins_test.go
+++ b/pkg/kgateway/translator/irtranslator/endpoint_plugins_test.go
@@ -24,16 +24,16 @@ func TestOrderedEndpointPluginsUsesStablePolicyOrder(t *testing.T) {
 	var calls []string
 	plugins := irtranslator.OrderedEndpointPlugins(sdk.ContributesPolicies{
 		{Group: "gateway.kgateway.dev", Kind: "BackendConfigPolicy"}: {
-			Name:                      "BackendConfigPolicy",
-			PerClientProcessEndpoints: recordingEndpointPlugin("backendconfigpolicy", &calls),
+			Name:                   "BackendConfigPolicy",
+			PerClientEditEndpoints: recordingEndpointPlugin("backendconfigpolicy", &calls),
 		},
 		{Group: "networking.istio.io", Kind: "DestinationRule"}: {
-			Name:                      "destrule",
-			PerClientProcessEndpoints: recordingEndpointPlugin("destrule", &calls),
+			Name:                   "destrule",
+			PerClientEditEndpoints: recordingEndpointPlugin("destrule", &calls),
 		},
 		{Group: "example.io", Kind: "ExamplePolicy"}: {
-			Name:                      "example",
-			PerClientProcessEndpoints: recordingEndpointPlugin("example", &calls),
+			Name:                   "example",
+			PerClientEditEndpoints: recordingEndpointPlugin("example", &calls),
 		},
 		{Group: "example.io", Kind: "NoEndpointPolicy"}: {
 			Name: "no-endpoint",
@@ -41,9 +41,7 @@ func TestOrderedEndpointPluginsUsesStablePolicyOrder(t *testing.T) {
 	})
 
 	require.Len(t, plugins, 3)
-	for _, plugin := range plugins {
-		plugin(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{}, &endpoints.EndpointsInputs{})
-	}
+	irtranslator.ResolveEndpointInputs(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{}, endpoints.EndpointsInputs{}, plugins)
 
 	assert.Equal(t, []string{"example", "backendconfigpolicy", "destrule"}, calls)
 }
@@ -72,21 +70,21 @@ func TestBackendTranslatorRunsOrderedEndpointPluginsForInlineEndpoints(t *testin
 		ContributedPolicies: sdk.ContributesPolicies{
 			kgwellknown.BackendConfigPolicyGVK.GroupKind(): {
 				Name: "BackendConfigPolicy",
-				PerClientProcessEndpoints: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, out *endpoints.EndpointsInputs) uint64 {
+				PerClientEditEndpoints: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, out endpoints.EndpointInputsEditor) uint64 {
 					calls = append(calls, "backendconfigpolicy")
-					out.PriorityInfo = &endpoints.PriorityInfo{
+					out.SetPriorityInfo(&endpoints.PriorityInfo{
 						FailoverPriority: endpoints.NewPriorities([]string{corev1.LabelTopologyZone + "=zone-a"}),
-					}
+					})
 					return 0
 				},
 			},
 			{Group: "networking.istio.io", Kind: "DestinationRule"}: {
 				Name: "destrule",
-				PerClientProcessEndpoints: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, out *endpoints.EndpointsInputs) uint64 {
+				PerClientEditEndpoints: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, out endpoints.EndpointInputsEditor) uint64 {
 					calls = append(calls, "destrule")
-					out.PriorityInfo = &endpoints.PriorityInfo{
+					out.SetPriorityInfo(&endpoints.PriorityInfo{
 						FailoverPriority: endpoints.NewPriorities([]string{corev1.LabelTopologyRegion}),
-					}
+					})
 					return 0
 				},
 			},
@@ -120,12 +118,12 @@ func TestBackendTranslatorRunsOrderedEndpointPluginsForInlineEndpoints(t *testin
 	assert.Equal(t, map[string]uint32{"zone-a": 0, "zone-b": 0}, prioritiesByZone)
 }
 
-func recordingEndpointPlugin(name string, calls *[]string) sdk.EndpointPlugin {
+func recordingEndpointPlugin(name string, calls *[]string) sdk.EndpointEditorPlugin {
 	return func(
 		kctx krt.HandlerContext,
 		ctx context.Context,
 		ucc ir.UniquelyConnectedClient,
-		out *endpoints.EndpointsInputs,
+		out endpoints.EndpointInputsEditor,
 	) uint64 {
 		*calls = append(*calls, name)
 		return 0

--- a/pkg/kgateway/translator/irtranslator/endpoint_plugins_test.go
+++ b/pkg/kgateway/translator/irtranslator/endpoint_plugins_test.go
@@ -46,6 +46,32 @@ func TestOrderedEndpointPluginsUsesStablePolicyOrder(t *testing.T) {
 	assert.Equal(t, []string{"example", "backendconfigpolicy", "destrule"}, calls)
 }
 
+func TestResolveEndpointInputsCombinesPluginHashesWithStableIdentity(t *testing.T) {
+	pluginA := schema.GroupKind{Group: "a.example.io", Kind: "Policy"}
+	pluginB := schema.GroupKind{Group: "b.example.io", Kind: "Policy"}
+	const contribution uint64 = 37
+
+	onlyA := resolveEndpointPluginHash(t, sdk.ContributesPolicies{
+		pluginA: {Name: "a", PerClientEditEndpoints: endpointHashPlugin(contribution)},
+	})
+	onlyB := resolveEndpointPluginHash(t, sdk.ContributesPolicies{
+		pluginB: {Name: "b", PerClientEditEndpoints: endpointHashPlugin(contribution)},
+	})
+	withZero := resolveEndpointPluginHash(t, sdk.ContributesPolicies{
+		pluginA: {Name: "a", PerClientEditEndpoints: endpointHashPlugin(contribution)},
+		pluginB: {Name: "b", PerClientEditEndpoints: endpointHashPlugin(0)},
+	})
+	both := resolveEndpointPluginHash(t, sdk.ContributesPolicies{
+		pluginA: {Name: "a", PerClientEditEndpoints: endpointHashPlugin(contribution)},
+		pluginB: {Name: "b", PerClientEditEndpoints: endpointHashPlugin(contribution)},
+	})
+
+	assert.NotZero(t, both, "equal nonzero contributions from two plugins must not cancel")
+	assert.NotEqual(t, onlyA, onlyB, "plugin identity must participate in the combined hash")
+	assert.Equal(t, onlyA, withZero, "a zero contribution must remain a no-op")
+	assert.NotEqual(t, onlyA, both, "adding a nonzero plugin contribution must change the combined hash")
+}
+
 func TestBackendTranslatorRunsOrderedEndpointPluginsForInlineEndpoints(t *testing.T) {
 	backendGK := schema.GroupKind{Group: "example.io", Kind: "InlineBackend"}
 	var calls []string
@@ -128,6 +154,29 @@ func recordingEndpointPlugin(name string, calls *[]string) sdk.EndpointEditorPlu
 		*calls = append(*calls, name)
 		return 0
 	}
+}
+
+func endpointHashPlugin(contribution uint64) sdk.EndpointEditorPlugin {
+	return func(
+		kctx krt.HandlerContext,
+		ctx context.Context,
+		ucc ir.UniquelyConnectedClient,
+		out endpoints.EndpointInputsEditor,
+	) uint64 {
+		return contribution
+	}
+}
+
+func resolveEndpointPluginHash(t *testing.T, policies sdk.ContributesPolicies) uint64 {
+	t.Helper()
+	_, combined := irtranslator.ResolveEndpointInputs(
+		krt.TestingDummyContext{},
+		context.Background(),
+		ir.UniquelyConnectedClient{},
+		endpoints.EndpointsInputs{},
+		irtranslator.OrderedEndpointPlugins(policies),
+	)
+	return combined
 }
 
 func endpointWithLabels(address string, labels map[string]string) ir.EndpointWithMd {

--- a/pkg/kgateway/translator/translator.go
+++ b/pkg/kgateway/translator/translator.go
@@ -36,7 +36,7 @@ type CombinedTranslator struct {
 	gwtranslator      sdk.KGwTranslator
 	irtranslator      *irtranslator.Translator
 	backendTranslator *irtranslator.BackendTranslator
-	endpointPlugins   []sdk.EndpointPlugin
+	endpointPlugins   []irtranslator.EndpointPlugin
 
 	logger *slog.Logger
 }
@@ -142,13 +142,8 @@ func (s *CombinedTranslator) TranslateGateway(kctx krt.HandlerContext, ctx conte
 }
 
 func (s *CombinedTranslator) TranslateEndpoints(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) (*envoyendpointv3.ClusterLoadAssignment, uint64) {
-	epInputs := endpoints.EndpointsInputs{
+	epInputs, hash := irtranslator.ResolveEndpointInputs(kctx, context.TODO(), ucc, endpoints.EndpointsInputs{
 		EndpointsForBackend: ep,
-	}
-	var hash uint64
-	for _, processEndpoints := range s.endpointPlugins {
-		additionalHash := processEndpoints(kctx, context.TODO(), ucc, &epInputs)
-		hash ^= additionalHash
-	}
+	}, s.endpointPlugins)
 	return endpoints.PrioritizeEndpoints(s.logger, ucc, epInputs), hash
 }

--- a/pkg/kgateway/translator/translator.go
+++ b/pkg/kgateway/translator/translator.go
@@ -141,9 +141,15 @@ func (s *CombinedTranslator) TranslateGateway(kctx krt.HandlerContext, ctx conte
 	return &xdsSnap, rm
 }
 
-func (s *CombinedTranslator) TranslateEndpoints(kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, ep ir.EndpointsForBackend) (*envoyendpointv3.ClusterLoadAssignment, uint64) {
-	epInputs, hash := irtranslator.ResolveEndpointInputs(kctx, context.TODO(), ucc, endpoints.EndpointsInputs{
+func (s *CombinedTranslator) TranslateEndpoints(
+	kctx krt.HandlerContext,
+	ucc ir.UniquelyConnectedClient,
+	ep ir.EndpointsForBackend,
+) (*envoyendpointv3.ClusterLoadAssignment, uint64, uint64) {
+	epInputs, additionalHash := irtranslator.ResolveEndpointInputs(kctx, context.TODO(), ucc, endpoints.EndpointsInputs{
 		EndpointsForBackend: ep,
 	}, s.endpointPlugins)
-	return endpoints.PrioritizeEndpoints(s.logger, ucc, epInputs), hash
+	return endpoints.PrioritizeEndpoints(s.logger, ucc, epInputs),
+		epInputs.EndpointsForBackend.LbEpsEqualityHash,
+		additionalHash
 }

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -239,6 +239,19 @@ func (e EndpointsForBackend) EmptyCopy() EndpointsForBackend {
 	}
 }
 
+// FoldVersion mixes an extra input into this row's equality hash. Use it for
+// state that changes what these endpoints translate into without changing the
+// endpoints themselves — newFinalBackendEndpoints folds in the attached-policy
+// hash for exactly that reason.
+//
+// Fold rather than assign LbEpsEqualityHash: EmptyCopy reseeds the hash from
+// backend identity alone, so a replacement endpoint set built through the
+// endpoint editor would otherwise silently drop the contribution and stop
+// distinguishing the states it was added to distinguish.
+func (e *EndpointsForBackend) FoldVersion(extra uint64) {
+	e.LbEpsEqualityHash = hash(e.LbEpsEqualityHash, extra)
+}
+
 func hashEndpoints(l PodLocality, emd EndpointWithMd) uint64 {
 	hasher := fnv.New64a()
 	hasher.Write([]byte(l.Region))

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"google.golang.org/protobuf/proto"
 	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
@@ -138,7 +139,28 @@ type EndpointWithMd struct {
 	// endpoint was added to its locality. It is derived state, not another hash
 	// input. Endpoint replacement builders reuse it for structurally shared
 	// endpoints instead of marshaling the same proto once per client.
+	//
+	// Zero means "no cached contribution". Clone clears it so a copy taken in
+	// order to be modified cannot version different content identically, and
+	// ReuseEndpoint recomputes when it sees zero.
 	endpointEqualityHash uint64
+}
+
+// Clone returns a transitively isolated copy of the endpoint that the caller
+// owns: the LbEndpoint proto and the metadata labels are both deep copied, so
+// neither the source nor any other holder of it observes later writes.
+//
+// The cached contribution hash is deliberately dropped. A clone exists to be
+// modified, and carrying the original's hash into ReuseEndpoint would publish
+// changed endpoint content under the unchanged version Envoy already has.
+func (e EndpointWithMd) Clone() EndpointWithMd {
+	out := e
+	out.endpointEqualityHash = 0
+	if e.LbEndpoint != nil {
+		out.LbEndpoint = proto.Clone(e.LbEndpoint).(*envoyendpointv3.LbEndpoint)
+	}
+	out.EndpointMd.Labels = maps.Clone(e.EndpointMd.Labels)
+	return out
 }
 
 type LocalityLbMap map[PodLocality][]EndpointWithMd
@@ -175,9 +197,15 @@ type EndpointsForBackend struct {
 	// Inherited from the backend object
 	TrafficDistribution wellknown.TrafficDistribution
 
-	LbEpsEqualityHash    uint64
-	upstreamHash         uint64
-	epsEqualityHash      uint64
+	LbEpsEqualityHash uint64
+	upstreamHash      uint64
+	epsEqualityHash   uint64
+	// endpointCount is the number of endpoints across all localities. The
+	// equality hash needs the empty/non-empty distinction, and it cannot be
+	// derived from epsEqualityHash: a non-empty set can xor to zero. Maintaining
+	// it here keeps every writer — Add, ReuseEndpointsFrom, AdoptEndpointsFrom —
+	// answering that question the same way.
+	endpointCount        int
 	foldedVersionHash    uint64
 	hasFoldedVersionHash bool
 }
@@ -246,7 +274,7 @@ func (e EndpointsForBackend) EmptyCopy() EndpointsForBackend {
 		foldedVersionHash:    e.foldedVersionHash,
 		hasFoldedVersionHash: e.hasFoldedVersionHash,
 	}
-	out.refreshLbEpsEqualityHash(false)
+	out.refreshLbEpsEqualityHash()
 	return out
 }
 
@@ -265,7 +293,7 @@ func (e *EndpointsForBackend) FoldVersion(extra uint64) {
 		e.foldedVersionHash = extra
 		e.hasFoldedVersionHash = true
 	}
-	e.refreshLbEpsEqualityHash(e.hasEndpoints())
+	e.refreshLbEpsEqualityHash()
 }
 
 func hashEndpoints(l PodLocality, emd EndpointWithMd) uint64 {
@@ -296,8 +324,16 @@ func (e *EndpointsForBackend) Add(l PodLocality, emd EndpointWithMd) {
 // was read, reusing the contribution hash computed by Add. Callers that change
 // either the endpoint or its locality must use Add so the contribution is
 // recomputed.
+//
+// A zero cached hash means the endpoint was never hashed by Add, or was cloned
+// in order to be modified. Rather than trust it, recompute: versioning changed
+// content under an unchanged hash is the one failure this cache must not cause.
 func (e *EndpointsForBackend) ReuseEndpoint(l PodLocality, emd EndpointWithMd) {
-	e.addWithEndpointHash(l, emd, emd.endpointEqualityHash)
+	endpointHash := emd.endpointEqualityHash
+	if endpointHash == 0 {
+		endpointHash = hashEndpoints(l, emd)
+	}
+	e.addWithEndpointHash(l, emd, endpointHash)
 }
 
 func (e *EndpointsForBackend) addWithEndpointHash(l PodLocality, emd EndpointWithMd, endpointHash uint64) {
@@ -306,21 +342,13 @@ func (e *EndpointsForBackend) addWithEndpointHash(l PodLocality, emd EndpointWit
 	e.epsEqualityHash ^= endpointHash
 	emd.endpointEqualityHash = endpointHash
 	e.LbEps[l] = append(e.LbEps[l], emd)
-	e.refreshLbEpsEqualityHash(true)
+	e.endpointCount++
+	e.refreshLbEpsEqualityHash()
 }
 
-func (e *EndpointsForBackend) hasEndpoints() bool {
-	for _, endpoints := range e.LbEps {
-		if len(endpoints) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func (e *EndpointsForBackend) refreshLbEpsEqualityHash(hasEndpoints bool) {
+func (e *EndpointsForBackend) refreshLbEpsEqualityHash() {
 	endpointHash := e.upstreamHash
-	if hasEndpoints {
+	if e.endpointCount > 0 {
 		// We can't xor the endpoint hash with the upstream hash, because
 		// upstreams with different names and similar endpoints will cancel out,
 		// so endpoint changes won't result in different equality hashes.
@@ -343,20 +371,28 @@ func (e *EndpointsForBackend) refreshLbEpsEqualityHash(hasEndpoints bool) {
 // present in e are dropped.
 func (e *EndpointsForBackend) ReuseEndpointsFrom(base *EndpointsForBackend) {
 	e.epsEqualityHash = base.epsEqualityHash
-	e.LbEpsEqualityHash = e.upstreamHash
-	// Mirror what Add() computes. Distinguish the empty set by endpoint count,
-	// not by hash value: a non-empty set can xor to a zero epsEqualityHash
-	// (e.g. duplicate endpoints across localities), and Add() would still
-	// produce hash(0, upstreamHash) in that case.
-	nonEmpty := false
+	e.endpointCount = base.endpointCount
 	e.LbEps = make(LocalityLbMap, len(base.LbEps))
 	for l, eps := range base.LbEps {
-		if len(eps) > 0 {
-			nonEmpty = true
-		}
 		e.LbEps[l] = slices.Clone(eps)
 	}
-	e.refreshLbEpsEqualityHash(nonEmpty)
+	e.refreshLbEpsEqualityHash()
+}
+
+// AdoptEndpointsFrom moves src's endpoint set and its content hash onto e,
+// leaving e's own backend identity and folded version in place. Unlike
+// ReuseEndpointsFrom it takes the per-locality slices as they are: the caller
+// must own src and must not use it afterwards.
+//
+// This is what installing a replacement endpoint set is made of. Overwriting e
+// with src wholesale would also reinstate whatever identity fields src happened
+// to be seeded with, silently reverting anything written to e while the
+// replacement was being built.
+func (e *EndpointsForBackend) AdoptEndpointsFrom(src *EndpointsForBackend) {
+	e.LbEps = src.LbEps
+	e.epsEqualityHash = src.epsEqualityHash
+	e.endpointCount = src.endpointCount
+	e.refreshLbEpsEqualityHash()
 }
 
 func (c EndpointsForBackend) ResourceName() string {
@@ -364,5 +400,5 @@ func (c EndpointsForBackend) ResourceName() string {
 }
 
 func (c EndpointsForBackend) Equals(in EndpointsForBackend) bool {
-	return c.UpstreamResourceName == in.UpstreamResourceName && c.ClusterName == in.ClusterName && c.Port == in.Port && c.LbEpsEqualityHash == in.LbEpsEqualityHash && c.Hostname == in.Hostname && c.TrafficDistribution == in.TrafficDistribution && c.upstreamHash == in.upstreamHash && c.epsEqualityHash == in.epsEqualityHash && c.foldedVersionHash == in.foldedVersionHash && c.hasFoldedVersionHash == in.hasFoldedVersionHash
+	return c.UpstreamResourceName == in.UpstreamResourceName && c.ClusterName == in.ClusterName && c.Port == in.Port && c.LbEpsEqualityHash == in.LbEpsEqualityHash && c.Hostname == in.Hostname && c.TrafficDistribution == in.TrafficDistribution && c.upstreamHash == in.upstreamHash && c.epsEqualityHash == in.epsEqualityHash && c.endpointCount == in.endpointCount && c.foldedVersionHash == in.foldedVersionHash && c.hasFoldedVersionHash == in.hasFoldedVersionHash
 }

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -175,9 +175,11 @@ type EndpointsForBackend struct {
 	// Inherited from the backend object
 	TrafficDistribution wellknown.TrafficDistribution
 
-	LbEpsEqualityHash uint64
-	upstreamHash      uint64
-	epsEqualityHash   uint64
+	LbEpsEqualityHash    uint64
+	upstreamHash         uint64
+	epsEqualityHash      uint64
+	foldedVersionHash    uint64
+	hasFoldedVersionHash bool
 }
 
 func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
@@ -231,7 +233,7 @@ func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
 // EmptyCopy creates a fresh EndpointsForBackend with no endpoints
 // for the same backend.
 func (e EndpointsForBackend) EmptyCopy() EndpointsForBackend {
-	return EndpointsForBackend{
+	out := EndpointsForBackend{
 		BackendLabels:        e.BackendLabels,
 		AttachedPolicies:     e.AttachedPolicies,
 		LbEps:                make(map[PodLocality][]EndpointWithMd),
@@ -239,10 +241,13 @@ func (e EndpointsForBackend) EmptyCopy() EndpointsForBackend {
 		UpstreamResourceName: e.UpstreamResourceName,
 		Port:                 e.Port,
 		Hostname:             e.Hostname,
-		LbEpsEqualityHash:    e.upstreamHash,
 		upstreamHash:         e.upstreamHash,
 		TrafficDistribution:  e.TrafficDistribution,
+		foldedVersionHash:    e.foldedVersionHash,
+		hasFoldedVersionHash: e.hasFoldedVersionHash,
 	}
+	out.refreshLbEpsEqualityHash(false)
+	return out
 }
 
 // FoldVersion mixes an extra input into this row's equality hash. Use it for
@@ -250,12 +255,17 @@ func (e EndpointsForBackend) EmptyCopy() EndpointsForBackend {
 // endpoints themselves — newFinalBackendEndpoints folds in the attached-policy
 // hash for exactly that reason.
 //
-// Fold rather than assign LbEpsEqualityHash: EmptyCopy reseeds the hash from
-// backend identity alone, so a replacement endpoint set built through the
-// endpoint editor would otherwise silently drop the contribution and stop
-// distinguishing the states it was added to distinguish.
+// Folded versions are tracked separately from endpoint content. EmptyCopy
+// preserves them, and Add recomputes the final equality hash from both parts,
+// so endpoint edits cannot silently erase an earlier contribution.
 func (e *EndpointsForBackend) FoldVersion(extra uint64) {
-	e.LbEpsEqualityHash = hash(e.LbEpsEqualityHash, extra)
+	if e.hasFoldedVersionHash {
+		e.foldedVersionHash = hash(e.foldedVersionHash, extra)
+	} else {
+		e.foldedVersionHash = extra
+		e.hasFoldedVersionHash = true
+	}
+	e.refreshLbEpsEqualityHash(e.hasEndpoints())
 }
 
 func hashEndpoints(l PodLocality, emd EndpointWithMd) uint64 {
@@ -294,12 +304,32 @@ func (e *EndpointsForBackend) addWithEndpointHash(l PodLocality, emd EndpointWit
 	// xor it as we dont care about order - if we have the same endpoints in the same locality
 	// we are good.
 	e.epsEqualityHash ^= endpointHash
-	// we can't xor the endpoint hash with the upstream hash, because upstreams with
-	// different names and similar endpoints will cancel out, so endpoint changes
-	// won't result in different equality hashes.
-	e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
 	emd.endpointEqualityHash = endpointHash
 	e.LbEps[l] = append(e.LbEps[l], emd)
+	e.refreshLbEpsEqualityHash(true)
+}
+
+func (e *EndpointsForBackend) hasEndpoints() bool {
+	for _, endpoints := range e.LbEps {
+		if len(endpoints) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *EndpointsForBackend) refreshLbEpsEqualityHash(hasEndpoints bool) {
+	endpointHash := e.upstreamHash
+	if hasEndpoints {
+		// We can't xor the endpoint hash with the upstream hash, because
+		// upstreams with different names and similar endpoints will cancel out,
+		// so endpoint changes won't result in different equality hashes.
+		endpointHash = hash(e.epsEqualityHash, e.upstreamHash)
+	}
+	if e.hasFoldedVersionHash {
+		endpointHash = hash(endpointHash, e.foldedVersionHash)
+	}
+	e.LbEpsEqualityHash = endpointHash
 }
 
 // ReuseEndpointsFrom copies the endpoint entries and their precomputed
@@ -326,9 +356,7 @@ func (e *EndpointsForBackend) ReuseEndpointsFrom(base *EndpointsForBackend) {
 		}
 		e.LbEps[l] = slices.Clone(eps)
 	}
-	if nonEmpty {
-		e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
-	}
+	e.refreshLbEpsEqualityHash(nonEmpty)
 }
 
 func (c EndpointsForBackend) ResourceName() string {
@@ -336,5 +364,5 @@ func (c EndpointsForBackend) ResourceName() string {
 }
 
 func (c EndpointsForBackend) Equals(in EndpointsForBackend) bool {
-	return c.UpstreamResourceName == in.UpstreamResourceName && c.ClusterName == in.ClusterName && c.Port == in.Port && c.LbEpsEqualityHash == in.LbEpsEqualityHash && c.Hostname == in.Hostname && c.TrafficDistribution == in.TrafficDistribution && c.upstreamHash == in.upstreamHash && c.epsEqualityHash == in.epsEqualityHash
+	return c.UpstreamResourceName == in.UpstreamResourceName && c.ClusterName == in.ClusterName && c.Port == in.Port && c.LbEpsEqualityHash == in.LbEpsEqualityHash && c.Hostname == in.Hostname && c.TrafficDistribution == in.TrafficDistribution && c.upstreamHash == in.upstreamHash && c.epsEqualityHash == in.epsEqualityHash && c.foldedVersionHash == in.foldedVersionHash && c.hasFoldedVersionHash == in.hasFoldedVersionHash
 }

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -133,6 +133,12 @@ type EndpointMetadata struct {
 type EndpointWithMd struct {
 	*envoyendpointv3.LbEndpoint
 	EndpointMd EndpointMetadata
+
+	// endpointEqualityHash is the contribution hashEndpoints computed when this
+	// endpoint was added to its locality. It is derived state, not another hash
+	// input. Endpoint replacement builders reuse it for structurally shared
+	// endpoints instead of marshaling the same proto once per client.
+	endpointEqualityHash uint64
 }
 
 type LocalityLbMap map[PodLocality][]EndpointWithMd
@@ -273,13 +279,26 @@ func hash(a, b uint64) uint64 {
 }
 
 func (e *EndpointsForBackend) Add(l PodLocality, emd EndpointWithMd) {
+	e.addWithEndpointHash(l, emd, hashEndpoints(l, emd))
+}
+
+// ReuseEndpoint adds an immutable endpoint in the same locality from which it
+// was read, reusing the contribution hash computed by Add. Callers that change
+// either the endpoint or its locality must use Add so the contribution is
+// recomputed.
+func (e *EndpointsForBackend) ReuseEndpoint(l PodLocality, emd EndpointWithMd) {
+	e.addWithEndpointHash(l, emd, emd.endpointEqualityHash)
+}
+
+func (e *EndpointsForBackend) addWithEndpointHash(l PodLocality, emd EndpointWithMd, endpointHash uint64) {
 	// xor it as we dont care about order - if we have the same endpoints in the same locality
 	// we are good.
-	e.epsEqualityHash ^= hashEndpoints(l, emd)
+	e.epsEqualityHash ^= endpointHash
 	// we can't xor the endpoint hash with the upstream hash, because upstreams with
 	// different names and similar endpoints will cancel out, so endpoint changes
 	// won't result in different equality hashes.
 	e.LbEpsEqualityHash = hash(e.epsEqualityHash, e.upstreamHash)
+	emd.endpointEqualityHash = endpointHash
 	e.LbEps[l] = append(e.LbEps[l], emd)
 }
 

--- a/pkg/pluginsdk/ir/model_endpoints_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_test.go
@@ -161,6 +161,42 @@ func TestReuseEndpointUsesPrecomputedContribution(t *testing.T) {
 	}
 }
 
+func TestFoldVersionSurvivesEndpointAdds(t *testing.T) {
+	locality := PodLocality{Region: "r1", Zone: "z1"}
+	endpoint := testEndpointWithMd(1)
+
+	foldedBeforeAdd := NewEndpointsForBackend(epsBackend("svc"))
+	foldedBeforeAdd.FoldVersion(11)
+	foldedBeforeAdd.FoldVersion(22)
+	foldedBeforeAdd.Add(locality, endpoint)
+
+	foldedAfterAdd := NewEndpointsForBackend(epsBackend("svc"))
+	foldedAfterAdd.Add(locality, endpoint)
+	foldedAfterAdd.FoldVersion(11)
+	foldedAfterAdd.FoldVersion(22)
+
+	if foldedBeforeAdd.LbEpsEqualityHash != foldedAfterAdd.LbEpsEqualityHash {
+		t.Fatalf(
+			"Add erased or reordered folded versions: before-add=%d after-add=%d",
+			foldedBeforeAdd.LbEpsEqualityHash,
+			foldedAfterAdd.LbEpsEqualityHash,
+		)
+	}
+	if !foldedBeforeAdd.hasFoldedVersionHash || foldedBeforeAdd.foldedVersionHash != hash(11, 22) {
+		t.Fatalf("folded version state was not retained: has=%v hash=%d", foldedBeforeAdd.hasFoldedVersionHash, foldedBeforeAdd.foldedVersionHash)
+	}
+
+	emptyCopy := foldedBeforeAdd.EmptyCopy()
+	emptyCopy.Add(locality, endpoint)
+	if emptyCopy.LbEpsEqualityHash != foldedBeforeAdd.LbEpsEqualityHash {
+		t.Fatalf(
+			"EmptyCopy dropped folded versions: rebuilt=%d original=%d",
+			emptyCopy.LbEpsEqualityHash,
+			foldedBeforeAdd.LbEpsEqualityHash,
+		)
+	}
+}
+
 // reuseCmpOpts compares two EndpointsForBackend in full, including the unexported
 // equality hashes.
 //

--- a/pkg/pluginsdk/ir/model_endpoints_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_test.go
@@ -139,6 +139,28 @@ func TestReuseEndpointsFromEmpty(t *testing.T) {
 	}
 }
 
+func TestReuseEndpointUsesPrecomputedContribution(t *testing.T) {
+	locality := PodLocality{Region: "r1", Zone: "z1"}
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	base.Add(locality, testEndpointWithMd(1))
+	endpoint := base.LbEps[locality][0]
+
+	// Replace the cached value with a sentinel so this test distinguishes reuse
+	// from another call to hashEndpoints. The cache is unexported derived state;
+	// production values are populated only by Add.
+	const sentinel = uint64(42)
+	endpoint.endpointEqualityHash = sentinel
+
+	rebuilt := NewEndpointsForBackend(epsBackend("svc"))
+	rebuilt.ReuseEndpoint(locality, endpoint)
+	if rebuilt.epsEqualityHash != sentinel {
+		t.Fatalf("ReuseEndpoint rehashed the endpoint: got %d want %d", rebuilt.epsEqualityHash, sentinel)
+	}
+	if got := rebuilt.LbEps[locality][0].endpointEqualityHash; got != sentinel {
+		t.Fatalf("cached contribution was not preserved: got %d want %d", got, sentinel)
+	}
+}
+
 // reuseCmpOpts compares two EndpointsForBackend in full, including the unexported
 // equality hashes.
 //
@@ -232,7 +254,7 @@ func TestReuseEndpointsFromCopiesEmptyLocality(t *testing.T) {
 func TestEndpointHashInputsUnchanged(t *testing.T) {
 	for ty, want := range map[reflect.Type][]string{
 		reflect.TypeFor[PodLocality]():      {"Region", "Zone", "Subzone"},
-		reflect.TypeFor[EndpointWithMd]():   {"LbEndpoint", "EndpointMd"},
+		reflect.TypeFor[EndpointWithMd]():   {"LbEndpoint", "EndpointMd", "endpointEqualityHash"},
 		reflect.TypeFor[EndpointMetadata](): {"Labels"},
 	} {
 		var got []string

--- a/pkg/pluginsdk/ir/model_endpoints_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_test.go
@@ -2,6 +2,7 @@ package ir
 
 import (
 	"fmt"
+	"hash/fnv"
 	"reflect"
 	"slices"
 	"strconv"
@@ -12,6 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
 )
 
 func epsBackend(name string) BackendObjectIR {
@@ -279,6 +282,114 @@ func TestReuseEndpointsFromCopiesEmptyLocality(t *testing.T) {
 			clone.LbEpsEqualityHash,
 			initialHash,
 		)
+	}
+}
+
+// FoldVersion replaced a hand-rolled combiner in newFinalBackendEndpoints:
+//
+//	hasher := fnv.New64a()
+//	utils.HashUint64(hasher, endpointHash)
+//	utils.HashUint64(hasher, policyHash)
+//
+// LbEpsEqualityHash is the EDS resource version every connected Envoy already
+// holds, so the conversion had to be bit-identical or the first control-plane
+// restart after upgrade would re-push every CLA in the fleet at once. This pins
+// that: FNV-1a is a streaming hash, so two 8-byte little-endian writes and one
+// 16-byte write of the same bytes agree.
+func TestFoldVersionMatchesTheReplacedCombiner(t *testing.T) {
+	locality := PodLocality{Region: "r1", Zone: "z1"}
+	const policyHash = uint64(0xfeedface)
+
+	folded := NewEndpointsForBackend(epsBackend("svc"))
+	folded.Add(locality, testEndpointWithMd(1))
+	unfoldedHash := folded.LbEpsEqualityHash
+	folded.FoldVersion(policyHash)
+
+	hasher := fnv.New64a()
+	utils.HashUint64(hasher, unfoldedHash)
+	utils.HashUint64(hasher, policyHash)
+	if want := hasher.Sum64(); folded.LbEpsEqualityHash != want {
+		t.Fatalf("FoldVersion changed the published EDS version: got %d want %d", folded.LbEpsEqualityHash, want)
+	}
+}
+
+// A clone is taken in order to be modified, so it must not carry the original's
+// contribution hash: ReuseEndpoint would then publish changed endpoint content
+// under the version Envoy already holds.
+func TestCloneDropsCachedContributionHash(t *testing.T) {
+	locality := PodLocality{Region: "r1", Zone: "z1"}
+	base := NewEndpointsForBackend(epsBackend("svc"))
+	base.Add(locality, testEndpointWithMd(1))
+	original := base.LbEps[locality][0]
+	if original.endpointEqualityHash == 0 {
+		t.Fatal("Add did not cache a contribution hash")
+	}
+
+	modified := original.Clone()
+	if modified.endpointEqualityHash != 0 {
+		t.Errorf("Clone kept the cached contribution: got %d", modified.endpointEqualityHash)
+	}
+	modified.EndpointMd.Labels["i"] = "rewritten"
+	modified.GetEndpoint().GetAddress().GetSocketAddress().Address = "10.9.9.9"
+
+	if original.EndpointMd.Labels["i"] == "rewritten" {
+		t.Error("Clone shares the label map with its source")
+	}
+	if original.GetEndpoint().GetAddress().GetSocketAddress().GetAddress() == "10.9.9.9" {
+		t.Error("Clone shares the LbEndpoint proto with its source")
+	}
+
+	reusedOriginal := NewEndpointsForBackend(epsBackend("svc"))
+	reusedOriginal.ReuseEndpoint(locality, original)
+	reusedModified := NewEndpointsForBackend(epsBackend("svc"))
+	reusedModified.ReuseEndpoint(locality, modified)
+	if reusedOriginal.LbEpsEqualityHash == reusedModified.LbEpsEqualityHash {
+		t.Errorf("different content versioned identically: %d", reusedOriginal.LbEpsEqualityHash)
+	}
+
+	// The recomputed value must match what Add would have produced.
+	readded := NewEndpointsForBackend(epsBackend("svc"))
+	readded.Add(locality, modified)
+	if readded.LbEpsEqualityHash != reusedModified.LbEpsEqualityHash {
+		t.Errorf("recomputed reuse hash differs from Add: reuse=%d add=%d", reusedModified.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+}
+
+// AdoptEndpointsFrom installs a set built elsewhere while leaving the
+// receiver's own identity and folded version alone.
+func TestAdoptEndpointsFromKeepsReceiverIdentity(t *testing.T) {
+	locality := PodLocality{Region: "r1", Zone: "z1"}
+	src := NewEndpointsForBackend(epsBackend("svc"))
+	src.Add(locality, testEndpointWithMd(1))
+	src.Add(locality, testEndpointWithMd(2))
+
+	target := NewEndpointsForBackend(epsBackend("svc-variant"))
+	target.FoldVersion(99)
+	target.AdoptEndpointsFrom(src)
+
+	readded := NewEndpointsForBackend(epsBackend("svc-variant"))
+	readded.FoldVersion(99)
+	for _, ep := range src.LbEps[locality] {
+		readded.Add(locality, ep)
+	}
+	if target.LbEpsEqualityHash != readded.LbEpsEqualityHash {
+		t.Errorf("adopt hash differs from re-Add: adopt=%d readd=%d", target.LbEpsEqualityHash, readded.LbEpsEqualityHash)
+	}
+	if target.UpstreamResourceName != readded.UpstreamResourceName {
+		t.Errorf("adopt overwrote backend identity: got %q", target.UpstreamResourceName)
+	}
+	if target.endpointCount != 2 {
+		t.Errorf("endpointCount not carried over: got %d", target.endpointCount)
+	}
+
+	// An empty source must reduce the receiver to its identity hash, not to
+	// hash(0, upstreamHash).
+	empty := NewEndpointsForBackend(epsBackend("svc"))
+	target.AdoptEndpointsFrom(empty)
+	wantEmpty := NewEndpointsForBackend(epsBackend("svc-variant"))
+	wantEmpty.FoldVersion(99)
+	if target.LbEpsEqualityHash != wantEmpty.LbEpsEqualityHash {
+		t.Errorf("adopting an empty set: got %d want %d", target.LbEpsEqualityHash, wantEmpty.LbEpsEqualityHash)
 	}
 }
 

--- a/pkg/pluginsdk/types.go
+++ b/pkg/pluginsdk/types.go
@@ -24,9 +24,26 @@ import (
 var ErrNotFound = errors.New("not found")
 
 type (
-	EndpointsInputs = endpoints.EndpointsInputs
-	ProcessBackend  func(ctx context.Context, pol ir.PolicyIR, in ir.BackendObjectIR, out *envoyclusterv3.Cluster)
-	EndpointPlugin  func(
+	EndpointsInputs      = endpoints.EndpointsInputs
+	EndpointInputsEditor = endpoints.EndpointInputsEditor
+	EndpointSetBuilder   = endpoints.EndpointSetBuilder
+	EndpointView         = endpoints.EndpointView
+	ProcessBackend       func(ctx context.Context, pol ir.PolicyIR, in ir.BackendObjectIR, out *envoyclusterv3.Cluster)
+	// EndpointEditorPlugin edits per-client endpoint inputs through a
+	// copy-on-write API. Read-only source state is exposed through accessors;
+	// endpoint rewrites build a replacement set and clone only modified protos.
+	// The returned hash must capture effects not already represented by the
+	// replacement endpoint set's LbEpsEqualityHash.
+	EndpointEditorPlugin func(
+		kctx krt.HandlerContext,
+		ctx context.Context,
+		ucc ir.UniquelyConnectedClient,
+		out EndpointInputsEditor,
+	) uint64
+	// EndpointPlugin is the legacy mutable endpoint hook.
+	// Deprecated: use EndpointEditorPlugin. The framework deep-copies all
+	// mutable nested state before invoking this hook.
+	EndpointPlugin func(
 		kctx krt.HandlerContext,
 		ctx context.Context,
 		ucc ir.UniquelyConnectedClient,
@@ -58,8 +75,10 @@ type PolicyPlugin struct {
 	NewGatewayTranslationPass func(tctx ir.GwTranslationCtx, reporter reporter.Reporter) ir.ProxyTranslationPass
 
 	// Backend processing for envoy proxy
-	ProcessBackend            ProcessBackend
-	PerClientProcessBackend   PerClientProcessBackend
+	ProcessBackend          ProcessBackend
+	PerClientProcessBackend PerClientProcessBackend
+	PerClientEditEndpoints  EndpointEditorPlugin
+	// Deprecated: use PerClientEditEndpoints.
 	PerClientProcessEndpoints EndpointPlugin
 
 	Policies       krt.Collection[ir.PolicyWrapper]

--- a/pkg/pluginsdk/types.go
+++ b/pkg/pluginsdk/types.go
@@ -28,6 +28,7 @@ type (
 	EndpointInputsEditor = endpoints.EndpointInputsEditor
 	EndpointSetBuilder   = endpoints.EndpointSetBuilder
 	EndpointView         = endpoints.EndpointView
+	PolicyView           = endpoints.PolicyView
 	ProcessBackend       func(ctx context.Context, pol ir.PolicyIR, in ir.BackendObjectIR, out *envoyclusterv3.Cluster)
 	// EndpointEditorPlugin edits per-client endpoint inputs through a
 	// copy-on-write API. Read-only source state is exposed through accessors;


### PR DESCRIPTION
# Description

Introduces a restricted endpoint editor for per-client endpoint plugins while preserving the legacy hook behind defensive copying.

Replacement builders structurally share unchanged endpoints and reuse their cached hash contributions, preserving the optimization from #14489. Builders are owner-bound and single-use, folded versions survive endpoint edits, plugin hashes include stable plugin identity, and `PriorityInfo` is cloned at the editor boundary.

Also makes locality emission deterministic, preventing unchanged inline-CLA backends from receiving new CDS versions and re-warming on recomputation.

# Change Type

/kind fix

# Changelog

```release-note
Fixes spurious CDS updates and Envoy cluster re-warming for inline endpoint backends spanning multiple localities.
```

# Additional Notes

At 1,000 unchanged endpoints, the replacement path measures approximately 40 µs and 48 KB, compared with 401 µs and 761 KB for the legacy deep copy.