### PR TITLE
[2.4] fix: de-duplicate api key credentials before emitting them (#14592)

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth.go
@@ -1,7 +1,10 @@
 package trafficpolicy
 
 import (
+	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoyapikeyauthv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/api_key_auth/v3"
@@ -57,6 +60,15 @@ func (a *apiKeyAuthIR) Validate() error {
 		return nil
 	}
 	return a.config.Validate()
+}
+
+// parsedAPIKey is one credential paired with the Secret it came from, so that duplicate
+// reporting can name the source without echoing the key value.
+type parsedAPIKey struct {
+	client string
+	key    string
+	// secret is the "namespace/name" of the Secret the credential was read from.
+	secret string
 }
 
 // constructAPIKeyAuth translates the API key authentication spec into an Envoy API key auth per-route configuration
@@ -116,10 +128,8 @@ func constructAPIKeyAuth(
 		return fmt.Errorf("either secretRef or secretSelector must be specified")
 	}
 
-	// Parse secrets and build credentials
-	var credentials []*envoyapikeyauthv3.Credential
-	var errs []error
-
+	// Parse secrets into credentials, then de-duplicate before emitting.
+	var parsed []parsedAPIKey
 	for _, secret := range secrets {
 		for keyName, keyValue := range secret.Data {
 			// Skip empty values
@@ -129,21 +139,17 @@ func constructAPIKeyAuth(
 
 			// The value is expected to be a plain string representing the API key
 			// The secret key name becomes the client identifier
-			apiKey := string(keyValue)
-			if apiKey == "" {
-				errs = append(errs, fmt.Errorf("secret %s key %s has empty API key value", secret.ObjectSource.Name, keyName))
-				continue
-			}
-
-			credentials = append(credentials, &envoyapikeyauthv3.Credential{
-				Key:    apiKey,
-				Client: keyName,
+			parsed = append(parsed, parsedAPIKey{
+				client: keyName,
+				key:    string(keyValue),
+				secret: secret.ObjectSource.Namespace + "/" + secret.ObjectSource.Name,
 			})
 		}
 	}
 
+	credentials, errs := dedupeAPIKeyCredentials(parsed, policy.Namespace+"/"+policy.Name)
 	if len(errs) > 0 {
-		return fmt.Errorf("errors processing API key secrets: %v", errs)
+		return fmt.Errorf("errors processing API key secrets: %w", errors.Join(errs...))
 	}
 
 	if len(credentials) == 0 {
@@ -205,6 +211,71 @@ func constructAPIKeyAuth(
 	}
 
 	return nil
+}
+
+// dedupeAPIKeyCredentials orders the parsed credentials and collapses duplicate key values.
+//
+// Envoy requires credential keys to be unique within a single ApiKeyAuth config
+// (source/extensions/filters/http/api_key_auth/api_key_auth.h) and NACKs the RouteConfiguration
+// that carries a repeated one. Because ApiKeyAuthPerRoute rides in typed_per_filter_config, that
+// rejection takes the whole RouteConfiguration with it and freezes config delivery for the entire
+// listener, while the policy and the route both keep reporting Accepted. The uniqueness rule is
+// knowable here, so never emit a list that violates it.
+//
+// Two duplicates are not the same mistake:
+//   - The same client with the same key is the same credential listed twice, which is what a Secret
+//     copied to a second namespace looks like once both copies are selected. Dropping the repeat is
+//     a no-op, so do it quietly.
+//   - Two clients sharing a key value is ambiguous. The client name is forwarded as the client id
+//     header and recorded in auth metadata, so keeping one of them silently would be picking an
+//     identity on an authn path. Report it: the caller turns that into Accepted=False on the policy
+//     and a 500 on the affected route, which is a smaller blast radius than a frozen listener.
+func dedupeAPIKeyCredentials(parsed []parsedAPIKey, policyRef string) ([]*envoyapikeyauthv3.Credential, []error) {
+	// Secret.Data is a map and neither GetSecretsBySelector nor krt.Fetch define an order, so sort
+	// before emitting. An unstable credential order makes apiKeyAuthIR.Equals report a change on
+	// every recompute, and it would make which duplicate survives, and which one is named in the
+	// error below, vary between translations of identical input.
+	slices.SortFunc(parsed, func(a, b parsedAPIKey) int {
+		if c := strings.Compare(a.client, b.client); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.key, b.key); c != 0 {
+			return c
+		}
+		return strings.Compare(a.secret, b.secret)
+	})
+
+	credentials := make([]*envoyapikeyauthv3.Credential, 0, len(parsed))
+	seen := make(map[string]parsedAPIKey, len(parsed))
+	var errs []error
+	for _, c := range parsed {
+		prev, dup := seen[c.key]
+		if !dup {
+			seen[c.key] = c
+			credentials = append(credentials, &envoyapikeyauthv3.Credential{
+				Key:    c.key,
+				Client: c.client,
+			})
+			continue
+		}
+
+		if prev.client == c.client {
+			logger.Debug("dropping duplicate api key credential",
+				"policy", policyRef,
+				"client", c.client,
+				"secret", c.secret,
+				"duplicate_of", prev.secret,
+			)
+			continue
+		}
+
+		// This message reaches policy status, so it must never contain the key value itself.
+		errs = append(errs, fmt.Errorf(
+			"duplicate API key value shared by client %q in secret %s and client %q in secret %s",
+			prev.client, prev.secret, c.client, c.secret))
+	}
+
+	return credentials, errs
 }
 
 // handleAPIKeyAuth configures the API key auth filter and per-route API key auth configuration.

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth_test.go
@@ -1,6 +1,7 @@
 package trafficpolicy
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	envoyapikeyauthv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/api_key_auth/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/filters"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
@@ -447,4 +449,138 @@ func TestAPIKeyAuthPolicyPlugin(t *testing.T) {
 		assert.NotEmpty(t, pCtx.TypedFilterConfig[APIKeyAuthEnabledFilterName])
 		assert.NotContains(t, fmt.Sprintf("%s", pCtx.TypedFilterConfig[APIKeyAuthEnabledFilterName]), AuthSucceededMetadataKey, "api_key_auth_enabled must not set dynamic metadata if the policy is disabled at the route level")
 	})
+}
+
+func TestDedupeAPIKeyCredentials(t *testing.T) {
+	const policyRef = "app/apikey"
+	// A value distinctive enough that finding it anywhere in an error message is proof of a leak.
+	const apiKeyValue = "k-le4k-canary-1111" //nolint:gosec // G101: a test fixture, not a credential
+
+	cred := func(client, key string) *envoyapikeyauthv3.Credential {
+		return &envoyapikeyauthv3.Credential{Client: client, Key: key}
+	}
+
+	tests := []struct {
+		name     string
+		parsed   []parsedAPIKey
+		expected []*envoyapikeyauthv3.Credential
+		// errContains are substrings every returned error message together must cover.
+		errContains []string
+		errCount    int
+	}{
+		{
+			name: "distinct credentials are all emitted, ordered by client",
+			parsed: []parsedAPIKey{
+				{client: "client2", key: "key-2", secret: "app/keys"},
+				{client: "client1", key: "key-1", secret: "app/keys"},
+			},
+			expected: []*envoyapikeyauthv3.Credential{
+				cred("client1", "key-1"),
+				cred("client2", "key-2"),
+			},
+		},
+		{
+			name: "one client may hold several distinct keys",
+			parsed: []parsedAPIKey{
+				{client: "client1", key: "key-b", secret: "app/keys"},
+				{client: "client1", key: "key-a", secret: "app/keys"},
+			},
+			expected: []*envoyapikeyauthv3.Credential{
+				cred("client1", "key-a"),
+				cred("client1", "key-b"),
+			},
+		},
+		{
+			name: "the same credential in two secrets is collapsed without an error",
+			parsed: []parsedAPIKey{
+				{client: "client1", key: "key-1", secret: "gateway-system/keys"},
+				{client: "client1", key: "key-1", secret: "app/keys"},
+				{client: "client2", key: "key-2", secret: "app/keys"},
+			},
+			expected: []*envoyapikeyauthv3.Credential{
+				cred("client1", "key-1"),
+				cred("client2", "key-2"),
+			},
+		},
+		{
+			name: "two clients sharing a key value is reported",
+			parsed: []parsedAPIKey{
+				{client: "client2", key: apiKeyValue, secret: "app/keys-b"},
+				{client: "client1", key: apiKeyValue, secret: "app/keys-a"},
+			},
+			// Only the first of the conflicting pair survives, so the emitted list still
+			// satisfies Envoy's uniqueness rule even though the caller discards it.
+			expected: []*envoyapikeyauthv3.Credential{
+				cred("client1", apiKeyValue),
+			},
+			errCount:    1,
+			errContains: []string{`client "client1" in secret app/keys-a`, `client "client2" in secret app/keys-b`},
+		},
+		{
+			name: "every conflicting client is reported",
+			parsed: []parsedAPIKey{
+				{client: "client1", key: apiKeyValue, secret: "app/keys-a"},
+				{client: "client2", key: apiKeyValue, secret: "app/keys-b"},
+				{client: "client3", key: apiKeyValue, secret: "app/keys-c"},
+			},
+			expected: []*envoyapikeyauthv3.Credential{
+				cred("client1", apiKeyValue),
+			},
+			errCount:    2,
+			errContains: []string{`"client2"`, `"client3"`},
+		},
+		{
+			name:     "no credentials",
+			parsed:   nil,
+			expected: []*envoyapikeyauthv3.Credential{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credentials, errs := dedupeAPIKeyCredentials(tt.parsed, policyRef)
+
+			require.Len(t, errs, tt.errCount)
+			joined := errors.Join(errs...)
+			for _, want := range tt.errContains {
+				require.ErrorContains(t, joined, want)
+			}
+			if tt.errCount > 0 {
+				// The message is copied verbatim into policy status, which is far more
+				// readable and more widely replicated than a log line.
+				assert.NotContains(t, joined.Error(), apiKeyValue, "error message must not contain the api key value")
+			}
+
+			require.Len(t, credentials, len(tt.expected))
+			for i, want := range tt.expected {
+				assert.True(t, proto.Equal(want, credentials[i]), "credential %d: want %v, got %v", i, want, credentials[i])
+			}
+		})
+	}
+}
+
+// TestDedupeAPIKeyCredentialsIsOrderIndependent guards the KRT contract: Secret.Data is a map
+// and the secret fetch is unordered, so the same inputs reaching the loop in a different order
+// must still produce byte-identical config. Otherwise apiKeyAuthIR.Equals reports a change on
+// every recompute and the gateway is pushed config it already has.
+func TestDedupeAPIKeyCredentialsIsOrderIndependent(t *testing.T) {
+	base := []parsedAPIKey{
+		{client: "client1", key: "key-1", secret: "app/keys-a"},
+		{client: "client2", key: "key-2", secret: "app/keys-b"},
+		{client: "client1", key: "key-1", secret: "gateway-system/keys-a"},
+		{client: "client3", key: "key-3", secret: "app/keys-c"},
+	}
+
+	want, errs := dedupeAPIKeyCredentials(base, "app/apikey")
+	require.Empty(t, errs)
+	wantCfg := &envoyapikeyauthv3.ApiKeyAuthPerRoute{Credentials: want}
+
+	// Every rotation of the input is a plausible map iteration order.
+	for i := range base {
+		rotated := append(append([]parsedAPIKey{}, base[i:]...), base[:i]...)
+		got, errs := dedupeAPIKeyCredentials(rotated, "app/apikey")
+		require.Empty(t, errs)
+		gotCfg := &envoyapikeyauthv3.ApiKeyAuthPerRoute{Credentials: got}
+		assert.True(t, proto.Equal(wantCfg, gotCfg), "rotation by %d produced a different config: %v", i, got)
+	}
 }

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"istio.io/istio/pkg/kube/krt"
-	"k8s.io/apimachinery/pkg/util/sets"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
@@ -139,14 +138,16 @@ func constructBasicAuth(
 	// Validate and filter users to only include SHA hashed passwords
 	validUsers, invalidUsers := validateAndFilterSHAUsers(htpasswdData)
 
+	// Report invalid users if any were found.
+	// Checked before the empty case because it names the entries that were dropped.
+	if len(invalidUsers) > 0 {
+		return fmt.Errorf("basic auth: dropped %d user(s), invalid hash format (only {SHA} is supported), malformed entry, or a username listed twice with different hashes: %v",
+			len(invalidUsers), invalidUsers)
+	}
+
 	// If there are no valid users after filtering, return an error
 	if len(validUsers) == 0 {
 		return fmt.Errorf("basic auth: no valid users with {SHA} hash format found")
-	}
-
-	// Report invalid users if any were found
-	if len(invalidUsers) > 0 {
-		err = fmt.Errorf("basic auth: dropped %d user(s) with invalid hash format (only {SHA} is supported) or duplicate usernames.", len(invalidUsers))
 	}
 
 	allUsers := strings.Join(validUsers, "\n")
@@ -166,7 +167,7 @@ func constructBasicAuth(
 		},
 	}
 
-	return err
+	return nil
 }
 
 // fetchHtpasswdFromSecret retrieves htpasswd data from a Kubernetes secret
@@ -219,13 +220,20 @@ func fetchHtpasswdFromSecret(
 	return strings.TrimSpace(string(data)), nil
 }
 
-// validateAndFilterSHAUsers validates htpasswd entries and filters out users with non-SHA hash formats.
-// Returns a slice of valid users, a slice of invalid usernames, and an error if validation fails.
+// validateAndFilterSHAUsers validates htpasswd entries and filters out users Envoy cannot accept.
 // Envoy only supports {SHA} hash format for basic auth.
+//
+// Returns the entries to emit and, for anything dropped, an identifier the caller can put in the
+// policy error: the username, or a line number where the entry is too malformed to have one.
+//
+// A username repeated with the identical hash is the same entry written twice, so it is collapsed
+// and not reported: that is what an htpasswd file concatenated with a copy of itself looks like.
+// A username repeated with a different hash is ambiguous, since only one of the two passwords can
+// be authoritative, so it is reported instead of resolved silently.
 func validateAndFilterSHAUsers(htpasswdData string) (validUsers []string, invalidUsernames []string) {
 	lines := strings.Split(htpasswdData, "\n")
 	validUsers = make([]string, 0, len(lines))
-	validUsernames := sets.New[string]()
+	validEntries := make(map[string]string, len(lines))
 	invalidUsernames = make([]string, 0)
 
 	for i, line := range lines {
@@ -239,9 +247,9 @@ func validateAndFilterSHAUsers(htpasswdData string) (validUsers []string, invali
 		// htpasswd format is "username:password_hash"
 		parts := strings.SplitN(line, ":", 2)
 		if len(parts) != 2 {
-			// Don't log the entire line to avoid leaking sensitive info
+			// Don't report the entire line to avoid leaking sensitive info
 			logger.Warn("malformed htpasswd entry, missing colon", "line", i+1)
-			invalidUsernames = append(invalidUsernames, line)
+			invalidUsernames = append(invalidUsernames, fmt.Sprintf("line %d", i+1))
 			continue
 		}
 
@@ -250,16 +258,24 @@ func validateAndFilterSHAUsers(htpasswdData string) (validUsers []string, invali
 
 		// 5=len("{SHA}"), 28=SHA1 base64 length. these validations are copied from envoy source code.
 		validHash := strings.HasPrefix(passwordHash, shaPrefix) && len(passwordHash) == (28+5)
-		isDuplicate := validUsernames.Has(username)
-
-		// Check if the password hash uses {SHA} format
-		if validHash && !isDuplicate {
-			validUsers = append(validUsers, line)
-			validUsernames.Insert(username)
-		} else {
-			logger.Warn("invalid basic auth user", "user", username, "isDuplicate", isDuplicate, "validHash", validHash)
+		if !validHash {
+			logger.Warn("invalid basic auth user", "user", username, "reason", "hash is not {SHA}")
 			invalidUsernames = append(invalidUsernames, username)
+			continue
 		}
+
+		if seenHash, seen := validEntries[username]; seen {
+			if seenHash == passwordHash {
+				logger.Debug("dropping duplicate basic auth user", "user", username)
+				continue
+			}
+			logger.Warn("invalid basic auth user", "user", username, "reason", "listed twice with different hashes")
+			invalidUsernames = append(invalidUsernames, username)
+			continue
+		}
+
+		validUsers = append(validUsers, line)
+		validEntries[username] = passwordHash
 	}
 
 	return validUsers, invalidUsernames

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy_test.go
@@ -96,10 +96,12 @@ user2:{SHA}2kuSN7rMzfGcB2DKt67EqDWQELA=
 			expectedInvalid: []string{},
 		},
 		{
+			// A malformed entry is reported by line number: it has no parsable username, and
+			// the line itself may carry a password hash that must not reach policy status.
 			name:            "malformed entry without colon",
 			htpasswdData:    "invalidentry",
 			expectedValid:   []string{},
-			expectedInvalid: []string{"invalidentry"},
+			expectedInvalid: []string{"line 1"},
 		},
 		{
 			name: "malformed entries mixed with valid ones",
@@ -110,7 +112,7 @@ user2:{SHA}2kuSN7rMzfGcB2DKt67EqDWQELA=`,
 				"user1:{SHA}NWoZK3kTsExUV00Ywo1G5jlUKKs=",
 				"user2:{SHA}2kuSN7rMzfGcB2DKt67EqDWQELA=",
 			},
-			expectedInvalid: []string{"malformedentry"},
+			expectedInvalid: []string{"line 2"},
 		},
 		{
 			name:            "username with special characters",
@@ -138,11 +140,26 @@ bob:$2y$05$r3J4d3VepzFkedkd/q1vI.pBYIpSqjfN0qOARV3ScUHysatnS0cL2`,
 			expectedInvalid: []string{"alice", "bob"},
 		},
 		{
-			name: "duplicate valid users",
+			// Two passwords for one username: only one can be authoritative, so it is reported
+			// rather than resolved silently.
+			name: "duplicate username with different hashes",
 			htpasswdData: `user:{SHA}NWoZK3kTsExUV00Ywo1G5jlUKKs=
 user:{SHA}2kuSN7rMzfGcB2DKt67EqDWQELA=`,
 			expectedValid:   []string{"user:{SHA}NWoZK3kTsExUV00Ywo1G5jlUKKs="},
 			expectedInvalid: []string{"user"},
+		},
+		{
+			// The same entry written twice, which is what concatenating an htpasswd file with a
+			// copy of itself produces. Collapsing it is a no-op, so it is not reported.
+			name: "duplicate username with the identical hash is collapsed",
+			htpasswdData: `user1:{SHA}NWoZK3kTsExUV00Ywo1G5jlUKKs=
+user2:{SHA}2kuSN7rMzfGcB2DKt67EqDWQELA=
+user1:{SHA}NWoZK3kTsExUV00Ywo1G5jlUKKs=`,
+			expectedValid: []string{
+				"user1:{SHA}NWoZK3kTsExUV00Ywo1G5jlUKKs=",
+				"user2:{SHA}2kuSN7rMzfGcB2DKt67EqDWQELA=",
+			},
+			expectedInvalid: []string{},
 		},
 	}
 

--- a/test/e2e/features/apikeyauth/suite.go
+++ b/test/e2e/features/apikeyauth/suite.go
@@ -4,15 +4,26 @@ package apikeyauth
 
 import (
 	"context"
+	"encoding/json"
+	"slices"
+	"time"
 
+	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+	"github.com/kgateway-dev/kgateway/v2/test/envoyutils/admincli"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite
@@ -584,4 +595,171 @@ func (s *testingSuite) TestAPIKeyAuthDisableAtRouteLevel() {
 		expectStatus200Success,
 		getWithAPIKeyCurlOpts...,
 	)
+}
+
+// xdsUpdatesRejected sums every Envoy *.update_rejected counter (rds, cds, lds, sds).
+//
+// The defect is a NACK, and a NACK leaves the last accepted config in force, so the listener keeps
+// answering exactly as a working one does. A flat counter is the direct evidence that every config
+// kgateway emitted was accepted.
+func (s *testingSuite) xdsUpdatesRejected() uint64 {
+	var total uint64
+	s.TestInstallation.AssertionsT(s.T()).AssertEnvoyAdminApi(
+		s.Ctx,
+		proxyObjectMeta,
+		func(ctx context.Context, adminClient *admincli.Client) {
+			out, err := adminClient.GetStats(ctx, map[string]string{
+				"format": "json",
+				"filter": ".*update_rejected$",
+			})
+			s.Require().NoError(err, "can get envoy stats")
+
+			var resp map[string][]adminv3.SimpleMetric
+			s.Require().NoError(json.Unmarshal([]byte(out), &resp), "can unmarshal envoy stats")
+			// An empty result would make every assertion below vacuous.
+			s.Require().NotEmpty(resp["stats"], "expected at least one update_rejected counter")
+
+			stats := resp["stats"]
+			for i := range stats {
+				total += stats[i].GetValue()
+			}
+		},
+	)
+	return total
+}
+
+// TestAPIKeyAuthDuplicateKeyValues covers duplicate api key values across the Secrets one policy
+// selects. Envoy requires credential keys to be unique within an ApiKeyAuth config and NACKs the
+// whole RouteConfiguration when they are not, which freezes config delivery for the entire listener
+// while every Kubernetes-facing surface still reports Accepted. Translation collapses the harmless
+// duplicate and rejects the ambiguous one, so neither shape ever reaches Envoy.
+//
+// Status codes alone cannot show this, since a frozen listener still answers. The steps below assert
+// two things a frozen listener could not produce: that new config still lands while the duplicate
+// exists, and that Envoy never rejected an update.
+func (s *testingSuite) TestAPIKeyAuthDuplicateKeyValues() {
+	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPRouteCondition(s.Ctx, "httpbin-route-duplicate", "kgateway-base", gwv1.RouteConditionAccepted, metav1.ConditionTrue)
+
+	statusReqCurlOpts := []curl.Option{
+		curl.WithHostHeader("httpbin"),
+		curl.WithPort(80),
+		curl.WithPath("/status/200"),
+	}
+
+	// Baseline rather than zero: an earlier suite may have left the counter non-zero.
+	rejectedAtStart := s.xdsUpdatesRejected()
+
+	// Step 1: two Secrets carry the identical credential. The repeat is collapsed, so the route is
+	// programmed and enforcing. Before the dedup, the RouteConfiguration carrying this route was
+	// rejected, so the route never landed and the listener kept serving whatever it last accepted.
+	s.T().Log("Step 1: the same credential in two Secrets is collapsed and the route enforces")
+	common.BaseGateway.Send(
+		s.T(),
+		expectStatus200Success,
+		append(slices.Clone(statusReqCurlOpts), curl.WithHeader("api-key", "k-dup-111"))...,
+	)
+	common.BaseGateway.Send(
+		s.T(),
+		expectAPIKeyAuthDenied,
+		statusReqCurlOpts...,
+	)
+	s.Require().Equal(rejectedAtStart, s.xdsUpdatesRejected(),
+		"Envoy must not have rejected any config: the repeated credential was collapsed, not emitted")
+
+	// Step 2: the differential. A brand new credential has to land while the duplicate pair is
+	// still in place. On a frozen listener it never would, and step 1 would still have passed.
+	s.T().Log("Step 2: a new credential still lands while the duplicate pair is in place")
+	newClientSecret := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-duplicate-new-client
+  namespace: kgateway-base
+  labels:
+    apikey-duplicate-test: "true"
+type: Opaque
+stringData:
+  client2: k-dup-222
+`) //gosec:disable G101
+	testutils.Cleanup(s.T(), func() {
+		_ = s.TestInstallation.Actions.Kubectl().Delete(s.Ctx, newClientSecret)
+	})
+	err := s.TestInstallation.Actions.Kubectl().Apply(s.Ctx, newClientSecret)
+	s.Require().NoError(err, "failed to apply the new client secret")
+
+	common.BaseGateway.Send(
+		s.T(),
+		expectStatus200Success,
+		append(slices.Clone(statusReqCurlOpts), curl.WithHeader("api-key", "k-dup-222"))...,
+	)
+	s.Require().Equal(rejectedAtStart, s.xdsUpdatesRejected(),
+		"the new credential landed through an accepted update, not on top of a frozen listener")
+
+	// Step 3: the ambiguous duplicate. A second client claiming client1's key value cannot be
+	// resolved, so translation fails: the policy reports Invalid and the route is replaced with a
+	// 500 rather than left on stale config that claims to enforce.
+	s.T().Log("Step 3: two clients sharing a key value fail translation and replace the route")
+	conflictingSecret := []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-duplicate-conflict
+  namespace: kgateway-base
+  labels:
+    apikey-duplicate-test: "true"
+type: Opaque
+stringData:
+  client3: k-dup-111
+`) //gosec:disable G101
+	testutils.Cleanup(s.T(), func() {
+		_ = s.TestInstallation.Actions.Kubectl().Delete(s.Ctx, conflictingSecret)
+	})
+	err = s.TestInstallation.Actions.Kubectl().Apply(s.Ctx, conflictingSecret)
+	s.Require().NoError(err, "failed to apply the conflicting secret")
+
+	s.TestInstallation.AssertionsT(s.T()).Gomega.Eventually(func(g gomega.Gomega) {
+		tp := &kgateway.TrafficPolicy{}
+		err := s.TestInstallation.ClusterContext.Client.Get(
+			s.Ctx,
+			types.NamespacedName{Name: "api-key-auth-policy-duplicate", Namespace: "kgateway-base"},
+			tp,
+		)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "can get api-key-auth-policy-duplicate TrafficPolicy")
+		g.Expect(tp.Status.Ancestors).NotTo(gomega.BeEmpty(), "TrafficPolicy should report ancestor status")
+
+		cond := apimeta.FindStatusCondition(tp.Status.Ancestors[0].Conditions, string(shared.PolicyConditionAccepted))
+		g.Expect(cond).NotTo(gomega.BeNil(), "TrafficPolicy should have an Accepted condition")
+		g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse), "conflicting api keys should be Accepted=False")
+		g.Expect(cond.Reason).To(gomega.Equal(string(shared.PolicyReasonInvalid)), "reason should be Invalid")
+		g.Expect(cond.Message).To(gomega.ContainSubstring("client1"), "status should name the conflicting clients")
+		g.Expect(cond.Message).To(gomega.ContainSubstring("client3"), "status should name the conflicting clients")
+		// A status message is more widely readable, and more widely replicated, than a log line.
+		g.Expect(cond.Message).NotTo(gomega.ContainSubstring("k-dup-111"), "status must not leak the api key value")
+	}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(gomega.Succeed())
+
+	// Matched on the body: the 500 has to be kgateway's replacement direct response, not an
+	// upstream error and not stale config.
+	common.BaseGateway.Send(
+		s.T(),
+		expectRouteReplaced,
+		append(slices.Clone(statusReqCurlOpts), curl.WithHeader("api-key", "k-dup-111"))...,
+	)
+	s.Require().Equal(rejectedAtStart, s.xdsUpdatesRejected(),
+		"the ambiguous duplicate must fail translation, so Envoy never sees a config to reject")
+
+	// Step 4: removing the conflict recovers the route.
+	s.T().Log("Step 4: removing the conflicting Secret recovers the route")
+	err = s.TestInstallation.Actions.Kubectl().Delete(s.Ctx, conflictingSecret)
+	s.Require().NoError(err, "failed to delete the conflicting secret")
+
+	common.BaseGateway.Send(
+		s.T(),
+		expectStatus200Success,
+		append(slices.Clone(statusReqCurlOpts), curl.WithHeader("api-key", "k-dup-111"))...,
+	)
+	common.BaseGateway.Send(
+		s.T(),
+		expectAPIKeyAuthDenied,
+		statusReqCurlOpts...,
+	)
+	s.Require().Equal(rejectedAtStart, s.xdsUpdatesRejected(),
+		"no update was rejected at any point in this arm")
 }

--- a/test/e2e/features/apikeyauth/testdata/api-key-auth-duplicate.yaml
+++ b/test/e2e/features/apikeyauth/testdata/api-key-auth-duplicate.yaml
@@ -1,0 +1,69 @@
+# Two Secrets holding the same api key value, selected by one policy. This is the shape a
+# Secret-namespace migration leaves behind: the original plus a co-located copy, both selected
+# once a ReferenceGrant is added. Envoy rejects an ApiKeyAuth config with a repeated key and
+# NACKs the whole RouteConfiguration, so translation has to collapse the copy before emitting.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-route-duplicate
+  namespace: kgateway-base
+spec:
+  hostnames:
+    - httpbin
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway
+      namespace: kgateway-base
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: httpbin
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /status/200
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-duplicate-original
+  namespace: kgateway-base
+  labels:
+    apikey-duplicate-test: "true"
+type: Opaque
+stringData:
+  client1: k-dup-111
+---
+# The co-located copy: same client, same value. Collapsing it is a no-op.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys-duplicate-copy
+  namespace: kgateway-base
+  labels:
+    apikey-duplicate-test: "true"
+type: Opaque
+stringData:
+  client1: k-dup-111
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: api-key-auth-policy-duplicate
+  namespace: kgateway-base
+spec:
+  targetRefs:
+    - name: httpbin-route-duplicate
+      kind: HTTPRoute
+      group: gateway.networking.k8s.io
+  apiKeyAuth:
+    keySources:
+      - header: "api-key"
+    secretSelector:
+      matchLabels:
+        apikey-duplicate-test: "true"

--- a/test/e2e/features/apikeyauth/types.go
+++ b/test/e2e/features/apikeyauth/types.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"path/filepath"
 
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
 	"github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
@@ -21,6 +24,7 @@ var (
 	apiKeyAuthManifestSecretUpdate = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-secret-update.yaml")
 	apiKeyAuthManifestOverride     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-override.yaml")
 	apiKeyAuthManifestDisable      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-disable.yaml")
+	apiKeyAuthManifestDuplicate    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "api-key-auth-duplicate.yaml")
 
 	expectStatus200Success = &matchers.HttpResponse{
 		StatusCode: http.StatusOK,
@@ -29,6 +33,20 @@ var (
 	expectAPIKeyAuthDenied = &matchers.HttpResponse{
 		StatusCode: http.StatusUnauthorized,
 		Body:       nil,
+	}
+	// proxyObjectMeta targets the shared gateway deployment for Envoy admin API access.
+	proxyObjectMeta = metav1.ObjectMeta{
+		Name:      "gateway",
+		Namespace: "kgateway-base",
+	}
+
+	// expectRouteReplaced matches the direct response kgateway substitutes for a route whose
+	// policy failed to translate. The body is what makes the assertion specific: a bare 500 could
+	// come from the upstream, from Envoy itself, or from a connection failure, none of which would
+	// show that the route was replaced rather than left serving stale config.
+	expectRouteReplaced = &matchers.HttpResponse{
+		StatusCode: http.StatusInternalServerError,
+		Body:       gomega.ContainSubstring("invalid route configuration detected and replaced with a direct response."),
 	}
 
 	// Base test setup - common infrastructure for all tests
@@ -57,6 +75,9 @@ var (
 		"TestAPIKeyAuthRouteOverrideGateway": {
 			Manifests:       []string{apiKeyAuthManifestOverride},
 			MinGwApiVersion: base.GwApiRequireRouteNames,
+		},
+		"TestAPIKeyAuthDuplicateKeyValues": {
+			Manifests: []string{apiKeyAuthManifestDuplicate},
 		},
 		"TestAPIKeyAuthDisableAtRouteLevel": {
 			Manifests:       []string{apiKeyAuthManifestDisable},


### PR DESCRIPTION
# Description

Backport of #14592 to `v2.4.x`.

**Motivation.** An `apiKeyAuth` TrafficPolicy that selects two Secrets holding the **same api-key
value** emits that key twice. Envoy requires credential keys to be unique within a single
`ApiKeyAuth` config and returns `Duplicated credential key: '<value>'`, rejecting the config. Because
`ApiKeyAuthPerRoute` rides in the route's `typed_per_filter_config`, that rejection takes the whole
`RouteConfiguration` with it: config delivery for the entire listener stops at the last accepted
version, and unrelated changes silently stop taking effect. No Kubernetes-facing surface reports it
— the policy reports `Accepted=Valid`, the HTTPRoute reports `Accepted`, and traffic keeps flowing
on stale config. Where the frozen config predates the policy, the route serves **unauthenticated**
traffic while the policy claims to enforce.

This is reachable by following documented guidance. The natural workaround for
`failed to get secrets by selector: missing reference grant` is to co-locate the Secret with the
application, since a same-namespace reference needs no ReferenceGrant. Later adding the
ReferenceGrant — the correct fix — makes the gateway-namespace Secret selectable *in addition* to
the co-located copy, leaving two selected Secrets holding one key value.

**What changed.** `constructAPIKeyAuth` no longer emits a list that violates the uniqueness rule.
Same client + same key is one credential listed twice, so it is collapsed quietly. Two clients
sharing a key value is ambiguous — the client name is forwarded as the client id header and recorded
in auth metadata — so translation fails instead, reporting `Accepted=False, reason: Invalid` on the
policy and replacing the affected route with a 500. The error names both clients and both Secrets
but never the key value, since that message is copied verbatim into policy status. Credentials are
also sorted before emitting, so the emitted order no longer varies between recomputes (which made
`apiKeyAuthIR.Equals` report a spurious change every time).

The same split is applied to basic auth, which had the shape of this fix but not the effect:
`constructBasicAuth` filtered invalid users and then returned an error *alongside* the built config,
and since the translator skips the plugin for any policy that errors, the filtered list was never
served.

# Change Type

/kind fix

# Changelog

```release-note
Fixed an apiKeyAuth TrafficPolicy selecting two Secrets that hold the same api-key value emitting a duplicate credential, which Envoy rejects, freezing xDS delivery for the entire listener while the policy still reported Accepted. Identical credentials are now collapsed, and two clients sharing one key value fail translation with the policy reporting Accepted=False.
```

# Additional Notes

**Differences from the original PR.** The cherry-pick applied cleanly; two adaptations were needed
for APIs that do not exist on this branch:

- `errors` added to the imports of `api_key_auth.go`. On `main` the import was already there (an
  earlier `fmt.Errorf` → `errors.New` cleanup that is not on this branch), so the commit carried no
  import diff.
- `curl.Extend(base, extra...)` does not exist here, so the four call sites use
  `append(slices.Clone(statusReqCurlOpts), ...)` instead. Rather than backport a new exported helper
  onto a release branch, this keeps the same non-aliasing semantics locally.

`go build -tags e2e ./...`, `go test ./pkg/kgateway/extensions2/plugins/trafficpolicy/...` and
`make analyze` are clean on this branch.
