### PR TITLE
gate on the cluster specifier oneof rather than on a specific arm

### DIFF
--- a/pkg/kgateway/translator/irtranslator/route.go
+++ b/pkg/kgateway/translator/irtranslator/route.go
@@ -689,7 +689,7 @@ func (h *httpRouteConfigurationTranslator) translateRouteAction(
 	// TODO: we should never get here
 	case 1:
 		// Only set the cluster name if unspecified since a plugin may have set it.
-		if action.GetCluster() == "" {
+		if action.GetClusterSpecifier() == nil {
 			action.ClusterSpecifier = &envoyroutev3.RouteAction_Cluster{
 				Cluster: clusters[0].GetName(),
 			}
@@ -698,7 +698,7 @@ func (h *httpRouteConfigurationTranslator) translateRouteAction(
 
 	default:
 		// Only set weighted clusters if unspecified since a plugin may have set it.
-		if action.GetWeightedClusters() == nil {
+		if action.GetClusterSpecifier() == nil {
 			action.ClusterSpecifier = &envoyroutev3.RouteAction_WeightedClusters{
 				WeightedClusters: &envoyroutev3.WeightedCluster{
 					Clusters: clusters,


### PR DESCRIPTION
# Description

gate on the cluster specifier oneof rather than on a specific arm. no functional change


# Change Type

/kind cleanup


# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
