### PR TITLE
ci: bump auto-merge runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -14,7 +14,7 @@ jobs:
       github.event.issue.pull_request &&
       (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') &&
       github.event.comment.body == '/merge'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -32,7 +32,7 @@ jobs:
       github.event.issue.pull_request &&
       (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') &&
       github.event.comment.body == '/unmerge'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
# Description

GitHub is retiring the `ubuntu-22.04` runner image. Deprecation
starts on September 17, 2026 with scheduled brownouts that fail
jobs, and the image becomes fully unsupported on April 17, 2027.
Ref: https://github.com/actions/runner-images/issues/14254

This bumps the `auto-merge` job runners to `ubuntu-24.04`.
This workflow only runs merge automation, so it has no dependency
on the runner OS version.

Other workflows are left untouched in this PR — happy to follow up
separately, or to switch to `ubuntu-latest` if preferred.

/kind cleanup

```release-note
NONE
```