### PR TITLE
[2.3] updated envoy to v1.37.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ else
 	OSV_SCANNER_PLATFORM := --platform=linux/amd64
 endif
 
-export ENVOY_IMAGE ?= envoyproxy/envoy:v1.37.5
+export ENVOY_IMAGE ?= envoyproxy/envoy:v1.37.6
 
 # ENVOY_IMAGE is used by some of the *-docker targets which are used by CI e2e tests, so figure out the correct image
 # to use base on GOARCH. This doesn't affect goreleaser

--- a/internal/envoy_modules/Cargo.lock
+++ b/internal/envoy_modules/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "envoy-proxy-dynamic-modules-rust-sdk"
 version = "0.1.0"
-source = "git+https://github.com/envoyproxy/envoy?tag=v1.37.5#f97695a50e11f5ff6719e129a466bf9204b64a7f"
+source = "git+https://github.com/envoyproxy/envoy?tag=v1.37.6#cf413bdb37b36d3ffbe570b8a48760abe2b588f5"
 dependencies = [
  "bindgen",
  "mockall",

--- a/internal/envoy_modules/Cargo.toml
+++ b/internal/envoy_modules/Cargo.toml
@@ -13,4 +13,4 @@ default-members = ["module-init"]
 [workspace.dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
 # Update this single entry when upgrading Envoy.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.37.5" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.37.6" }

--- a/tilt-settings.yaml
+++ b/tilt-settings.yaml
@@ -38,7 +38,7 @@ providers:
     # NOTE: Do NOT include ENTRYPOINT here - the Tiltfile will append the correct
     # entrypoint (standard or debug) based on whether debug_port is set.
     dockerfile_contents: |
-      FROM envoyproxy/envoy:v1.37.5 as envoy-bin
+      FROM envoyproxy/envoy:v1.37.6 as envoy-bin
 
       FROM golang:latest as tilt
       WORKDIR /app


### PR DESCRIPTION
# Description

update envoy to v1.37.6

# Change Type

/kind bump

# Changelog

```release-note
updated envoy for CVE fixes
```

# Additional Notes

see envoy [v1.37.6 release note](https://github.com/envoyproxy/envoy/releases#release-v1.37.6) for details