### PR TITLE
[2.4] updated envoy to v1.38.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ else
 	OSV_SCANNER_PLATFORM := --platform=linux/amd64
 endif
 
-export ENVOY_IMAGE ?= envoyproxy/envoy:v1.38.3
+export ENVOY_IMAGE ?= envoyproxy/envoy:v1.38.4
 
 # ENVOY_IMAGE is used by some of the *-docker targets which are used by CI e2e tests, so figure out the correct image
 # to use base on GOARCH. This doesn't affect goreleaser
@@ -1242,7 +1242,7 @@ run-load-tests-production: ## Run production load tests (5000 routes)
 CONFORMANCE_GATEWAY_CLASS ?= kgateway
 CONFORMANCE_REPORT_ARGS ?= -report-output=$(TEST_ASSET_DIR)/conformance/$(VERSION)-report.yaml -organization=kgateway-dev -project=kgateway -version=$(VERSION) -url=github.com/kgateway-dev/kgateway -contact=github.com/kgateway-dev/kgateway/issues/new/choose
 # This test uses port 9091 which is reserved for the metrics port. The test passes if the port in the conformance test is changed
-CONFORMANCE_SKIP_TESTS := 
+CONFORMANCE_SKIP_TESTS :=
 CONFORMANCE_ARGS := -gateway-class=$(CONFORMANCE_GATEWAY_CLASS) $(CONFORMANCE_SKIP_TESTS) $(CONFORMANCE_REPORT_ARGS)
 
 CONFORMANCE_TEST_DIR ?= ./test/conformance/...

--- a/internal/envoy_modules/Cargo.lock
+++ b/internal/envoy_modules/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "envoy-proxy-dynamic-modules-rust-sdk"
 version = "0.1.0"
-source = "git+https://github.com/envoyproxy/envoy?tag=v1.38.3#0ebfcfe5b0484b89ca85b761da9e05ce75dbda8d"
+source = "git+https://github.com/envoyproxy/envoy?tag=v1.38.4#ef2d997c1b022cf8b849a1d3521fbf234d79ca26"
 dependencies = [
  "bindgen",
  "mockall",

--- a/internal/envoy_modules/Cargo.toml
+++ b/internal/envoy_modules/Cargo.toml
@@ -13,4 +13,4 @@ default-members = ["module-init"]
 [workspace.dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
 # Update this single entry when upgrading Envoy.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.38.3" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.38.4" }

--- a/tilt-settings.yaml
+++ b/tilt-settings.yaml
@@ -38,7 +38,7 @@ providers:
     # NOTE: Do NOT include ENTRYPOINT here - the Tiltfile will append the correct
     # entrypoint (standard or debug) based on whether debug_port is set.
     dockerfile_contents: |
-      FROM envoyproxy/envoy:v1.38.3 as envoy-bin
+      FROM envoyproxy/envoy:v1.38.4 as envoy-bin
 
       FROM golang:latest as tilt
       WORKDIR /app


### PR DESCRIPTION
# Description

updated envoy to v1.38.4

# Change Type

/kind bump

# Changelog

<!--
Provide the exact line to appear in the release notes for this PR.

A PR gets one release note, filed under the highest-precedence /kind above.
If this change needs no release note, write "NONE" in the block below.
-->

```release-note
updated envoy for CVE fixes
```

# Additional Notes

see envoy [v1.38.4 release note](https://github.com/envoyproxy/envoy/releases#release-v1.38.4) for details