### PR TITLE
ci: bump lint and stalebot runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
   # Run source-tree linting and formatting checks
   go-lint:
     name: Go
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Check out code into the Go module directory
@@ -32,7 +32,7 @@ jobs:
   # Lint Helm charts
   helm-lint:
     name: Helm
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Check out code into the Go module directory
@@ -43,7 +43,7 @@ jobs:
   # Lint GitHub workflow files
   action-lint:
     name: GHA
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   close-stale-issues:
     name: Close Stale Issues
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:
@@ -36,7 +36,7 @@ jobs:
 
   close-stale-prs:
     name: Close Stale PRs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
# Description

Follow-up to #14609. GitHub is retiring the `ubuntu-22.04` runner
image — deprecation starts September 17, 2026 with scheduled
brownouts that fail jobs, and the image becomes fully unsupported
on April 17, 2027.
Ref: https://github.com/actions/runner-images/issues/14254

This bumps the runners in `lint.yaml` (3 jobs) and `stalebot.yaml`
(2 jobs) to `ubuntu-24.04`. Neither workflow depends on the runner
OS version.

Build, release, and e2e workflows are deliberately left untouched.
Happy to switch to `ubuntu-latest` instead if that's preferred.

/kind cleanup

```release-note
NONE
```