### PR TITLE
proxy_syncer: intern equivalent per-client cluster deltas

### DIFF
--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -789,7 +789,7 @@ func NewPerClientEnvoyClusters(
 		// Intern identical per-client clusters across UCCs. Inline-CLA backends
 		// materialize a delta for every UCC, but UCCs that share the relevant
 		// inputs often produce byte-identical clusters.
-		internByVersion := map[uint64]sharedproto.Shared[*envoyclusterv3.Cluster]{}
+		var clusterInterner sharedproto.Interner[*envoyclusterv3.Cluster]
 		// Lend ApplyPerClient the shared base proto rather than a copy of it. It
 		// only reads this proto, and clones internally before letting an overlay
 		// touch one, so it already performs the single clone a materialized delta
@@ -834,11 +834,7 @@ func NewPerClientEnvoyClusters(
 				continue
 			}
 			clusterVersion := utils.HashProto(perClient)
-			shared, ok := internByVersion[clusterVersion]
-			if !ok {
-				shared = sharedproto.WrapPrehashed(perClient, clusterVersion)
-				internByVersion[clusterVersion] = shared
-			}
+			shared := clusterInterner.Intern(perClient, clusterVersion)
 			if set.Deltas == nil {
 				set.Deltas = make(map[string]uccClusterDelta)
 			}

--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -834,7 +834,7 @@ func NewPerClientEnvoyClusters(
 				continue
 			}
 			clusterVersion := utils.HashProto(perClient)
-			shared := clusterInterner.Intern(perClient, clusterVersion)
+			shared := clusterInterner.InternPrehashed(perClient, clusterVersion)
 			if set.Deltas == nil {
 				set.Deltas = make(map[string]uccClusterDelta)
 			}

--- a/pkg/kgateway/proxy_syncer/backends.go
+++ b/pkg/kgateway/proxy_syncer/backends.go
@@ -786,6 +786,10 @@ func NewPerClientEnvoyClusters(
 			// variation possible. The empty set explicitly records resolution.
 			return set
 		}
+		// Intern identical per-client clusters across UCCs. Inline-CLA backends
+		// materialize a delta for every UCC, but UCCs that share the relevant
+		// inputs often produce byte-identical clusters.
+		internByVersion := map[uint64]sharedproto.Shared[*envoyclusterv3.Cluster]{}
 		// Lend ApplyPerClient the shared base proto rather than a copy of it. It
 		// only reads this proto, and clones internally before letting an overlay
 		// touch one, so it already performs the single clone a materialized delta
@@ -830,13 +834,18 @@ func NewPerClientEnvoyClusters(
 				continue
 			}
 			clusterVersion := utils.HashProto(perClient)
+			shared, ok := internByVersion[clusterVersion]
+			if !ok {
+				shared = sharedproto.WrapPrehashed(perClient, clusterVersion)
+				internByVersion[clusterVersion] = shared
+			}
 			if set.Deltas == nil {
 				set.Deltas = make(map[string]uccClusterDelta)
 			}
 			set.Deltas[ucc.ResourceName()] = uccClusterDelta{
 				Client:         ucc,
 				Name:           perClient.GetName(),
-				Cluster:        sharedproto.WrapPrehashed(perClient, clusterVersion),
+				Cluster:        shared,
 				ClusterVersion: clusterVersion,
 			}
 		}

--- a/pkg/kgateway/proxy_syncer/backends_integration_test.go
+++ b/pkg/kgateway/proxy_syncer/backends_integration_test.go
@@ -28,8 +28,8 @@ import (
 //   - A UCC the overlay declines sees the shared base proto (no delta emitted).
 //   - A UCC the overlay matches sees a distinct per-client proto carrying the
 //     mutation, while the base proto stays pristine.
-//   - Two matching UCCs receive independently owned delta protos; interning is
-//     intentionally left to a later optimization.
+//   - Two UCCs whose overlay produces byte-identical clusters share one interned
+//     delta proto, so equivalent clients do not each retain a clone.
 func TestNewPerClientEnvoyClusters_SparseOverlayWiring(t *testing.T) {
 	ctx := t.Context()
 	krtopts := krtutil.NewKrtOptions(ctx.Done(), nil)
@@ -99,8 +99,8 @@ func TestNewPerClientEnvoyClusters_SparseOverlayWiring(t *testing.T) {
 	assert.NotNil(t, gotA[0].Cluster.Clone().GetOutlierDetection(), "matched client must see the overlay mutation")
 	assert.False(t, sharedproto.Same(gotOther[0].Cluster, gotA[0].Cluster), "matched client must not share the base proto")
 
-	assert.False(t, sharedproto.Same(gotA[0].Cluster, gotB[0].Cluster),
-		"the sparse-correctness layer must not depend on delta interning")
+	assert.True(t, sharedproto.Same(gotA[0].Cluster, gotB[0].Cluster),
+		"clients whose overlay output is byte-identical must share one interned proto")
 
 	// The delta transform lends the base proto to ApplyPerClient rather than
 	// handing it a defensive copy, so the overlay pass above ran against the

--- a/pkg/kgateway/proxy_syncer/sharedproto/sharedproto.go
+++ b/pkg/kgateway/proxy_syncer/sharedproto/sharedproto.go
@@ -55,6 +55,34 @@ type Shared[M proto.Message] struct {
 	hash uint64
 }
 
+// Interner shares immutable protos with equal content. The caller supplies the
+// content hash it already computed for versioning; equal hashes are only a
+// bucket lookup, never proof of equality. This keeps 64-bit hash collisions
+// from making distinct xDS resources alias the same proto.
+//
+// The zero value is ready to use. Intern takes ownership of msg only when it
+// returns a newly wrapped value; when an equal value was already interned, msg
+// is discarded and the existing wrapper is returned.
+type Interner[M proto.Message] struct {
+	byHash map[uint64][]Shared[M]
+}
+
+// Intern returns the existing shared proto whose content equals msg, or wraps
+// and records msg when its hash bucket contains no equal proto.
+func (i *Interner[M]) Intern(msg M, contentHash uint64) Shared[M] {
+	for _, existing := range i.byHash[contentHash] {
+		if proto.Equal(existing.msg, msg) {
+			return existing
+		}
+	}
+	shared := WrapPrehashed(msg, contentHash)
+	if i.byHash == nil {
+		i.byHash = make(map[uint64][]Shared[M])
+	}
+	i.byHash[contentHash] = append(i.byHash[contentHash], shared)
+	return shared
+}
+
 // Wrap takes ownership of msg as a shared, read-only proto. The caller must
 // not retain or mutate msg after wrapping; hand out copies via Clone.
 func Wrap[M proto.Message](msg M) Shared[M] {

--- a/pkg/kgateway/proxy_syncer/sharedproto/sharedproto.go
+++ b/pkg/kgateway/proxy_syncer/sharedproto/sharedproto.go
@@ -55,10 +55,10 @@ type Shared[M proto.Message] struct {
 	hash uint64
 }
 
-// Interner shares immutable protos with equal content. The caller supplies the
-// content hash it already computed for versioning; equal hashes are only a
-// bucket lookup, never proof of equality. This keeps 64-bit hash collisions
-// from making distinct xDS resources alias the same proto.
+// Interner shares immutable protos with equal content. The caller supplies a
+// hash used to select candidates; equal hashes are only a bucket lookup, never
+// proof of equality. This keeps 64-bit hash collisions from making distinct
+// xDS resources alias the same proto.
 //
 // The zero value is ready to use. Intern takes ownership of msg only when it
 // returns a newly wrapped value; when an equal value was already interned, msg
@@ -68,18 +68,32 @@ type Interner[M proto.Message] struct {
 }
 
 // Intern returns the existing shared proto whose content equals msg, or wraps
-// and records msg when its hash bucket contains no equal proto.
-func (i *Interner[M]) Intern(msg M, contentHash uint64) Shared[M] {
-	for _, existing := range i.byHash[contentHash] {
+// and records msg when its bucket contains no equal proto. bucketHash need not
+// be the proto's content hash; Wrap captures the correct tripwire hash when
+// immutability assertions are enabled.
+func (i *Interner[M]) Intern(msg M, bucketHash uint64) Shared[M] {
+	return i.intern(msg, bucketHash, Wrap[M])
+}
+
+// InternPrehashed is Intern for callers whose bucket hash is utils.HashProto(msg).
+// It reuses that hash when arming the immutability tripwire.
+func (i *Interner[M]) InternPrehashed(msg M, contentHash uint64) Shared[M] {
+	return i.intern(msg, contentHash, func(msg M) Shared[M] {
+		return WrapPrehashed(msg, contentHash)
+	})
+}
+
+func (i *Interner[M]) intern(msg M, bucketHash uint64, wrap func(M) Shared[M]) Shared[M] {
+	for _, existing := range i.byHash[bucketHash] {
 		if proto.Equal(existing.msg, msg) {
 			return existing
 		}
 	}
-	shared := WrapPrehashed(msg, contentHash)
+	shared := wrap(msg)
 	if i.byHash == nil {
 		i.byHash = make(map[uint64][]Shared[M])
 	}
-	i.byHash[contentHash] = append(i.byHash[contentHash], shared)
+	i.byHash[bucketHash] = append(i.byHash[bucketHash], shared)
 	return shared
 }
 

--- a/pkg/kgateway/proxy_syncer/sharedproto/sharedproto_test.go
+++ b/pkg/kgateway/proxy_syncer/sharedproto/sharedproto_test.go
@@ -116,6 +116,7 @@ func TestIsNil(t *testing.T) {
 }
 
 func TestInternerUsesContentEqualityWithinHashBuckets(t *testing.T) {
+	withAssertions(t, true)
 	var interner Interner[*envoyclusterv3.Cluster]
 	first := &envoyclusterv3.Cluster{Name: "first"}
 	second := &envoyclusterv3.Cluster{Name: "second"}
@@ -131,4 +132,7 @@ func TestInternerUsesContentEqualityWithinHashBuckets(t *testing.T) {
 		"equal protos in the same hash bucket must share one wrapper")
 	require.Len(t, interner.byHash[collidingHash], 2,
 		"one collision bucket must retain each distinct proto exactly once")
+	require.Equal(t, utils.HashProto(first), sharedFirst.hash,
+		"a non-content bucket hash must not be reused as the mutation-tripwire hash")
+	require.NotPanics(t, func() { sharedFirst.ResourceWithTTL() })
 }

--- a/pkg/kgateway/proxy_syncer/sharedproto/sharedproto_test.go
+++ b/pkg/kgateway/proxy_syncer/sharedproto/sharedproto_test.go
@@ -114,3 +114,21 @@ func TestIsNil(t *testing.T) {
 	require.True(t, Wrap[*envoyclusterv3.Cluster](nil).IsNil(), "wrapped typed-nil is nil")
 	require.False(t, Wrap(&envoyclusterv3.Cluster{}).IsNil())
 }
+
+func TestInternerUsesContentEqualityWithinHashBuckets(t *testing.T) {
+	var interner Interner[*envoyclusterv3.Cluster]
+	first := &envoyclusterv3.Cluster{Name: "first"}
+	second := &envoyclusterv3.Cluster{Name: "second"}
+	const collidingHash = 42
+
+	sharedFirst := interner.Intern(first, collidingHash)
+	sharedSecond := interner.Intern(second, collidingHash)
+	sharedFirstCopy := interner.Intern(&envoyclusterv3.Cluster{Name: "first"}, collidingHash)
+
+	require.False(t, Same(sharedFirst, sharedSecond),
+		"distinct protos in the same hash bucket must not alias")
+	require.True(t, Same(sharedFirst, sharedFirstCopy),
+		"equal protos in the same hash bucket must share one wrapper")
+	require.Len(t, interner.byHash[collidingHash], 2,
+		"one collision bucket must retain each distinct proto exactly once")
+}


### PR DESCRIPTION
# Description

The sparse CDS representation materializes only clients whose cluster differs from the shared base, but several of those clients can still produce byte-for-byte equivalent clusters. This PR deduplicates those materialized results within each backend transform.

Equivalent results are interned by their already-computed content version and share the immutable-proto ownership boundary introduced by sparse CDS. Distinct overlay results and the shared base remain separately owned.

This is an allocation optimization only. It does not change sparse-absence resolution, readiness, client identity, or cross-collection fencing.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

This is in a PR stack. Keeping it separate makes the aliasing and memory optimization independently measurable and revertible.

Tested with:

```sh
go test ./pkg/kgateway/proxy_syncer
```