### PR TITLE
[WIP] bump: move all GitHub Actions pins to Node 24-compatible releases

### DIFF
--- a/.github/actions/kube-conformance-tests/action.yaml
+++ b/.github/actions/kube-conformance-tests/action.yaml
@@ -38,7 +38,7 @@ runs:
       uses: ./.github/actions/prep-go-runner
 
 
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       id: kubectl
       with:
         version: ${{ inputs.kubectl-version }}

--- a/.github/actions/prep-go-runner/action.yaml
+++ b/.github/actions/prep-go-runner/action.yaml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Cancel Previous Actions
-      uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+      uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
       with:
         access_token: ${{ github.token }}
     - name: Free disk space
@@ -71,7 +71,7 @@ runs:
         docker system df -v
     - name: Set up Go
       id: setup-go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         # https://github.com/actions/setup-go/blob/main/action.yml
         go-version-file: ${{ inputs.working-directory }}/go.mod
@@ -97,7 +97,7 @@ runs:
         echo "go-build-race=${{ runner.os }}-go-build-race-v3-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
         echo "go-build-race-restore=${{ runner.os }}-go-build-race-v3-${{ steps.setup-go.outputs.go-version }}-" >> $GITHUB_OUTPUT
     - name: Restore Go Build Cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: go-build-cache
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
@@ -112,7 +112,7 @@ runs:
         restore-keys: |
           ${{ steps.go-cache-keys.outputs.go-build-restore }}
     - name: Cache Go Modules
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: go-mod-cache
       with:
         # https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/.github/actions/setup-k3d-cluster/action.yaml
+++ b/.github/actions/setup-k3d-cluster/action.yaml
@@ -34,7 +34,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       id: kubectl
       with:
         version: ${{ inputs.kubectl-version }}

--- a/.github/actions/setup-kind-cluster/action.yaml
+++ b/.github/actions/setup-kind-cluster/action.yaml
@@ -30,7 +30,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+    - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
       id: kubectl
       with:
         version: ${{ inputs.kubectl-version }}

--- a/.github/actions/upload-artifact/action.yaml
+++ b/.github/actions/upload-artifact/action.yaml
@@ -27,7 +27,7 @@ runs:
           echo "job_id=$ts" >> $GITHUB_OUTPUT
         fi
     - name: Upload artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.name }}-${{ github.run_id }}-${{ steps.get-job-id.outputs.job_id }}
         path: ${{ inputs.path }}

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Enable auto-merge
         shell: bash
         env:
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Disable auto-merge
         shell: bash
         env:

--- a/.github/workflows/build-tools.yaml
+++ b/.github/workflows/build-tools.yaml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set tags
         id: tags
@@ -63,21 +63,21 @@ jobs:
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GHCR
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (and optionally push)
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: tools/build-tools/Dockerfile

--- a/.github/workflows/cache-eviction.yaml
+++ b/.github/workflows/cache-eviction.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cleanup Cache for PR
         # In this step we will delete the cache keys for the PR that was just closed.
         # We use a GitHub CLI extension (https://github.com/actions/gh-actions-cache).

--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         id: prep-go-runner
         uses: ./.github/actions/prep-go-runner
@@ -43,7 +43,7 @@ jobs:
           go test -run '^$' -tags e2e ./...
       - name: Save Go Build Cache
         if: success() && steps.prep-go-runner.outputs.go-build-cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key }}
@@ -53,7 +53,7 @@ jobs:
       # race-instrumented build cache instead of recompiling the world.
       - name: Restore Race Go Build Cache
         id: race-build-cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}
@@ -75,7 +75,7 @@ jobs:
           go test -run '^$' -race ./...
       - name: Save Race Go Build Cache
         if: success() && steps.race-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -29,9 +29,9 @@ jobs:
         test-type: [gateway-api]
         arch: ['amd64', 'arm64']
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: "./.github/workflows/.env/pr-tests/versions.env"

--- a/.github/workflows/devcontainer-smoke.yaml
+++ b/.github/workflows/devcontainer-smoke.yaml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smoke-test-debug
           path: artifacts/

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,13 +24,13 @@ jobs:
     timeout-minutes: 45
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Restore envoyinit BuildKit cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/.buildx-cache-envoyinit
           key: ${{ runner.os }}-buildx-envoyinit-v1-${{ hashFiles('internal/envoy_modules/Cargo.lock', 'internal/envoy_modules/**/Cargo.toml', 'cmd/envoyinit/Dockerfile.tmpl', 'cmd/envoyinit/generate-dockerfile.sh') }}
@@ -51,7 +51,7 @@ jobs:
             mv /tmp/.buildx-cache-envoyinit-new /tmp/.buildx-cache-envoyinit
           fi
       - name: Upload shared e2e images
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-shared-images
           path: _output/e2e-images/shared-images.tar
@@ -133,19 +133,19 @@ jobs:
         version-files:
           - file: './.github/workflows/.env/pr-tests/versions.env'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       # The dotenv action is used to load key-value pairs from files.
       # In this case, the file is specified in the matrix and will contain the versions of the tools to use
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.version-files.file }}
           log-variables: true
       - name: Download shared e2e images
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: e2e-shared-images
           path: _output/e2e-images

--- a/.github/workflows/flake-validation.yaml
+++ b/.github/workflows/flake-validation.yaml
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Restore envoyinit BuildKit cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/.buildx-cache-envoyinit
           key: ${{ runner.os }}-buildx-envoyinit-v1-${{ hashFiles('internal/envoy_modules/Cargo.lock', 'internal/envoy_modules/**/Cargo.toml', 'cmd/envoyinit/Dockerfile.tmpl', 'cmd/envoyinit/generate-dockerfile.sh') }}
@@ -63,7 +63,7 @@ jobs:
             mv /tmp/.buildx-cache-envoyinit-new /tmp/.buildx-cache-envoyinit
           fi
       - name: Upload shared e2e images
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-shared-images
           path: _output/e2e-images/shared-images.tar
@@ -95,17 +95,17 @@ jobs:
         version-files:
           - file: './.github/workflows/.env/pr-tests/versions.env'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.version-files.file }}
           log-variables: true
       - name: Download shared e2e images
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: e2e-shared-images
           path: _output/e2e-images

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -25,10 +25,10 @@ jobs:
           exit 0
 
       - if: github.event_name != 'merge_group'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Sync /kind labels & enforce changelog fields
         if: github.event_name != 'merge_group'
-        uses: kgateway-dev/pr-kind-labeler@7df01fd3b367aa68271aad255db94693e8f63f68 # untagged main
+        uses: kgateway-dev/pr-kind-labeler@7df01fd3b367aa68271aad255db94693e8f63f68 # main (2026-06-24)
         with:
           # Github Actions cannot trigger Github Actions, but with this
           # Personal Access Token we can make labels that trigger

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Analyze source tree
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Lint Helm Charts
         run: make lint-kgateway-charts
 
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
       - run: make lint-actions
@@ -61,12 +61,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Read Rust toolchain version
         id: rust
         run: echo "channel=$(awk -F'"' '/^channel[[:space:]]*=/ {print $2}' internal/envoy_modules/rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: ${{ steps.rust.outputs.channel }}
           components: clippy,rustfmt

--- a/.github/workflows/merge-queue-delete.yaml
+++ b/.github/workflows/merge-queue-delete.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cancel GH workflows
         # This action cancels any running builds for MQ branches which have already been deleted.

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -82,11 +82,11 @@ jobs:
             label: min_versions
         gateway-api-channel: ['experimental', 'standard']
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ matrix.ref.checkout_ref }}
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.env-versions.file }}
@@ -115,11 +115,11 @@ jobs:
           - file: "./.github/workflows/.env/nightly-tests/min_versions.env"
             label: min_versions
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ matrix.ref.checkout_ref }}
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.env-versions.file }}
@@ -163,13 +163,13 @@ jobs:
         controllers:
           - regex: "^TestKgateway|^TestAPIValidation|^TestListenerSet|^TestCustomGWP$$|^TestRouteReplacement$$|^TestZeroDowntimeRollout$$/^TestZeroDowntimeRollout$$|^TestControlPlaneTLS$$"
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ matrix.ref.checkout_ref }}
       # Runs before the guard step below so the guard can key its Kubernetes-version check off
       # the real kubectl_version output instead of guessing from the min/max label.
       - name: Dotenv Action
-        uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 # v1.1.4
+        uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 # v1.2.1
         id: dotenv
         with:
           path: ${{ matrix.env-versions.file }}

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -23,7 +23,7 @@ permissions:
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  OSV_SCANNER_IMAGE: ghcr.io/google/osv-scanner-action:v2.3.5
+  OSV_SCANNER_IMAGE: ghcr.io/google/osv-scanner-action:v2.5.0
   # Severity used to report a scan target that this repository does not have.
   # Forks routinely track a subset of the release branches and do not publish
   # release images, so a gap there is expected; on the repository that cuts
@@ -123,7 +123,7 @@ jobs:
         branch: ${{ fromJson(needs.determine_branches.outputs.branches) }}
     steps:
       - name: Checkout branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ matrix.branch }}
@@ -141,7 +141,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run source scanner
-        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        uses: google/osv-scanner-action/osv-scanner-action@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
         with:
           scan-args: |-
             --output=results.json
@@ -153,7 +153,7 @@ jobs:
         continue-on-error: true
 
       - name: Convert source results to SARIF
-        uses: google/osv-scanner-action/osv-reporter-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        uses: google/osv-scanner-action/osv-reporter-action@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
         with:
           scan-args: |-
             --output=results.sarif
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload source SARIF
         if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif
           ref: ${{ steps.metadata.outputs.ref }}
@@ -199,7 +199,7 @@ jobs:
           - envoy-wrapper
     steps:
       - name: Checkout branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ matrix.branch }}
@@ -465,7 +465,7 @@ jobs:
 
       - name: Upload image SARIF
         if: ${{ !cancelled() && hashFiles('image-result.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: image-result.sarif
           ref: ${{ steps.metadata.outputs.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       needs_release: ${{ steps.set_vars.outputs.needs_release }}
       previous_tag: ${{ steps.set_vars.outputs.previous_tag }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Set the release related variables
@@ -141,7 +141,7 @@ jobs:
     needs: [setup, goreleaser]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Helm login to ${{ env.IMAGE_REGISTRY }}
         if: ${{ github.event_name != 'pull_request' }}
@@ -151,7 +151,7 @@ jobs:
       # (`docker buildx imagetools create`); gate them on the same condition as that step.
       - name: Log into ${{ env.IMAGE_REGISTRY }}
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.setup.outputs.floating_version != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -159,7 +159,7 @@ jobs:
 
       - name: Setup Buildx
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.setup.outputs.floating_version != '' }}
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Package kgateway charts
         run: make package-kgateway-charts
@@ -212,7 +212,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ needs.setup.outputs.needs_release == 'true' }}
         with:
           fetch-depth: 0
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upload release notes
         if: ${{ needs.setup.outputs.needs_release == 'true' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-notes
           path: _output/RELEASE_NOTES.md
@@ -240,7 +240,7 @@ jobs:
     needs: [setup, release-notes]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Prep Go Runner
@@ -253,13 +253,13 @@ jobs:
 
       - name: Log into ghcr.io
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392" # v3.6.0
+      - uses: "docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8" # v4.2.0
         with:
           # Pin the binfmt/QEMU emulator to a specific version. The action caches
           # the emulator image (`cache-image: true`) under a key derived from the
@@ -272,11 +272,11 @@ jobs:
           # A versioned tag gives a version-specific cache key (sidestepping the
           # poisoned `latest` cache) and a QEMU build that contains the upstream fix.
           image: tonistiigi/binfmt:qemu-v10.2.3
-      - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10.0
+      - uses: "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c" # v4.2.0
 
       - name: Download release notes
         if: ${{ needs.setup.outputs.needs_release == 'true' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-notes
           path: _output
@@ -328,7 +328,7 @@ jobs:
       matrix:
         arch: ['amd64', 'arm64']
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
 
@@ -375,7 +375,7 @@ jobs:
     if: ${{ inputs.run_load_tests }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
 

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Re-run failed jobs
         shell: bash
         env:

--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: ${{ env.DAYS_BEFORE_ISSUE_STALE }}
@@ -40,7 +40,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-pr-stale: ${{ env.DAYS_BEFORE_PR_STALE }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Prep Go Runner
@@ -35,7 +35,7 @@ jobs:
         # distinct set of GOCACHE entries from the CGO-disabled cache that
         # prep-go-runner restores. This race-instrumented cache is seeded by
         # the Cache Setup workflow on main; restore it so unit runs start warm.
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.prep-go-runner.outputs.go-build-cache-path }}
           key: ${{ steps.prep-go-runner.outputs.go-build-cache-key-race }}
@@ -65,7 +65,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Setup Buildx
         if: ${{ steps.validator-image.outputs.rebuild == 'true' }}
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build validator image
         if: ${{ steps.validator-image.outputs.rebuild == 'true' }}
         env:
@@ -140,9 +140,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: tools/go.mod
       - name: Run drift tests

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Prep Go Runner
         uses: ./.github/actions/prep-go-runner
       - name: Generate Code


### PR DESCRIPTION
# Description

TODO(chandler): test as much of CI as possible, e.g. a dev build.

**Motivation:** GitHub is removing Node 20 from the Actions runners. Runners defaulted to Node 24 on 2026-06-16, the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` escape hatch stops working once Node 20 is fully removed in fall 2026, and every JavaScript action we pinned still declared `runs.using: node20`.

**What changed:** each external action is repinned to the newest stable release that (a) had been published at least 168 hours, (b) declares `node24` — or is a composite/Docker action with no Node 20 nested inside — and (c) is non-breaking for how we actually invoke it. Every pin is a full 40-character SHA with an exact release-tag comment. No opt-out env var was added.

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v4.3.1 | v7.0.1 |
| `actions/cache` (+ `/restore`, `/save`) | v4.3.0 | v6.1.0 | | `actions/setup-go` | v6.2.0 | v7.0.0 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `actions/download-artifact` | v4.3.0 | v8.0.1 |
| `actions/stale` | v10.3.0 | v11.0.0 |
| `azure/setup-kubectl` | v4.0.1 | v5.1.0 |
| `styfle/cancel-workflow-action` | 0.12.1 | 0.13.1 | | `docker/setup-qemu-action` | v3.6.0 | v4.2.0 |
| `docker/setup-buildx-action` | v3.10.0 | v4.2.0 | | `docker/login-action` | v3.4.0 | v4.6.0 |
| `docker/build-push-action` | v6.18.0 | v7.3.0 |
| `falti/dotenv-action` | v1.1.4 | v1.2.1 |
| `actions-rust-lang/setup-rust-toolchain` | v1.15.4 | v1.17.0 | | `google/osv-scanner-action` (both sub-actions) | v2.3.5 | v2.5.0 | | `github/codeql-action/upload-sarif` | v4.31.10 | v4.37.6 |

Unchanged: `nolar/setup-k3d-k3s` v1.1.0 (already newest; composite, bash-only steps) and `kgateway-dev/pr-kind-labeler` (Docker action with no releases or tags, already at `main` HEAD — only its comment was corrected from `# untagged main` to `# main (2026-06-24)`).

# Change Type

/kind bump

# Changelog

```release-note
NONE
```

# Additional Notes

Behavior deltas worth a reviewer's attention. Everything not listed here was verified additive-only by diffing each `action.yml` at the proposed SHA.

- **`actions/checkout` v7 blocks fork-PR checkout under `pull_request_target`.** `labeler.yaml` is our only such workflow; its checkout passes no `ref`/`repository`, and v7.0.1 skips the guard for default inputs (`actions/checkout#2518`), so no `allow-unsafe-pr-checkout` opt-in is needed.
- **`actions/download-artifact` v8 defaults `digest-mismatch` to `error`** instead of warning. Kept the secure default: upload and download move together on the same artifact service, and forcing `warn` would mask a real corruption signal. All three download sites fetch by `name`, so v5's download-by-ID path change does not apply.
- **`actions/setup-go` v6.3.0 changed the default module-cache key** from `go.sum` to `go.mod`, affecting the two sites that leave `cache` at its default (`lint.yaml`, `unit.yaml`) — one cold cache, then steady state. `prep-go-runner` sets `cache: false` and is unaffected.
- **`docker/setup-buildx-action` v4 removed `install`, `config`, and `config-inline`**; all five call sites invoke it with no `with:` block. **`docker/build-push-action` v7 removed `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS`**; neither is set anywhere in the repo.
- **`OSV_SCANNER_IMAGE` in `osv-scanner.yaml` was bumped to `v2.5.0`** alongside the action pin. That env feeds a plain `docker run` of the same image for the container-image scan, so leaving it behind would split the source scan and the image scan onto different scanner versions. v2.4/v2.5 add extractors and may surface additional findings, but the job is `continue-on-error: true` and the reporter runs `--fail-on-vuln=false`, so it cannot newly fail CI.

Excluded as younger than seven days when this was authored: `docker/setup-buildx-action` v4.3.0, `google/osv-scanner-action` v2.5.1, and `github/codeql-action` v4.37.7.

Composite recursion audited: `actions-rust-lang/setup-rust-toolchain` v1.17.0 nests `Swatinem/rust-cache` v2.9.1, which declares `node24`.

Runner requirements are met — the strictest documented minimum among these releases is Actions Runner v2.327.1, and every `runs-on:` here is GitHub-hosted (`ubuntu-22.04`, `ubuntu-22.04-arm`, `ubuntu-latest`). No macOS (the ≤13.4 exclusion) and no ARM32.

Validated with `make lint-actions` (clean) and `make fmt-yaml-changed` (no additional diff). All 21 pins were re-checked against the GitHub API: every ref is a 40-character SHA whose comment tag re-resolves to that exact commit, and no selected action declares node20/16/12.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command.

If you pick more than one, the release note is filed under whichever appears first here (manual reordering does not have any effect):
```
/kind breaking_change
/kind feature
/kind fix
/kind deprecation
/kind documentation
/kind cleanup
/kind install
/kind bump
(the following kinds are not included in release notes)
/kind design
/kind flake
/kind test
```
-->

# Changelog

<!--
Provide the exact line to appear in the release notes for this PR.

A PR gets one release note, filed under the highest-precedence /kind above.
If this change needs no release note, write "NONE" in the block below.
-->

```release-note

```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
