### PR TITLE
[2.4] fix: SDS binds to loopback address

### DIFF
--- a/cmd/sds/main.go
+++ b/cmd/sds/main.go
@@ -1,9 +1,60 @@
 package main
 
 import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
 	"github.com/kgateway-dev/kgateway/v2/pkg/sds"
 )
 
+// defaultSDSAddress matches pkg/sds.Config's default SdsServerAddress. Used
+// as a fallback for the healthcheck subcommand below when SDS_SERVER_ADDRESS
+// is unset.
+const defaultSDSAddress = "127.0.0.1:8234"
+
+// healthCheckTimeout bounds the readiness-probe dial.
+const healthCheckTimeout = time.Second
+
 func main() {
+	// The "healthcheck" subcommand is used by the sds container's readiness
+	// probe. SDS binds to loopback, so a kubelet tcpSocket probe - which dials
+	// the pod IP - can't reach it; instead the probe execs this binary inside
+	// the pod and dials loopback directly.
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		runHealthCheck()
+		return
+	}
+
 	sds.RunMain()
+}
+
+// runHealthCheck dials the SDS server over loopback and exits non-zero if it
+// is not accepting connections.
+func runHealthCheck() {
+	addr := healthCheckAddress(os.Getenv("SDS_SERVER_ADDRESS"))
+	conn, err := net.DialTimeout("tcp", addr, healthCheckTimeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sds healthcheck: %v\n", err)
+		os.Exit(1)
+	}
+	_ = conn.Close()
+}
+
+// healthCheckAddress returns the loopback address to probe. SDS always
+// serves Envoy over loopback, so we dial 127.0.0.1 using the port from the
+// configured bind address (env), falling back to the default. Resolving
+// against loopback keeps the probe correct even if the bind address is a
+// wildcard (e.g. 0.0.0.0:8234) or unset.
+func healthCheckAddress(env string) string {
+	if env == "" {
+		env = defaultSDSAddress
+	}
+	_, port, err := net.SplitHostPort(env)
+	if err != nil {
+		// Not host:port (e.g. just a port or malformed); fall back to default port.
+		_, port, _ = net.SplitHostPort(defaultSDSAddress)
+	}
+	return net.JoinHostPort("127.0.0.1", port)
 }

--- a/cmd/sds/main_test.go
+++ b/cmd/sds/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestHealthCheckAddress(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "unset defaults to loopback:8234", env: "", want: "127.0.0.1:8234"},
+		{name: "loopback bind dialed as-is", env: "127.0.0.1:8234", want: "127.0.0.1:8234"},
+		{name: "wildcard bind dialed over loopback", env: "0.0.0.0:8234", want: "127.0.0.1:8234"},
+		{name: "custom port preserved", env: "0.0.0.0:9999", want: "127.0.0.1:9999"},
+		{name: "ipv6 wildcard bind", env: "[::]:8234", want: "127.0.0.1:8234"},
+		{name: "malformed falls back to default port", env: "not-an-address", want: "127.0.0.1:8234"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := healthCheckAddress(tc.env); got != tc.want {
+				t.Fatalf("healthCheckAddress(%q) = %q, want %q", tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/kgateway/helm/envoy/templates/deployment.yaml
+++ b/pkg/kgateway/helm/envoy/templates/deployment.yaml
@@ -185,12 +185,14 @@ spec:
             name: sds
             protocol: TCP
         readinessProbe:
+          exec:
+            command:
+              - /usr/local/bin/sds
+              - healthcheck
           failureThreshold: 3
           initialDelaySeconds: 3
           periodSeconds: 10
           successThreshold: 1
-          tcpSocket:
-            port: 8234
           timeoutSeconds: 1
         {{- with $gateway.sdsContainer.resources }}
         resources:

--- a/pkg/sds/run.go
+++ b/pkg/sds/run.go
@@ -23,7 +23,7 @@ var (
 )
 
 type Config struct {
-	SdsServerAddress string `split_words:"true" default:"0.0.0.0:8234"` // sds_config target_uri in the envoy instance that it provides secrets to
+	SdsServerAddress string `split_words:"true" default:"127.0.0.1:8234"` // sds_config target_uri in the envoy instance that it provides secrets to; loopback-only since Envoy always dials it from the same pod
 	SdsClient        string `split_words:"true"`
 
 	PodName      string `split_words:"true"`

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -412,12 +412,14 @@ spec:
           name: sds
           protocol: TCP
         readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/sds
+            - healthcheck
           failureThreshold: 3
           initialDelaySeconds: 3
           periodSeconds: 10
           successThreshold: 1
-          tcpSocket:
-            port: 8234
           timeoutSeconds: 1
         resources:
           limits:

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -406,12 +406,14 @@ spec:
           name: sds
           protocol: TCP
         readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/sds
+            - healthcheck
           failureThreshold: 3
           initialDelaySeconds: 3
           periodSeconds: 10
           successThreshold: 1
-          tcpSocket:
-            port: 8234
           timeoutSeconds: 1
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -415,12 +415,14 @@ spec:
           name: sds
           protocol: TCP
         readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/sds
+            - healthcheck
           failureThreshold: 3
           initialDelaySeconds: 3
           periodSeconds: 10
           successThreshold: 1
-          tcpSocket:
-            port: 8234
           timeoutSeconds: 1
         resources: {}
         terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
# Description

Backport of https://github.com/kgateway-dev/kgateway/pull/14638#top

**Motivation:** The SDS sidecar is deployed in the same pod as Envoy and every legitimate consumer in the codebase targets `127.0.0.1:8234` (see `pkg/kgateway/wellknown/constants.go` and `pkg/kgateway/helm/envoy/templates/configmap.yaml`). The default in `pkg/sds/run.go` was `0.0.0.0:8234`, exposing the endpoint to any pod that could reach the Envoy pod over the cluster network.

**What changed:** Flipped the default to `127.0.0.1:8234`. Operators who genuinely need the previous behavior can still override via `SDS_SERVER_ADDRESS=0.0.0.0:8234`.

# Change Type

/kind fix

# Changelog

```release-note
The SDS sidecar now binds to 127.0.0.1:8234 by default instead of 0.0.0.0:8234, preventing other pods on the cluster network from reaching the endpoint. Override by setting SDS_SERVER_ADDRESS if the previous behavior is required.
```