### PR TITLE
fix: deny ListenerSet attachment when allowedListeners cannot be parsed

### DIFF
--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -2865,6 +2865,28 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("listener set and gateway with allowedListeners selector unset", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-sets/allowed-listeners-selector-unset.yaml"},
+			outputFile: "listener-sets/allowed-listeners-selector-unset.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("listener set and gateway with an invalid allowedListeners selector", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-sets/allowed-listeners-selector-invalid.yaml"},
+			outputFile: "listener-sets/allowed-listeners-selector-invalid.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("listener set accepted with rejected individual listener", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"listener-sets/accepted-ls-rejected-listener.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/allowed-listeners-selector-invalid.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/allowed-listeners-selector-invalid.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http-8080
+    protocol: HTTP
+    port: 8080
+  allowedListeners:
+    namespaces:
+      from: Selector
+      selector:
+        matchExpressions:
+        - key: team
+          operator: Bogus
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: foo-listenerset
+spec:
+  parentRef:
+    name: example-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: http-9090
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/allowed-listeners-selector-unset.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-sets/allowed-listeners-selector-unset.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: kgateway
+  listeners:
+  - name: http-8080
+    protocol: HTTP
+    port: 8080
+  allowedListeners:
+    namespaces:
+      from: Selector
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: foo-listenerset
+spec:
+  parentRef:
+    name: example-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: http-9090
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/allowed-listeners-selector-invalid.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/allowed-listeners-selector-invalid.yaml
@@ -1,0 +1,93 @@
+Clusters:
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-8080
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  listenerSets:
+    default/foo-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: Unable to parse allowedListeners
+        reason: NotAllowed
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Unable to parse allowedListeners
+        reason: NotAllowed
+        status: "False"
+        type: Programmed

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/allowed-listeners-selector-unset.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/allowed-listeners-selector-unset.yaml
@@ -1,0 +1,93 @@
+Clusters:
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~8080
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~8080
+  name: listener~8080
+Routes:
+- ignorePortInHostMatching: true
+  name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 0
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http-8080
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  listenerSets:
+    default/foo-listenerset:
+      conditions:
+      - lastTransitionTime: null
+        message: Unable to parse allowedListeners
+        reason: NotAllowed
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Unable to parse allowedListeners
+        reason: NotAllowed
+        status: "False"
+        type: Programmed

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -580,6 +580,13 @@ func GatewaysForEnvoyTransformationFunc(config *GatewayIndexConfig) func(kctx kr
 				continue
 			}
 
+			// allowedNs is nil if allowedListeners could not be parsed, so deny the attachment.
+			if err != nil {
+				lsIR.Err = errors.New("Unable to parse allowedListeners")
+				gwIR.DeniedListenerSets[lsGVK] = append(gwIR.DeniedListenerSets[lsGVK], lsIR)
+				continue
+			}
+
 			// Check if the namespace of the listenerSet is allowed by the gateway
 			// We return the denied list of ls to have their status set to rejected during validation
 			if !allowedNs(kctx, ls.GetNamespace()) {


### PR DESCRIPTION
# Description

A Gateway whose `allowedListeners` selector cannot be parsed panics the control plane: the error from `AllowedListenerSet` is only logged, so `allowedNs` is nil where it is called at `pkg/krtcollections/policy.go:585`. Two specs reach it, `from: Selector` with no `selector` and a selector `metav1.LabelSelectorAsSelector` rejects, so CRD validation on `selector` alone would not close it.

#12926 moved the call out of the ListenerSet loop and dropped the branch that denied the attachment on a parse error. This puts the branch back, with the call left where it is, so the ListenerSet gets the status it used to get.

Two translator cases, one per spec. Both panic without the change.

Fixes #14624

# Change Type

/kind fix

# Changelog

```release-note
Reject ListenerSet attachment when a Gateway's allowedListeners selector cannot be parsed instead of crashing the control plane.
```

# Additional Notes

Validated with `go test ./pkg/krtcollections/... ./pkg/kgateway/translator/...`. The same manifests through `TEST_PREFIX=f001 go test ./pkg/kgateway/setup/ -run TestWithStandardSettings` panic on main and pass with this change.
