### PR TITLE
fix: make the ReferenceGrant source identity configurable and stop leaking selector matches

### DIFF
--- a/devel/reference_grant/reference-grant-mode.md
+++ b/devel/reference_grant/reference-grant-mode.md
@@ -118,6 +118,39 @@ spec:
       kind: GatewayExtension
 ```
 
+## Source identity
+
+A ReferenceGrant's `from.group`/`from.kind` name the kind that holds the reference,
+and translation decides which kind that is. Every cross-namespace reference in
+`TrafficPolicySpec` resolves under `gateway.kgateway.dev/TrafficPolicy` by default:
+`basicAuth.secretRef`, `apiKeyAuth.secretRef`, `apiKeyAuth.secretSelector`,
+secret-backed `headerModifiers` values, and `extensionRef` in Strict mode. References
+held by another resource are unaffected - a `GatewayExtension` backend ref is granted
+from `GatewayExtension` no matter what pointed at it.
+
+When a kind other than `TrafficPolicy` carries the spec being translated, that kind is
+what a user creates and what a namespace owner is deciding to trust, so it is the
+identity a grant has to name. `WithSourceGroupKind` sets it:
+
+```go
+constructor := trafficpolicy.NewTrafficPolicyConstructor(ctx, commoncol,
+    trafficpolicy.WithSourceGroupKind(schema.GroupKind{
+        Group: "example.io", Kind: "ExamplePolicy",
+    }))
+```
+
+The identity replaces the default rather than adding to it. A grant permits one
+referencing kind, and the kinds involved here are usually creatable by different sets
+of users, so treating them as interchangeable would let a grant hand out access its
+author did not intend.
+
+When no grant permits the reference, `MissingReferenceGrantError` names the namespace
+the grant belongs in and the identity it has to allow, so the grant to write is
+readable off the policy status. For a reference by label selector the message names
+neither the matched resource nor its namespace: the match set is not observable
+without a grant, and disclosing it would let a referrer probe for resources it has no
+access to.
+
 ## Code flow
 
 ### Off mode — all checks bypassed
@@ -161,10 +194,11 @@ mode is `Strict` and the target namespace differs from the source namespace:
 FetchGatewayExtension()                pkg/.../trafficpolicy/constructor.go
   if mode == Strict:
     RefGrants.ReferenceAllowed(
-      from: TrafficPolicy GK, fromNs,
+      from: TrafficPolicy GK (or the kind set via
+            WithSourceGroupKind), fromNs,
       to:   GatewayExtension GK, targetNs, name
     )
-    -> ErrMissingReferenceGrant if denied
+    -> MissingReferenceGrantError if denied
   krt.FetchOne(gatewayExtensions, ...)
 ```
 
@@ -179,10 +213,10 @@ invalidation is needed.
 | File | Role |
 |---|---|
 | `api/settings/settings.go` | `ReferenceGrantMode` type and `Settings.ReferenceGrantMode` field |
-| `pkg/krtcollections/policy.go` | `RefGrantIndex`, `NewRefGrantIndex`, `ReferenceAllowed` |
+| `pkg/krtcollections/policy.go` | `RefGrantIndex`, `NewRefGrantIndex`, `ReferenceAllowed`, `MissingReferenceGrantError` |
 | `pkg/pluginsdk/collections/collections.go` | Wires mode from settings into `NewRefGrantIndex` |
-| `pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go` | `FetchGatewayExtension` — Strict-mode ExtensionRef check |
-| `pkg/krtcollections/secrets.go` | SecretRef enforcement via `GetSecret` -> `ReferenceAllowed` |
+| `pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go` | `FetchGatewayExtension` — Strict-mode ExtensionRef check; `WithSourceGroupKind` |
+| `pkg/krtcollections/secrets.go` | SecretRef enforcement via `GetSecret` -> `ReferenceAllowed`; `From` |
 
 ## Tests
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/api_key_auth.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
@@ -64,6 +63,7 @@ func (a *apiKeyAuthIR) Validate() error {
 func constructAPIKeyAuth(
 	krtctx krt.HandlerContext,
 	policy *kgateway.TrafficPolicy,
+	from krtcollections.From,
 	commoncol *collections.CommonCollections,
 	out *trafficPolicySpecIr,
 ) error {
@@ -85,11 +85,6 @@ func constructAPIKeyAuth(
 	// Resolve secrets using SecretIndex with ReferenceGrant validation
 	var secrets []ir.Secret
 	secretGK := schema.GroupKind{Group: "", Kind: "Secret"}
-	policyGK := wellknown.TrafficPolicyGVK.GroupKind()
-	from := krtcollections.From{
-		GroupKind: policyGK,
-		Namespace: policy.Namespace,
-	}
 
 	if ak.SecretRef != nil {
 		secret, err := commoncol.Secrets.GetSecret(krtctx, from, *ak.SecretRef)

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/basic_auth_policy.go
@@ -15,7 +15,6 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
@@ -103,6 +102,7 @@ func (p *trafficPolicyPluginGwPass) handleBasicAuth(
 func constructBasicAuth(
 	krtctx krt.HandlerContext,
 	in *kgateway.TrafficPolicy,
+	from krtcollections.From,
 	out *trafficPolicySpecIr,
 	secrets *krtcollections.SecretIndex,
 ) error {
@@ -128,7 +128,7 @@ func constructBasicAuth(
 		htpasswdData = strings.Join(spec.Users, "\n")
 	} else if spec.SecretRef != nil {
 		// Fetch from secret
-		htpasswdData, err = fetchHtpasswdFromSecret(krtctx, secrets, spec.SecretRef, in.Namespace)
+		htpasswdData, err = fetchHtpasswdFromSecret(krtctx, secrets, spec.SecretRef, from)
 		if err != nil {
 			return fmt.Errorf("basic auth: %w", err)
 		}
@@ -175,10 +175,10 @@ func fetchHtpasswdFromSecret(
 	krtctx krt.HandlerContext,
 	secrets *krtcollections.SecretIndex,
 	secretRef *kgateway.SecretReference,
-	policyNamespace string,
+	from krtcollections.From,
 ) (string, error) {
 	// Determine namespace - use secret's namespace if specified, otherwise policy's namespace
-	namespace := gwv1.Namespace(policyNamespace)
+	namespace := gwv1.Namespace(from.Namespace)
 	if secretRef.Namespace != nil {
 		namespace = *secretRef.Namespace
 	}
@@ -193,12 +193,6 @@ func fetchHtpasswdFromSecret(
 	secretObjRef := gwv1.SecretObjectReference{
 		Name:      secretRef.Name,
 		Namespace: &namespace,
-	}
-
-	// Use TrafficPolicy as the source for reference grants
-	from := krtcollections.From{
-		GroupKind: wellknown.TrafficPolicyGVK.GroupKind(),
-		Namespace: policyNamespace,
 	}
 
 	// Fetch the secret

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"istio.io/istio/pkg/kube/krt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -26,22 +27,62 @@ type TrafficPolicyConstructor struct {
 	commoncol         *collections.CommonCollections
 	gatewayExtensions krt.Collection[TrafficPolicyGatewayExtensionIR]
 	extBuilder        func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR
+
+	// sourceGroupKind is the identity a ReferenceGrant has to name to permit the
+	// cross-namespace references in TrafficPolicySpec. Empty means TrafficPolicy;
+	// see WithSourceGroupKind.
+	sourceGroupKind schema.GroupKind
+}
+
+// TrafficPolicyConstructorOption configures a TrafficPolicyConstructor.
+type TrafficPolicyConstructorOption func(*TrafficPolicyConstructor)
+
+// WithSourceGroupKind sets the identity that ReferenceGrants are evaluated against
+// for the cross-namespace references TrafficPolicySpec holds: API key and basic auth
+// secrets, secret-backed header values, and, in Strict mode, GatewayExtension
+// references.
+//
+// It defaults to gateway.kgateway.dev/TrafficPolicy, the kind that declares the spec.
+// Set it when a different kind carries the spec being translated, so a ReferenceGrant
+// names the resource that actually holds the reference. It replaces the default
+// rather than adding to it: from.kind identifies one referencing kind, and a
+// namespace granting access to one kind has not granted it to another, which may well
+// be creatable by a different set of users.
+func WithSourceGroupKind(gk schema.GroupKind) TrafficPolicyConstructorOption {
+	return func(c *TrafficPolicyConstructor) {
+		c.sourceGroupKind = gk
+	}
 }
 
 func NewTrafficPolicyConstructor(
 	ctx context.Context,
 	commoncol *collections.CommonCollections,
+	opts ...TrafficPolicyConstructorOption,
 ) *TrafficPolicyConstructor {
 	extBuilder := TranslateGatewayExtensionBuilder(ctx, commoncol)
 	defaultExtBuilder := func(krtctx krt.HandlerContext, gExt ir.GatewayExtension) *TrafficPolicyGatewayExtensionIR {
 		return extBuilder(krtctx, gExt)
 	}
 	gatewayExtensions := krt.NewCollection(commoncol.GatewayExtensions, defaultExtBuilder)
-	return &TrafficPolicyConstructor{
+	c := &TrafficPolicyConstructor{
 		commoncol:         commoncol,
 		gatewayExtensions: gatewayExtensions,
 		extBuilder:        extBuilder,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// refGrantSource returns the source identity that ReferenceGrants are evaluated
+// against for references held by a TrafficPolicySpec in ns.
+func (c *TrafficPolicyConstructor) refGrantSource(ns string) krtcollections.From {
+	gk := c.sourceGroupKind
+	if gk.Empty() {
+		gk = wellknown.TrafficPolicyGVK.GroupKind()
+	}
+	return krtcollections.From{GroupKind: gk, Namespace: ns}
 }
 
 func (c *TrafficPolicyConstructor) ConstructIR(
@@ -81,7 +122,7 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 	constructCompression(policyCR.Spec, &outSpec)
 
 	// Construct header modifiers specific IR
-	if err := constructHeaderModifiers(krtctx, policyCR, c.commoncol.Secrets, &outSpec); err != nil {
+	if err := constructHeaderModifiers(krtctx, policyCR, c.refGrantSource(policyCR.Namespace), c.commoncol.Secrets, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
 	// Construct request mirror specific IR
@@ -107,7 +148,7 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 	}
 
 	// Construct API key auth specific IR
-	if err := constructAPIKeyAuth(krtctx, policyCR, c.commoncol, &outSpec); err != nil {
+	if err := constructAPIKeyAuth(krtctx, policyCR, c.refGrantSource(policyCR.Namespace), c.commoncol, &outSpec); err != nil {
 		errors = append(errors, err)
 	}
 
@@ -127,7 +168,7 @@ func (c *TrafficPolicyConstructor) ConstructIR(
 	// Construct stat prefix specific IR
 	constructStatPrefix(policyCR.Spec, &outSpec)
 	// Construct basic auth specific IR
-	if err := constructBasicAuth(krtctx, policyCR, &outSpec, c.commoncol.Secrets); err != nil {
+	if err := constructBasicAuth(krtctx, policyCR, c.refGrantSource(policyCR.Namespace), &outSpec, c.commoncol.Secrets); err != nil {
 		errors = append(errors, err)
 	}
 
@@ -147,17 +188,15 @@ func (c *TrafficPolicyConstructor) FetchGatewayExtension(krtctx krt.HandlerConte
 
 	// In Strict mode, cross-namespace ExtensionRef requires a ReferenceGrant.
 	if c.commoncol.Settings.ReferenceGrantMode == apisettings.ReferenceGrantStrict {
-		if !c.commoncol.RefGrants.ReferenceAllowed(krtctx,
-			wellknown.TrafficPolicyGVK.GroupKind(),
-			ns,
-			ir.ObjectSource{
-				Group:     wellknown.GatewayExtensionGVK.Group,
-				Kind:      wellknown.GatewayExtensionGVK.Kind,
-				Namespace: string(namespace),
-				Name:      string(extensionRef.Name),
-			},
-		) {
-			return nil, krtcollections.ErrMissingReferenceGrant
+		from := c.refGrantSource(ns)
+		to := ir.ObjectSource{
+			Group:     wellknown.GatewayExtensionGVK.Group,
+			Kind:      wellknown.GatewayExtensionGVK.Kind,
+			Namespace: string(namespace),
+			Name:      string(extensionRef.Name),
+		}
+		if !c.commoncol.RefGrants.ReferenceAllowed(krtctx, from.GroupKind, from.Namespace, to) {
+			return nil, &krtcollections.MissingReferenceGrantError{From: from, To: to}
 		}
 	}
 

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor_refgrant_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/constructor_refgrant_test.go
@@ -1,0 +1,128 @@
+package trafficpolicy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"istio.io/istio/pkg/kube/krt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
+	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/shared"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/pluginutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/collections"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+)
+
+// overrideGK stands in for a kind other than TrafficPolicy that carries the spec being
+// translated, and so holds the references a ReferenceGrant has to name.
+var overrideGK = schema.GroupKind{Group: "example.io", Kind: "ExamplePolicy"}
+
+// gatewayExtensionRefGrant builds a ReferenceGrant in ext-ns permitting references to
+// GatewayExtensions from fromGK in app-ns.
+func gatewayExtensionRefGrant(fromGK schema.GroupKind) *gwv1b1.ReferenceGrant {
+	return &gwv1b1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: "ext-ns"},
+		Spec: gwv1b1.ReferenceGrantSpec{
+			From: []gwv1b1.ReferenceGrantFrom{{
+				Group:     gwv1.Group(fromGK.Group),
+				Kind:      gwv1.Kind(fromGK.Kind),
+				Namespace: "app-ns",
+			}},
+			To: []gwv1b1.ReferenceGrantTo{{
+				Group: gwv1.Group(wellknown.GatewayExtensionGVK.Group),
+				Kind:  gwv1.Kind(wellknown.GatewayExtensionGVK.Kind),
+			}},
+		},
+	}
+}
+
+// TestFetchGatewayExtensionRefGrantSourceIdentity covers a strict-mode cross-namespace
+// extensionRef. The source identity is exactly one kind, so overriding it moves which
+// grant applies rather than widening the set. Passing the grant check is observable as
+// the ExtensionRef then failing to resolve, since no GatewayExtension exists.
+func TestFetchGatewayExtensionRefGrantSourceIdentity(t *testing.T) {
+	tests := []struct {
+		name    string
+		grantGK schema.GroupKind
+		opts    []TrafficPolicyConstructorOption
+		allowed bool
+	}{
+		{
+			name:    "default identity, grant names TrafficPolicy",
+			grantGK: wellknown.TrafficPolicyGVK.GroupKind(),
+			allowed: true,
+		},
+		{
+			name:    "default identity, grant names another kind",
+			grantGK: overrideGK,
+		},
+		{
+			name:    "overridden identity, grant names that kind",
+			grantGK: overrideGK,
+			opts:    []TrafficPolicyConstructorOption{WithSourceGroupKind(overrideGK)},
+			allowed: true,
+		},
+		{
+			// The override replaces the default: a namespace that granted access to
+			// TrafficPolicy has not granted it to the overriding kind.
+			name:    "overridden identity, grant names TrafficPolicy",
+			grantGK: wellknown.TrafficPolicyGVK.GroupKind(),
+			opts:    []TrafficPolicyConstructorOption{WithSourceGroupKind(overrideGK)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			krtopts := krtutil.NewKrtOptions(ctx.Done(), nil)
+			grants := krt.NewStaticCollection[*gwv1b1.ReferenceGrant](nil,
+				[]*gwv1b1.ReferenceGrant{gatewayExtensionRefGrant(tt.grantGK)}, krtopts.ToOptions("RefGrants")...)
+			commoncol := &collections.CommonCollections{
+				Settings:          apisettings.Settings{ReferenceGrantMode: apisettings.ReferenceGrantStrict},
+				RefGrants:         krtcollections.NewRefGrantIndex(grants, apisettings.ReferenceGrantStrict),
+				GatewayExtensions: krt.NewStaticCollection[ir.GatewayExtension](nil, nil, krtopts.ToOptions("GatewayExtensions")...),
+			}
+
+			c := NewTrafficPolicyConstructor(ctx, commoncol, tt.opts...)
+			_, err := c.FetchGatewayExtension(krt.TestingDummyContext{},
+				shared.NamespacedObjectReference{Name: "ext", Namespace: ptr.To(gwv1.Namespace("ext-ns"))}, "app-ns")
+
+			switch {
+			case tt.allowed && !errors.Is(err, pluginutils.ErrGatewayExtensionNotFound):
+				t.Fatalf("FetchGatewayExtension() = %v, want the reference to clear the grant check", err)
+			case !tt.allowed && !errors.Is(err, krtcollections.ErrMissingReferenceGrant):
+				t.Fatalf("FetchGatewayExtension() = %v, want a missing reference grant error", err)
+			}
+		})
+	}
+}
+
+func TestRefGrantSource(t *testing.T) {
+	ctx := context.Background()
+	krtopts := krtutil.NewKrtOptions(ctx.Done(), nil)
+	commoncol := &collections.CommonCollections{
+		GatewayExtensions: krt.NewStaticCollection[ir.GatewayExtension](nil, nil, krtopts.ToOptions("GatewayExtensions")...),
+	}
+
+	from := NewTrafficPolicyConstructor(ctx, commoncol).refGrantSource("app-ns")
+	if want := wellknown.TrafficPolicyGVK.GroupKind(); from.GroupKind != want {
+		t.Errorf("refGrantSource().GroupKind = %v, want %v", from.GroupKind, want)
+	}
+	if from.Namespace != "app-ns" {
+		t.Errorf("refGrantSource().Namespace = %q, want %q", from.Namespace, "app-ns")
+	}
+
+	from = NewTrafficPolicyConstructor(ctx, commoncol, WithSourceGroupKind(overrideGK)).refGrantSource("app-ns")
+	if from.GroupKind != overrideGK {
+		t.Errorf("refGrantSource().GroupKind = %v, want %v", from.GroupKind, overrideGK)
+	}
+}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/header_modifiers.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/header_modifiers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
 	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/extensions2/pluginutils"
-	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
 	"github.com/kgateway-dev/kgateway/v2/pkg/krtcollections"
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
@@ -49,6 +48,7 @@ func (hm *headerModifiersIR) Validate() error {
 func constructHeaderModifiers(
 	krtctx krt.HandlerContext,
 	policy *kgateway.TrafficPolicy,
+	from krtcollections.From,
 	secrets *krtcollections.SecretIndex,
 	out *trafficPolicySpecIr,
 ) error {
@@ -57,10 +57,6 @@ func constructHeaderModifiers(
 	}
 
 	spec := policy.Spec.HeaderModifiers
-	from := krtcollections.From{
-		GroupKind: wellknown.TrafficPolicyGVK.GroupKind(),
-		Namespace: policy.Namespace,
-	}
 
 	p := &header_mutationv3.HeaderMutationPerRoute{
 		Mutations: &header_mutationv3.Mutations{},

--- a/pkg/kgateway/translator/gateway/testutils/outputs/reference-grant-mode/strict-extensionref-no-grant.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/reference-grant-mode/strict-extensionref-no-grant.yaml
@@ -107,7 +107,9 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): gateway.kgateway.dev/TrafficPolicy/default/jwt-policy:
-            jwt: missing reference grant'
+            jwt: missing reference grant: create a ReferenceGrant in namespace "other-ns"
+            allowing GatewayExtension "jwt-ext" to be referenced from group "gateway.kgateway.dev"
+            kind "TrafficPolicy" in namespace "default"'
           reason: RouteRuleReplaced
           status: "False"
           type: kgateway.dev/Programmed
@@ -136,7 +138,9 @@ Statuses:
           namespace: default
         conditions:
         - lastTransitionTime: null
-          message: 'jwt: missing reference grant'
+          message: 'jwt: missing reference grant: create a ReferenceGrant in namespace
+            "other-ns" allowing GatewayExtension "jwt-ext" to be referenced from group
+            "gateway.kgateway.dev" kind "TrafficPolicy" in namespace "default"'
           reason: Invalid
           status: "False"
           type: Accepted

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-selector-no-matching-secret.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/api-key-auth-selector-no-matching-secret.yaml
@@ -107,7 +107,9 @@ Statuses:
       - conditions:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): gateway.kgateway.dev/TrafficPolicy/default/api-key-auth-selector:
-            failed to get secrets by selector: missing reference grant'
+            failed to get secrets by selector: missing reference grant: create a ReferenceGrant
+            in the namespace of the referenced Secret allowing references from group
+            "gateway.kgateway.dev" kind "TrafficPolicy" in namespace "default"'
           reason: RouteRuleReplaced
           status: "False"
           type: kgateway.dev/Programmed
@@ -136,7 +138,9 @@ Statuses:
           namespace: default
         conditions:
         - lastTransitionTime: null
-          message: 'failed to get secrets by selector: missing reference grant'
+          message: 'failed to get secrets by selector: missing reference grant: create
+            a ReferenceGrant in the namespace of the referenced Secret allowing references
+            from group "gateway.kgateway.dev" kind "TrafficPolicy" in namespace "default"'
           reason: Invalid
           status: "False"
           type: Accepted

--- a/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/traffic-policy/header-modifiers-from-secret-cross-namespace-no-refgrant.yaml
@@ -108,7 +108,9 @@ Statuses:
         - lastTransitionTime: null
           message: 'Replaced Rule (0): gateway.kgateway.dev/TrafficPolicy/default/header-modifiers-from-secret-cross-ns-no-refgrant:
             request: failed to resolve header ''X-Api-Key'': secret other/backend-creds:
-            cannot reference secret other/backend-creds : missing reference grant'
+            missing reference grant: create a ReferenceGrant in namespace "other"
+            allowing Secret "backend-creds" to be referenced from group "gateway.kgateway.dev"
+            kind "TrafficPolicy" in namespace "default"'
           reason: RouteRuleReplaced
           status: "False"
           type: kgateway.dev/Programmed
@@ -138,7 +140,9 @@ Statuses:
         conditions:
         - lastTransitionTime: null
           message: 'request: failed to resolve header ''X-Api-Key'': secret other/backend-creds:
-            cannot reference secret other/backend-creds : missing reference grant'
+            missing reference grant: create a ReferenceGrant in namespace "other"
+            allowing Secret "backend-creds" to be referenced from group "gateway.kgateway.dev"
+            kind "TrafficPolicy" in namespace "default"'
           reason: Invalid
           status: "False"
           type: Accepted

--- a/pkg/krtcollections/configmaps.go
+++ b/pkg/krtcollections/configmaps.go
@@ -46,7 +46,7 @@ func (c *ConfigMapIndex) GetConfigMap(kctx krt.HandlerContext, from From, config
 	}
 
 	if !c.refgrants.ReferenceAllowed(kctx, from.GroupKind, from.Namespace, to) {
-		return nil, ErrMissingReferenceGrant
+		return nil, &MissingReferenceGrantError{From: from, To: to}
 	}
 
 	nn := types.NamespacedName{

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -42,6 +42,43 @@ var (
 	ErrPolicyNotFound        = errors.New("policy not found")
 )
 
+// MissingReferenceGrantError reports a cross-namespace reference that no
+// ReferenceGrant permits. Its message names the grant the user has to create: the
+// namespace it belongs in (the referent's, not the referrer's) and the source
+// identity it has to allow, which is the kind translation resolved the reference
+// under and not necessarily the kind that declares the field.
+type MissingReferenceGrantError struct {
+	From From
+
+	// To is the referenced resource. Namespace and Name are set only when the
+	// reference names them; a reference by label selector leaves them empty,
+	// because the matched resources are not observable without a grant and
+	// naming one would disclose that it exists.
+	To ir.ObjectSource
+}
+
+func (e *MissingReferenceGrantError) Error() string {
+	kind := e.To.Kind
+	if kind == "" {
+		kind = "resource"
+	}
+	from := fmt.Sprintf("group %q kind %q in namespace %q", e.From.Group, e.From.Kind, e.From.Namespace)
+	if e.To.Namespace == "" || e.To.Name == "" {
+		return fmt.Sprintf(
+			"%s: create a ReferenceGrant in the namespace of the referenced %s allowing references from %s",
+			ErrMissingReferenceGrant, kind, from,
+		)
+	}
+	return fmt.Sprintf(
+		"%s: create a ReferenceGrant in namespace %q allowing %s %q to be referenced from %s",
+		ErrMissingReferenceGrant, e.To.Namespace, kind, e.To.Name, from,
+	)
+}
+
+func (e *MissingReferenceGrantError) Unwrap() error {
+	return ErrMissingReferenceGrant
+}
+
 type NotFoundError struct {
 	// I call this `NotFound` so its easy to find in krt dump.
 	NotFoundObj ir.ObjectSource

--- a/pkg/krtcollections/refgrant_source_test.go
+++ b/pkg/krtcollections/refgrant_source_test.go
@@ -1,0 +1,183 @@
+package krtcollections
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/kube/krt/krttest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	apisettings "github.com/kgateway-dev/kgateway/v2/api/settings"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+var (
+	// sourceGK is the identity the reference is resolved under, and otherGK a kind
+	// that is not it.
+	sourceGK = schema.GroupKind{Group: "gateway.kgateway.dev", Kind: "TrafficPolicy"}
+	otherGK  = schema.GroupKind{Group: "example.io", Kind: "OtherPolicy"}
+
+	secretGK = corev1.SchemeGroupVersion.WithKind("Secret").GroupKind()
+)
+
+// secretRefGrant builds a ReferenceGrant in ns permitting references to Secrets from
+// fromGK in fromNs.
+func secretRefGrant(ns string, fromGK schema.GroupKind, fromNs string) *gwv1b1.ReferenceGrant {
+	return &gwv1b1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "grant", Namespace: ns},
+		Spec: gwv1b1.ReferenceGrantSpec{
+			From: []gwv1b1.ReferenceGrantFrom{{
+				Group:     gwv1.Group(fromGK.Group),
+				Kind:      gwv1.Kind(fromGK.Kind),
+				Namespace: gwv1.Namespace(fromNs),
+			}},
+			To: []gwv1b1.ReferenceGrantTo{{Group: "", Kind: "Secret"}},
+		},
+	}
+}
+
+func newTestSecretIndex(t *testing.T, objs ...any) *SecretIndex {
+	t.Helper()
+	mock := krttest.NewMock(t, objs)
+	secretCol := krttest.GetMockCollection[*corev1.Secret](mock)
+	refgrants := NewRefGrantIndex(krttest.GetMockCollection[*gwv1b1.ReferenceGrant](mock), apisettings.ReferenceGrantPermissive)
+	secretsCol := map[schema.GroupKind]krt.Collection[ir.Secret]{
+		secretGK: krt.NewCollection(secretCol, func(kctx krt.HandlerContext, i *corev1.Secret) *ir.Secret {
+			return &ir.Secret{
+				ObjectSource: ir.ObjectSource{Kind: "Secret", Namespace: i.Namespace, Name: i.Name},
+				Obj:          i,
+				Data:         i.Data,
+			}
+		}),
+	}
+	idx := NewSecretIndex(secretsCol, refgrants)
+	secretCol.WaitUntilSynced(nil)
+	for !idx.HasSynced() {
+	}
+	return idx
+}
+
+func testSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-keys",
+			Namespace: "secrets-ns",
+			Labels:    map[string]string{"app": "keys"},
+		},
+		Data: map[string][]byte{"user": []byte("k1")},
+	}
+}
+
+// TestSecretIndexReferenceGrantSourceIdentity pins that both secret paths permit a
+// reference only when a grant names the identity in From - a grant naming any other
+// kind stays inert, since from.kind is what scopes the permission.
+func TestSecretIndexReferenceGrantSourceIdentity(t *testing.T) {
+	tests := []struct {
+		name    string
+		grants  []any
+		allowed bool
+	}{
+		{
+			name:    "grant names the source identity",
+			grants:  []any{secretRefGrant("secrets-ns", sourceGK, "app-ns")},
+			allowed: true,
+		},
+		{
+			name:   "grant names another kind",
+			grants: []any{secretRefGrant("secrets-ns", otherGK, "app-ns")},
+		},
+		{
+			name: "no grant",
+		},
+		{
+			name:   "grant sits in the referrer namespace instead of the referent one",
+			grants: []any{secretRefGrant("app-ns", sourceGK, "app-ns")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := newTestSecretIndex(t, append([]any{testSecret()}, tt.grants...)...)
+			from := From{GroupKind: sourceGK, Namespace: "app-ns"}
+			krtctx := krt.TestingDummyContext{}
+
+			// secretRef, as spec.basicAuth.secretRef and spec.apiKeyAuth.secretRef resolve it.
+			ns := gwv1.Namespace("secrets-ns")
+			got, err := idx.GetSecret(krtctx, from, gwv1.SecretObjectReference{Name: "api-keys", Namespace: &ns})
+			switch {
+			case tt.allowed && err != nil:
+				t.Fatalf("GetSecret() = %v, want the reference to be permitted", err)
+			case tt.allowed && got.Name != "api-keys":
+				t.Errorf("GetSecret() returned secret %q, want %q", got.Name, "api-keys")
+			case !tt.allowed && !errors.Is(err, ErrMissingReferenceGrant):
+				t.Fatalf("GetSecret() = %v, want a missing reference grant error", err)
+			}
+
+			// secretSelector, as spec.apiKeyAuth.secretSelector resolves it.
+			secrets, err := idx.GetSecretsBySelector(krtctx, from, secretGK, map[string]string{"app": "keys"})
+			switch {
+			case tt.allowed && err != nil:
+				t.Fatalf("GetSecretsBySelector() = %v, want the reference to be permitted", err)
+			case tt.allowed && len(secrets) != 1:
+				t.Errorf("GetSecretsBySelector() returned %d secrets, want 1", len(secrets))
+			case !tt.allowed && !errors.Is(err, ErrMissingReferenceGrant):
+				t.Fatalf("GetSecretsBySelector() = %v, want a missing reference grant error", err)
+			case !tt.allowed && len(secrets) != 0:
+				t.Errorf("GetSecretsBySelector() returned %d secrets, want none", len(secrets))
+			}
+		})
+	}
+}
+
+// TestMissingReferenceGrantErrorNamesTheGrant covers the message for a reference that
+// names its referent: the user wrote that name, so repeating it discloses nothing, and
+// it is what makes the grant to create readable off the policy status.
+func TestMissingReferenceGrantErrorNamesTheGrant(t *testing.T) {
+	idx := newTestSecretIndex(t, testSecret())
+
+	ns := gwv1.Namespace("secrets-ns")
+	_, err := idx.GetSecret(krt.TestingDummyContext{}, From{GroupKind: sourceGK, Namespace: "app-ns"},
+		gwv1.SecretObjectReference{Name: "api-keys", Namespace: &ns})
+	if !errors.Is(err, ErrMissingReferenceGrant) {
+		t.Fatalf("GetSecret() = %v, want a missing reference grant error", err)
+	}
+	for _, want := range []string{`namespace "secrets-ns"`, `Secret "api-keys"`, `kind "TrafficPolicy"`, `namespace "app-ns"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("GetSecret() error = %q, want it to mention %s", err, want)
+		}
+	}
+}
+
+// TestSecretsBySelectorErrorOmitsMatchedSecrets pins that a denied selector says
+// nothing about what it matched. Which secrets carry a label is not observable without
+// a grant, so naming one in policy status would let a referrer probe labels to learn
+// that a secret exists in a namespace that never granted it access.
+func TestSecretsBySelectorErrorOmitsMatchedSecrets(t *testing.T) {
+	idx := newTestSecretIndex(t, testSecret())
+
+	secrets, err := idx.GetSecretsBySelector(krt.TestingDummyContext{},
+		From{GroupKind: sourceGK, Namespace: "app-ns"}, secretGK, map[string]string{"app": "keys"})
+	if !errors.Is(err, ErrMissingReferenceGrant) {
+		t.Fatalf("GetSecretsBySelector() = %v, want a missing reference grant error", err)
+	}
+	if len(secrets) != 0 {
+		t.Fatalf("GetSecretsBySelector() returned %d secrets, want none", len(secrets))
+	}
+	for _, leaked := range []string{"api-keys", "secrets-ns"} {
+		if strings.Contains(err.Error(), leaked) {
+			t.Errorf("GetSecretsBySelector() error = %q, want it to disclose nothing about the matched secrets, but it names %q", err, leaked)
+		}
+	}
+	// The source side is entirely user-authored, so it stays in the message.
+	for _, want := range []string{`kind "TrafficPolicy"`, `namespace "app-ns"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("GetSecretsBySelector() error = %q, want it to mention %s", err, want)
+		}
+	}
+}

--- a/pkg/krtcollections/secrets.go
+++ b/pkg/krtcollections/secrets.go
@@ -10,6 +10,9 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
+// From identifies the resource that holds a cross-namespace reference, for the
+// purpose of evaluating ReferenceGrants against it. GroupKind is the identity a
+// ReferenceGrant has to name in from.group and from.kind to permit the reference.
 type From struct {
 	schema.GroupKind
 	Namespace string
@@ -63,7 +66,7 @@ func (s *SecretIndex) GetSecret(kctx krt.HandlerContext, from From, secretRef gw
 	}
 
 	if !s.refgrants.ReferenceAllowed(kctx, from.GroupKind, from.Namespace, to) {
-		return nil, fmt.Errorf("cannot reference secret %s : %w", to.NamespacedName(), ErrMissingReferenceGrant)
+		return nil, &MissingReferenceGrantError{From: from, To: to}
 	}
 	secret := krt.FetchOne(kctx, col, krt.FilterKey(to.ResourceName()))
 	if secret == nil {
@@ -148,10 +151,14 @@ func (s *SecretIndex) GetSecretsBySelector(
 	}
 
 	// Only return an error if no allowed secrets were found and there were missing grants.
-	// We don't want to list all the secrets that were skipped. We only want to hint
-	// the user that it might be a configuration issue.
+	// The error names no matched secret: which secrets carry the labels is not observable
+	// without a grant, so reporting one would disclose whether a resource exists in a
+	// namespace the referrer has no access to.
 	if len(allowedSecrets) == 0 && hasMissingGrants {
-		return allowedSecrets, ErrMissingReferenceGrant
+		return allowedSecrets, &MissingReferenceGrantError{
+			From: from,
+			To:   ir.ObjectSource{Group: secretGK.Group, Kind: secretGK.Kind},
+		}
 	}
 
 	return allowedSecrets, nil

--- a/pkg/plugins/gwextbase/base.go
+++ b/pkg/plugins/gwextbase/base.go
@@ -20,6 +20,7 @@ type (
 	ProviderNeededMap               = trafficpolicy.ProviderNeededMap
 	TrafficPolicyGatewayExtensionIR = trafficpolicy.TrafficPolicyGatewayExtensionIR
 	TrafficPolicyMergeOpts          = trafficpolicy.TrafficPolicyMergeOpts
+	TrafficPolicyConstructorOption  = trafficpolicy.TrafficPolicyConstructorOption
 )
 
 var (
@@ -27,14 +28,20 @@ var (
 	EnableFilterPerRoute           = trafficpolicy.EnableFilterPerRoute
 	MergeTrafficPolicies           = trafficpolicy.MergeTrafficPolicies
 	AddDisableFilterIfNeeded       = trafficpolicy.AddDisableFilterIfNeeded
+
+	// WithSourceGroupKind sets the identity a ReferenceGrant has to name for the
+	// cross-namespace references held by a TrafficPolicySpec. See
+	// trafficpolicy.WithSourceGroupKind.
+	WithSourceGroupKind = trafficpolicy.WithSourceGroupKind
 )
 
 // NewTrafficPolicyConstructor creates a traffic policy constructor. This converts a traffic policy into its IR form.
 func NewTrafficPolicyConstructor(
 	ctx context.Context,
 	commoncol *collections.CommonCollections,
+	opts ...trafficpolicy.TrafficPolicyConstructorOption,
 ) *trafficpolicy.TrafficPolicyConstructor {
-	return trafficpolicy.NewTrafficPolicyConstructor(ctx, commoncol)
+	return trafficpolicy.NewTrafficPolicyConstructor(ctx, commoncol, opts...)
 }
 
 func NewGatewayTranslationPass(tctx ir.GwTranslationCtx, reporter reporter.Reporter, enableAuthSucceededMetadata bool) ir.ProxyTranslationPass {


### PR DESCRIPTION
# Description

**Motivation.** A ReferenceGrant's `from.group`/`from.kind` name the kind that *holds* the
reference, and translation decides which kind that is. Every cross-namespace reference in
`TrafficPolicySpec` is evaluated against `gateway.kgateway.dev/TrafficPolicy`, whichever kind
actually carries the spec being translated. When a different kind carries it, the grant a user
writes names the kind they created, the API server accepts it, and it never matches — the
reference stays denied and nothing about the config changes. The only signal is a bare
`missing reference grant`, which does not say which identity would have satisfied it.

While fixing that, the same paths turned out to disclose cross-namespace Secret names. A denied
`apiKeyAuth.secretSelector` reported the Secret it matched, e.g. for a policy in `default`:

```
missing reference grant: create a ReferenceGrant in namespace "other"
allowing Secret "other-ns-secret" to be referenced from ...
```

Which secrets carry a label is not observable without a grant, so surfacing one in policy status
lets a referrer probe labels to learn that a Secret exists in a namespace that never granted it
access. Gateway API is explicit that an implementation must not reveal whether a cross-namespace
resource exists before a grant permits it.

**What changed.**

- `WithSourceGroupKind(gk)` sets the identity ReferenceGrants are evaluated against for the
  references `TrafficPolicySpec` owns: `basicAuth.secretRef`, `apiKeyAuth.secretRef`,
  `apiKeyAuth.secretSelector`, secret-backed `headerModifiers` values, and `extensionRef` in
  Strict mode. It defaults to `TrafficPolicy` and is exposed through `pkg/plugins/gwextbase`.
  The identity **replaces** the default rather than being ORed with it: `from.kind` scopes a
  grant to one referencing kind, and the kinds involved are typically creatable by different
  sets of users, so accepting either would hand out access the grant's author did not intend.
- Denials now return `MissingReferenceGrantError`, naming the namespace the grant belongs in and
  the identity it has to allow, so the grant to write is readable off the policy status.
- A denied label selector names neither the matched Secret nor its namespace. The referent kind
  comes from the API path, not from anything matched, and the source side is entirely
  user-authored, so both stay.
- Reference-grant behavior itself is unchanged for any existing config: with no option set the
  source identity is still `TrafficPolicy`, and the same references are permitted and denied as
  before. Only the message text changes.

# Change Type

/kind fix

# Changelog

```release-note
Cross-namespace reference denials now name the ReferenceGrant to create — the namespace it belongs in and the source identity it must allow — instead of reporting a bare "missing reference grant". A denied apiKeyAuth.secretSelector no longer names the Secrets it matched or their namespace, which previously disclosed that a Secret existed in a namespace that had granted no access. Embedders translating TrafficPolicySpec from another kind can set the identity grants are evaluated against with trafficpolicy.WithSourceGroupKind.
```

# Additional Notes

**Tests.** `pkg/krtcollections/refgrant_source_test.go` covers both secret paths across grant
placement and identity, pins that the selector error discloses nothing about what it matched,
and pins that a named reference still names the grant to create.
`constructor_refgrant_test.go` covers the Strict-mode `extensionRef` check across the default and
overridden identity — including that with the override set, a grant naming `TrafficPolicy` is
inert, which is the trust boundary the replace-don't-OR choice buys.
Three golden files under `translator/gateway/testutils/outputs/` are refreshed for the new
message; the selector one is where the old Secret-name disclosure is visible in the diff.

**Adopters.** `WithSourceGroupKind` replaces rather than adds, so an embedder that adopts it
invalidates grants naming `TrafficPolicy` for the references listed above. That is the intended
security property, but it is a breaking change for whoever adopts it downstream and should land
with its own release note there rather than silently on a repin.

`make analyze` is clean; `./pkg/krtcollections/...`,
`./pkg/kgateway/extensions2/plugins/trafficpolicy/...` and `./pkg/kgateway/translator/...` pass.
