### PR TITLE
test(e2e): StrictChurn is the best #14184 reproducer

### DIFF
--- a/.github/actions/kube-gateway-api-load-tests/action.yaml
+++ b/.github/actions/kube-gateway-api-load-tests/action.yaml
@@ -30,7 +30,7 @@ runs:
           --namespace kgateway-system --create-namespace \
           --wait --timeout 5m
 
-    - name: Run load tests in each validation mode
+    - name: Run load tests and strict churn convergence
       shell: bash
       env:
         KGATEWAY_RUN_LOAD_TESTS: "true"
@@ -52,3 +52,9 @@ runs:
 
           echo "::endgroup::"
         done
+
+        # StrictChurn sets strict validation itself and mutates the controller
+        # deployment, so run it once and only after the shared load suites.
+        echo "::group::KGateway strict churn convergence test"
+        make run-load-tests-strict-churn
+        echo "::endgroup::"

--- a/Makefile
+++ b/Makefile
@@ -1246,6 +1246,11 @@ run-load-tests-production: ## Run production load tests (5000 routes)
 	SKIP_INSTALL=true CLUSTER_NAME=$(CLUSTER_NAME) INSTALL_NAMESPACE=$(INSTALL_NAMESPACE) \
 	go test -tags=e2e $(LOAD_TEST_GO_ARGS) -v ./test/e2e/tests -run "^TestKgateway$$/^AttachedRoutes$$/^TestAttachedRoutesProduction$$"
 
+.PHONY: run-load-tests-strict-churn
+run-load-tests-strict-churn: ## Run strict-validation churn convergence test (mutates the controller deployment; requires existing cluster and installation)
+	SKIP_INSTALL=true KGW_ENABLE_STRICT_CHURN=true CLUSTER_NAME=$(CLUSTER_NAME) INSTALL_NAMESPACE=$(INSTALL_NAMESPACE) \
+	go test -tags=e2e -v -timeout 30m ./test/e2e/tests -run "^TestKgateway$$/^StrictChurn$$"
+
 #----------------------------------------------------------------------------------
 # MARK: Conformance
 # Targets for running Kubernetes Gateway API conformance tests

--- a/test/e2e/features/loadtesting/README.md
+++ b/test/e2e/features/loadtesting/README.md
@@ -200,7 +200,9 @@ Envoys still beat the rollout bound. Scale past the laptop-friendly defaults
 with `KGW_LOADTEST_BACKENDS` / `KGW_LOADTEST_ROUTES`.
 
 Because the suite mutates the controller deployment, it is registered with the
-suite runner but excluded from the CI e2e clusters; run it explicitly with
+suite runner but excluded from the shared CI e2e clusters. The nightly
+load-test action runs it once per load-test cluster, after the standard and
+strict AttachedRoutes runs. Run it locally with
 `make run-load-tests-strict-churn`.
 
 ## Framework Architecture

--- a/test/e2e/features/loadtesting/README.md
+++ b/test/e2e/features/loadtesting/README.md
@@ -174,6 +174,35 @@ duration, and failure diagnostics.
 - **Total Writes**: Number of status updates during test
 - **Resource Usage**: CPU, memory, and API call metrics
 
+### StrictChurn Test (per-client xDS convergence)
+
+`strictchurn_suite.go` is a convergence/liveness test for the per-client xDS
+pipeline under its worst-case shape (#14184) rather than a latency benchmark:
+
+- **Setup**: Enables `KGW_VALIDATION_MODE=STRICT` on the controller (restored on
+  teardown), creates ~200 simulated backends and baseline routes across two
+  gateways, plus one stable route to a real nginx backend.
+- **Load**: Cycles of Service+EndpointSlice+HTTPRoute create/delete, a
+  background rewriter that keeps the simulated fleet's EndpointSlices moving
+  continuously, persistent dangling and starved backend references, two
+  gateway Envoy rolls, and a controller restart mid-churn.
+- **Assertions**: The stable route answers 200 at every checkpoint (connected
+  proxies are never stranded on stale or withheld config); rolled gateway
+  Envoys become Ready within a bound (a fresh xDS client's first snapshot is
+  never withheld indefinitely); a route created after churn becomes routable
+  within a bound (publication liveness).
+
+To probe the xDS first-connect grace period, set `KGW_XDS_FIRST_CONNECT_DELAY`
+in the environment: the suite forwards it to the controller deployment for the
+duration of the run. `0` exercises the raw reconnect race the delay narrows;
+large values verify warm clients keep serving through the delay and rolled
+Envoys still beat the rollout bound. Scale past the laptop-friendly defaults
+with `KGW_LOADTEST_BACKENDS` / `KGW_LOADTEST_ROUTES`.
+
+Because the suite mutates the controller deployment, it is registered with the
+suite runner but excluded from the CI e2e clusters; run it explicitly with
+`make run-load-tests-strict-churn`.
+
 ## Framework Architecture
 
 ### Components

--- a/test/e2e/features/loadtesting/strictchurn_suite.go
+++ b/test/e2e/features/loadtesting/strictchurn_suite.go
@@ -56,9 +56,10 @@ import (
 //
 // The suite mutates the controller deployment (KGW_VALIDATION_MODE=STRICT,
 // plus the optional delay override) and restores it on teardown, so it must
-// not share a cluster with suites that assume a steady controller. It is
-// registered with the suite runner but excluded from the CI e2e clusters; run
-// it via `make run-load-tests-strict-churn`.
+// not run before suites that assume a steady controller. It is registered with
+// the suite runner, excluded from the shared CI e2e clusters, and run once at
+// the end of each nightly load-test lane. Run it locally via
+// `make run-load-tests-strict-churn`.
 //
 // Honesty note: this suite is a regression pin for the anti-starvation
 // properties, not a reproducer of the #14184 wedge. Verified empirically

--- a/test/e2e/features/loadtesting/strictchurn_suite.go
+++ b/test/e2e/features/loadtesting/strictchurn_suite.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,11 +48,11 @@ import (
 //
 // To probe the first-connect grace period specifically, set
 // KGW_XDS_FIRST_CONNECT_DELAY in the test environment: the suite forwards it
-// to the controller deployment for the duration of the run (and removes it on
-// teardown). `KGW_XDS_FIRST_CONNECT_DELAY=0` runs the raw reconnect race the
-// delay exists to narrow; large values probe the other boundary (warm clients
-// must keep serving through the delay and rolled Envoys must still beat
-// gatewayRolloutBound).
+// to the controller deployment for the duration of the run (and restores the
+// original value on teardown). `KGW_XDS_FIRST_CONNECT_DELAY=0` runs the raw
+// reconnect race the delay exists to narrow; large values probe the other
+// boundary (warm clients must keep serving through the delay and rolled Envoys
+// must still beat gatewayRolloutBound).
 //
 // The suite mutates the controller deployment (KGW_VALIDATION_MODE=STRICT,
 // plus the optional delay override) and restores it on teardown, so it must
@@ -189,11 +190,11 @@ func NewStrictChurnSuite(ctx context.Context, testInst *e2e.TestInstallation) su
 
 type StrictChurnSuite struct {
 	LoadTestingSuite
-	loadTestManager         *LoadTestManager
-	installNamespace        string
-	controllerDeployment    string
-	delayOverridden         bool
-	validatorModeOverridden bool
+	loadTestManager       *LoadTestManager
+	installNamespace      string
+	controllerDeployment  string
+	controllerContainer   string
+	originalControllerEnv map[string]*corev1.EnvVar
 }
 
 func (s *StrictChurnSuite) SetupSuite() {
@@ -225,15 +226,14 @@ func (s *StrictChurnSuite) SetupSuite() {
 	envExprs := []string{"KGW_VALIDATION_MODE=STRICT"}
 	if d := os.Getenv("KGW_XDS_FIRST_CONNECT_DELAY"); d != "" {
 		envExprs = append(envExprs, "KGW_XDS_FIRST_CONNECT_DELAY="+d)
-		s.delayOverridden = true
 	}
 	// KGW_VALIDATOR_MODE=BINARY disables the strict-validation verdict cache,
 	// restoring the #14184-era per-call validation cost on every rebuild —
 	// the field-shaped amplifier of the per-client derivation window.
 	if m := os.Getenv("KGW_VALIDATOR_MODE"); m != "" {
 		envExprs = append(envExprs, "KGW_VALIDATOR_MODE="+m)
-		s.validatorModeOverridden = true
 	}
+	s.Require().NoError(s.snapshotControllerEnv(envExprs), "should snapshot controller env before overriding it")
 	s.T().Logf("Setting controller env on deployment/%s in %s: %v", s.controllerDeployment, s.installNamespace, envExprs)
 	s.Require().NoError(s.setControllerEnv(envExprs...))
 }
@@ -246,20 +246,15 @@ func (s *StrictChurnSuite) TearDownSuite() {
 	}
 	// Restore the controller before anything else so a failed run doesn't
 	// leave the install in strict mode for whoever uses the cluster next.
-	if s.controllerDeployment != "" {
-		envExprs := []string{"KGW_VALIDATION_MODE-"}
-		if s.delayOverridden {
-			envExprs = append(envExprs, "KGW_XDS_FIRST_CONNECT_DELAY-")
-		}
-		if s.validatorModeOverridden {
-			envExprs = append(envExprs, "KGW_VALIDATOR_MODE-")
-		}
-		if err := s.setControllerEnv(envExprs...); err != nil {
+	if s.originalControllerEnv != nil {
+		if err := s.restoreControllerEnv(); err != nil {
 			s.T().Logf("WARNING: failed to restore controller env: %v", err)
 		}
 	}
 	if s.loadTestManager != nil {
-		s.loadTestManager.CleanupAll()
+		if err := s.loadTestManager.CleanupAll(); err != nil {
+			s.T().Logf("Warning: failed to cleanup load test namespaces: %v", err)
+		}
 	}
 	// The nginx-shared ReferenceGrant outlives the per-run namespaces
 	// (nginx-shared belongs to the harness), so delete it explicitly.
@@ -289,6 +284,103 @@ func (s *StrictChurnSuite) resolveControllerDeployment() (string, error) {
 	return name, nil
 }
 
+func (s *StrictChurnSuite) snapshotControllerEnv(envExprs []string) error {
+	deployment := &appsv1.Deployment{}
+	if err := s.testInstallation.ClusterContext.Client.Get(s.ctx, types.NamespacedName{
+		Namespace: s.installNamespace,
+		Name:      s.controllerDeployment,
+	}, deployment); err != nil {
+		return err
+	}
+
+	names := make(map[string]struct{}, len(envExprs))
+	for _, expr := range envExprs {
+		name, _, _ := strings.Cut(expr, "=")
+		names[name] = struct{}{}
+	}
+
+	originals := make(map[string]*corev1.EnvVar, len(names))
+	for name := range names {
+		originals[name] = nil
+	}
+	container, err := findControllerContainer(deployment, "")
+	if err != nil {
+		return err
+	}
+	s.controllerContainer = container.Name
+	for _, env := range container.Env {
+		if _, ok := names[env.Name]; ok {
+			originals[env.Name] = env.DeepCopy()
+		}
+	}
+	s.originalControllerEnv = originals
+	return nil
+}
+
+func (s *StrictChurnSuite) restoreControllerEnv() error {
+	deployment := &appsv1.Deployment{}
+	if err := s.testInstallation.ClusterContext.Client.Get(s.ctx, types.NamespacedName{
+		Namespace: s.installNamespace,
+		Name:      s.controllerDeployment,
+	}, deployment); err != nil {
+		return err
+	}
+
+	before := deployment.DeepCopy()
+	container, err := findControllerContainer(deployment, s.controllerContainer)
+	if err != nil {
+		return err
+	}
+	restoreControllerEnvVars(container, s.originalControllerEnv)
+
+	if err := s.testInstallation.ClusterContext.Client.Patch(s.ctx, deployment, client.MergeFrom(before)); err != nil {
+		return err
+	}
+	return s.testInstallation.Actions.Kubectl().DeploymentRolloutStatus(s.ctx,
+		s.controllerDeployment, "-n", s.installNamespace, "--timeout=120s")
+}
+
+func restoreControllerEnvVars(container *corev1.Container, originals map[string]*corev1.EnvVar) {
+	restored := make(map[string]struct{}, len(originals))
+	env := make([]corev1.EnvVar, 0, len(container.Env))
+	for _, current := range container.Env {
+		original, tracked := originals[current.Name]
+		if !tracked {
+			env = append(env, current)
+			continue
+		}
+		restored[current.Name] = struct{}{}
+		if original != nil {
+			env = append(env, *original.DeepCopy())
+		}
+	}
+	for name, original := range originals {
+		if original == nil {
+			continue
+		}
+		if _, ok := restored[name]; !ok {
+			env = append(env, *original.DeepCopy())
+		}
+	}
+	container.Env = env
+}
+
+func findControllerContainer(deployment *appsv1.Deployment, name string) (*corev1.Container, error) {
+	for i := range deployment.Spec.Template.Spec.Containers {
+		if deployment.Spec.Template.Spec.Containers[i].Name == name ||
+			(name == "" && deployment.Spec.Template.Spec.Containers[i].Name == "controller") {
+			return &deployment.Spec.Template.Spec.Containers[i], nil
+		}
+	}
+	if name != "" {
+		return nil, fmt.Errorf("deployment/%s has no container named %q", deployment.Name, name)
+	}
+	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("deployment/%s has no containers", deployment.Name)
+	}
+	return &deployment.Spec.Template.Spec.Containers[0], nil
+}
+
 // setControllerEnv applies `kubectl set env` expressions (KEY=VALUE or KEY-)
 // to the controller deployment in a single call and waits for the resulting
 // rollout.
@@ -296,6 +388,7 @@ func (s *StrictChurnSuite) setControllerEnv(envExprs ...string) error {
 	args := append([]string{
 		"set", "env", "-n", s.installNamespace,
 		"deployment/" + s.controllerDeployment,
+		"--containers=" + s.controllerContainer,
 	}, envExprs...)
 	if err := s.testInstallation.Actions.Kubectl().RunCommand(s.ctx, args...); err != nil {
 		return err

--- a/test/e2e/features/loadtesting/strictchurn_suite.go
+++ b/test/e2e/features/loadtesting/strictchurn_suite.go
@@ -1,0 +1,695 @@
+//go:build e2e
+
+package loadtesting
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
+	testdefaults "github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
+	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
+)
+
+// StrictChurn is a control-plane convergence test for the per-client xDS
+// pipeline under a #14184-inspired load shape: strict validation (every
+// translated cluster pays an external envoy invocation), a few hundred
+// backends, sustained route/Service churn including a dangling backend
+// reference, and a controller restart mid-churn. It asserts the anti-starvation
+// properties at the traffic level:
+//
+//   - stable routes keep serving throughout churn and across the restart
+//     (connected clients are never stranded on stale or withheld config);
+//   - a gateway Envoy rolled mid-churn becomes Ready within a bound (a fresh
+//     xDS client's first snapshot is never withheld indefinitely);
+//   - new config still converges after the churn stops (a route created
+//     post-churn becomes routable within a bound).
+//
+// To probe the first-connect grace period specifically, set
+// KGW_XDS_FIRST_CONNECT_DELAY in the test environment: the suite forwards it
+// to the controller deployment for the duration of the run (and removes it on
+// teardown). `KGW_XDS_FIRST_CONNECT_DELAY=0` runs the raw reconnect race the
+// delay exists to narrow; large values probe the other boundary (warm clients
+// must keep serving through the delay and rolled Envoys must still beat
+// gatewayRolloutBound).
+//
+// The suite mutates the controller deployment (KGW_VALIDATION_MODE=STRICT,
+// plus the optional delay override) and restores it on teardown, so it must
+// not share a cluster with suites that assume a steady controller. It is
+// registered with the suite runner but excluded from the CI e2e clusters; run
+// it via `make run-load-tests-strict-churn`.
+//
+// Honesty note: this suite is a regression pin for the anti-starvation
+// properties, not a reproducer of the #14184 wedge. Verified empirically
+// (2026-07-10): it passes unchanged against a gated (#13868) build — with the
+// strict-validation cache and per-client fan-out fixes on main, per-client
+// derivation at this scale completes in microseconds, so the gate's defer
+// state never persists for any reference shape a laptop fixture can construct
+// (dangling, selector-matches-nothing, selectorless, ExternalName, and
+// garbage-CA TLS were all probed; errored clusters are exempt from the gates
+// by design, and every kube backend yields a CDS row plus an explicit —
+// possibly empty — CLA). Reproducing the field wedge needs production-scale
+// derivation lag: the transient defer window stretched by fan-out x config
+// size x churn, self-amplified by crashloop reconnects.
+//
+// A second experiment (KGW_VALIDATOR_MODE=BINARY, 5000 backends, 8 gateways,
+// 240s bounds) reproduced the #14184 SYMPTOM — every gateway pod crashlooping
+// on its startup probe, "gateways are unable to spawn" — but on BOTH builds
+// identically: uncached validation saturates shared translation upstream of
+// publication policy, so fresh clients get nothing within the probe window on
+// any build (the gated build logged 40 transient defers against 3670 snapshot
+// sets — the gate was not the constraint). Saturation is therefore not a
+// discriminator either; the gate's marginal harm only separates when
+// translation is slow-but-flowing, a regime this fixture cannot reach on one
+// machine.
+
+// Scale and timing knobs. The scale is sized so a full per-client fan-out is
+// hundreds of strict validations per connected client — large enough that a
+// wedged or backlogged pipeline fails the convergence bounds, small enough to
+// run on a laptop kind cluster in a few minutes.
+const (
+	strictChurnCycles  = 8
+	churnCycleInterval = 5 * time.Second
+	// endpointChurnInterval paces the background EndpointSlice rewriter that
+	// keeps the fleet's endpoints from ever quiescing during phases 4-5.
+	endpointChurnInterval = 250 * time.Millisecond
+	// Defaults for the assertion bounds below, overridable via env for
+	// scaled experiments (e.g. KGW_VALIDATOR_MODE=BINARY at thousands of
+	// backends pushes translation past the laptop-calibrated defaults on
+	// every build; measuring time-to-converge then needs longer bounds).
+	defaultRolloutBoundSeconds     = 180
+	defaultStableBoundSeconds      = 30
+	defaultConvergenceBoundSeconds = 90
+
+	stableRouteHost    = "stable.strict-churn.example.com"
+	postChurnRouteHost = "postchurn.strict-churn.example.com"
+
+	// nginxBackendService is the shared nginx fixture the TestKgateway harness
+	// deploys (common.SetupSharedNginxBackend) into common.SharedNginxNamespace.
+	nginxBackendService = "nginx"
+	nginxBackendPort    = 8080
+
+	referenceGrantName = "strict-churn-grant"
+)
+
+// Fleet scale, overridable to push past the laptop-friendly defaults when
+// hunting load-dependent behavior (e.g. KGW_LOADTEST_BACKENDS=800).
+// KGW_LOADTEST_GATEWAYS matters beyond raw load: each Gateway is its own xDS
+// role and therefore its own unique client, and on a single-node cluster
+// (where every pod shares one locality) distinct Gateways are the ONLY way to
+// multiply unique-client fan-out — the axis that stretched the per-client
+// derivation window in the #14184 field reports.
+var (
+	strictChurnBackends = envScale("KGW_LOADTEST_BACKENDS", 200)
+	strictChurnRoutes   = envScale("KGW_LOADTEST_ROUTES", 200)
+	strictChurnGateways = churnGatewayNames(envScale("KGW_LOADTEST_GATEWAYS", 2))
+
+	// gatewayRolloutBound is how long a rolling-restarted gateway Envoy has to
+	// come back Ready. A fresh Envoy is a brand-new xDS client with no
+	// fallback config: if its first snapshot is withheld indefinitely, the
+	// pod never reports Ready and the rollout wedges ("gateways are unable to
+	// spawn"). Generous enough to absorb one full per-client rebuild on a
+	// healthy control plane.
+	gatewayRolloutBound = fmt.Sprintf("%ds", envScale("KGW_LOADTEST_ROLLOUT_BOUND_SECONDS", defaultRolloutBoundSeconds))
+	// stableRouteBound is how quickly the stable route must answer 200 at
+	// every checkpoint during churn. It was reachable before churn started,
+	// so any sustained failure means the data plane lost working config.
+	stableRouteBound = time.Duration(envScale("KGW_LOADTEST_STABLE_BOUND_SECONDS", defaultStableBoundSeconds)) * time.Second
+	// convergenceBound is how quickly a route created after the churn stops
+	// must become routable end to end. This is the liveness property: the
+	// per-client pipeline still publishes after churn plus a restart.
+	convergenceBound = time.Duration(envScale("KGW_LOADTEST_CONVERGENCE_BOUND_SECONDS", defaultConvergenceBoundSeconds)) * time.Second
+)
+
+func churnGatewayNames(n int) []string {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("churn-gw-%d", i+1)
+	}
+	return names
+}
+
+func envScale(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// controllerAppName returns the app.kubernetes.io/name of the controller under
+// test. Defaults to the OSS controller; override with
+// KGW_LOADTEST_CONTROLLER_APP (e.g. for a downstream distribution) to point
+// the deployment lookup at a differently-labeled control plane. The gateway
+// class is not parameterized — create a GatewayClass named "kgateway" bound to
+// the distribution's controllerName instead.
+func controllerAppName() string {
+	if app := os.Getenv("KGW_LOADTEST_CONTROLLER_APP"); app != "" {
+		return app
+	}
+	return "kgateway"
+}
+
+func controllerSelector() string {
+	return fmt.Sprintf("%s=%s", testdefaults.WellKnownAppLabel, controllerAppName())
+}
+
+var _ e2e.NewSuiteFunc = NewStrictChurnSuite
+
+func NewStrictChurnSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &StrictChurnSuite{
+		LoadTestingSuite: LoadTestingSuite{
+			Suite:            suite.Suite{},
+			ctx:              ctx,
+			testInstallation: testInst,
+		},
+	}
+}
+
+type StrictChurnSuite struct {
+	LoadTestingSuite
+	loadTestManager         *LoadTestManager
+	installNamespace        string
+	controllerDeployment    string
+	delayOverridden         bool
+	validatorModeOverridden bool
+}
+
+func (s *StrictChurnSuite) SetupSuite() {
+	// Hard opt-in gate, independent of -run regexes: this suite mutates the
+	// controller deployment (strict validation env, a mid-test restart), so a
+	// broad invocation like the nightly's unanchored `^TestKgateway` matcher
+	// must not pick it up implicitly. `make run-load-tests-strict-churn` sets
+	// the variable.
+	if os.Getenv("KGW_ENABLE_STRICT_CHURN") != "true" {
+		s.T().Skip("StrictChurn mutates the controller deployment; set KGW_ENABLE_STRICT_CHURN=true (or use `make run-load-tests-strict-churn`) to run it")
+	}
+	s.loadTestManager = NewLoadTestManager(s.ctx, s.testInstallation,
+		fmt.Sprintf("kgateway-strictchurn-%d", time.Now().UnixNano()))
+	s.installNamespace = s.testInstallation.Metadata.InstallNamespace
+
+	name, err := s.resolveControllerDeployment()
+	s.Require().NoError(err, "should find the kgateway controller deployment in %s", s.installNamespace)
+	s.controllerDeployment = name
+
+	// The curl pod issues the data-plane probes; the harness's shared nginx
+	// (nginx-shared, applied once by TestKgateway's base setup) is the real
+	// backend behind the stable and post-churn routes (the simulated services
+	// have unroutable endpoints, so they can't answer traffic).
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, testdefaults.CurlPodManifest)
+	s.Require().NoError(err, "should apply curl pod")
+	s.testInstallation.AssertionsT(s.T()).EventuallyPodsRunning(s.ctx,
+		testdefaults.CurlPod.GetNamespace(), metav1.ListOptions{LabelSelector: testdefaults.CurlPodLabelSelector})
+
+	envExprs := []string{"KGW_VALIDATION_MODE=STRICT"}
+	if d := os.Getenv("KGW_XDS_FIRST_CONNECT_DELAY"); d != "" {
+		envExprs = append(envExprs, "KGW_XDS_FIRST_CONNECT_DELAY="+d)
+		s.delayOverridden = true
+	}
+	// KGW_VALIDATOR_MODE=BINARY disables the strict-validation verdict cache,
+	// restoring the #14184-era per-call validation cost on every rebuild —
+	// the field-shaped amplifier of the per-client derivation window.
+	if m := os.Getenv("KGW_VALIDATOR_MODE"); m != "" {
+		envExprs = append(envExprs, "KGW_VALIDATOR_MODE="+m)
+		s.validatorModeOverridden = true
+	}
+	s.T().Logf("Setting controller env on deployment/%s in %s: %v", s.controllerDeployment, s.installNamespace, envExprs)
+	s.Require().NoError(s.setControllerEnv(envExprs...))
+}
+
+func (s *StrictChurnSuite) TearDownSuite() {
+	// SetupSuite skipped (opt-in gate) before creating anything: do not touch
+	// the cluster — the curl/nginx manifests may be in use by other suites.
+	if s.loadTestManager == nil {
+		return
+	}
+	// Restore the controller before anything else so a failed run doesn't
+	// leave the install in strict mode for whoever uses the cluster next.
+	if s.controllerDeployment != "" {
+		envExprs := []string{"KGW_VALIDATION_MODE-"}
+		if s.delayOverridden {
+			envExprs = append(envExprs, "KGW_XDS_FIRST_CONNECT_DELAY-")
+		}
+		if s.validatorModeOverridden {
+			envExprs = append(envExprs, "KGW_VALIDATOR_MODE-")
+		}
+		if err := s.setControllerEnv(envExprs...); err != nil {
+			s.T().Logf("WARNING: failed to restore controller env: %v", err)
+		}
+	}
+	if s.loadTestManager != nil {
+		s.loadTestManager.CleanupAll()
+	}
+	// The nginx-shared ReferenceGrant outlives the per-run namespaces
+	// (nginx-shared belongs to the harness), so delete it explicitly.
+	_ = s.testInstallation.ClusterContext.Client.Delete(s.ctx, &gwv1b1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      referenceGrantName,
+			Namespace: common.SharedNginxNamespace,
+		},
+	})
+	// The shared nginx backend belongs to the harness, not this suite — do
+	// not delete it. The curl pod is per-suite (siblings re-apply it).
+	_ = s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, testdefaults.CurlPodManifest)
+}
+
+func (s *StrictChurnSuite) resolveControllerDeployment() (string, error) {
+	out, _, err := s.testInstallation.ClusterContext.Cli.Execute(s.ctx,
+		"get", "deploy", "-n", s.installNamespace,
+		"-l", controllerSelector(),
+		"-o", "jsonpath={.items[0].metadata.name}")
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(out)
+	if name == "" {
+		return "", fmt.Errorf("no deployment matching %q in %s", controllerSelector(), s.installNamespace)
+	}
+	return name, nil
+}
+
+// setControllerEnv applies `kubectl set env` expressions (KEY=VALUE or KEY-)
+// to the controller deployment in a single call and waits for the resulting
+// rollout.
+func (s *StrictChurnSuite) setControllerEnv(envExprs ...string) error {
+	args := append([]string{
+		"set", "env", "-n", s.installNamespace,
+		"deployment/" + s.controllerDeployment,
+	}, envExprs...)
+	if err := s.testInstallation.Actions.Kubectl().RunCommand(s.ctx, args...); err != nil {
+		return err
+	}
+	return s.testInstallation.Actions.Kubectl().DeploymentRolloutStatus(s.ctx,
+		s.controllerDeployment, "-n", s.installNamespace, "--timeout=120s")
+}
+
+func (s *StrictChurnSuite) TestStrictChurnConvergence() {
+	s.T().Log("=== StrictChurn: strict validation + route/Service churn + controller restart ===")
+
+	// Phase 1: scale fixture — fake Services/EndpointSlices and baseline routes.
+	s.Require().NoError(s.loadTestManager.SetupSimulation(strictChurnBackends, "strict-churn"),
+		"should setup cluster simulation")
+	s.Require().NoError(s.loadTestManager.SetupTestInfrastructure(), "should setup test infrastructure")
+	s.createReferenceGrants()
+
+	s.Require().NoError(s.loadTestManager.CreateGateways(strictChurnGateways), "should create gateways")
+	s.Require().NoError(s.loadTestManager.WaitForGatewayReadiness(gatewayReadinessTimeout), "gateways should be ready")
+
+	config := &AttachedRoutesConfig{
+		Gateways:    strictChurnGateways,
+		Routes:      strictChurnRoutes,
+		GracePeriod: GetConfig(strictChurnRoutes).GracePeriod,
+		BatchSize:   GetOptimalBatchSize(strictChurnRoutes),
+	}
+	s.Require().NoError(s.loadTestManager.CreateRoutesBatched(config), "should create baseline routes")
+	s.waitForAttachedRoutes(strictChurnGateways[0], strictChurnRoutes/len(strictChurnGateways), translationCompletionTimeout)
+
+	// Phase 2: a stable route to a real backend, verified working before any
+	// churn. This is the route that must never break.
+	s.createRouteToNginx("stable-route", strictChurnGateways[0], stableRouteHost)
+	s.assertRouteServes(strictChurnGateways[0], stableRouteHost, stableRouteBound)
+	s.T().Log("Stable route serving 200 — starting churn")
+
+	// Phase 3: two permanently-unhealthy references that persist through the
+	// run, attached to the stable route's gateway. The dangling route's
+	// Service never exists (kgateway replaces the route with a 500 direct
+	// response); the starved route's Service exists but its selector matches
+	// no pods, so its cluster never has a ready endpoint. Neither shape
+	// wedges the #13868 gates on its own (the per-client CDS row and an
+	// empty CLA both materialize within milliseconds, so the gate's defer is
+	// transient — verified against a gated build); they are here as permanent
+	// sources of not-fully-ready reference state under which publication must
+	// keep flowing for everything else.
+	s.createDanglingRoute(strictChurnGateways[0])
+	s.createStarvedRoute(strictChurnGateways[0])
+
+	// Phase 4: churn — create/delete a Service+EndpointSlice and a route each
+	// cycle, restart the controller halfway through, and require the stable
+	// route back at 200 before the next cycle. A background churner also
+	// rewrites the simulated fleet's EndpointSlices continuously: real
+	// clusters never quiesce, and an all-or-nothing consistency gate that
+	// requires a globally-consistent instant will never find one while
+	// endpoints keep moving. (This is the load shape that separates a
+	// bounded-wait control plane from a wedged one; quiet-endpoint runs
+	// converge even on builds with the unbounded gate.)
+	churnerCtx, stopChurner := context.WithCancel(s.ctx)
+	defer stopChurner()
+	s.startEndpointChurner(churnerCtx)
+	for cycle := range strictChurnCycles {
+		s.runChurnCycle(cycle)
+
+		// Client identity churn: roll each gateway's Envoy once mid-run. A
+		// rolled pod reconnects as a brand-new xDS client whose first
+		// snapshot must be built from scratch while the fleet churns —
+		// completion is asserted after the loop (gatewayRolloutBound). The
+		// schedule spreads rolls across cycles (gcd(3, strictChurnCycles)=1,
+		// so up to strictChurnCycles gateways land on distinct cycles; for
+		// the default two gateways this is the original cycles 2 and 5).
+		for i, gw := range strictChurnGateways {
+			if cycle == (2+i*3)%strictChurnCycles {
+				s.rollGateway(gw)
+			}
+		}
+
+		if cycle == strictChurnCycles/2 {
+			s.T().Logf("Cycle %d: restarting controller mid-churn", cycle)
+			s.Require().NoError(s.testInstallation.Actions.Kubectl().RestartDeploymentAndWait(s.ctx,
+				s.controllerDeployment, "-n", s.installNamespace), "controller should restart cleanly mid-churn")
+		}
+
+		s.assertRouteServes(strictChurnGateways[0], stableRouteHost, stableRouteBound)
+		time.Sleep(churnCycleInterval)
+	}
+
+	// Phase 4b: every rolled gateway must finish its rollout — the freshly
+	// started Envoy only reports Ready once it has received config, so a
+	// control plane that withholds a new client's first snapshot indefinitely
+	// fails here with a wedged rollout.
+	for _, gw := range strictChurnGateways {
+		s.Require().NoError(s.testInstallation.Actions.Kubectl().DeploymentRolloutStatus(s.ctx,
+			gw, "-n", s.loadTestManager.testNamespace, "--timeout="+gatewayRolloutBound),
+			"gateway %s rollout must complete: a fresh Envoy client must receive its first xDS snapshot", gw)
+	}
+	s.T().Log("Route churn + gateway rolls complete — asserting convergence under live endpoint churn")
+
+	// Phase 5: liveness — config created while the fleet's endpoints are
+	// still moving must flow to the data plane within the bound. A control
+	// plane that waits for a globally-consistent instant never finds one on
+	// a busy fleet; unconditional publication must deliver regardless.
+	s.createRouteToNginx("postchurn-route", strictChurnGateways[1], postChurnRouteHost)
+	s.assertRouteServes(strictChurnGateways[1], postChurnRouteHost, convergenceBound)
+	stopChurner()
+
+	s.T().Log("=== StrictChurn PASSED: stable traffic held, gateway rolls completed, post-churn config converged ===")
+}
+
+// runChurnCycle creates this cycle's Service+EndpointSlice+route, then deletes
+// the previous cycle's, so the controller continuously sees backend and route
+// add/remove events without the resource count growing.
+func (s *StrictChurnSuite) runChurnCycle(cycle int) {
+	simNS := s.loadTestManager.simulator.config.Namespace
+	svcName := fmt.Sprintf("churn-svc-%d", cycle)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: simNS,
+			Labels:    map[string]string{"loadtest": "true", "churn": "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": svcName},
+			Ports: []corev1.ServicePort{{
+				Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
+	port := int32(8080)
+	portName := "http"
+	protocol := corev1.ProtocolTCP
+	eps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: simNS,
+			Labels: map[string]string{
+				"kubernetes.io/service-name": svcName,
+				"loadtest":                   "true",
+				"churn":                      "true",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{{
+			Addresses: []string{fmt.Sprintf("10.250.0.%d", (cycle%250)+1)},
+		}},
+		Ports: []discoveryv1.EndpointPort{{Name: &portName, Port: &port, Protocol: &protocol}},
+	}
+	route := s.buildChurnRoute(fmt.Sprintf("churn-route-%d", cycle), strictChurnGateways[cycle%len(strictChurnGateways)],
+		fmt.Sprintf("churn-%d.strict-churn.example.com", cycle), svcName, simNS)
+
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, svc), "churn service create")
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, eps), "churn endpointslice create")
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "churn route create")
+
+	// Delete the previous cycle's resources (kept alive one cycle so the
+	// controller always overlaps an add with a remove).
+	if cycle > 0 {
+		prev := cycle - 1
+		prevSvc := fmt.Sprintf("churn-svc-%d", prev)
+		_ = s.testInstallation.Actions.Kubectl().RunCommand(s.ctx,
+			"delete", "httproute", fmt.Sprintf("churn-route-%d", prev),
+			"-n", s.loadTestManager.testNamespace, "--ignore-not-found", "--wait=false")
+		_ = s.testInstallation.Actions.Kubectl().RunCommand(s.ctx,
+			"delete", "service", prevSvc, "-n", simNS, "--ignore-not-found", "--wait=false")
+		_ = s.testInstallation.Actions.Kubectl().RunCommand(s.ctx,
+			"delete", "endpointslice", prevSvc, "-n", simNS, "--ignore-not-found", "--wait=false")
+	}
+	// The last cycle's leftovers are deleted by namespace teardown.
+}
+
+func (s *StrictChurnSuite) createDanglingRoute(gateway string) {
+	route := s.buildChurnRoute("dangling-route", gateway,
+		"dangling.strict-churn.example.com", "no-such-service", s.loadTestManager.testNamespace)
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "dangling route create")
+	s.loadTestManager.createdRoutes = append(s.loadTestManager.createdRoutes, route)
+}
+
+// startEndpointChurner continuously rewrites simulated EndpointSlices, one
+// every endpointChurnInterval, rotating through the fleet. Each write is a
+// real input change (the endpoint IP moves), so every referenced backend's
+// per-client endpoint translation keeps re-running for every connected
+// client — the steady-state load shape of a production fleet where pods are
+// always rolling somewhere.
+func (s *StrictChurnSuite) startEndpointChurner(ctx context.Context) {
+	cfg := s.loadTestManager.simulator.config
+	simNS := cfg.Namespace
+	// The simulator sizes the fleet itself: the number of sim-service-*
+	// EndpointSlices is FakeNodeCount*ServicesPerNode, NOT strictChurnBackends.
+	// Rotate over what actually exists or the churner runs off the end of the
+	// fleet and stops producing churn.
+	totalSimServices := cfg.FakeNodeCount * cfg.ServicesPerNode
+	s.Require().Positive(totalSimServices, "simulation must have services to churn")
+	go func() {
+		ticker := time.NewTicker(endpointChurnInterval)
+		defer ticker.Stop()
+		attempts, writes := 0, 0
+		for {
+			select {
+			case <-ctx.Done():
+				s.T().Logf("Endpoint churner stopped after %d EndpointSlice rewrites (%d attempts)", writes, attempts)
+				return
+			case <-ticker.C:
+			}
+			idx := attempts % totalSimServices
+			ip := fmt.Sprintf("10.246.%d.%d", (attempts/250)%200, attempts%250+1)
+			// Advance every tick regardless of outcome so one unpatchable
+			// slice can never wedge the rotation.
+			attempts++
+			patch := fmt.Sprintf(`[{"op":"replace","path":"/endpoints/0/addresses/0","value":%q}]`, ip)
+			eps := &discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("sim-service-%d", idx), Namespace: simNS,
+			}}
+			if err := s.testInstallation.ClusterContext.Client.Patch(ctx, eps,
+				client.RawPatch(types.JSONPatchType, []byte(patch))); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				s.T().Logf("endpoint churn patch failed (continuing): %v", err)
+				continue
+			}
+			writes++
+		}
+	}()
+}
+
+// rollGateway triggers a rolling restart of a gateway's Envoy deployment
+// (named after the Gateway by the deployer) without waiting — completion is
+// asserted later against gatewayRolloutBound.
+func (s *StrictChurnSuite) rollGateway(gateway string) {
+	s.T().Logf("Rolling gateway %s (new xDS client identity)", gateway)
+	s.Require().NoError(s.testInstallation.Actions.Kubectl().RestartDeployment(s.ctx,
+		gateway, "-n", s.loadTestManager.testNamespace), "should roll gateway %s", gateway)
+}
+
+// createStarvedRoute creates a Service whose selector matches no pods plus a
+// route referencing it: the backendRef resolves (the Service exists), so the
+// gateway's referenced-cluster set permanently contains an EDS cluster that
+// will never have a ready endpoint.
+func (s *StrictChurnSuite) createStarvedRoute(gateway string) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "starved-svc",
+			Namespace: s.loadTestManager.testNamespace,
+			Labels:    map[string]string{"loadtest": "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "starved-no-such-pod"},
+			Ports: []corev1.ServicePort{{
+				Name: "http", Port: 80, TargetPort: intstr.FromInt(8080), Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
+	s.Require().NoError(s.loadTestManager.createResource(svc), "starved service create")
+	route := s.buildChurnRoute("starved-route", gateway,
+		"starved.strict-churn.example.com", "starved-svc", s.loadTestManager.testNamespace)
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "starved route create")
+	s.loadTestManager.createdRoutes = append(s.loadTestManager.createdRoutes, route)
+}
+
+func (s *StrictChurnSuite) createRouteToNginx(name, gateway, hostname string) {
+	route := s.buildChurnRoute(name, gateway, hostname,
+		nginxBackendService, common.SharedNginxNamespace)
+	s.Require().NoError(s.testInstallation.ClusterContext.Client.Create(s.ctx, route), "route %s create", name)
+	s.loadTestManager.createdRoutes = append(s.loadTestManager.createdRoutes, route)
+}
+
+func (s *StrictChurnSuite) buildChurnRoute(name, gateway, hostname, backendSvc, backendNS string) *gwv1.HTTPRoute {
+	pathType := gwv1.PathMatchPathPrefix
+	pathValue := "/"
+	ns := gwv1.Namespace(backendNS)
+	port := gwv1.PortNumber(80)
+	if backendNS == common.SharedNginxNamespace {
+		port = gwv1.PortNumber(nginxBackendPort)
+	}
+	return &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: s.loadTestManager.testNamespace,
+			Labels:    map[string]string{"loadtest": "true"},
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{{Name: gwv1.ObjectName(gateway)}},
+			},
+			Hostnames: []gwv1.Hostname{gwv1.Hostname(hostname)},
+			Rules: []gwv1.HTTPRouteRule{{
+				Matches: []gwv1.HTTPRouteMatch{{
+					Path: &gwv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				BackendRefs: []gwv1.HTTPBackendRef{{
+					BackendRef: gwv1.BackendRef{
+						BackendObjectReference: gwv1.BackendObjectReference{
+							Name:      gwv1.ObjectName(backendSvc),
+							Namespace: &ns,
+							Port:      &port,
+						},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+// createReferenceGrants permits the test namespace's routes to reference
+// Services in the simulation and nginx namespaces. Without these, every
+// cross-namespace backendRef is RefNotPermitted and no clusters are built —
+// which would silence the strict-validation load this scenario exists to apply.
+//
+// The grants are UPSERTED, not created-and-ignore-exists: the nginx-shared
+// grant has a fixed name in a namespace the harness owns (CleanupAll never
+// deletes it), so a leftover grant from a previous run permits only that
+// run's — long deleted — test namespace. Silently keeping it starves every
+// route of the current run into a steady 500 (RefNotPermitted -> route
+// replacement), which is indistinguishable at the data plane from the xDS
+// starvation this suite exists to detect.
+func (s *StrictChurnSuite) createReferenceGrants() {
+	for _, targetNS := range []string{
+		s.loadTestManager.simulator.config.Namespace,
+		common.SharedNginxNamespace,
+	} {
+		grant := &gwv1b1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      referenceGrantName,
+				Namespace: targetNS,
+				Labels:    map[string]string{"loadtest": "true"},
+			},
+			Spec: gwv1b1.ReferenceGrantSpec{
+				From: []gwv1b1.ReferenceGrantFrom{{
+					Group:     gwv1b1.Group(gwv1.GroupName),
+					Kind:      "HTTPRoute",
+					Namespace: gwv1b1.Namespace(s.loadTestManager.testNamespace),
+				}},
+				To: []gwv1b1.ReferenceGrantTo{{
+					Group: "",
+					Kind:  "Service",
+				}},
+			},
+		}
+		s.Require().NoError(s.upsertReferenceGrant(grant),
+			"should create ReferenceGrant in %s", targetNS)
+	}
+}
+
+func (s *StrictChurnSuite) upsertReferenceGrant(grant *gwv1b1.ReferenceGrant) error {
+	err := s.testInstallation.ClusterContext.Client.Create(s.ctx, grant)
+	if err == nil || !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	existing := &gwv1b1.ReferenceGrant{}
+	if err := s.testInstallation.ClusterContext.Client.Get(s.ctx,
+		client.ObjectKeyFromObject(grant), existing); err != nil {
+		return err
+	}
+	existing.Spec = grant.Spec
+	existing.Labels = grant.Labels
+	return s.testInstallation.ClusterContext.Client.Update(s.ctx, existing)
+}
+
+// assertRouteServes requires the given hostname to answer 200 with the nginx
+// body through the gateway's in-cluster Service within the bound.
+func (s *StrictChurnSuite) assertRouteServes(gateway, hostname string, bound time.Duration) {
+	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(metav1.ObjectMeta{
+				Name: gateway, Namespace: s.loadTestManager.testNamespace,
+			})),
+			curl.WithHostHeader(hostname),
+			curl.WithPath("/"),
+			curl.WithPort(80),
+		},
+		&testmatchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Body:       gomega.ContainSubstring(testdefaults.NginxResponse),
+		},
+		bound, 2*time.Second,
+	)
+}
+
+// waitForAttachedRoutes polls a gateway's listener status until at least
+// minRoutes report attached.
+func (s *StrictChurnSuite) waitForAttachedRoutes(gateway string, minRoutes int, timeout time.Duration) {
+	s.Require().Eventually(func() bool {
+		gw := &gwv1.Gateway{}
+		if err := s.testInstallation.ClusterContext.Client.Get(s.ctx,
+			types.NamespacedName{Namespace: s.loadTestManager.testNamespace, Name: gateway}, gw); err != nil {
+			return false
+		}
+		if len(gw.Status.Listeners) == 0 {
+			return false
+		}
+		attached := int(gw.Status.Listeners[0].AttachedRoutes)
+		s.T().Logf("Gateway %s: AttachedRoutes=%d (waiting for >=%d)", gateway, attached, minRoutes)
+		return attached >= minRoutes
+	}, timeout, translationPollingInterval, "baseline routes should attach to %s", gateway)
+}

--- a/test/e2e/features/loadtesting/strictchurn_suite_test.go
+++ b/test/e2e/features/loadtesting/strictchurn_suite_test.go
@@ -1,0 +1,42 @@
+//go:build e2e
+
+package loadtesting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRestoreControllerEnvVars(t *testing.T) {
+	originalValidation := &corev1.EnvVar{Name: "KGW_VALIDATION_MODE", Value: "standard"}
+	originalValidator := &corev1.EnvVar{
+		Name: "KGW_VALIDATOR_MODE",
+		ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "controller-env"},
+				Key:                  "validator-mode",
+			},
+		},
+	}
+	container := &corev1.Container{Env: []corev1.EnvVar{
+		{Name: "UNCHANGED", Value: "true"},
+		{Name: "KGW_VALIDATION_MODE", Value: "STRICT"},
+		{Name: "KGW_XDS_FIRST_CONNECT_DELAY", Value: "0"},
+		{Name: "KGW_VALIDATOR_MODE", Value: "BINARY"},
+	}}
+
+	restoreControllerEnvVars(container, map[string]*corev1.EnvVar{
+		"KGW_VALIDATION_MODE":         originalValidation,
+		"KGW_XDS_FIRST_CONNECT_DELAY": nil,
+		"KGW_VALIDATOR_MODE":          originalValidator,
+	})
+
+	assert.Equal(t, []corev1.EnvVar{
+		{Name: "UNCHANGED", Value: "true"},
+		*originalValidation,
+		*originalValidator,
+	}, container.Env)
+	assert.Equal(t, "controller-env", container.Env[2].ValueFrom.ConfigMapKeyRef.Name)
+}

--- a/test/e2e/features/xds_starvation/suite.go
+++ b/test/e2e/features/xds_starvation/suite.go
@@ -4,10 +4,18 @@
 // xDS publication (#14184): a gateway whose config contains a reference that
 // can never become ready (an ExternalName Service, which produces no
 // EndpointSlices) must still publish config, keep its pods Ready across
-// rollouts, and keep receiving updates across controller restarts. Under the
-// former whole-snapshot readiness gates (#13868, reverted) this exact shape
-// withheld the entire snapshot forever: warm proxies were stranded and fresh
-// pods crash-looped (#14352).
+// rollouts, and keep receiving updates across controller restarts.
+//
+// Honesty note: this suite is a regression pin for these properties, not a
+// reproducer of the #14184/#14352 wedge. Verified empirically (2026-07-10, on
+// a build with the #13868 gates plus the strict-validation cache and per-client
+// fan-out fixes): the gate's defer state for this reference shape is transient
+// — the ExternalName backend still yields a per-client CDS row microseconds
+// after the route arrives, so the gate unblocks and the suite passes on gated
+// builds too. The field wedge required per-client derivation lag at production
+// scale (the transient defer window stretched by fan-out x config size x
+// churn, self-amplified by crashloop reconnects), which a laptop-scale
+// fixture does not produce.
 package xds_starvation
 
 import (

--- a/test/e2e/features/xds_starvation/testdata/setup.yaml
+++ b/test/e2e/features/xds_starvation/testdata/setup.yaml
@@ -13,10 +13,10 @@ spec:
           from: Same
 ---
 # A backend that can never become ready: an ExternalName Service produces no
-# EndpointSlices, so the referenced cluster never gets endpoints. This is the
-# steady-state shape (#14352) that made #13868's whole-snapshot readiness
-# gates permanently unsatisfiable; with the gates removed, routes to it fail
-# individually while everything else keeps publishing.
+# EndpointSlices, so the referenced cluster never gets endpoints and requests
+# to it always fail. A permanently-unready reference is the steady-state shape
+# from the #14184/#14352 reports; the suite pins that its presence never
+# withholds publication for the rest of the config.
 apiVersion: v1
 kind: Service
 metadata:

--- a/test/e2e/tests/kgateway/suite_runner.go
+++ b/test/e2e/tests/kgateway/suite_runner.go
@@ -98,8 +98,9 @@ func SuiteRunner() e2e.SuiteRunner {
 	// StrictChurn mutates the controller deployment (strict validation, a
 	// mid-test restart), so it is hard-gated behind KGW_ENABLE_STRICT_CHURN
 	// in its SetupSuite and skips otherwise — broad -run regexes (e.g. the
-	// nightly's unanchored ^TestKgateway) cannot run it implicitly. Use
-	// `make run-load-tests-strict-churn`.
+	// nightly e2e lane's unanchored ^TestKgateway) cannot run it implicitly.
+	// The nightly load-test lane invokes `make run-load-tests-strict-churn`
+	// explicitly after its shared suites.
 	kubeGatewaySuiteRunner.Register("StrictChurn", loadtesting.NewStrictChurnSuite)
 	kubeGatewaySuiteRunner.Register("DirectResponse", directresponse.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("PathMatching", path_matching.NewTestingSuite)

--- a/test/e2e/tests/kgateway/suite_runner.go
+++ b/test/e2e/tests/kgateway/suite_runner.go
@@ -95,6 +95,12 @@ func SuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("CSRF", csrf.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("AutoHostRewrite", auto_host_rewrite.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("AttachedRoutes", loadtesting.NewAttachedRoutesSuite)
+	// StrictChurn mutates the controller deployment (strict validation, a
+	// mid-test restart), so it is hard-gated behind KGW_ENABLE_STRICT_CHURN
+	// in its SetupSuite and skips otherwise — broad -run regexes (e.g. the
+	// nightly's unanchored ^TestKgateway) cannot run it implicitly. Use
+	// `make run-load-tests-strict-churn`.
+	kubeGatewaySuiteRunner.Register("StrictChurn", loadtesting.NewStrictChurnSuite)
 	kubeGatewaySuiteRunner.Register("DirectResponse", directresponse.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("PathMatching", path_matching.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TimeoutRetry", timeoutretry.NewTestingSuite)

--- a/test/e2e/tests/shards_test.go
+++ b/test/e2e/tests/shards_test.go
@@ -26,6 +26,7 @@ type workflowConfig struct {
 
 var e2eTestsNotRequiredInPRShards = map[string]string{
 	"TestKgateway/AttachedRoutes": "load tests run in the dedicated nightly load-test workflow",
+	"TestKgateway/StrictChurn":    "opt-in load test mutates the controller deployment and runs manually",
 	"TestZoneAwareRouting":        "requires a multi-zone multi-worker kind cluster; check guide to run manually",
 }
 

--- a/test/e2e/tests/shards_test.go
+++ b/test/e2e/tests/shards_test.go
@@ -26,7 +26,7 @@ type workflowConfig struct {
 
 var e2eTestsNotRequiredInPRShards = map[string]string{
 	"TestKgateway/AttachedRoutes": "load tests run in the dedicated nightly load-test workflow",
-	"TestKgateway/StrictChurn":    "opt-in load test mutates the controller deployment and runs manually",
+	"TestKgateway/StrictChurn":    "opt-in load test runs in the dedicated nightly load-test workflow",
 	"TestZoneAwareRouting":        "requires a multi-zone multi-worker kind cluster; check guide to run manually",
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
StrictChurn suite helps with performance work and correctness work by simulating a large, churning k8s cluster. It restarts both the control and data planes midstream.

This is expensive, so it only runs nightly unless you run it locally.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind test

<!--
Select one or more of the following by including the corresponding slash-command.

If you pick more than one, the release note is filed under whichever appears first here (manual reordering does not have any effect):
```
/kind breaking_change
/kind feature
/kind fix
/kind deprecation
/kind documentation
/kind cleanup
/kind install
/kind bump
(the following kinds are not included in release notes)
/kind design
/kind flake
/kind test
```
-->

# Changelog

<!--
Provide the exact line to appear in the release notes for this PR.

A PR gets one release note, filed under the highest-precedence /kind above.
If this change needs no release note, write "NONE" in the block below.
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
