### PR TITLE
test: align backend translation goldens with base overlays

### DIFF
--- a/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin.go
@@ -42,7 +42,7 @@ func NewPlugin(ctx context.Context, commoncol *collections.CommonCollections) sd
 		ContributesPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
 			gk: {
 				Name:                    "destrule",
-				PerClientProcessBackend: d.processBackend,
+				PerClientClusterOverlay: d.clusterOverlay,
 				PerClientEditEndpoints:  d.processEndpoints,
 			},
 		},
@@ -79,22 +79,25 @@ func (d *destrulePlugin) processEndpoints(
 	return hasher.Sum64()
 }
 
-func (d *destrulePlugin) processBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR, outCluster *envoyclusterv3.Cluster) {
+func (d *destrulePlugin) clusterOverlay(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
 	destrule := d.destinationRulesIndex.FetchDestRulesFor(kctx, ucc.Namespace, in.CanonicalHostname, ucc.Labels)
 	if destrule == nil {
-		return
+		return nil
 	}
 
 	trafficPolicy := getTrafficPolicy(destrule, uint32(in.GetPort())) //nolint:gosec // G115: BackendObjectIR port is int32 representing a port number, always in valid range
 	outlier := trafficPolicy.GetOutlierDetection()
 	if outlier == nil {
-		return
+		return nil
 	}
 
-	// All of the following are only applied when outlier detection is present
-	applyLocalityLbConfig(trafficPolicy, outCluster)
-	applyOutlierDetection(outlier, outCluster)
-	applyTCPKeepalive(trafficPolicy, outCluster)
+	return &sdk.ClusterOverlay{
+		Mutate: func(outCluster *envoyclusterv3.Cluster) {
+			applyLocalityLbConfig(trafficPolicy, outCluster)
+			applyOutlierDetection(outlier, outCluster)
+			applyTCPKeepalive(trafficPolicy, outCluster)
+		},
+	}
 }
 
 func applyLocalityLbConfig(trafficPolicy *v1alpha3.TrafficPolicy, outCluster *envoyclusterv3.Cluster) {

--- a/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin_test.go
@@ -96,4 +96,3 @@ func TestClusterOverlay_AppliesOutlierDetection(t *testing.T) {
 	assert.NotNil(t, out.GetOutlierDetection(), "overlay must apply outlier detection to the cluster")
 	assert.Equal(t, uint32(5), out.GetOutlierDetection().GetConsecutive_5Xx().GetValue())
 }
-

--- a/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin_test.go
+++ b/pkg/kgateway/extensions2/plugins/destrule/destrule_plugin_test.go
@@ -1,0 +1,99 @@
+package destrule
+
+import (
+	"context"
+	"testing"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"istio.io/api/networking/v1alpha3"
+	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
+	"istio.io/istio/pkg/kube/krt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+const drHost = "reviews.default.svc.cluster.local"
+
+func newDestrulePlugin(t *testing.T, drs ...DestinationRuleWrapper) *destrulePlugin {
+	t.Helper()
+	col := krt.NewStaticCollection(nil, drs)
+	return &destrulePlugin{
+		destinationRulesIndex: DestinationRuleIndex{
+			Destrules:  col,
+			ByHostname: newDestruleIndex(col),
+		},
+	}
+}
+
+func destRule(name string, tp *v1alpha3.TrafficPolicy) DestinationRuleWrapper {
+	return DestinationRuleWrapper{
+		DestinationRule: &networkingclient.DestinationRule{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+			Spec: v1alpha3.DestinationRule{
+				Host:          drHost,
+				TrafficPolicy: tp,
+			},
+		},
+	}
+}
+
+func drBackend() ir.BackendObjectIR {
+	b := ir.NewBackendObjectIR(ir.ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "reviews"}, 80, "", "")
+	b.CanonicalHostname = drHost
+	return b
+}
+
+// TestClusterOverlay_NilWhenNoDestinationRule: the self-gating overlay must
+// return nil when no destination rule matches the backend, so no per-client
+// delta is materialized. This is the dominant path the sparseness relies on.
+func TestClusterOverlay_NilWhenNoDestinationRule(t *testing.T) {
+	d := newDestrulePlugin(t) // no destination rules at all
+	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
+
+	got := d.clusterOverlay(krt.TestingDummyContext{}, context.Background(), ucc, drBackend())
+	assert.Nil(t, got, "no matching destination rule must yield no overlay")
+}
+
+// TestClusterOverlay_NilWhenNoOutlierDetection: a matching destination rule with
+// no outlier detection must still return nil. The overlay's gate mirrors the
+// mutation it would perform — outlier detection is the only cluster-level change
+// — so a DR without it contributes nothing per client.
+func TestClusterOverlay_NilWhenNoOutlierDetection(t *testing.T) {
+	d := newDestrulePlugin(t, destRule("dr", &v1alpha3.TrafficPolicy{
+		// LoadBalancer/locality settings only affect endpoints, not the cluster overlay.
+		LoadBalancer: &v1alpha3.LoadBalancerSettings{
+			LocalityLbSetting: &v1alpha3.LocalityLoadBalancerSetting{},
+		},
+	}))
+	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
+
+	got := d.clusterOverlay(krt.TestingDummyContext{}, context.Background(), ucc, drBackend())
+	assert.Nil(t, got, "destination rule without outlier detection must yield no cluster overlay")
+}
+
+// TestClusterOverlay_AppliesOutlierDetection: a matching destination rule with
+// outlier detection must return an overlay that writes OutlierDetection onto the
+// cluster. This confirms the positive path and that Mutate produces the expected
+// mutation.
+func TestClusterOverlay_AppliesOutlierDetection(t *testing.T) {
+	d := newDestrulePlugin(t, destRule("dr", &v1alpha3.TrafficPolicy{
+		OutlierDetection: &v1alpha3.OutlierDetection{
+			Consecutive_5XxErrors: &wrapperspb.UInt32Value{Value: 5},
+		},
+	}))
+	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
+
+	got := d.clusterOverlay(krt.TestingDummyContext{}, context.Background(), ucc, drBackend())
+	require.NotNil(t, got, "matching destination rule with outlier detection must produce an overlay")
+	require.NotNil(t, got.Mutate)
+
+	out := &envoyclusterv3.Cluster{Name: "reviews"}
+	got.Mutate(out)
+	assert.NotNil(t, out.GetOutlierDetection(), "overlay must apply outlier detection to the cluster")
+	assert.Equal(t, uint32(5), out.GetOutlierDetection().GetConsecutive_5Xx().GetValue())
+}
+

--- a/pkg/kgateway/extensions2/plugins/waypoint/cluster_overlay_test.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/cluster_overlay_test.go
@@ -1,0 +1,41 @@
+package waypoint
+
+import (
+	"context"
+	"testing"
+
+	istioannot "istio.io/api/annotation"
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+// TestClusterOverlay_NilForNonAmbientClient pins the cheap UCC-only fast path:
+// a client without the ambient-redirection annotation can never be affected by
+// the waypoint cluster overlay, so clusterOverlay must return nil before doing
+// any of the expensive Gateway/service lookups. This is the gate that keeps the
+// per-client cluster collection sparse for the dominant (non-ambient) client.
+func TestClusterOverlay_NilForNonAmbientClient(t *testing.T) {
+	// commonCols is intentionally left nil: a correct fast path returns before
+	// dereferencing it, so a panic here would mean the gate regressed.
+	p := &PerClientProcessor{}
+	backend := ir.NewBackendObjectIR(ir.ObjectSource{Group: "", Kind: "Service", Namespace: "ns", Name: "svc"}, 80, "", "")
+
+	cases := map[string]map[string]string{
+		"no ambient label":      {"some": "label"},
+		"ambient label not set": nil,
+		"ambient label != enabled": {
+			istioannot.AmbientRedirection.Name: "disabled",
+		},
+	}
+	for name, labels := range cases {
+		t.Run(name, func(t *testing.T) {
+			ucc := ir.NewUniquelyConnectedClient("role", "ns", labels, ir.PodLocality{})
+			got := p.clusterOverlay(krt.TestingDummyContext{}, context.Background(), ucc, backend)
+			if got != nil {
+				t.Fatalf("expected nil overlay for non-ambient client, got %#v", got)
+			}
+		})
+	}
+}
+

--- a/pkg/kgateway/extensions2/plugins/waypoint/cluster_overlay_test.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/cluster_overlay_test.go
@@ -38,4 +38,3 @@ func TestClusterOverlay_NilForNonAmbientClient(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
+++ b/pkg/kgateway/extensions2/plugins/waypoint/plugin.go
@@ -69,7 +69,7 @@ func NewPlugin(
 			// Contributing a PerClientProcessEndpoints function can return an empty CLA but
 			// it is still redundant.
 			VirtualWaypointGK: {
-				PerClientProcessBackend: pcp.processBackend,
+				PerClientClusterOverlay: pcp.clusterOverlay,
 			},
 		}
 	}
@@ -83,19 +83,19 @@ type PerClientProcessor struct {
 	waypointGatewayClassName string
 }
 
-func (t *PerClientProcessor) processBackend(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) {
+func (t *PerClientProcessor) clusterOverlay(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
 	// Cheap UCC-only filter first: if the ucc doesn't have the
 	// ambient.istio.io/redirection=enabled annotation, nothing this plugin does
 	// can affect the output. Skipping here avoids the expensive Gateway
 	// FetchOne below for the dominant case (most UCCs are not ambient).
 	if val, ok := ucc.Labels[istioannot.AmbientRedirection.Name]; !ok || val != "enabled" {
-		return
+		return nil
 	}
 
 	// Cheap backend filter next: skip backends (and their namespaces/aliases)
 	// that aren't opted in to ingress-use-waypoint.
 	if !HasIngressUseWaypointLabel(kctx, t.commonCols, in) {
-		return
+		return nil
 	}
 
 	// If the ucc has a waypoint gateway class we will let it have an EDS cluster
@@ -113,7 +113,7 @@ func (t *PerClientProcessor) processBackend(kctx krt.HandlerContext, ctx context
 	gwir := krt.FetchOne(kctx, t.commonCols.GatewayIndex.Gateways, krt.FilterKey(gwKey.ResourceName()))
 	if gwir == nil || gwir.Obj == nil || string(gwir.Obj.Spec.GatewayClassName) == t.waypointGatewayClassName {
 		// no op
-		return
+		return nil
 	}
 
 	// Verify that the service is indeed attached to a waypoint by querying the reverse
@@ -121,11 +121,15 @@ func (t *PerClientProcessor) processBackend(kctx krt.HandlerContext, ctx context
 	waypointForService := t.waypointQueries.GetServiceWaypoint(kctx, ctx, in.Obj)
 	if waypointForService == nil {
 		// no op
-		return
+		return nil
 	}
 
 	// All preliminary checks passed, apply ingress-use-waypoint cluster changes
-	ApplyIngressUseWaypointCluster(in, out, &t.commonCols.Settings)
+	return &sdk.ClusterOverlay{
+		Mutate: func(out *envoyclusterv3.Cluster) {
+			ApplyIngressUseWaypointCluster(in, out, &t.commonCols.Settings)
+		},
+	}
 }
 
 // ApplyIngressUseWaypointCluster mutates out to configure a STATIC cluster with inlined

--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"google.golang.org/protobuf/proto"
 	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/irtranslator"
@@ -80,15 +81,29 @@ func NewPerClientEnvoyClusters(
 ) PerClientEnvoyClusters {
 	clusters := krt.NewManyCollection(finalBackends, func(kctx krt.HandlerContext, backendObj *ir.BackendObjectIR) []uccWithCluster {
 		backendLogger := logger.With("backend", backendObj)
-		uccs := krt.Fetch(kctx, uccs)
-		uccWithClusterRet := make([]uccWithCluster, 0, len(uccs))
+		clients := krt.Fetch(kctx, uccs)
+		if len(clients) == 0 {
+			return nil
+		}
+		base := translator.TranslateBackendBase(ctx, backendObj)
+		if base == nil {
+			return nil
+		}
+		uccWithClusterRet := make([]uccWithCluster, 0, len(clients))
 
-		for _, ucc := range uccs {
+		for _, ucc := range clients {
 			backendLogger.Debug("applying destination rules for backend", "ucc", ucc.ResourceName())
 
-			c, err := translator.TranslateBackend(ctx, kctx, ucc, backendObj)
+			c, err := translator.ApplyPerClient(kctx, ctx, ucc, backendObj, base)
 			if c == nil {
-				continue
+				// Keep the existing dense ownership model for this preparatory
+				// change: every KRT row receives its own proto even when no overlay
+				// applies. A later change can make sharing explicit and enforce
+				// immutability at the collection boundary.
+				c = proto.Clone(base.Cluster).(*envoyclusterv3.Cluster)
+				if err == nil {
+					err = base.Error
+				}
 			}
 			var backendGeneration int64
 			if backendObj.Obj != nil {

--- a/pkg/kgateway/proxy_syncer/backends_dense_overlay_test.go
+++ b/pkg/kgateway/proxy_syncer/backends_dense_overlay_test.go
@@ -1,0 +1,70 @@
+package proxy_syncer
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/stretchr/testify/require"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/irtranslator"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+func TestDenseClustersTranslateBaseOnceAndRetainPerRowOwnership(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	krtopts := krtutil.NewKrtOptions(ctx.Done(), nil)
+
+	var baseTranslations atomic.Int32
+	backendGK := schema.GroupKind{Kind: "Service"}
+	overlayGK := schema.GroupKind{Group: "example.io", Kind: "Overlay"}
+	translator := &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			backendGK: {
+				InitEnvoyBackend: func(_ context.Context, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+					baseTranslations.Add(1)
+					out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}
+					return nil
+				},
+			},
+		},
+		ContributedPolicies: sdk.ContributesPolicies{
+			overlayGK: {
+				PerClientClusterOverlay: func(_ krt.HandlerContext, _ context.Context, ucc ir.UniquelyConnectedClient, _ ir.BackendObjectIR) *sdk.ClusterOverlay {
+					if ucc.Role != "role-b" {
+						return nil
+					}
+					return &sdk.ClusterOverlay{Mutate: func(out *envoyclusterv3.Cluster) {
+						out.AltStatName = "client-b"
+					}}
+				},
+			},
+		},
+	}
+
+	a := ir.NewUniquelyConnectedClient("role-a", "default", nil, ir.PodLocality{})
+	b := ir.NewUniquelyConnectedClient("role-b", "default", nil, ir.PodLocality{})
+	backend := clustersTestBackend("backend")
+	clients := krt.NewStaticCollection(nil, []ir.UniquelyConnectedClient{a, b}, krtopts.ToOptions("DenseTestClients")...)
+	backends := krt.NewStaticCollection(nil, []*ir.BackendObjectIR{backend}, krtopts.ToOptions("DenseTestBackends")...)
+	clusters := NewPerClientEnvoyClusters(ctx, krtopts, translator, backends, clients)
+
+	require.Eventually(t, func() bool {
+		return len(clusters.FetchClustersForClient(krt.TestingDummyContext{}, a)) == 1 &&
+			len(clusters.FetchClustersForClient(krt.TestingDummyContext{}, b)) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	clusterA := clusters.FetchClustersForClient(krt.TestingDummyContext{}, a)[0].Cluster
+	clusterB := clusters.FetchClustersForClient(krt.TestingDummyContext{}, b)[0].Cluster
+	require.EqualValues(t, 1, baseTranslations.Load(), "base translation should run once for both clients")
+	require.NotSame(t, clusterA, clusterB, "dense KRT rows must retain independent proto ownership")
+	require.Empty(t, clusterA.GetAltStatName())
+	require.Equal(t, "client-b", clusterB.GetAltStatName())
+}

--- a/pkg/kgateway/proxy_syncer/gateway_backend_variants_test.go
+++ b/pkg/kgateway/proxy_syncer/gateway_backend_variants_test.go
@@ -187,8 +187,10 @@ func TestGatewayBackendVariantBackendsRetainBackendPolicies(t *testing.T) {
 		},
 	}
 
-	cluster, err := translator.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ir.UniquelyConnectedClient{}, variantBackend)
-	require.NoError(t, err)
+	base := translator.TranslateBackendBase(context.Background(), variantBackend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error)
+	cluster := base.Cluster
 	require.NotNil(t, cluster)
 	require.NotNil(t, cluster.TransportSocket)
 

--- a/pkg/kgateway/translator/gateway/testutils/outputs/backends/priority_groups_aws_error.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/backends/priority_groups_aws_error.yaml
@@ -55,11 +55,6 @@ Clusters:
             hostname: nginx.nginx-shared.svc
           hostname: nginx.nginx-shared.svc
   name: backend_default_primary-nginx_0
-- loadAssignment:
-    clusterName: backend_default_priority-groups_0
-  metadata: {}
-  name: backend_default_priority-groups_0
-  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tlsroute-terminated-invalid.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/backendtlspolicy/tlsroute-terminated-invalid.yaml
@@ -1,9 +1,4 @@
 Clusters:
-- loadAssignment:
-    clusterName: kube_default_example-tls-svc_443
-  metadata: {}
-  name: kube_default_example-tls-svc_443
-  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -1,9 +1,4 @@
 Clusters:
-- loadAssignment:
-    clusterName: kube_gwtest_backend-service_443
-  metadata: {}
-  name: kube_gwtest_backend-service_443
-  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/standard/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -1,9 +1,4 @@
 Clusters:
-- loadAssignment:
-    clusterName: kube_gwtest_backend-service_443
-  metadata: {}
-  name: kube_gwtest_backend-service_443
-  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-cipher-suites-out.yaml
@@ -1,9 +1,4 @@
 Clusters:
-- loadAssignment:
-    clusterName: kube_gwtest_example-svc_80
-  metadata: {}
-  name: kube_gwtest_example-svc_80
-  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-missing-secret-out.yaml
@@ -1,9 +1,4 @@
 Clusters:
-- loadAssignment:
-    clusterName: kube_gwtest_backend-service_443
-  metadata: {}
-  name: kube_gwtest_backend-service_443
-  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/route-replacement/strict/backendconfigpolicy/invalid-tlsfiles-nonexistent-out.yaml
@@ -1,9 +1,4 @@
 Clusters:
-- loadAssignment:
-    clusterName: kube_gwtest_backend-service_443
-  metadata: {}
-  name: kube_gwtest_backend-service_443
-  type: STATIC
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
 Listeners:

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -1,8 +1,10 @@
 package irtranslator
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -46,54 +48,227 @@ type BackendTranslator struct {
 	Mode                apisettings.ValidationMode
 }
 
-// TranslateBackend translates a BackendObjectIR to an Envoy Cluster. If we encounter any
-// errors during translation, a blackhole cluster is returned along with the error. The error
-// return value is what matters as consumers (pkg/kgateway/proxy_syncer/perclient.go) will
-// drop errored clusters from the xDS snapshot and track them separately for status reporting.
-// The blackhole cluster itself is not sent to Envoy but provides a consistent return structure.
-func (t *BackendTranslator) TranslateBackend(
+// BaseCluster is the UCC-invariant result of translating a backend into an Envoy
+// cluster. The Cluster field is shared across all UCCs that target this backend —
+// callers MUST NOT mutate it. Per-client mutations layer on top via ApplyPerClient,
+// which clones before mutating.
+//
+// When Error is non-nil, Cluster is a blackhole cluster and all UCCs targeting this
+// backend should treat it as errored. There is no per-client variation when the base
+// is errored, so ApplyPerClient is a no-op in that case.
+type BaseCluster struct {
+	Cluster *envoyclusterv3.Cluster
+	// EndpointInputs carries inline endpoints from InitEnvoyBackend, if the backend
+	// produced any. Used by per-client overlay to build the inline CLA and to drive
+	// per-client endpoint hooks.
+	EndpointInputs *endpoints.EndpointsInputs
+	// SupportsInlineCLA is true when the cluster type accepts an inline
+	// ClusterLoadAssignment (STATIC, STRICT_DNS, LOGICAL_DNS, or the DNS extension).
+	// When this is true AND EndpointInputs is non-nil AND Cluster.LoadAssignment is
+	// nil, the per-client overlay must always build a CLA — the CLA varies per UCC
+	// via PrioritizeEndpoints and so cannot live on the shared base.
+	SupportsInlineCLA bool
+	// DefaultedLocalityConfig records that defaultLocalityConfig — not a policy
+	// plugin — chose this cluster's locality mode. Its guard depends on the cluster
+	// still being a kgateway-managed EDS cluster, which a per-client overlay can
+	// invalidate after the fact, so ApplyPerClient re-evaluates the guard and undoes
+	// the default when it no longer holds. Nothing else may be inferred from it: a
+	// false value means either "a policy chose the mode" or "no mode applies".
+	DefaultedLocalityConfig bool
+	Error                   error
+}
+
+// NeedsInlineCLA reports whether this base cluster is incomplete without a
+// per-client ClusterLoadAssignment: the cluster type takes an inline CLA, the
+// backend produced inline endpoints, and no plugin already set a LoadAssignment.
+// For such clusters ApplyPerClient always materializes a per-client cluster, and
+// the CLA-less base proto must be neither validated nor published as-is.
+func (b *BaseCluster) NeedsInlineCLA() bool {
+	return b != nil &&
+		b.Error == nil &&
+		b.SupportsInlineCLA &&
+		b.EndpointInputs != nil &&
+		b.Cluster.GetLoadAssignment() == nil
+}
+
+// TranslateBackendBase performs the UCC-invariant phase of cluster translation. The
+// returned BaseCluster can be shared across all UCCs targeting this backend.
+//
+// Returns nil only when the backend GK has no contributed translator at all — a
+// configuration error that prevents producing even a blackhole cluster.
+func (t *BackendTranslator) TranslateBackendBase(
 	ctx context.Context,
-	kctx krt.HandlerContext,
-	ucc ir.UniquelyConnectedClient,
 	backend *ir.BackendObjectIR,
-) (*envoyclusterv3.Cluster, error) {
-	// defensive checks that the backend is supported and has a plugin that can translate it.
+) *BaseCluster {
 	gk := backend.GetGroupKind()
 	process, ok := t.ContributedBackends[gk]
-	if !ok {
-		return nil, errors.New("no backend translator found for " + gk.String())
-	}
-	if process.InitEnvoyBackend == nil {
-		return nil, errors.New("no backend plugin found for " + gk.String())
+	if !ok || process.InitEnvoyBackend == nil {
+		return nil
 	}
 
-	// Check for pre-existing errors in the Backend IR before starting translation.
-	// Exit translation early if we have errors
 	if backend.Errors != nil {
 		logger.Error("backend has pre-existing errors", "backend", backend.GetName(), "errors", backend.Errors)
-		return buildBlackholeCluster(backend), errors.Join(backend.Errors...)
+		return &BaseCluster{
+			Cluster: buildBlackholeCluster(backend),
+			Error:   errors.Join(backend.Errors...),
+		}
 	}
 
-	// Initialize the cluster with minimal configuration
 	out := initializeCluster(backend)
 	inlineEps := process.InitEnvoyBackend(ctx, *backend, out)
 	processDnsLookupFamily(out, t.CommonCols)
 
-	// Apply policies to the computed cluster
-	if err := t.runPolicies(kctx, ctx, ucc, backend, inlineEps, out); err != nil {
+	// Apply non-per-client policies. Plugins with PerClientClusterOverlay run
+	// later in ApplyPerClient; plugins with ProcessBackend are UCC-invariant
+	// and run here once.
+	if err := t.applyBasePolicies(ctx, backend, out); err != nil {
 		logger.Error("failed to apply policies to cluster", "cluster", out.GetName(), "error", err)
-		return buildBlackholeCluster(backend), err
+		return &BaseCluster{Cluster: buildBlackholeCluster(backend), Error: err}
 	}
-	defaultLocalityConfig(out)
+	defaultedLocality := defaultLocalityConfig(out)
 	if err := applyGatewayBackendClientCertificate(out, backend); err != nil {
 		logger.Error("failed to apply gateway backend client certificate", "cluster", out.GetName(), "error", err)
-		return buildBlackholeCluster(backend), err
+		return &BaseCluster{Cluster: buildBlackholeCluster(backend), Error: err}
 	}
 
-	// In strict mode, validate the final cluster configuration using Envoy
-	if t.Mode == apisettings.ValidationStrict && t.Validator != nil {
+	var endpointInputs *endpoints.EndpointsInputs
+	if inlineEps != nil {
+		endpointInputs = &endpoints.EndpointsInputs{EndpointsForBackend: *inlineEps}
+		endpointInputs.EndpointsForBackend.AttachedPolicies = backend.AttachedPolicies
+	}
+
+	result := &BaseCluster{
+		Cluster:                 out,
+		EndpointInputs:          endpointInputs,
+		SupportsInlineCLA:       clusterSupportsInlineCLA(out),
+		DefaultedLocalityConfig: defaultedLocality,
+	}
+
+	// Skip strict-mode validation when the CLA is built per client: the base
+	// proto has no LoadAssignment yet, and Envoy rejects some CLA-less clusters
+	// outright (e.g. logical-DNS semantics require exactly one endpoint), which
+	// would blackhole a valid backend for every client. ApplyPerClient always
+	// materializes for these clusters and validates the complete per-client
+	// cluster, so nothing escapes validation.
+	if t.Mode == apisettings.ValidationStrict && t.Validator != nil && !result.NeedsInlineCLA() {
 		if err := t.validateClusterConfig(ctx, out); err != nil {
 			logger.Error("cluster failed xDS validation in strict mode", "cluster", out.GetName(), "error", err)
+			return &BaseCluster{Cluster: buildBlackholeCluster(backend), Error: err}
+		}
+	}
+
+	return result
+}
+
+// ApplyPerClient computes per-client cluster mutations on top of base. Returns nil
+// when the (ucc, backend) pair needs no per-client processing — callers must then
+// reference base.Cluster directly. When non-nil, the returned cluster is a freshly
+// allocated proto that callers may retain independently of base.Cluster.
+//
+// When base.Error is non-nil, this is a no-op (returns nil, nil).
+func (t *BackendTranslator) ApplyPerClient(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniquelyConnectedClient,
+	backend *ir.BackendObjectIR,
+	base *BaseCluster,
+) (*envoyclusterv3.Cluster, error) {
+	// A base error is terminal for every client — base.Cluster is already the blackhole,
+	// so there is nothing to overlay. It is deliberately not propagated: the base row is
+	// what carries it to status, and returning it here would attribute the same failure
+	// a second time, once per connected client.
+	if base == nil || base.Error != nil {
+		return nil, nil //nolint:nilerr // base.Error is reported by the base row, not per client
+	}
+
+	// Gather overlays. Each plugin must self-determine applicability and return
+	// nil in the common case; this keeps the per-client cluster collection sparse.
+	type overlayEntry struct {
+		gk schema.GroupKind
+		ov *sdk.ClusterOverlay
+	}
+	var overlays []overlayEntry
+	for gk, policyPlugin := range t.ContributedPolicies {
+		switch {
+		case policyPlugin.PerClientClusterOverlay != nil:
+			if ov := policyPlugin.PerClientClusterOverlay(kctx, ctx, ucc, *backend); ov != nil {
+				overlays = append(overlays, overlayEntry{gk: gk, ov: ov})
+			}
+		case policyPlugin.PerClientProcessBackend != nil: //nolint:staticcheck // compatibility boundary for legacy plugins
+			legacy := policyPlugin.PerClientProcessBackend //nolint:staticcheck // wrapped as an always-applicable overlay
+			overlays = append(overlays, overlayEntry{gk: gk, ov: &sdk.ClusterOverlay{
+				Mutate: func(out *envoyclusterv3.Cluster) {
+					legacy(kctx, ctx, ucc, *backend, out)
+				},
+			}})
+		}
+	}
+	// ContributedPolicies is a map, so gathering order is nondeterministic. When
+	// more than one overlay applies, apply in GroupKind order so the mutated proto
+	// (and therefore its version hash, which drives KRT equality and interning) is
+	// byte-stable across recomputes.
+	if len(overlays) > 1 {
+		slices.SortFunc(overlays, func(a, b overlayEntry) int {
+			if c := cmp.Compare(a.gk.Group, b.gk.Group); c != 0 {
+				return c
+			}
+			return cmp.Compare(a.gk.Kind, b.gk.Kind)
+		})
+	}
+
+	// Determine whether we need to build an inline CLA. Even with no overlays,
+	// inline-CLA clusters need a per-client CLA because PrioritizeEndpoints is
+	// UCC-dependent (locality, labels). This depends only on the base, not the UCC.
+	needsInlineCLA := base.NeedsInlineCLA()
+
+	if len(overlays) == 0 && !needsInlineCLA {
+		return nil, nil
+	}
+
+	// Materialize a per-client cluster. Clone is required because the base proto
+	// is shared across UCCs and must remain unmodified.
+	out, ok := proto.Clone(base.Cluster).(*envoyclusterv3.Cluster)
+	if !ok {
+		return nil, errors.New("failed to clone base cluster")
+	}
+
+	for _, entry := range overlays {
+		if entry.ov.Mutate != nil {
+			entry.ov.Mutate(out)
+		}
+	}
+
+	// Overlays can change the cluster shape out from under decisions the base made
+	// on the shape it saw, so re-evaluate those before the CLA and validation below.
+	if base.DefaultedLocalityConfig {
+		undoDefaultedLocalityConfig(out)
+	}
+
+	if needsInlineCLA {
+		// Gather endpoint plugins lazily — only inline-CLA clusters consume them,
+		// so the common EDS path (which returns early above) never pays for this.
+		// Resolve through the copy-on-write editor. Modern plugins clone only
+		// endpoint protos they modify; legacy raw mutators receive a one-time
+		// defensive deep copy of the entire nested input graph.
+		epIn, _ := ResolveEndpointInputs(kctx, ctx, ucc, *base.EndpointInputs, t.orderedEndpointPlugins())
+		// Re-check LoadAssignment: an overlay may have set it.
+		if out.GetLoadAssignment() == nil {
+			out.LoadAssignment = endpoints.PrioritizeEndpoints(logger, ucc, epIn)
+		}
+	}
+
+	// Strict-mode validation on the post-overlay cluster. Non-inline-CLA bases
+	// were already validated in TranslateBackendBase (inline-CLA bases defer
+	// validation to here, where the CLA exists), but overlays (destrule,
+	// waypoint, …) run here and can produce invalid configs that Envoy would
+	// NACK at runtime.
+	// We must reject them at translation time when the user opted into strict
+	// validation. Returning the blackhole keeps the same shape as base errors,
+	// so the snapshot consumer's erroredClusters tracking still works.
+	if t.Mode == apisettings.ValidationStrict && t.Validator != nil {
+		if err := t.validateClusterConfig(ctx, out); err != nil {
+			logger.Error("per-client cluster failed xDS validation in strict mode",
+				"cluster", out.GetName(), "ucc", ucc.ResourceName(), "error", err)
 			return buildBlackholeCluster(backend), err
 		}
 	}
@@ -106,22 +281,26 @@ func (t *BackendTranslator) TranslateBackend(
 // cluster_manager.local_cluster_name, and once the gateway fleet spans multiple
 // zones Envoy's implicit zone-aware defaults (routing_enabled 100%,
 // min_cluster_size 6) would otherwise engage with no policy configured.
-func defaultLocalityConfig(c *envoyclusterv3.Cluster) {
+//
+// Reports whether it set the specifier, so ApplyPerClient can undo it if a
+// per-client overlay later invalidates the EDS guard below. See
+// undoDefaultedLocalityConfig.
+func defaultLocalityConfig(c *envoyclusterv3.Cluster) bool {
 	if c.GetLoadBalancingPolicy() != nil {
 		// Typed load balancing policies carry their own locality_lb_config and
 		// ignore common_lb_config.locality_config_specifier (see the
 		// backendconfigpolicy plugin's buildTypedLocalityLbConfig).
-		return
+		return false
 	}
 	if c.GetCommonLbConfig().GetLocalityConfigSpecifier() != nil {
 		// A policy plugin already chose a locality mode.
-		return
+		return false
 	}
 	if c.GetEdsClusterConfig() == nil {
 		// Only kgateway-managed EDS clusters are guaranteed to carry locality
 		// load-balancing weights on their CLAs; leave plugin-provided inline
 		// clusters untouched.
-		return
+		return false
 	}
 	if c.CommonLbConfig == nil {
 		c.CommonLbConfig = &envoyclusterv3.Cluster_CommonLbConfig{}
@@ -129,37 +308,50 @@ func defaultLocalityConfig(c *envoyclusterv3.Cluster) {
 	c.CommonLbConfig.LocalityConfigSpecifier = &envoyclusterv3.Cluster_CommonLbConfig_LocalityWeightedLbConfig_{
 		LocalityWeightedLbConfig: &envoyclusterv3.Cluster_CommonLbConfig_LocalityWeightedLbConfig{},
 	}
+	return true
 }
 
-func (t *BackendTranslator) runPolicies(
-	kctx krt.HandlerContext,
+// undoDefaultedLocalityConfig removes the locality mode defaultLocalityConfig applied
+// to the base when a per-client overlay has since replaced the EDS cluster with a
+// plugin-provided inline one — the waypoint ingress redirect (STATIC cluster with an
+// inlined CLA) does exactly this.
+//
+// Before base/overlay translation was split, per-client hooks ran ahead of
+// defaultLocalityConfig, so its EDS guard saw the final cluster shape and skipped
+// these. Now the guard runs on the base, where the cluster is still EDS, and the
+// overlay invalidates it afterwards. Left in place, the cluster asks for locality
+// weighting while carrying a CLA whose LocalityLbEndpoints have no
+// load_balancing_weight — which Envoy rejects, and which strict-mode validation
+// turns into a blackholed cluster for every affected client.
+func undoDefaultedLocalityConfig(c *envoyclusterv3.Cluster) {
+	if c.GetEdsClusterConfig() != nil {
+		// Still an EDS cluster; the guard that admitted the default still holds.
+		return
+	}
+	if _, ok := c.GetCommonLbConfig().GetLocalityConfigSpecifier().(*envoyclusterv3.Cluster_CommonLbConfig_LocalityWeightedLbConfig_); !ok {
+		// An overlay replaced the specifier with its own choice. That is the
+		// overlay's call to make, so leave it alone.
+		return
+	}
+	c.CommonLbConfig.LocalityConfigSpecifier = nil
+	if proto.Equal(c.GetCommonLbConfig(), &envoyclusterv3.Cluster_CommonLbConfig{}) {
+		// defaultLocalityConfig allocated CommonLbConfig itself and nothing else
+		// ever populated it. Drop it so the emitted cluster is byte-identical to
+		// what the pre-split ordering produced.
+		c.CommonLbConfig = nil
+	}
+}
+
+// applyBasePolicies runs only the UCC-invariant ProcessBackend hooks. Per-client
+// hooks (PerClientClusterOverlay and endpoint editors) are handled by
+// ApplyPerClient.
+func (t *BackendTranslator) applyBasePolicies(
 	ctx context.Context,
-	ucc ir.UniquelyConnectedClient,
 	backend *ir.BackendObjectIR,
-	inlineEps *ir.EndpointsForBackend,
 	out *envoyclusterv3.Cluster,
 ) error {
-	// if the backend was initialized with inlineEps then we
-	// need an EndpointsInputs to run plugins against
-	var endpointInputs *endpoints.EndpointsInputs
-	if inlineEps != nil {
-		endpointInputs = &endpoints.EndpointsInputs{
-			EndpointsForBackend: *inlineEps,
-		}
-		endpointInputs.EndpointsForBackend.AttachedPolicies = backend.AttachedPolicies
-	}
-
 	var errs []error
 	for gk, policyPlugin := range t.ContributedPolicies {
-		// TODO: in theory it would be nice to do `ProcessBackend` once, and only do
-		// the the per-client processing for each client.
-		// that would require refactoring and thinking about the proper IR, so we'll punt on that for
-		// now, until we have more backend plugin examples to properly understand what it should look
-		// like.
-		if policyPlugin.PerClientProcessBackend != nil {
-			policyPlugin.PerClientProcessBackend(kctx, ctx, ucc, *backend, out)
-		}
-		// if the policy plugin has no ProcessBackend function, skip it
 		if policyPlugin.ProcessBackend == nil {
 			continue
 		}
@@ -167,8 +359,6 @@ func (t *BackendTranslator) runPolicies(
 		if policyPlugin.MergePolicies != nil && len(policies) > 0 {
 			policies = []ir.PolicyAtt{policyPlugin.MergePolicies(policies)}
 		}
-		// apply plugins to the backend. we want to skip applying the plugin if the
-		// attached IR encountered any errors during construction.
 		for _, polAttachment := range policies {
 			if len(polAttachment.Errors) > 0 {
 				logger.Error("policy has errors", "gk", gk, "errors", polAttachment.Errors, "policyRef", polAttachment.PolicyRef)
@@ -178,22 +368,6 @@ func (t *BackendTranslator) runPolicies(
 			policyPlugin.ProcessBackend(ctx, polAttachment.PolicyIr, *backend, out)
 		}
 	}
-
-	if endpointInputs != nil {
-		resolved, _ := ResolveEndpointInputs(kctx, ctx, ucc, *endpointInputs, t.orderedEndpointPlugins())
-		endpointInputs = &resolved
-	}
-
-	// for clusters that want a CLA _and_ initialized with inlineEps, build the CLA.
-	// never overwrite the CLA that was already initialized (potentially within a plugin).
-	if out.GetLoadAssignment() == nil && endpointInputs != nil && clusterSupportsInlineCLA(out) {
-		out.LoadAssignment = endpoints.PrioritizeEndpoints(
-			logger,
-			ucc,
-			*endpointInputs,
-		)
-	}
-
 	return errors.Join(errs...)
 }
 

--- a/pkg/kgateway/translator/irtranslator/backend_bench_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_bench_test.go
@@ -197,4 +197,3 @@ func BenchmarkPerClientClusters(b *testing.B) {
 		}
 	}
 }
-

--- a/pkg/kgateway/translator/irtranslator/backend_bench_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_bench_test.go
@@ -1,0 +1,200 @@
+package irtranslator
+
+// White-box benchmark (internal package) comparing the per-client cluster fan-out before and after
+// the base+overlay refactor.
+//
+//	Old: full translation per (backend, client) pair, in place — no base cache, no clone, no fast
+//	     path. This faithfully reconstructs the former monolithic translation body.
+//	New: base translated once per backend (TranslateBackendBase), then a cheap per-client overlay
+//	     (ApplyPerClient) per pair. When no overlay applies, ApplyPerClient returns nil and the
+//	     caller shares the base proto — the dominant path for a sparsely-matched destination rule.
+//
+// Swept across Istio off/on (whether a per-client overlay plugin is registered) and light/heavy
+// backends (how expensive the client-independent base translation is). The delta scales with the
+// number of (backend, client) pairs and with how sparsely the per-client overlay actually matches.
+//
+// Run with:
+//
+//	go test -run=^$ -bench=BenchmarkPerClientClusters -benchmem \
+//	    ./pkg/kgateway/translator/irtranslator/
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+const (
+	benchNumBackends = 200
+	benchNumClients  = 20
+)
+
+var benchGK = schema.GroupKind{Group: "bench", Kind: "Backend"}
+
+// benchSink prevents the compiler from optimizing away the translated clusters.
+var benchSink *envoyclusterv3.Cluster
+
+func benchInit(heavy bool) func(context.Context, ir.BackendObjectIR, *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+	return func(_ context.Context, _ ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+		out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}
+		out.EdsClusterConfig = &envoyclusterv3.Cluster_EdsClusterConfig{
+			EdsConfig: &envoycorev3.ConfigSource{
+				ConfigSourceSpecifier: &envoycorev3.ConfigSource_Ads{Ads: &envoycorev3.AggregatedConfigSource{}},
+			},
+		}
+		if heavy {
+			// Simulate a TLS backend: a proto marshal as part of base translation.
+			if tlsAny, err := utils.MessageToAny(&envoytlsv3.UpstreamTlsContext{Sni: out.GetName()}); err == nil {
+				out.TransportSocket = &envoycorev3.TransportSocket{
+					Name:       "envoy.transport_sockets.tls",
+					ConfigType: &envoycorev3.TransportSocket_TypedConfig{TypedConfig: tlsAny},
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func benchTranslator(istioOn, heavy bool) *BackendTranslator {
+	t := &BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			benchGK: {InitEnvoyBackend: benchInit(heavy)},
+		},
+		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{},
+		// Mode left as zero value (non-strict): validation is skipped, matching the default deployment.
+	}
+	if istioOn {
+		// A destination-rule-like per-client overlay: it only mutates clients whose label matches
+		// (a "destination rule" is present) and self-gates by returning nil for everyone else, so
+		// the translator can skip the per-client clone entirely for non-matching pairs.
+		t.ContributedPolicies[benchGK] = sdk.PolicyPlugin{
+			PerClientClusterOverlay: func(_ krt.HandlerContext, _ context.Context, ucc ir.UniquelyConnectedClient, _ ir.BackendObjectIR) *sdk.ClusterOverlay {
+				if ucc.Labels["bench-mutate"] != "yes" {
+					return nil
+				}
+				return &sdk.ClusterOverlay{
+					Mutate: func(out *envoyclusterv3.Cluster) {
+						out.OutlierDetection = &envoyclusterv3.OutlierDetection{}
+					},
+				}
+			},
+		}
+	}
+	return t
+}
+
+func benchBackends(n int) []*ir.BackendObjectIR {
+	out := make([]*ir.BackendObjectIR, n)
+	for i := range n {
+		b := ir.NewBackendObjectIR(ir.ObjectSource{
+			Group:     "bench",
+			Kind:      "Backend",
+			Namespace: "default",
+			Name:      fmt.Sprintf("b%d", i),
+		}, 8080, "", "")
+		out[i] = &b
+	}
+	return out
+}
+
+func benchUCCs(m int) []ir.UniquelyConnectedClient {
+	out := make([]ir.UniquelyConnectedClient, m)
+	for i := range m {
+		// Model sparse destination-rule matching: only ~1 in 10 clients is targeted by a DR.
+		mutate := "no"
+		if i%10 == 0 {
+			mutate = "yes"
+		}
+		out[i] = ir.NewUniquelyConnectedClient(
+			fmt.Sprintf("role%d", i),
+			"default",
+			map[string]string{"bench-mutate": mutate, "idx": strconv.Itoa(i)},
+			ir.PodLocality{Region: "r", Zone: fmt.Sprintf("z%d", i%3)},
+		)
+	}
+	return out
+}
+
+// legacyTranslate reconstructs the pre-refactor per-pair translation: a full, in-place translation
+// for every (backend, client), with no base caching, no clone, and no fast path. The benchmark uses
+// EDS backends (benchInit returns nil inline endpoints), so the inline-CLA branch is intentionally
+// omitted here — it would be dead code for this input and is identically absent on the New path.
+func (t *BackendTranslator) legacyTranslate(ctx context.Context, kctx krt.HandlerContext, ucc ir.UniquelyConnectedClient, backend *ir.BackendObjectIR) *envoyclusterv3.Cluster {
+	process := t.ContributedBackends[backend.GetGroupKind()]
+	out := initializeCluster(backend)
+	process.InitEnvoyBackend(ctx, *backend, out)
+	processDnsLookupFamily(out, t.CommonCols)
+	_ = t.applyBasePolicies(ctx, backend, out)
+	// Per-client overlays applied in place, once per pair — the pre-refactor behavior.
+	for _, policyPlugin := range t.ContributedPolicies {
+		if policyPlugin.PerClientClusterOverlay == nil {
+			continue
+		}
+		if ov := policyPlugin.PerClientClusterOverlay(kctx, ctx, ucc, *backend); ov != nil && ov.Mutate != nil {
+			ov.Mutate(out)
+		}
+	}
+	_ = applyGatewayBackendClientCertificate(out, backend)
+	return out
+}
+
+func benchmarkPerClientClusters(b *testing.B, istioOn, heavy bool) {
+	t := benchTranslator(istioOn, heavy)
+	backends := benchBackends(benchNumBackends)
+	uccs := benchUCCs(benchNumClients)
+	ctx := context.Background()
+	var kctx krt.TestingDummyContext
+
+	b.Run("Old", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			for _, backend := range backends {
+				for _, ucc := range uccs {
+					benchSink = t.legacyTranslate(ctx, kctx, ucc, backend)
+				}
+			}
+		}
+	})
+
+	b.Run("New", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			bases := make([]*BaseCluster, len(backends))
+			for j, backend := range backends {
+				bases[j] = t.TranslateBackendBase(ctx, backend)
+			}
+			for j, backend := range backends {
+				for _, ucc := range uccs {
+					c, _ := t.ApplyPerClient(kctx, ctx, ucc, backend, bases[j])
+					if c == nil {
+						// Fast path: no per-client variation, the base proto is shared.
+						c = bases[j].Cluster
+					}
+					benchSink = c
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkPerClientClusters(b *testing.B) {
+	for _, istioOn := range []bool{false, true} {
+		for _, heavy := range []bool{false, true} {
+			b.Run(fmt.Sprintf("istio=%v/heavy=%v", istioOn, heavy), func(b *testing.B) {
+				benchmarkPerClientClusters(b, istioOn, heavy)
+			})
+		}
+	}
+}
+

--- a/pkg/kgateway/translator/irtranslator/backend_overlay_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_overlay_test.go
@@ -418,4 +418,3 @@ func pipeEndpoint(path string) *envoyendpointv3.LbEndpoint {
 		},
 	}
 }
-

--- a/pkg/kgateway/translator/irtranslator/backend_overlay_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_overlay_test.go
@@ -1,0 +1,421 @@
+package irtranslator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/endpoints"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/translator/irtranslator"
+	sdk "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+// edsBackendTranslator returns a translator whose single backend produces a
+// plain EDS cluster (no inline endpoints) plus the supplied per-client policy
+// plugins keyed by their GroupKind.
+func edsBackendTranslator(policies map[schema.GroupKind]sdk.PolicyPlugin) *irtranslator.BackendTranslator {
+	bt := &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			{Group: "group", Kind: "kind"}: {
+				InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+					out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}
+					return nil
+				},
+			},
+		},
+		ContributedPolicies: policies,
+	}
+	return bt
+}
+
+func overlayBackend() *ir.BackendObjectIR {
+	b := newTestBackend(ir.ObjectSource{Group: "group", Kind: "kind", Name: "name", Namespace: "ns"}, 80)
+	b.AttachedPolicies = ir.AttachedPolicies{Policies: map[schema.GroupKind][]ir.PolicyAtt{}}
+	return b
+}
+
+// TestApplyPerClient_FastPathSharesBase: when no plugin contributes an overlay
+// and the cluster does not need an inline CLA, ApplyPerClient returns nil so the
+// caller shares the (read-only) base proto. This is the dominant path that keeps
+// the per-client cluster collection sparse.
+func TestApplyPerClient_FastPathSharesBase(t *testing.T) {
+	bt := edsBackendTranslator(map[schema.GroupKind]sdk.PolicyPlugin{})
+	backend := overlayBackend()
+	ctx := context.Background()
+
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error)
+
+	perClient, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, ir.UniquelyConnectedClient{}, backend, base)
+	require.NoError(t, err)
+	assert.Nil(t, perClient, "no overlay and no inline CLA must take the fast path (nil => share base)")
+}
+
+// TestApplyPerClient_DoesNotMutateBase is the central copy-on-write guard. An
+// overlay that mutates the cluster for a matching UCC must not touch the shared
+// base proto, and must return a distinct proto carrying the mutation. A second
+// UCC the overlay declines (returns nil) takes the fast path and shares the base.
+func TestApplyPerClient_DoesNotMutateBase(t *testing.T) {
+	overlayGK := schema.GroupKind{Group: "test", Kind: "Overlay"}
+	bt := edsBackendTranslator(map[schema.GroupKind]sdk.PolicyPlugin{
+		overlayGK: {
+			PerClientClusterOverlay: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
+				if ucc.Labels["match"] != "yes" {
+					return nil
+				}
+				return &sdk.ClusterOverlay{
+					Mutate: func(out *envoyclusterv3.Cluster) {
+						out.OutlierDetection = &envoyclusterv3.OutlierDetection{}
+					},
+				}
+			},
+		},
+	})
+	backend := overlayBackend()
+	ctx := context.Background()
+
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error)
+	require.Nil(t, base.Cluster.GetOutlierDetection(), "base must start without the overlay mutation")
+
+	matching := ir.NewUniquelyConnectedClient("role", "ns", map[string]string{"match": "yes"}, ir.PodLocality{})
+	other := ir.NewUniquelyConnectedClient("role", "ns", map[string]string{"match": "no"}, ir.PodLocality{})
+
+	matched, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, matching, backend, base)
+	require.NoError(t, err)
+	require.NotNil(t, matched)
+	assert.NotSame(t, base.Cluster, matched, "matching client must get its own proto, not the shared base")
+	assert.NotNil(t, matched.GetOutlierDetection(), "overlay mutation must land on the returned proto")
+
+	// The base proto must remain pristine after the overlay ran.
+	assert.Nil(t, base.Cluster.GetOutlierDetection(), "overlay must not mutate the shared base proto")
+
+	// A client the overlay declines shares the base (fast path).
+	declined, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, other, backend, base)
+	require.NoError(t, err)
+	assert.Nil(t, declined, "non-matching client must take the fast path and share the base")
+}
+
+// TestApplyPerClient_BaseErrorIsNoOp: when the base is errored there is no
+// per-client variation to compute — ApplyPerClient is a no-op so every client
+// shares the single blackhole/error recorded on the base.
+func TestApplyPerClient_BaseErrorIsNoOp(t *testing.T) {
+	overlayGK := schema.GroupKind{Group: "test", Kind: "Overlay"}
+	overlayCalls := 0
+	bt := edsBackendTranslator(map[schema.GroupKind]sdk.PolicyPlugin{
+		overlayGK: {
+			PerClientClusterOverlay: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
+				overlayCalls++
+				return &sdk.ClusterOverlay{Mutate: func(out *envoyclusterv3.Cluster) {}}
+			},
+		},
+	})
+	backend := overlayBackend()
+
+	erroredBase := &irtranslator.BaseCluster{
+		Cluster: &envoyclusterv3.Cluster{Name: backend.ClusterName()},
+		Error:   errors.New("base boom"),
+	}
+	perClient, err := bt.ApplyPerClient(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{}, backend, erroredBase)
+	require.NoError(t, err)
+	assert.Nil(t, perClient, "errored base must short-circuit to a no-op")
+	assert.Equal(t, 0, overlayCalls, "overlays must not run for an errored base")
+}
+
+// TestApplyPerClient_InlineCLAMaterializesAndIsolatesBaseEndpoints exercises the
+// inline-CLA path: a STRICT_DNS backend with inline endpoints and no overlay
+// must still materialize a per-client cluster (the CLA is UCC-dependent via
+// PrioritizeEndpoints). It must build the LoadAssignment without mutating either
+// the base cluster proto or the base EndpointInputs that a per-client endpoint
+// hook writes to.
+func TestApplyPerClient_InlineCLAMaterializesAndIsolatesBaseEndpoints(t *testing.T) {
+	endpointGK := schema.GroupKind{Group: "test", Kind: "Endpoints"}
+	bt := &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			{Group: "group", Kind: "kind"}: {
+				InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+					out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_STRICT_DNS}
+					eps := ir.NewEndpointsForBackend(in)
+					eps.Add(ir.PodLocality{Region: "r1"}, ir.EndpointWithMd{LbEndpoint: pipeEndpoint("a")})
+					return eps
+				},
+			},
+		},
+		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
+			endpointGK: {
+				// Mimics destrule: writes PriorityInfo onto the per-client inputs.
+				PerClientEditEndpoints: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, out sdk.EndpointInputsEditor) uint64 {
+					out.SetPriorityInfo(&endpoints.PriorityInfo{})
+					return 1
+				},
+			},
+		},
+	}
+	backend := overlayBackend()
+	ctx := context.Background()
+
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error)
+	require.True(t, base.SupportsInlineCLA, "STRICT_DNS cluster must support an inline CLA")
+	require.NotNil(t, base.EndpointInputs)
+	require.Nil(t, base.Cluster.GetLoadAssignment(), "base must not carry a per-client LoadAssignment")
+	require.Nil(t, base.EndpointInputs.PriorityInfo, "base EndpointInputs must start without PriorityInfo")
+
+	uccA := ir.NewUniquelyConnectedClient("a", "ns", nil, ir.PodLocality{Region: "r1"})
+	uccB := ir.NewUniquelyConnectedClient("b", "ns", nil, ir.PodLocality{Region: "r2"})
+
+	clusterA, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, uccA, backend, base)
+	require.NoError(t, err)
+	require.NotNil(t, clusterA, "inline-CLA backend must materialize a per-client cluster even with no overlay")
+	assert.NotNil(t, clusterA.GetLoadAssignment(), "per-client cluster must carry the built LoadAssignment")
+	assert.NotSame(t, base.Cluster, clusterA)
+
+	// Base must remain pristine: neither the proto nor the EndpointInputs the
+	// endpoint hook wrote to may be mutated by the overlay.
+	assert.Nil(t, base.Cluster.GetLoadAssignment(), "inline-CLA build must not mutate the shared base proto")
+	assert.Nil(t, base.EndpointInputs.PriorityInfo,
+		"the endpoint editor must leave base EndpointInputs untouched")
+
+	clusterB, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, uccB, backend, base)
+	require.NoError(t, err)
+	require.NotNil(t, clusterB)
+	assert.NotSame(t, clusterA, clusterB, "each client must get an independent inline-CLA proto")
+}
+
+func TestApplyPerClient_LegacyEndpointPluginDeepCopiesNestedInputs(t *testing.T) {
+	endpointGK := schema.GroupKind{Group: "test", Kind: "LegacyEndpoints"}
+	locality := ir.PodLocality{Region: "r1"}
+	bt := &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			{Group: "group", Kind: "kind"}: {
+				InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+					out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_STRICT_DNS}
+					eps := ir.NewEndpointsForBackend(in)
+					eps.BackendLabels = map[string]string{"owner": "base"}
+					eps.Add(locality, endpointWithLabels("10.0.0.1", map[string]string{"owner": "base"}))
+					return eps
+				},
+			},
+		},
+		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{
+			endpointGK: {
+				PerClientProcessEndpoints: func(_ krt.HandlerContext, _ context.Context, ucc ir.UniquelyConnectedClient, out *sdk.EndpointsInputs) uint64 {
+					if ucc.Role != "mutate" {
+						return 0
+					}
+					out.EndpointsForBackend.BackendLabels["owner"] = "mutated"
+					out.EndpointsForBackend.LbEps[locality][0].EndpointMd.Labels["owner"] = "mutated"
+					out.EndpointsForBackend.LbEps[locality][0].GetEndpoint().GetAddress().GetSocketAddress().Address = "127.0.0.1"
+					return 1
+				},
+			},
+		},
+	}
+	backend := overlayBackend()
+	base := bt.TranslateBackendBase(context.Background(), backend)
+	require.NotNil(t, base)
+	require.NotNil(t, base.EndpointInputs)
+
+	mutated, err := bt.ApplyPerClient(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{Role: "mutate"}, backend, base)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", mutated.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+
+	assert.Equal(t, "base", base.EndpointInputs.EndpointsForBackend.BackendLabels["owner"])
+	assert.Equal(t, "base", base.EndpointInputs.EndpointsForBackend.LbEps[locality][0].EndpointMd.Labels["owner"])
+	assert.Equal(t, "10.0.0.1", base.EndpointInputs.EndpointsForBackend.LbEps[locality][0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+
+	pristine, err := bt.ApplyPerClient(krt.TestingDummyContext{}, context.Background(), ir.UniquelyConnectedClient{Role: "pristine"}, backend, base)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.1", pristine.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+}
+
+// TestTranslateBackendBase_NilForUnsupportedGroupKind: a backend whose GroupKind
+// has no contributed translator cannot produce even a blackhole base cluster.
+func TestTranslateBackendBase_NilForUnsupportedGroupKind(t *testing.T) {
+	bt := &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{},
+		ContributedPolicies: map[schema.GroupKind]sdk.PolicyPlugin{},
+	}
+	backend := overlayBackend()
+
+	base := bt.TranslateBackendBase(context.Background(), backend)
+	assert.Nil(t, base, "unsupported GroupKind must yield a nil base")
+}
+
+// edsWithConfigBackendTranslator mirrors what a real EDS backend plugin (e.g.
+// kubernetes) emits: the discovery type AND an EdsClusterConfig. The latter is what
+// defaultLocalityConfig gates on, so it is required to exercise that path.
+func edsWithConfigBackendTranslator(policies map[schema.GroupKind]sdk.PolicyPlugin) *irtranslator.BackendTranslator {
+	return &irtranslator.BackendTranslator{
+		ContributedBackends: map[schema.GroupKind]ir.BackendInit{
+			{Group: "group", Kind: "kind"}: {
+				InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+					out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS}
+					out.EdsClusterConfig = &envoyclusterv3.Cluster_EdsClusterConfig{
+						EdsConfig: &envoycorev3.ConfigSource{
+							ConfigSourceSpecifier: &envoycorev3.ConfigSource_Ads{Ads: &envoycorev3.AggregatedConfigSource{}},
+						},
+					}
+					return nil
+				},
+			},
+		},
+		ContributedPolicies: policies,
+	}
+}
+
+// inlineRedirectOverlay mimics the waypoint ingress redirect: it converts the EDS
+// cluster into a STATIC one with an inlined CLA whose LocalityLbEndpoints carry no
+// load_balancing_weight — exactly the shape that cannot coexist with locality
+// weighted LB.
+func inlineRedirectOverlay(gk schema.GroupKind) map[schema.GroupKind]sdk.PolicyPlugin {
+	return map[schema.GroupKind]sdk.PolicyPlugin{
+		gk: {
+			PerClientClusterOverlay: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
+				return &sdk.ClusterOverlay{
+					Mutate: func(out *envoyclusterv3.Cluster) {
+						out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_STATIC}
+						out.EdsClusterConfig = nil
+						out.LoadAssignment = &envoyendpointv3.ClusterLoadAssignment{
+							ClusterName: out.GetName(),
+							Endpoints: []*envoyendpointv3.LocalityLbEndpoints{
+								{LbEndpoints: []*envoyendpointv3.LbEndpoint{pipeEndpoint("redirect")}},
+							},
+						}
+					},
+				}
+			},
+		},
+	}
+}
+
+// TestApplyPerClient_UndoesDefaultedLocalityOnInlineOverlay is the ordering
+// regression guard for the base/overlay split. defaultLocalityConfig declines to
+// touch plugin-provided inline clusters because their CLAs carry no per-locality
+// load_balancing_weight, and Envoy rejects locality weighted LB without it. Before
+// the split, per-client hooks ran first, so that guard saw the final cluster. Now the
+// guard runs on the still-EDS base, so an overlay that inlines the CLA afterwards
+// must undo the default rather than ship a cluster Envoy will reject.
+func TestApplyPerClient_UndoesDefaultedLocalityOnInlineOverlay(t *testing.T) {
+	overlayGK := schema.GroupKind{Group: "test", Kind: "Overlay"}
+	bt := edsWithConfigBackendTranslator(inlineRedirectOverlay(overlayGK))
+	backend := overlayBackend()
+	ctx := context.Background()
+
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error)
+	require.True(t, base.DefaultedLocalityConfig, "an EDS base with no LB policy must get the locality default")
+	require.NotNil(t, base.Cluster.GetCommonLbConfig().GetLocalityWeightedLbConfig(),
+		"precondition: the base carries the defaulted locality mode")
+
+	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
+	perClient, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, ucc, backend, base)
+	require.NoError(t, err)
+	require.NotNil(t, perClient, "the overlay applies, so a per-client cluster must materialize")
+
+	require.NotNil(t, perClient.GetLoadAssignment(), "precondition: the overlay inlined a CLA")
+	require.Nil(t, perClient.GetEdsClusterConfig(), "precondition: the overlay dropped EDS")
+	assert.Nil(t, perClient.GetCommonLbConfig().GetLocalityConfigSpecifier(),
+		"locality weighting must not survive onto an inlined CLA with no load_balancing_weight")
+	assert.Nil(t, perClient.GetCommonLbConfig(),
+		"CommonLbConfig was allocated only to hold the default, so it must not be emitted empty")
+
+	assert.NotNil(t, base.Cluster.GetCommonLbConfig().GetLocalityWeightedLbConfig(),
+		"undoing the default must not reach back into the shared base")
+}
+
+// TestApplyPerClient_KeepsDefaultedLocalityWhenStillEDS is the other half: an
+// overlay that leaves the cluster EDS keeps the defaulted locality mode, so the undo
+// above cannot regress the ordinary per-client path.
+func TestApplyPerClient_KeepsDefaultedLocalityWhenStillEDS(t *testing.T) {
+	overlayGK := schema.GroupKind{Group: "test", Kind: "Overlay"}
+	bt := edsWithConfigBackendTranslator(map[schema.GroupKind]sdk.PolicyPlugin{
+		overlayGK: {
+			PerClientClusterOverlay: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
+				return &sdk.ClusterOverlay{
+					Mutate: func(out *envoyclusterv3.Cluster) {
+						out.OutlierDetection = &envoyclusterv3.OutlierDetection{}
+					},
+				}
+			},
+		},
+	})
+	backend := overlayBackend()
+	ctx := context.Background()
+
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.True(t, base.DefaultedLocalityConfig)
+
+	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
+	perClient, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, ucc, backend, base)
+	require.NoError(t, err)
+	require.NotNil(t, perClient)
+
+	assert.NotNil(t, perClient.GetCommonLbConfig().GetLocalityWeightedLbConfig(),
+		"a cluster that is still EDS must keep the defaulted locality mode")
+}
+
+// TestApplyPerClient_LeavesOverlayChosenLocalityMode: the undo is scoped to the mode
+// defaultLocalityConfig itself installed. An overlay that inlines the CLA and picks
+// its own locality mode has made a deliberate choice, which must survive.
+func TestApplyPerClient_LeavesOverlayChosenLocalityMode(t *testing.T) {
+	overlayGK := schema.GroupKind{Group: "test", Kind: "Overlay"}
+	bt := edsWithConfigBackendTranslator(map[schema.GroupKind]sdk.PolicyPlugin{
+		overlayGK: {
+			PerClientClusterOverlay: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
+				return &sdk.ClusterOverlay{
+					Mutate: func(out *envoyclusterv3.Cluster) {
+						out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_STATIC}
+						out.EdsClusterConfig = nil
+						out.CommonLbConfig = &envoyclusterv3.Cluster_CommonLbConfig{
+							LocalityConfigSpecifier: &envoyclusterv3.Cluster_CommonLbConfig_ZoneAwareLbConfig_{
+								ZoneAwareLbConfig: &envoyclusterv3.Cluster_CommonLbConfig_ZoneAwareLbConfig{},
+							},
+						}
+					},
+				}
+			},
+		},
+	})
+	backend := overlayBackend()
+	ctx := context.Background()
+
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.True(t, base.DefaultedLocalityConfig)
+
+	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
+	perClient, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, ucc, backend, base)
+	require.NoError(t, err)
+	require.NotNil(t, perClient)
+
+	assert.NotNil(t, perClient.GetCommonLbConfig().GetZoneAwareLbConfig(),
+		"an overlay's own locality choice must not be undone")
+}
+
+func pipeEndpoint(path string) *envoyendpointv3.LbEndpoint {
+	return &envoyendpointv3.LbEndpoint{
+		HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
+			Endpoint: &envoyendpointv3.Endpoint{
+				Address: &envoycorev3.Address{
+					Address: &envoycorev3.Address_Pipe{Pipe: &envoycorev3.Pipe{Path: path}},
+				},
+			},
+		},
+	}
+}
+

--- a/pkg/kgateway/translator/irtranslator/backend_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_test.go
@@ -34,10 +34,15 @@ func newTestBackend(objSrc ir.ObjectSource, port int32) *ir.BackendObjectIR {
 	return &backend
 }
 
+func translateBackendBase(t *testing.T, bt *irtranslator.BackendTranslator, backend *ir.BackendObjectIR) (*envoyclusterv3.Cluster, error) {
+	t.Helper()
+	base := bt.TranslateBackendBase(t.Context(), backend)
+	require.NotNil(t, base)
+	return base.Cluster, base.Error
+}
+
 func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 	var bt irtranslator.BackendTranslator
-	var ucc ir.UniquelyConnectedClient
-	var kctx krt.TestingDummyContext
 	backend := newTestBackend(ir.ObjectSource{
 		Group:     "group",
 		Kind:      "kind",
@@ -53,7 +58,7 @@ func TestBackendTranslatorTranslatesAppProtocol(t *testing.T) {
 		},
 	}
 
-	c, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+	c, err := translateBackendBase(t, &bt, backend)
 	require.NoError(t, err)
 	opts := c.GetTypedExtensionProtocolOptions()["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
 	assert.NotNil(t, opts)
@@ -97,10 +102,7 @@ func TestBackendTranslatorAppliesDnsLookupFamilyToDnsCluster(t *testing.T) {
 	}
 	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{}
 
-	var ucc ir.UniquelyConnectedClient
-	var kctx krt.TestingDummyContext
-
-	cluster, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+	cluster, err := translateBackendBase(t, &bt, backend)
 	require.NoError(t, err)
 
 	clusterType := cluster.GetClusterType()
@@ -139,10 +141,8 @@ func TestBackendTranslatorHandlesBackendIRErrors(t *testing.T) {
 	}
 	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{}
 
-	var ucc ir.UniquelyConnectedClient
-	var kctx krt.TestingDummyContext
 	// Validate that the backend IR errors are propagated.
-	cluster, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+	cluster, err := translateBackendBase(t, &bt, backend)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid backend hostname")
 	assert.Contains(t, err.Error(), "unsupported backend protocol")
@@ -208,9 +208,7 @@ func TestBackendTranslatorPropagatesPolicyErrors(t *testing.T) {
 		},
 	}
 
-	var ucc ir.UniquelyConnectedClient
-	var kctx krt.TestingDummyContext
-	cluster, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+	cluster, err := translateBackendBase(t, &bt, backend)
 	// Validate that the policy errors are propagated.
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid TLS certificate")
@@ -262,9 +260,7 @@ func TestBackendTranslatorHandlesXDSValidationErrors(t *testing.T) {
 	bt.Mode = apisettings.ValidationStrict
 	bt.Validator = mockValidator
 
-	var ucc ir.UniquelyConnectedClient
-	var kctx krt.TestingDummyContext
-	cluster, err := bt.TranslateBackend(context.Background(), kctx, ucc, backend)
+	cluster, err := translateBackendBase(t, &bt, backend)
 
 	// Should get an error because xDS validation failed
 	require.Error(t, err)
@@ -333,7 +329,7 @@ func TestBackendTranslatorAppliesGatewayBackendClientCertificate(t *testing.T) {
 		},
 	}
 
-	cluster, err := bt.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ir.UniquelyConnectedClient{}, backend)
+	cluster, err := translateBackendBase(t, &bt, backend)
 	require.NoError(t, err)
 	require.NotNil(t, cluster)
 	require.NotNil(t, cluster.TransportSocket)
@@ -373,7 +369,7 @@ func TestBackendTranslatorDoesNotEnableTLSForGatewayBackendClientCertificate(t *
 	}
 	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{}
 
-	cluster, err := bt.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ir.UniquelyConnectedClient{}, backend)
+	cluster, err := translateBackendBase(t, &bt, backend)
 	require.NoError(t, err)
 	require.NotNil(t, cluster)
 	assert.Nil(t, cluster.TransportSocket)
@@ -452,7 +448,7 @@ func TestBackendTranslatorAppliesGatewayBackendClientCertificateToTransportSocke
 		},
 	}
 
-	cluster, err := bt.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ir.UniquelyConnectedClient{}, backend)
+	cluster, err := translateBackendBase(t, &bt, backend)
 	require.NoError(t, err)
 	require.NotNil(t, cluster)
 	require.Nil(t, cluster.TransportSocket)
@@ -491,4 +487,196 @@ func (t *testPolicyIR) CreationTime() time.Time {
 func (t *testPolicyIR) Equals(other any) bool {
 	_, ok := other.(*testPolicyIR)
 	return ok
+}
+
+// TestApplyPerClient_StrictModeRejectsInvalidOverlay is a regression test for
+// the strict-mode bypass: PerClientClusterOverlay hooks (destrule, waypoint,
+// …) mutate the cluster AFTER TranslateBackendBase has validated it. Without
+// per-client validation, invalid overlay output would only surface as Envoy
+// NACKs at the data plane. The fix runs strict-mode validation on the
+// post-overlay cluster too. This test:
+//
+//  1. Sets up a translator where the validator rejects only clusters that have
+//     an OutlierDetection set (the marker of our test overlay).
+//  2. Translates the base — passes validation (no outlier).
+//  3. Calls ApplyPerClient with an overlay that sets OutlierDetection.
+//  4. Asserts the result is an error + the blackhole cluster.
+func TestApplyPerClient_StrictModeRejectsInvalidOverlay(t *testing.T) {
+	backendIR := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "core",
+		Kind:      "Service",
+		Name:      "svc",
+		Namespace: "ns",
+	}, 80, "", "")
+	backendIR.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{},
+	}
+	backend := &backendIR
+
+	overlayGK := schema.GroupKind{Group: "test", Kind: "DestructiveOverlay"}
+
+	var bt irtranslator.BackendTranslator
+	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
+		{Group: "core", Kind: "Service"}: {
+			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+				return nil
+			},
+		},
+	}
+	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{
+		overlayGK: {
+			PerClientClusterOverlay: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
+				return &sdk.ClusterOverlay{
+					Mutate: func(out *envoyclusterv3.Cluster) {
+						out.OutlierDetection = &envoyclusterv3.OutlierDetection{}
+					},
+				}
+			},
+		},
+	}
+	bt.Mode = apisettings.ValidationStrict
+	bt.Validator = &mockValidator{
+		validateFunc: func(ctx context.Context, config *envoybootstrapv3.Bootstrap) error {
+			for _, c := range config.GetStaticResources().GetClusters() {
+				if c.GetOutlierDetection() != nil {
+					return errors.New("overlay produced invalid cluster")
+				}
+			}
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error, "base must pass strict validation (no overlay applied yet)")
+
+	cluster, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, ir.UniquelyConnectedClient{}, backend, base)
+	require.Error(t, err, "strict-mode validation must reject invalid overlay output")
+	assert.Contains(t, err.Error(), "overlay produced invalid cluster")
+	require.NotNil(t, cluster, "must return a blackhole cluster so the snapshot can mark it errored")
+	assert.Equal(t, envoyclusterv3.Cluster_STATIC, cluster.GetType(),
+		"errored per-client cluster should be the blackhole STATIC cluster")
+}
+
+// TestApplyPerClient_StrictModePassesValidOverlay confirms the validator is
+// invoked on overlay output but does not reject when the result is valid.
+func TestApplyPerClient_StrictModePassesValidOverlay(t *testing.T) {
+	backendIR := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "core",
+		Kind:      "Service",
+		Name:      "svc",
+		Namespace: "ns",
+	}, 80, "", "")
+	backendIR.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{},
+	}
+	backend := &backendIR
+
+	overlayGK := schema.GroupKind{Group: "test", Kind: "MarkerOverlay"}
+
+	var validatorCalls int
+	var bt irtranslator.BackendTranslator
+	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
+		{Group: "core", Kind: "Service"}: {
+			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+				return nil
+			},
+		},
+	}
+	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{
+		overlayGK: {
+			PerClientClusterOverlay: func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR) *sdk.ClusterOverlay {
+				return &sdk.ClusterOverlay{
+					Mutate: func(out *envoyclusterv3.Cluster) {
+						out.OutlierDetection = &envoyclusterv3.OutlierDetection{}
+					},
+				}
+			},
+		},
+	}
+	bt.Mode = apisettings.ValidationStrict
+	bt.Validator = &mockValidator{
+		validateFunc: func(ctx context.Context, config *envoybootstrapv3.Bootstrap) error {
+			validatorCalls++
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error)
+	require.Equal(t, 1, validatorCalls, "base translation must invoke the validator once")
+
+	cluster, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, ir.UniquelyConnectedClient{}, backend, base)
+	require.NoError(t, err)
+	require.NotNil(t, cluster)
+	require.NotNil(t, cluster.OutlierDetection, "overlay mutation must be retained on the returned cluster")
+	assert.Equal(t, 2, validatorCalls,
+		"strict mode must invoke the validator a second time on the post-overlay cluster")
+}
+
+// TestTranslateBackendBase_StrictModeDefersValidationForInlineCLA is a
+// regression test for strict-mode validation of CLA-built-per-client backends
+// (e.g. ServiceEntry DNS/STATIC resolution). The base cluster carries no
+// LoadAssignment — the CLA is attached per client in ApplyPerClient — and Envoy
+// rejects some CLA-less clusters outright (logical-DNS semantics require exactly
+// one endpoint). Validating the incomplete base would blackhole a perfectly
+// valid backend for every client, so TranslateBackendBase must defer validation
+// to ApplyPerClient, which validates the complete per-client cluster.
+func TestTranslateBackendBase_StrictModeDefersValidationForInlineCLA(t *testing.T) {
+	backendIR := ir.NewBackendObjectIR(ir.ObjectSource{
+		Group:     "core",
+		Kind:      "Service",
+		Name:      "svc",
+		Namespace: "ns",
+	}, 80, "", "")
+	backendIR.AttachedPolicies = ir.AttachedPolicies{
+		Policies: map[schema.GroupKind][]ir.PolicyAtt{},
+	}
+	backend := &backendIR
+
+	var validatedClusters []*envoyclusterv3.Cluster
+	var bt irtranslator.BackendTranslator
+	bt.ContributedBackends = map[schema.GroupKind]ir.BackendInit{
+		{Group: "core", Kind: "Service"}: {
+			InitEnvoyBackend: func(ctx context.Context, in ir.BackendObjectIR, out *envoyclusterv3.Cluster) *ir.EndpointsForBackend {
+				out.ClusterDiscoveryType = &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_STRICT_DNS}
+				eps := ir.NewEndpointsForBackend(in)
+				eps.Add(ir.PodLocality{}, ir.EndpointWithMd{LbEndpoint: pipeEndpoint("a")})
+				return eps
+			},
+		},
+	}
+	bt.ContributedPolicies = map[schema.GroupKind]sdk.PolicyPlugin{}
+	bt.Mode = apisettings.ValidationStrict
+	// Mimics Envoy's logical-DNS check: any cluster without a load_assignment
+	// is rejected. A valid ServiceEntry-style backend passed this on main only
+	// because validation ran after the CLA was attached.
+	bt.Validator = &mockValidator{
+		validateFunc: func(ctx context.Context, config *envoybootstrapv3.Bootstrap) error {
+			for _, c := range config.GetStaticResources().GetClusters() {
+				validatedClusters = append(validatedClusters, c)
+				if c.GetLoadAssignment() == nil {
+					return errors.New("clusters must have a load_assignment")
+				}
+			}
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	base := bt.TranslateBackendBase(ctx, backend)
+	require.NotNil(t, base)
+	require.NoError(t, base.Error,
+		"the CLA-less base must not be validated (and so must not error) — its CLA is built per client")
+	require.Empty(t, validatedClusters, "validation must be deferred until the per-client CLA exists")
+
+	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
+	perClient, err := bt.ApplyPerClient(krt.TestingDummyContext{}, ctx, ucc, backend, base)
+	require.NoError(t, err, "the complete per-client cluster must pass validation")
+	require.NotNil(t, perClient)
+	require.NotNil(t, perClient.GetLoadAssignment(), "per-client cluster must carry the built CLA")
+	require.Len(t, validatedClusters, 1, "strict mode must validate the complete per-client cluster exactly once")
 }

--- a/pkg/kgateway/translator/irtranslator/backend_validation_test.go
+++ b/pkg/kgateway/translator/irtranslator/backend_validation_test.go
@@ -10,7 +10,6 @@ import (
 	envoybootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/stretchr/testify/require"
-	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
@@ -53,19 +52,25 @@ func validationTestBackend(name string) *ir.BackendObjectIR {
 	return &b
 }
 
+func translateValidationTestBase(t *testing.T, tr *BackendTranslator, backend *ir.BackendObjectIR) (*envoyclusterv3.Cluster, error) {
+	t.Helper()
+	base := tr.TranslateBackendBase(t.Context(), backend)
+	require.NotNil(t, base)
+	return base.Cluster, base.Error
+}
+
 func TestStrictValidationCachedByClusterContent(t *testing.T) {
 	counting := &recordingValidator{}
 	tr := validationTestTranslator(validator.NewCaching(counting, 0))
-	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
 
 	for range 5 {
-		c, err := tr.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ucc, validationTestBackend("b1"))
+		c, err := translateValidationTestBase(t, tr, validationTestBackend("b1"))
 		require.NoError(t, err)
 		require.NotNil(t, c)
 	}
 	require.EqualValues(t, 1, counting.calls.Load(), "identical cluster content must be validated once")
 
-	_, err := tr.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ucc, validationTestBackend("b2"))
+	_, err := translateValidationTestBase(t, tr, validationTestBackend("b2"))
 	require.NoError(t, err)
 	require.EqualValues(t, 2, counting.calls.Load(), "distinct cluster content must be validated separately")
 }
@@ -73,10 +78,9 @@ func TestStrictValidationCachedByClusterContent(t *testing.T) {
 func TestStrictValidationCachesInvalidVerdicts(t *testing.T) {
 	counting := &recordingValidator{err: fmt.Errorf("%w: bad cluster", validator.ErrInvalidXDS)}
 	tr := validationTestTranslator(validator.NewCaching(counting, 0))
-	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
 
 	for range 3 {
-		c, err := tr.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ucc, validationTestBackend("b1"))
+		c, err := translateValidationTestBase(t, tr, validationTestBackend("b1"))
 		require.ErrorIs(t, err, validator.ErrInvalidXDS)
 		require.NotNil(t, c, "errored translation returns the blackhole cluster")
 	}
@@ -86,13 +90,12 @@ func TestStrictValidationCachesInvalidVerdicts(t *testing.T) {
 func TestStrictValidationDoesNotCacheTransientErrors(t *testing.T) {
 	counting := &recordingValidator{err: errors.New("exec: envoy binary not found")}
 	tr := validationTestTranslator(validator.NewCaching(counting, 0))
-	ucc := ir.NewUniquelyConnectedClient("role", "ns", nil, ir.PodLocality{})
 
-	_, err := tr.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ucc, validationTestBackend("b1"))
+	_, err := translateValidationTestBase(t, tr, validationTestBackend("b1"))
 	require.Error(t, err)
 
 	counting.err = nil
-	c, err := tr.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ucc, validationTestBackend("b1"))
+	c, err := translateValidationTestBase(t, tr, validationTestBackend("b1"))
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	require.EqualValues(t, 2, counting.calls.Load(), "a transient failure must not be served from cache")

--- a/pkg/kgateway/translator/irtranslator/endpoint_plugins_test.go
+++ b/pkg/kgateway/translator/irtranslator/endpoint_plugins_test.go
@@ -105,8 +105,12 @@ func TestBackendTranslatorRunsOrderedEndpointPluginsForInlineEndpoints(t *testin
 		},
 	}
 
-	cluster, err := translator.TranslateBackend(context.Background(), krt.TestingDummyContext{}, ucc, backendPtr)
+	ctx := context.Background()
+	base := translator.TranslateBackendBase(ctx, backendPtr)
+	require.NotNil(t, base)
+	cluster, err := translator.ApplyPerClient(krt.TestingDummyContext{}, ctx, ucc, backendPtr, base)
 	require.NoError(t, err)
+	require.NotNil(t, cluster, "inline endpoints must materialize a per-client cluster")
 	assert.Equal(t, []string{"backendconfigpolicy", "destrule"}, calls)
 
 	assignment := cluster.GetLoadAssignment()

--- a/pkg/pluginsdk/types.go
+++ b/pkg/pluginsdk/types.go
@@ -51,10 +51,23 @@ type (
 	) uint64
 )
 
-// TODO: consider changing PerClientProcessBackend to look like this:
-// PerClientProcessBackend  func(kctx krt.HandlerContext, ctx context.Context, ucc ir.UniquelyConnectedClient, in ir.BackendObjectIR)
-// so that it only attaches the policy to the backend, and doesn't modify the backend (except for attached policies) or the cluster itself.
-// leaving as is for now as this requires better understanding of how krt would handle this.
+// ClusterOverlay carries per-client cluster mutations. Returning nil from a
+// PerClientClusterOverlay means the client/backend pair needs no mutation.
+// Mutate receives a fresh clone and must not retain it after returning.
+type ClusterOverlay struct {
+	Mutate func(out *envoyclusterv3.Cluster)
+}
+
+type PerClientClusterOverlay func(
+	kctx krt.HandlerContext,
+	ctx context.Context,
+	ucc ir.UniquelyConnectedClient,
+	in ir.BackendObjectIR,
+) *ClusterOverlay
+
+// PerClientProcessBackend is the legacy eager cluster mutation hook.
+// Deprecated: use PerClientClusterOverlay. Legacy hooks are treated as
+// applicable to every client because they cannot report a no-op cheaply.
 type PerClientProcessBackend func(
 	kctx krt.HandlerContext,
 	ctx context.Context,
@@ -76,6 +89,8 @@ type PolicyPlugin struct {
 
 	// Backend processing for envoy proxy
 	ProcessBackend          ProcessBackend
+	PerClientClusterOverlay PerClientClusterOverlay
+	// Deprecated: use PerClientClusterOverlay.
 	PerClientProcessBackend PerClientProcessBackend
 	PerClientEditEndpoints  EndpointEditorPlugin
 	// Deprecated: use PerClientEditEndpoints.

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -880,7 +880,10 @@ func (tc TestCase) Run(
 		for _, col := range commoncol.BackendIndex.BackendsWithPolicy() {
 			for _, backend := range col.List() {
 				// In strict mode, backend validation errors are expected and should not fail the test.
-				cluster, _ := t.TranslateBackend(ctx, krt.TestingDummyContext{}, ucc, backend)
+				cluster, err := translateBackendForGolden(ctx, krt.TestingDummyContext{}, t, ucc, backend)
+				if err != nil {
+					continue
+				}
 				if cluster != nil {
 					clusters = append(clusters, cluster)
 				}
@@ -894,7 +897,7 @@ func (tc TestCase) Run(
 						continue
 					}
 
-					cluster, err := t.TranslateBackend(ctx, krt.TestingDummyContext{}, ucc, &clone)
+					cluster, err := translateBackendForGolden(ctx, krt.TestingDummyContext{}, t, ucc, &clone)
 					if err != nil {
 						continue
 					}
@@ -910,6 +913,33 @@ func (tc TestCase) Run(
 	}
 
 	return results, nil
+}
+
+// translateBackendForGolden selects the same base or per-client cluster that
+// the production sparse collection publishes. Errored translations return no
+// cluster because snapshotPerClient excludes errored rows from CDS.
+func translateBackendForGolden(
+	ctx context.Context,
+	kctx krt.HandlerContext,
+	backendTranslator *irtranslator.BackendTranslator,
+	ucc ir.UniquelyConnectedClient,
+	backend *ir.BackendObjectIR,
+) (*envoyclusterv3.Cluster, error) {
+	base := backendTranslator.TranslateBackendBase(ctx, backend)
+	if base == nil {
+		return nil, fmt.Errorf("no backend translator found for %s", backend.GetGroupKind())
+	}
+	if base.Error != nil {
+		return nil, base.Error
+	}
+	perClient, err := backendTranslator.ApplyPerClient(kctx, ctx, ucc, backend, base)
+	if err != nil {
+		return nil, err
+	}
+	if perClient != nil {
+		return perClient, nil
+	}
+	return base.Cluster, nil
 }
 
 func ReadProxyFromFile(filename string) (*irtranslator.TranslationResult, error) {


### PR DESCRIPTION
# Description

Update the gateway translation fixtures affected by the base/overlay split.

Seven fixtures previously expected a synthetic blackhole cluster when backend translation failed. Base and per-client errors are now carried separately, and errored clusters are omitted from emitted CDS, so those stale cluster entries are removed. Route output and policy status remain unchanged.

The fixture-only change is kept separate to make the observable translation difference explicit during review.

# Change Type

/kind test

# Changelog

```release-note
NONE
```

# Additional Notes

This is PR 3 of 7 and depends on `chandler/14343-base-overlays-dense`. It completes the dense base-plus-overlay portion of the stack; the sparse KRT work begins in the next PR.

Tested with:

```sh
go test ./pkg/kgateway/translator/gateway
```