### PR TITLE
feat: add values.schema.json for kgateway Helm chart

### DIFF
--- a/install/helm/kgateway/values.schema.json
+++ b/install/helm/kgateway/values.schema.json
@@ -1,0 +1,723 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Set a list of image pull secrets for Kubernetes to use when pulling container images from a private registry.",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Additional labels to add to all resources created by the Helm chart.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Add a name to the default Helm base release name."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of resources created by the Helm chart."
+    },
+    "rbac": {
+      "type": "object",
+      "description": "Configure RBAC resources (ClusterRole and ClusterRoleBinding) for the deployment.",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create the ClusterRole and ClusterRoleBinding."
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "Configure the service account for the deployment.",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specify whether a service account should be created."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Add annotations to the service account.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Set the name of the service account to use."
+        }
+      }
+    },
+    "deploymentAnnotations": {
+      "type": "object",
+      "description": "Add annotations to the kgateway deployment.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Add annotations to the kgateway pods. Deprecated in favor of controller.podAnnotations.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Set the pod-level security context. Deprecated in favor of controller.podSecurityContext."
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Set the container-level security context. Deprecated in favor of controller.securityContext."
+    },
+    "resources": {
+      "type": "object",
+      "description": "Configure resource requests and limits for the container. Deprecated in favor of controller.resources.",
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "description": "Resource requests (cpu, memory, ephemeral-storage, hugepages, etc.)",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "limits": {
+          "type": "object",
+          "description": "Resource limits (cpu, memory, ephemeral-storage, hugepages, etc.)",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Set node selector labels for pod scheduling. Deprecated in favor of controller.nodeSelector.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Set tolerations for pod scheduling. Deprecated in favor of controller.tolerations.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Set affinity rules for pod scheduling. Deprecated in favor of controller.affinity."
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "description": "Set topology spread constraints for pod scheduling. Deprecated in favor of controller.topologySpreadConstraints.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "controller": {
+      "type": "object",
+      "description": "Configure the kgateway control plane deployment.",
+      "additionalProperties": false,
+      "properties": {
+        "replicaCount": {
+          "description": "Set the number of controller pod replicas.",
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "priorityClassName": {
+          "type": "string",
+          "description": "Set the priority class name for the controller pod."
+        },
+        "logLevel": {
+          "type": "string",
+          "description": "Set the log level for the controller.",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
+        },
+        "image": {
+          "type": "object",
+          "description": "Configure the controller container image.",
+          "additionalProperties": false,
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "Set the image registry for the controller."
+            },
+            "repository": {
+              "type": "string",
+              "description": "Set the image repository for the controller."
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "Set the image pull policy for the controller.",
+              "enum": [
+                "",
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            },
+            "tag": {
+              "type": "string",
+              "description": "Set the image tag for the controller."
+            }
+          }
+        },
+        "podAnnotations": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Add annotations to the controller pods."
+        },
+        "podSecurityContext": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Set the pod-level security context for the controller pod."
+        },
+        "securityContext": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Set the container-level security context for the controller container."
+        },
+        "resources": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Configure resource requests and limits for the controller container."
+        },
+        "goMemLimitPercent": {
+          "description": "Compute GOMEMLIMIT as this percentage of resources.limits.memory at render time. 0 disables percentage calculation. Type and range (1-100) are validated by the chart template, not this schema, so it can emit a descriptive error message."
+        },
+        "nodeSelector": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Set node selector labels for controller pod scheduling."
+        },
+        "tolerations": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Set tolerations for controller pod scheduling."
+        },
+        "affinity": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Set affinity rules for controller pod scheduling."
+        },
+        "topologySpreadConstraints": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Set topology spread constraints for controller pod scheduling."
+        },
+        "service": {
+          "type": "object",
+          "description": "Controller service configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create the controller Service."
+            },
+            "type": {
+              "type": "string",
+              "description": "Service type.",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer",
+                "ExternalName"
+              ]
+            },
+            "ports": {
+              "type": "object",
+              "description": "Service ports.",
+              "additionalProperties": false,
+              "properties": {
+                "grpc": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "health": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "metrics": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                }
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Service annotations.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "extraLabels": {
+              "type": "object",
+              "description": "Extra labels for the Service.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "clusterIP": {
+              "type": "string",
+              "description": "Cluster IP address."
+            },
+            "clusterIPs": {
+              "type": "array",
+              "description": "Cluster IPs for dual-stack.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "externalIPs": {
+              "type": "array",
+              "description": "External IP addresses.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "externalName": {
+              "type": "string",
+              "description": "External name for ExternalName services."
+            },
+            "loadBalancerIP": {
+              "type": "string",
+              "description": "Load balancer IP address."
+            },
+            "loadBalancerSourceRanges": {
+              "type": "array",
+              "description": "Allowed source ranges for load balancer.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "loadBalancerClass": {
+              "type": "string",
+              "description": "Load balancer class."
+            },
+            "externalTrafficPolicy": {
+              "type": "string",
+              "description": "External traffic policy.",
+              "enum": [
+                "",
+                "Cluster",
+                "Local"
+              ]
+            },
+            "internalTrafficPolicy": {
+              "type": "string",
+              "description": "Internal traffic policy.",
+              "enum": [
+                "",
+                "Cluster",
+                "Local"
+              ]
+            },
+            "healthCheckNodePort": {
+              "description": "Health check node port.",
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sessionAffinity": {
+              "type": "string",
+              "description": "Session affinity.",
+              "enum": [
+                "",
+                "None",
+                "ClientIP"
+              ]
+            },
+            "sessionAffinityConfig": {
+              "type": "object",
+              "description": "Session affinity configuration."
+            },
+            "ipFamilies": {
+              "type": "array",
+              "description": "IP families.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "IPv4",
+                  "IPv6"
+                ]
+              }
+            },
+            "ipFamilyPolicy": {
+              "type": "string",
+              "description": "IP family policy.",
+              "enum": [
+                "",
+                "SingleStack",
+                "PreferDualStack",
+                "RequireDualStack"
+              ]
+            },
+            "publishNotReadyAddresses": {
+              "type": "boolean",
+              "description": "Publish not ready addresses."
+            },
+            "allocateLoadBalancerNodePorts": {
+              "description": "Allocate load balancer node ports.",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "trafficDistribution": {
+              "type": "string",
+              "description": "Traffic distribution.",
+              "enum": [
+                "",
+                "PreferClose",
+                "PreferSameZone",
+                "PreferSameNode"
+              ]
+            }
+          }
+        },
+        "prometheusAnnotations": {
+          "type": "boolean",
+          "description": "Add Prometheus scrape annotations to the controller pods."
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "description": "Controller ServiceMonitor configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create the controller ServiceMonitor when the Prometheus Operator CRDs are installed."
+            },
+            "annotations": {
+              "type": "object",
+              "description": "ServiceMonitor annotations.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "extraLabels": {
+              "type": "object",
+              "description": "Extra labels for the ServiceMonitor.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "readinessProbe": {
+          "type": "object",
+          "description": "Configure the readiness probe for the controller container. Overrides the default probe when set."
+        },
+        "startupProbe": {
+          "type": "object",
+          "description": "Configure the startup probe for the controller container. Overrides the default probe when set."
+        },
+        "extraEnv": {
+          "type": "object",
+          "description": "Add extra environment variables to the controller container."
+        },
+        "admin": {
+          "type": "object",
+          "description": "Controller admin/debug server configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "bindAddress": {
+              "type": "string",
+              "description": "Bind host for the controller admin/debug server on port 9095."
+            }
+          }
+        },
+        "xds": {
+          "type": "object",
+          "description": "Configure TLS settings for the xDS gRPC servers.",
+          "additionalProperties": false,
+          "properties": {
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable TLS encryption for xDS communication."
+                }
+              }
+            }
+          }
+        },
+        "enableAwsEc2Discovery": {
+          "type": "boolean",
+          "description": "Enable dynamic discovery of AWS EC2 instances for Backend resources."
+        },
+        "awsEc2RefreshInterval": {
+          "type": "string",
+          "description": "Set how often the controller refreshes discovered AWS EC2 instances for Backend resources."
+        },
+        "strategy": {
+          "type": "object",
+          "description": "Change the rollout strategy from the Kubernetes default."
+        },
+        "podDisruptionBudget": {
+          "type": "object",
+          "description": "Set pod disruption budget for the controller."
+        },
+        "horizontalPodAutoscaler": {
+          "type": "object",
+          "description": "Set horizontal pod autoscaler for the controller."
+        },
+        "verticalPodAutoscaler": {
+          "type": "object",
+          "description": "Set vertical pod autoscaler for the controller."
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "description": "Configure the default container image for the components that Helm deploys.",
+      "additionalProperties": false,
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "Set the default image registry."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Set the default image tag."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Set the default image pull policy.",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      }
+    },
+    "discoveryNamespaceSelectors": {
+      "type": "array",
+      "description": "List of namespace selectors for config discovery.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "serviceEntriesExclusionLabelSelectors": {
+      "type": "array",
+      "description": "List of ServiceEntry exclusion label selectors.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "gatewayClassParametersRefs": {
+      "type": "object",
+      "description": "Map of GatewayClass names to GatewayParameters references.",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "name",
+          "namespace"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the GatewayParameters resource."
+          },
+          "namespace": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Namespace of the GatewayParameters resource."
+          }
+        }
+      }
+    },
+    "policyMerge": {
+      "type": "object",
+      "description": "Policy merging settings.",
+      "additionalProperties": false,
+      "properties": {
+        "trafficPolicy": {
+          "type": "object",
+          "description": "Merge strategy per TrafficPolicy field. Supported keys: extAuth, extProc, transformation.",
+          "additionalProperties": false,
+          "properties": {
+            "extAuth": {
+              "type": "string",
+              "description": "Merge strategy for ExtAuth policy.",
+              "enum": [
+                "DeepMerge",
+                "StrategicMerge"
+              ]
+            },
+            "extProc": {
+              "type": "string",
+              "description": "Merge strategy for ExtProc policy.",
+              "enum": [
+                "DeepMerge",
+                "StrategicMerge"
+              ]
+            },
+            "transformation": {
+              "type": "string",
+              "description": "Merge strategy for Transformation policy.",
+              "enum": [
+                "DeepMerge",
+                "StrategicMerge"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "waypoint": {
+      "type": "object",
+      "description": "Enable the waypoint integration.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable kgateway as a waypoint in an Istio Ambient service mesh setup."
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "description": "Configure validation behavior for route and policy safety checks.",
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "description": "Validation level. Accepted values: standard or strict (case-insensitive).",
+          "pattern": "^\\s*([sS][tT][aA][nN][dD][aA][rR][dD]|[sS][tT][rR][iI][cC][tT])\\s*$"
+        }
+      }
+    },
+    "enableRouteSourceMetadata": {
+      "type": "boolean",
+      "description": "Enable attaching dev.kgateway.route_source filter metadata to every Envoy route. Experimental."
+    }
+  }
+}

--- a/test/helm/helm_schema_test.go
+++ b/test/helm/helm_schema_test.go
@@ -1,0 +1,159 @@
+package helm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+type helmValuesSchemaNode struct {
+	Properties map[string]*helmValuesSchemaNode `json:"properties,omitempty"`
+}
+
+// TestHelmValuesSchemaMatchesDefaults ensures values.schema.json stays in sync with values.yaml.
+// It's a lightweight guard against silent schema drift: if a field is added to values.yaml without
+// a matching schema entry, additionalProperties:false won't catch it (the new field is simply
+// unvalidated), so we catch it here instead.
+func TestHelmValuesSchemaMatchesDefaults(t *testing.T) {
+	valuesPath := filepath.Join("..", "..", "install", "helm", "kgateway", "values.yaml")
+	schemaPath := filepath.Join("..", "..", "install", "helm", "kgateway", "values.schema.json")
+
+	values, err := loadHelmValues(valuesPath)
+	require.NoError(t, err)
+
+	schema, err := loadHelmValuesSchema(schemaPath)
+	require.NoError(t, err)
+
+	missingFromSchema, missingFromValues := compareHelmValuesSchemaKeys(values, schema, "")
+	if len(missingFromSchema) > 0 || len(missingFromValues) > 0 {
+		t.Fatalf("values.yaml and values.schema.json are out of sync:\n%s",
+			formatHelmValuesSchemaDiff(missingFromSchema, missingFromValues))
+	}
+}
+
+func compareHelmValuesSchemaKeys(values map[string]any, schema *helmValuesSchemaNode, prefix string) (missingFromSchema, missingFromValues []string) {
+	valuesKeys := keysOfHelmValuesMap(values)
+	var schemaKeys []string
+	if schema != nil {
+		schemaKeys = make([]string, 0, len(schema.Properties))
+		for k := range schema.Properties {
+			schemaKeys = append(schemaKeys, k)
+		}
+	}
+
+	valuesSet := helmValuesKeySet(valuesKeys)
+	schemaSet := helmValuesKeySet(schemaKeys)
+
+	missingFromSchema = sortedHelmValuesKeyDiff(valuesSet, schemaSet, prefix)
+	missingFromValues = sortedHelmValuesKeyDiff(schemaSet, valuesSet, prefix)
+
+	for _, k := range sortedHelmValuesKeyIntersect(valuesSet, schemaSet) {
+		nestedValues, ok := values[k].(map[string]any)
+		if !ok || len(nestedValues) == 0 {
+			continue
+		}
+
+		nestedSchema := schema.Properties[k]
+		// Open maps and default-empty extension points need not mirror every schema option.
+		if nestedSchema == nil || len(nestedSchema.Properties) == 0 {
+			continue
+		}
+
+		missing, extra := compareHelmValuesSchemaKeys(nestedValues, nestedSchema, prefix+k+".")
+		missingFromSchema = append(missingFromSchema, missing...)
+		missingFromValues = append(missingFromValues, extra...)
+	}
+
+	return missingFromSchema, missingFromValues
+}
+
+func formatHelmValuesSchemaDiff(missingFromSchema, missingFromValues []string) string {
+	var out strings.Builder
+	if len(missingFromSchema) > 0 {
+		out.WriteString("keys in values.yaml but missing from values.schema.json:\n")
+		for _, key := range missingFromSchema {
+			out.WriteString("  - ")
+			out.WriteString(key)
+			out.WriteString("\n")
+		}
+	}
+	if len(missingFromValues) > 0 {
+		out.WriteString("keys in values.schema.json but missing from values.yaml:\n")
+		for _, key := range missingFromValues {
+			out.WriteString("  - ")
+			out.WriteString(key)
+			out.WriteString("\n")
+		}
+	}
+	return out.String()
+}
+
+func keysOfHelmValuesMap(values map[string]any) []string {
+	out := make([]string, 0, len(values))
+	for k := range values {
+		out = append(out, k)
+	}
+	return out
+}
+
+func helmValuesKeySet(keys []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func sortedHelmValuesKeyDiff(a, b map[string]struct{}, prefix string) []string {
+	var out []string
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			out = append(out, prefix+k)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+func sortedHelmValuesKeyIntersect(a, b map[string]struct{}) []string {
+	var out []string
+	for k := range a {
+		if _, ok := b[k]; ok {
+			out = append(out, k)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+func loadHelmValues(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	out := map[string]any{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func loadHelmValuesSchema(path string) (*helmValuesSchemaNode, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var out helmValuesSchemaNode
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/test/helm/helm_version_test.go
+++ b/test/helm/helm_version_test.go
@@ -256,6 +256,87 @@ func TestHelmChartRBACToggle(t *testing.T) {
 	})
 }
 
+func TestHelmValuesSchemaValidation(t *testing.T) {
+	testCases := []struct {
+		name       string
+		valuesYAML string
+		wantErr    string
+	}{
+		{
+			name: "resources allow numeric quantities",
+			valuesYAML: `resources:
+  requests:
+    cpu: 1
+    memory: 128Mi
+  limits:
+    cpu: 2
+`,
+		},
+		{
+			name: "validation level is trimmed and case insensitive",
+			valuesYAML: `validation:
+  level: " sTrIcT "
+`,
+		},
+		{
+			name: "replicas allow null",
+			valuesYAML: `controller:
+  replicaCount: null
+`,
+		},
+		{
+			name: "goMemLimitPercent allows 0-100",
+			valuesYAML: `controller:
+  goMemLimitPercent: 90
+  resources:
+    limits:
+      memory: 512Mi
+`,
+		},
+		{
+			name: "replicas reject negative values",
+			valuesYAML: `controller:
+  replicaCount: -1
+`,
+			wantErr: "replicaCount",
+		},
+		{
+			name: "traffic distribution rejects unknown values",
+			valuesYAML: `controller:
+  service:
+    trafficDistribution: SomewhereElse
+`,
+			wantErr: "trafficDistribution",
+		},
+		{
+			name: "goMemLimitPercent rejects values over 100",
+			valuesYAML: `controller:
+  goMemLimitPercent: 150
+`,
+			wantErr: "goMemLimitPercent",
+		},
+		{
+			name: "unknown top-level key is rejected",
+			valuesYAML: `notARealField: true
+`,
+			wantErr: "notARealField",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, stderr, err := runHelmTemplate(t, "kgateway", tc.valuesYAML, nil)
+			if tc.wantErr == "" {
+				require.NoError(t, err, "helm template failed: %s", stderr)
+				return
+			}
+
+			require.Error(t, err, "helm template should fail")
+			require.Contains(t, stderr, tc.wantErr)
+		})
+	}
+}
+
 // extractImageLines extracts lines containing "image:" from the output for debugging
 func extractImageLines(output string) string {
 	var lines []string


### PR DESCRIPTION
# Description

Adds `install/helm/kgateway/values.schema.json`, a JSON Schema (draft 2020-12) covering every field in `values.yaml`. Helm validates incoming values against this schema before rendering templates, so common mistakes (unknown keys, wrong types, bad enum values) now fail fast with a clear message instead of surfacing as a confusing template render error (or silently doing the wrong thing).

**What changed:**
- New `install/helm/kgateway/values.schema.json`, hand-authored to mirror `values.yaml` (`additionalProperties: false` at every object level, enums for constrained string fields, `oneOf [type, null]` for nullable `controller.*` fields).
- Deliberately left `controller.goMemLimitPercent` unconstrained (no `type`/`minimum`/`maximum`) because the chart already validates it at template time with a specific, human-readable error message (`_helpers.tpl` / `deployment.yaml`); a strict schema constraint here would pre-empt that message with Helm's generic schema error instead. Verified with `TestControllerGoMemLimitPercent`.
- New `test/helm/helm_schema_test.go`: a recursive key-diff test that fails the build if `values.yaml` and `values.schema.json` fall out of sync, so the two can't silently drift.
- New `TestHelmValuesSchemaValidation` in `test/helm/helm_version_test.go`: exercises `helm template` against the real chart for both accepted and rejected values.

**On codegen vs. hand-authored:** @davidjumani noted on the issue that this schema should ideally be part of codegen. I looked into this and didn't find any maintained tooling in the Go/Helm ecosystem for deriving a `values.schema.json` from `values.yaml` (matching @timflannagan's earlier comment on the issue) - so, consistent with the two prior attempts at this issue (#13718, #13941), I went with a hand-authored schema plus the drift-guard test above as a lightweight substitute for codegen-enforced sync. Happy to discuss alternatives if there's a preferred direction here.

**Related issues:** Fixes #12488

# Change Type

/kind feature

# Changelog

```release-note
Add a JSON schema (`values.schema.json`) for the kgateway Helm chart so `helm template`/`helm install` validate values up front and fail with clear errors on typos or invalid types.
```

# Additional Notes

- Verified on Windows and re-verified on a clean, native-Linux environment (to rule out line-ending/OS-specific false passes).
- `go test ./test/helm/...`: full pass.
- `make analyze -B`: 0 issues.
- `make verify -B`: no codegen side effects from this change.
