### PR TITLE
fix: validate signature-algorithms TLS option

### DIFF
--- a/pkg/kgateway/translator/sslutils/ssl_utils.go
+++ b/pkg/kgateway/translator/sslutils/ssl_utils.go
@@ -67,6 +67,22 @@ var (
 		return fmt.Errorf("invalid ca.crt kind %s in %s/%s: %w", kind, ns, n, ErrInvalidCACertificateKind)
 	}
 	ErrMissingCaCertificateRefGrant = errors.New("missing CA certificate reference grant")
+
+	// validSignatureAlgorithms is the set of signature algorithms supported by Envoy/BoringSSL
+	validSignatureAlgorithms = map[string]struct{}{
+		"rsa_pkcs1_sha256":    {},
+		"rsa_pkcs1_sha384":    {},
+		"rsa_pkcs1_sha512":    {},
+		"ecdsa_secp256r1_sha256": {},
+		"ecdsa_secp384r1_sha384": {},
+		"ecdsa_secp521r1_sha512": {},
+		"rsa_pss_rsae_sha256": {},
+		"rsa_pss_rsae_sha384": {},
+		"rsa_pss_rsae_sha512": {},
+		"ed25519":             {},
+		"rsa_pkcs1_sha1":      {},
+		"ecdsa_sha1":          {},
+	}
 )
 
 // ValidateTlsSecret and return a cleaned cert
@@ -175,11 +191,25 @@ func ApplyEcdhCurves(in string, out *ir.TLSConfig) error {
 
 func ApplySignatureAlgorithms(in string, out *ir.TLSConfig) error {
 	signatureAlgorithms := strings.Split(in, ",")
-	for i, suite := range signatureAlgorithms {
-		signatureAlgorithms[i] = strings.TrimSpace(suite)
+
+	var errs error
+	var validAlgorithms []string
+	for _, suite := range signatureAlgorithms {
+		trimmed := strings.TrimSpace(suite)
+		// Skip empty entries (from trailing commas or multiple consecutive commas)
+		if trimmed == "" {
+			continue
+		}
+		// Validate against known signature algorithms
+		if _, ok := validSignatureAlgorithms[trimmed]; !ok {
+			errs = errors.Join(errs, fmt.Errorf("invalid signature algorithm: %s", trimmed))
+			continue
+		}
+		validAlgorithms = append(validAlgorithms, trimmed)
 	}
-	out.SignatureAlgorithms = signatureAlgorithms
-	return nil
+
+	out.SignatureAlgorithms = validAlgorithms
+	return errs
 }
 
 func ApplyAlpnProtocols(in string, out *ir.TLSConfig) error {

--- a/pkg/kgateway/translator/sslutils/ssl_utils.go
+++ b/pkg/kgateway/translator/sslutils/ssl_utils.go
@@ -70,18 +70,18 @@ var (
 
 	// validSignatureAlgorithms is the set of signature algorithms supported by Envoy/BoringSSL
 	validSignatureAlgorithms = map[string]struct{}{
-		"rsa_pkcs1_sha256":    {},
-		"rsa_pkcs1_sha384":    {},
-		"rsa_pkcs1_sha512":    {},
+		"rsa_pkcs1_sha256":       {},
+		"rsa_pkcs1_sha384":       {},
+		"rsa_pkcs1_sha512":       {},
 		"ecdsa_secp256r1_sha256": {},
 		"ecdsa_secp384r1_sha384": {},
 		"ecdsa_secp521r1_sha512": {},
-		"rsa_pss_rsae_sha256": {},
-		"rsa_pss_rsae_sha384": {},
-		"rsa_pss_rsae_sha512": {},
-		"ed25519":             {},
-		"rsa_pkcs1_sha1":      {},
-		"ecdsa_sha1":          {},
+		"rsa_pss_rsae_sha256":    {},
+		"rsa_pss_rsae_sha384":    {},
+		"rsa_pss_rsae_sha512":    {},
+		"ed25519":                {},
+		"rsa_pkcs1_sha1":         {},
+		"ecdsa_sha1":             {},
 	}
 )
 

--- a/pkg/kgateway/translator/sslutils/ssl_utils_test.go
+++ b/pkg/kgateway/translator/sslutils/ssl_utils_test.go
@@ -120,9 +120,7 @@ func TestApplyTLSExtensionOptions(t *testing.T) {
 			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
 				annotations.SignatureAlgorithms: "rsa_pss_rsae_sha255",
 			},
-			out: &ir.TLSConfig{
-				SignatureAlgorithms: []string{},
-			},
+			out: &ir.TLSConfig{},
 			errors: []string{
 				"invalid signature algorithm: rsa_pss_rsae_sha255",
 			},

--- a/pkg/kgateway/translator/sslutils/ssl_utils_test.go
+++ b/pkg/kgateway/translator/sslutils/ssl_utils_test.go
@@ -73,6 +73,61 @@ func TestApplyTLSExtensionOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "signature_algorithms_trailing_comma",
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "ecdsa_secp256r1_sha256,rsa_pss_rsae_sha256,rsa_pkcs1_sha256,",
+			},
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{"ecdsa_secp256r1_sha256", "rsa_pss_rsae_sha256", "rsa_pkcs1_sha256"},
+			},
+		},
+		{
+			name: "signature_algorithms_multiple_commas",
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "ecdsa_secp256r1_sha256,,rsa_pss_rsae_sha256,,rsa_pkcs1_sha256",
+			},
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{"ecdsa_secp256r1_sha256", "rsa_pss_rsae_sha256", "rsa_pkcs1_sha256"},
+			},
+		},
+		{
+			name: "signature_algorithms_invalid",
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "bogus_alg,rsa_pss_rsae_sha256",
+			},
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{"rsa_pss_rsae_sha256"},
+			},
+			errors: []string{
+				"invalid signature algorithm: bogus_alg",
+			},
+		},
+		{
+			name: "signature_algorithms_multiple_invalid",
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "bogus_alg,invalid_algo,rsa_pss_rsae_sha256",
+			},
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{"rsa_pss_rsae_sha256"},
+			},
+			errors: []string{
+				"invalid signature algorithm: bogus_alg",
+				"invalid signature algorithm: invalid_algo",
+			},
+		},
+		{
+			name: "signature_algorithms_typo",
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "rsa_pss_rsae_sha255",
+			},
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{},
+			},
+			errors: []string{
+				"invalid signature algorithm: rsa_pss_rsae_sha255",
+			},
+		},
+		{
 			name: "subject_alt_names",
 			out: &ir.TLSConfig{
 				VerifySubjectAltNames: []string{"foo", "bar"},
@@ -179,6 +234,55 @@ func TestApplyTLSExtensionOptions(t *testing.T) {
 			},
 			errors: []string{
 				"unknown tls option: kgateway.dev/min-tls-versions",
+			},
+		},
+		{
+			name: "invalid_signature_algorithm",
+			out:  &ir.TLSConfig{},
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "invalid_algo",
+			},
+			errors: []string{
+				"invalid signature algorithm: invalid_algo",
+			},
+		},
+		{
+			name: "signature_algorithms_with_invalid",
+			out:  &ir.TLSConfig{},
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "rsa_pkcs1_sha256,invalid_algo,ecdsa_secp256r1_sha256",
+			},
+			errors: []string{
+				"invalid signature algorithm: invalid_algo",
+			},
+		},
+		{
+			name: "signature_algorithms_trailing_comma",
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{"rsa_pkcs1_sha256", "ecdsa_secp256r1_sha256"},
+			},
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "rsa_pkcs1_sha256,ecdsa_secp256r1_sha256,",
+			},
+		},
+		{
+			name: "signature_algorithms_multiple_commas",
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{"rsa_pkcs1_sha256", "ecdsa_secp256r1_sha256"},
+			},
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "rsa_pkcs1_sha256,,ecdsa_secp256r1_sha256,",
+			},
+		},
+		{
+			name: "signature_algorithms_all_invalid",
+			out:  &ir.TLSConfig{},
+			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				annotations.SignatureAlgorithms: "bogus1,bogus2",
+			},
+			errors: []string{
+				"invalid signature algorithm: bogus1",
+				"invalid signature algorithm: bogus2",
 			},
 		},
 	}

--- a/pkg/kgateway/translator/sslutils/ssl_utils_test.go
+++ b/pkg/kgateway/translator/sslutils/ssl_utils_test.go
@@ -246,7 +246,9 @@ func TestApplyTLSExtensionOptions(t *testing.T) {
 		},
 		{
 			name: "signature_algorithms_with_invalid",
-			out:  &ir.TLSConfig{},
+			out: &ir.TLSConfig{
+				SignatureAlgorithms: []string{"rsa_pkcs1_sha256", "ecdsa_secp256r1_sha256"},
+			},
 			in: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
 				annotations.SignatureAlgorithms: "rsa_pkcs1_sha256,invalid_algo,ecdsa_secp256r1_sha256",
 			},
@@ -255,7 +257,7 @@ func TestApplyTLSExtensionOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "signature_algorithms_trailing_comma",
+			name: "signature_algorithms_trailing_comma_filtered",
 			out: &ir.TLSConfig{
 				SignatureAlgorithms: []string{"rsa_pkcs1_sha256", "ecdsa_secp256r1_sha256"},
 			},
@@ -264,7 +266,7 @@ func TestApplyTLSExtensionOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "signature_algorithms_multiple_commas",
+			name: "signature_algorithms_multiple_commas_filtered",
 			out: &ir.TLSConfig{
 				SignatureAlgorithms: []string{"rsa_pkcs1_sha256", "ecdsa_secp256r1_sha256"},
 			},


### PR DESCRIPTION
# Description

Adds validation for the `kgateway.dev/signature-algorithms` listener TLS option to prevent invalid algorithm names from reaching Envoy and causing NACK retry storms (connection refused + ~10/s retry loop).

**Changes**
- `pkg/kgateway/translator/sslutils/ssl_utils.go`:
  - Added `validSignatureAlgorithms` map with all 12 supported algorithms from Envoy/BoringSSL
  - Modified `ApplySignatureAlgorithms` to validate each algorithm against the known set, filter out empty entries (trailing commas, multiple consecutive commas), and return errors for invalid algorithms while still applying valid ones
- `pkg/kgateway/translator/sslutils/ssl_utils_test.go`:
  - Added test cases for trailing comma, multiple consecutive commas, invalid algorithm detection, multiple invalid algorithms, and typo detection (`rsa_pss_rsae_sha255`)

**Before**: Invalid algorithms like `bogus_alg` or `rsa_pss_rsae_sha255` (typo) or trailing commas passed through to Envoy, causing the listener to report `Programmed=True` while the data plane rejected it and Envoy NACKed in a tight retry loop.

**After**: Invalid algorithms are rejected at translation time with clear error messages, preventing the NACK retry storm.

Fixes #14453

# Change Type

/kind fix

# Changelog

```release-note
Validate the kgateway.dev/signature-algorithms TLS option during translation so invalid algorithm names are rejected instead of reaching Envoy and triggering listener NACK retry storms.
```
