### PR TITLE
deployer: refactor helm values mapping

### DIFF
--- a/pkg/deployer/values_helpers.go
+++ b/pkg/deployer/values_helpers.go
@@ -10,6 +10,7 @@ import (
 
 	istioslices "istio.io/istio/pkg/slices"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
@@ -319,6 +320,97 @@ func toHelmStringMatcher(l []shared.StringMatcher) []HelmStringMatcher {
 		})
 	}
 	return out
+}
+
+// ApplyKubernetesProxyConfigValues maps every field of a KubernetesProxyConfig onto the
+// gateway helm values. gateway.Ports must already be populated, since the security context
+// defaulting depends on whether privileged ports are in use, and cfg may be mutated by that
+// defaulting. Values derived from the Gateway or the environment (ports, xds, gateway
+// labels/annotations, load-balancer IP) remain the caller's responsibility.
+func ApplyKubernetesProxyConfigValues(gateway *HelmGateway, cfg *kgateway.KubernetesProxyConfig, istioAutoMtlsEnabled bool) error {
+	// The security contexts may need to be updated if privileged ports are used.
+	// This may affect both the PodSecurityContext and the SecurityContexts for the containers defined in cfg.
+	// Note: this call may populate the PodSecurityContext and SecurityContext fields in cfg if they are null,
+	// so this needs to happen before those fields are extracted to local variables.
+	UpdateSecurityContexts(cfg, gateway.Ports)
+
+	deployConfig := cfg.GetDeployment()
+	podConfig := cfg.GetPodTemplate()
+	envoyContainerConfig := cfg.GetEnvoyContainer()
+	svcConfig := cfg.GetService()
+	svcAccountConfig := cfg.GetServiceAccount()
+	istioConfig := cfg.GetIstio()
+
+	sdsContainerConfig := cfg.GetSdsContainer()
+	statsConfig := cfg.GetStats()
+	istioContainerConfig := istioConfig.GetIstioProxyContainer()
+
+	// deployment values
+	if deployConfig.GetReplicas() != nil {
+		gateway.ReplicaCount = new(uint32(*deployConfig.GetReplicas())) // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	}
+	gateway.Strategy = deployConfig.GetStrategy()
+
+	// service values
+	gateway.Service = GetServiceValues(svcConfig)
+	// serviceaccount values
+	gateway.ServiceAccount = GetServiceAccountValues(svcAccountConfig)
+	// pod template values
+	gateway.ExtraPodAnnotations = podConfig.GetExtraAnnotations()
+	gateway.ExtraPodLabels = podConfig.GetExtraLabels()
+	gateway.ImagePullSecrets = podConfig.GetImagePullSecrets()
+	gateway.PodSecurityContext = podConfig.GetSecurityContext()
+	gateway.NodeSelector = podConfig.GetNodeSelector()
+	gateway.Affinity = podConfig.GetAffinity()
+	gateway.Tolerations = podConfig.GetTolerations()
+	gateway.StartupProbe = podConfig.GetStartupProbe()
+	gateway.ReadinessProbe = podConfig.GetReadinessProbe()
+	gateway.LivenessProbe = podConfig.GetLivenessProbe()
+	gateway.GracefulShutdown = podConfig.GetGracefulShutdown()
+	gateway.TerminationGracePeriodSeconds = podConfig.GetTerminationGracePeriodSeconds()
+	gateway.TopologySpreadConstraints = podConfig.GetTopologySpreadConstraints()
+	gateway.ExtraVolumes = podConfig.GetExtraVolumes()
+	gateway.PriorityClassName = podConfig.GetPriorityClassName()
+
+	gateway.DataPlaneType = DataPlaneEnvoy
+	gateway.LogFormat = envoyContainerConfig.GetBootstrap().GetLogFormat()
+	gateway.LogLevel = envoyContainerConfig.GetBootstrap().GetLogLevel()
+	compLogLevels := envoyContainerConfig.GetBootstrap().GetComponentLogLevels()
+	compLogLevelStr, err := ComponentLogLevelsToString(compLogLevels)
+	if err != nil {
+		return err
+	}
+	gateway.ComponentLogLevel = &compLogLevelStr
+
+	// Extract DNS resolver configuration
+	dnsResolverConfig := envoyContainerConfig.GetBootstrap().GetDnsResolver()
+	if dnsResolverConfig != nil {
+		var udpMaxQueries *int32
+		if maybeMaxQ := ptr.Deref(dnsResolverConfig.GetUdpMaxQueries(), 0); maybeMaxQ > 0 {
+			udpMaxQueries = &maybeMaxQ
+		}
+		gateway.DnsResolver = &HelmDnsResolver{
+			UdpMaxQueries: udpMaxQueries,
+		}
+	}
+
+	gateway.EnableReadinessProbeProxyProtocol = envoyContainerConfig.GetBootstrap().GetEnableReadinessProbeProxyProtocol()
+
+	gateway.Resources = envoyContainerConfig.GetResources()
+	gateway.SecurityContext = envoyContainerConfig.GetSecurityContext()
+	gateway.Image = GetImageValues(envoyContainerConfig.GetImage())
+	gateway.ExtraArgs = envoyContainerConfig.GetExtraArgs()
+	gateway.Env = envoyContainerConfig.GetEnv()
+	gateway.ExtraVolumeMounts = envoyContainerConfig.ExtraVolumeMounts
+
+	// istio values
+	gateway.Istio = GetIstioValues(istioAutoMtlsEnabled, istioConfig)
+	gateway.SdsContainer = GetSdsContainerValues(sdsContainerConfig)
+	gateway.IstioContainer = GetIstioContainerValues(istioContainerConfig)
+
+	gateway.Stats = GetStatsValues(statsConfig)
+
+	return nil
 }
 
 // ComponentLogLevelsToString converts the key-value pairs in the map into a string of the

--- a/pkg/kgateway/deployer/gateway_parameters.go
+++ b/pkg/kgateway/deployer/gateway_parameters.go
@@ -375,99 +375,15 @@ func (k *kgatewayParameters) getValues(gw *gwv1.Gateway, gwParam *kgateway.Gatew
 		return vals, nil
 	}
 
-	// The security contexts may need to be updated if privileged ports are used.
-	// This may affect both the PodSecurityContext and the SecurityContexts for the containers defined in gwParam
-	// Note: this call may populate the PodSecurityContext and SecurityContext fields in the gateway parameters if they are null,
-	// so this needs to happen before those kubeProxyConfig fields are extracted to local variables.
-	deployer.UpdateSecurityContexts(gwParam.Spec.Kube, vals.Gateway.Ports)
-
 	// extract all the custom values from the GatewayParameters
-	// (note: if we add new fields to GatewayParameters, they will
-	// need to be plumbed through here as well)
-
-	kubeProxyConfig := gwParam.Spec.Kube
-	deployConfig := kubeProxyConfig.GetDeployment()
-	podConfig := kubeProxyConfig.GetPodTemplate()
-	envoyContainerConfig := kubeProxyConfig.GetEnvoyContainer()
-	svcConfig := kubeProxyConfig.GetService()
-	svcAccountConfig := kubeProxyConfig.GetServiceAccount()
-	istioConfig := kubeProxyConfig.GetIstio()
-
-	sdsContainerConfig := kubeProxyConfig.GetSdsContainer()
-	statsConfig := kubeProxyConfig.GetStats()
-	istioContainerConfig := istioConfig.GetIstioProxyContainer()
-
-	gateway := vals.Gateway
-
-	// deployment values
-	if deployConfig.GetReplicas() != nil {
-		gateway.ReplicaCount = new(uint32(*deployConfig.GetReplicas())) // nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	if err := deployer.ApplyKubernetesProxyConfigValues(vals.Gateway, gwParam.Spec.Kube, k.inputs.IstioAutoMtlsEnabled); err != nil {
+		return nil, err
 	}
-	gateway.Strategy = deployConfig.GetStrategy()
 
-	// service values
-	gateway.Service = deployer.GetServiceValues(svcConfig)
 	// Extract loadBalancerIP from Gateway.spec.addresses and set it on the service if service type is LoadBalancer
-	if err := deployer.SetLoadBalancerIPFromGateway(gw, gateway.Service); err != nil {
+	if err := deployer.SetLoadBalancerIPFromGateway(gw, vals.Gateway.Service); err != nil {
 		return nil, err
 	}
-	// serviceaccount values
-	gateway.ServiceAccount = deployer.GetServiceAccountValues(svcAccountConfig)
-	// pod template values
-	gateway.ExtraPodAnnotations = podConfig.GetExtraAnnotations()
-	gateway.ExtraPodLabels = podConfig.GetExtraLabels()
-	gateway.ImagePullSecrets = podConfig.GetImagePullSecrets()
-	gateway.PodSecurityContext = podConfig.GetSecurityContext()
-	gateway.NodeSelector = podConfig.GetNodeSelector()
-	gateway.Affinity = podConfig.GetAffinity()
-	gateway.Tolerations = podConfig.GetTolerations()
-	gateway.StartupProbe = podConfig.GetStartupProbe()
-	gateway.ReadinessProbe = podConfig.GetReadinessProbe()
-	gateway.LivenessProbe = podConfig.GetLivenessProbe()
-	gateway.GracefulShutdown = podConfig.GetGracefulShutdown()
-	gateway.TerminationGracePeriodSeconds = podConfig.GetTerminationGracePeriodSeconds()
-	gateway.TopologySpreadConstraints = podConfig.GetTopologySpreadConstraints()
-	gateway.ExtraVolumes = podConfig.GetExtraVolumes()
-	gateway.PriorityClassName = podConfig.GetPriorityClassName()
-
-	gateway.DataPlaneType = deployer.DataPlaneEnvoy
-	gateway.LogFormat = envoyContainerConfig.GetBootstrap().GetLogFormat()
-	logLevel := envoyContainerConfig.GetBootstrap().GetLogLevel()
-	gateway.LogLevel = logLevel
-	compLogLevels := envoyContainerConfig.GetBootstrap().GetComponentLogLevels()
-	compLogLevelStr, err := deployer.ComponentLogLevelsToString(compLogLevels)
-	if err != nil {
-		return nil, err
-	}
-	gateway.ComponentLogLevel = &compLogLevelStr
-
-	// Extract DNS resolver configuration
-	dnsResolverConfig := envoyContainerConfig.GetBootstrap().GetDnsResolver()
-	if dnsResolverConfig != nil {
-		var udpMaxQueries *int32
-		if maybeMaxQ := ptr.Deref(dnsResolverConfig.GetUdpMaxQueries(), 0); maybeMaxQ > 0 {
-			udpMaxQueries = &maybeMaxQ
-		}
-		gateway.DnsResolver = &deployer.HelmDnsResolver{
-			UdpMaxQueries: udpMaxQueries,
-		}
-	}
-
-	gateway.EnableReadinessProbeProxyProtocol = envoyContainerConfig.GetBootstrap().GetEnableReadinessProbeProxyProtocol()
-
-	gateway.Resources = envoyContainerConfig.GetResources()
-	gateway.SecurityContext = envoyContainerConfig.GetSecurityContext()
-	gateway.Image = deployer.GetImageValues(envoyContainerConfig.GetImage())
-	gateway.ExtraArgs = envoyContainerConfig.GetExtraArgs()
-	gateway.Env = envoyContainerConfig.GetEnv()
-	gateway.ExtraVolumeMounts = envoyContainerConfig.ExtraVolumeMounts
-
-	// istio values
-	gateway.Istio = deployer.GetIstioValues(k.inputs.IstioAutoMtlsEnabled, istioConfig)
-	gateway.SdsContainer = deployer.GetSdsContainerValues(sdsContainerConfig)
-	gateway.IstioContainer = deployer.GetIstioContainerValues(istioContainerConfig)
-
-	gateway.Stats = deployer.GetStatsValues(statsConfig)
 
 	return vals, nil
 }


### PR DESCRIPTION
# Description

Exports the `KubernetesProxyConfig` → helm values mapping from `getValues` as `deployer.ApplyKubernetesProxyConfigValues`, and refactors `getValues` to call it.

No functional change.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```
