### PR TITLE
[2.4] fix: make Lambda Backend AssumeRole auth actually assume the role

### DIFF
--- a/hack/localstack-values.yaml
+++ b/hack/localstack-values.yaml
@@ -8,7 +8,7 @@ mountDind:
   enabled: true
   forceTLS: true
   image: "docker:26-dind"
-startServices: "lambda,ec2"
+startServices: "lambda,ec2,sts"
 volumes:
   - name: docker-sock
     hostPath:

--- a/pkg/kgateway/extensions2/plugins/backend/aws.go
+++ b/pkg/kgateway/extensions2/plugins/backend/aws.go
@@ -190,8 +190,8 @@ func configureAWSAuth(auth *kgateway.AwsAuth, secret *ir.Secret, region string) 
 	case kgateway.AwsAuthTypeAssumeRole:
 		// handle STS role chaining. The base credentials that sign the AssumeRole request are
 		// left unset so Envoy resolves them from the default provider chain (e.g. the gateway
-		// ServiceAccount's IRSA identity). The temporary credentials returned by STS are then
-		// used to sign requests to the backend.
+		// ServiceAccount's IRSA or EKS Pod Identity credentials). The temporary credentials
+		// returned by STS are then used to sign requests to the backend.
 		if auth.AssumeRole == nil {
 			return nil, fmt.Errorf("assumeRole is required for %q auth", kgateway.AwsAuthTypeAssumeRole)
 		}
@@ -199,6 +199,9 @@ func configureAWSAuth(auth *kgateway.AwsAuth, secret *ir.Secret, region string) 
 			AssumeRoleCredentialProvider: &envoy_aws_common_v3.AssumeRoleCredentialProvider{
 				RoleArn: auth.AssumeRole.RoleArn,
 			},
+			// Without a custom chain, Envoy treats this message as a set of modifiers to the
+			// default provider chain, which does not accept an assume-role provider
+			CustomCredentialProviderChain: true,
 		}
 
 	default:

--- a/pkg/kgateway/extensions2/plugins/backend/aws_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/aws_test.go
@@ -87,6 +87,10 @@ func TestConfigureAWSAuthAssumeRole(t *testing.T) {
 	assert.Equal(t, "arn:aws:iam::311275790335:role/project-invoke-role", assumeRole.GetRoleArn())
 	// base credentials must be left unset so Envoy falls back to the default provider chain (IRSA).
 	assert.Nil(t, assumeRole.GetCredentialProvider(), "base credential provider should be unset to use the gateway's ambient credentials")
+	// Envoy's default chain discards an assume-role provider passed as a modifier, so a custom
+	// chain is required for the provider to take effect at all.
+	assert.True(t, signing.GetCredentialProvider().GetCustomCredentialProviderChain(),
+		"custom credential provider chain must be set or Envoy silently ignores the assume role provider")
 }
 
 func TestBuildLambdaARNUsesPreferredNestedAccountID(t *testing.T) {

--- a/pkg/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda_assume_role.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda_assume_role.yaml
@@ -39,6 +39,7 @@ Clusters:
           credentialProvider:
             assumeRoleCredentialProvider:
               roleArn: arn:aws:iam::311275790335:role/project-invoke-role
+            customCredentialProviderChain: true
           region: us-east-1
           serviceName: lambda
       - name: envoy.filters.http.upstream_codec

--- a/pkg/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda_assume_role_strict.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/backends/aws_lambda_assume_role_strict.yaml
@@ -39,6 +39,7 @@ Clusters:
           credentialProvider:
             assumeRoleCredentialProvider:
               roleArn: arn:aws:iam::311275790335:role/project-invoke-role
+            customCredentialProviderChain: true
           region: us-east-1
           serviceName: lambda
       - name: envoy.filters.http.upstream_codec

--- a/test/e2e/features/lambda/suite.go
+++ b/test/e2e/features/lambda/suite.go
@@ -9,29 +9,39 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e"
 	testdefaults "github.com/kgateway-dev/kgateway/v2/test/e2e/defaults"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/testutils/localstack"
+	"github.com/kgateway-dev/kgateway/v2/test/envoyutils/admincli"
 	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
 	"github.com/kgateway-dev/kgateway/v2/test/testutils"
 )
 
+// stsSuccessStatRegex matches the 2xx request counter of the internal cluster
+// Envoy creates for its assume-role credential provider's STS calls.
+var stsSuccessStatRegex = regexp.MustCompile(`cluster\.sts_token_service_internal-us-east-1\.upstream_rq_2xx: (\d+)`)
+
 // testingSuite is a suite of Lambda backend routing tests
 type testingSuite struct {
 	suite.Suite
-	ctx         context.Context
-	ti          *e2e.TestInstallation
-	manifests   map[string][]string
-	endpointURL string
+	ctx          context.Context
+	ti           *e2e.TestInstallation
+	manifests    map[string][]string
+	endpointURL  string
+	stsServiceIP string
 }
 
 var _ e2e.NewSuiteFunc = NewTestingSuite
@@ -61,9 +71,14 @@ func (s *testingSuite) SetupSuite() {
 		"TestLambdaBackendRouting":      {lambdaBackendManifest},
 		"TestLambdaBackendAsyncRouting": {lambdaAsyncManifest},
 		"TestLambdaBackendQualifier":    {lambdaQualifierManifest},
+		"TestLambdaBackendAssumeRole":   {lambdaAssumeRoleManifest},
 	}
 
+	err = s.ti.Actions.Kubectl().ApplyFile(s.ctx, stsServiceManifest)
+	s.NoError(err, "can apply "+stsServiceManifest)
+
 	s.extractLocalstackEndpoint()
+	s.extractSTSServiceIP()
 	s.createLambdaFunctions()
 }
 
@@ -75,6 +90,8 @@ func (s *testingSuite) TearDownSuite() {
 	s.NoError(err, "can delete setup manifest")
 	err = s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, testdefaults.CurlPodManifest)
 	s.NoError(err, "can delete curl pod manifest")
+	err = s.ti.Actions.Kubectl().DeleteFileSafe(s.ctx, stsServiceManifest)
+	s.NoError(err, "can delete sts service manifest")
 }
 
 func (s *testingSuite) BeforeTest(suiteName, testName string) {
@@ -88,8 +105,9 @@ func (s *testingSuite) BeforeTest(suiteName, testName string) {
 		content, err := os.ReadFile(manifest)
 		s.Assert().NoError(err, "can read manifest "+manifest)
 
-		// Replace the endpointURL placeholder with actual URL
+		// Replace the endpointURL and STS service IP placeholders with the actual values
 		newContent := strings.Replace(string(content), "http://172.18.0.2:31566", s.endpointURL, -1)
+		newContent = strings.Replace(newContent, stsServiceIPPlaceholder, s.stsServiceIP, -1)
 		tmpFile, err := os.CreateTemp("", "lambda-manifest-*.yaml")
 		s.Assert().NoError(err, "can create temp file")
 		defer os.Remove(tmpFile.Name())
@@ -253,6 +271,54 @@ func (s *testingSuite) TestLambdaBackendQualifier() {
 	)
 }
 
+// TestLambdaBackendAssumeRole verifies STS role chaining: the proxy must use its
+// base credentials (env vars on the dedicated gateway's Envoy container) to call
+// sts:AssumeRole on the Backend's roleArn, then sign the Lambda invocation with
+// the temporary credentials STS returns.
+func (s *testingSuite) TestLambdaBackendAssumeRole() {
+	// BeforeTest waits on the shared gateway; this test brings its own.
+	s.ti.AssertionsT(s.T()).EventuallyObjectsExist(s.ctx, assumeRoleProxyServiceMeta, assumeRoleProxyDeploymentMeta)
+	s.ti.AssertionsT(s.T()).EventuallyPodsRunning(s.ctx, lambdaNamespace, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", testdefaults.WellKnownAppLabel, assumeRoleGatewayName),
+	})
+
+	// The route must work end to end through the assumed role's credentials.
+	s.ti.AssertionsT(s.T()).AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(assumeRoleGatewayObjectMeta)),
+			curl.WithHostHeader("www.example.com"),
+			curl.WithPort(8080),
+			curl.WithPath("/lambda"),
+		},
+		&testmatchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Body:       gomega.ContainSubstring(`Hello from Lambda`),
+		},
+	)
+
+	// A 200 alone doesn't prove role chaining: localstack doesn't enforce IAM, so
+	// a proxy that (incorrectly) signs with its base credentials also gets a 200.
+	// Envoy only creates and uses the internal STS cluster when the assume-role
+	// credential provider is actually active, so require a successful AssumeRole
+	// call to have gone through it.
+	s.ti.AssertionsT(s.T()).AssertEnvoyAdminApi(s.ctx, assumeRoleProxyDeploymentMeta.ObjectMeta,
+		func(ctx context.Context, adminClient *admincli.Client) {
+			stats, err := adminClient.GetStats(ctx, map[string]string{
+				"filter": `cluster\.sts_token_service_internal-us-east-1\.upstream_rq_2xx`,
+			})
+			s.Assert().NoError(err, "can fetch envoy stats")
+			matches := stsSuccessStatRegex.FindStringSubmatch(stats)
+			s.Require().Len(matches, 2, "expected an upstream_rq_2xx stat for the STS cluster; "+
+				"its absence means Envoy never called sts:AssumeRole and signed with its base credentials instead. stats: %q", stats)
+			count, err := strconv.Atoi(matches[1])
+			s.Assert().NoError(err, "can parse STS 2xx stat value")
+			s.Assert().GreaterOrEqual(count, 1, "expected at least one successful sts:AssumeRole call")
+		},
+	)
+}
+
 func (s *testingSuite) extractLocalstackEndpoint() {
 	s.T().Log("extracting localstack endpoint URL from cluster")
 
@@ -262,6 +328,20 @@ func (s *testingSuite) extractLocalstackEndpoint() {
 
 	s.endpointURL = endpoint
 	s.T().Logf("localstack endpoint URL: %s", s.endpointURL)
+}
+
+// extractSTSServiceIP resolves the cluster IP of the localstack-sts service so
+// the assume-role test can alias sts.us-east-1.amazonaws.com (which Envoy's
+// assume-role credential provider hardcodes) to localstack via pod hostAliases.
+func (s *testingSuite) extractSTSServiceIP() {
+	svc := &corev1.Service{}
+	err := s.ti.ClusterContext.Client.Get(s.ctx,
+		client.ObjectKey{Namespace: "localstack", Name: "localstack-sts"}, svc)
+	s.Require().NoError(err, "can get localstack-sts service")
+	s.Require().NotEmpty(svc.Spec.ClusterIP, "localstack-sts service must have a cluster IP")
+
+	s.stsServiceIP = svc.Spec.ClusterIP
+	s.T().Logf("localstack STS service cluster IP: %s", s.stsServiceIP)
 }
 
 func (s *testingSuite) createLambdaFunctions() {

--- a/test/e2e/features/lambda/testdata/lambda-assume-role.yaml
+++ b/test/e2e/features/lambda/testdata/lambda-assume-role.yaml
@@ -1,0 +1,90 @@
+---
+# A dedicated gateway for the AssumeRole test so the base AWS credentials
+# (env vars) and the STS host alias don't leak into the other lambda tests.
+#
+# Role chaining requires the proxy to reach https://sts.us-east-1.amazonaws.com:443,
+# which Envoy hardcodes; the hostAliases entry points that hostname at the
+# localstack-sts service (port 443 -> localstack's gateway port). The suite
+# replaces STS_SERVICE_CLUSTER_IP with the service's cluster IP before applying.
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: lambda-assume-role-gateway
+  namespace: lambda-test
+spec:
+  kube:
+    envoyContainer:
+      bootstrap:
+        logLevel: debug
+      # The base credentials Envoy's default provider chain resolves to sign the
+      # sts:AssumeRole call itself. Localstack accepts any credentials.
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          value: base-identity
+        - name: AWS_SECRET_ACCESS_KEY
+          value: base-secret
+    deploymentOverlay:
+      spec:
+        template:
+          spec:
+            hostAliases:
+              - ip: "STS_SERVICE_CLUSTER_IP"
+                hostnames:
+                  - sts.us-east-1.amazonaws.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: lambda-assume-role-gateway
+  namespace: lambda-test
+spec:
+  gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      name: lambda-assume-role-gateway
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: lambda-assume-role-route
+  namespace: lambda-test
+spec:
+  parentRefs:
+    - name: lambda-assume-role-gateway
+  hostnames:
+    - "www.example.com"
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /lambda
+      backendRefs:
+        - name: lambda-assume-role-backend
+          kind: Backend
+          group: gateway.kgateway.dev
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: Backend
+metadata:
+  name: lambda-assume-role-backend
+  namespace: lambda-test
+spec:
+  type: AWS
+  aws:
+    auth:
+      type: AssumeRole
+      assumeRole:
+        roleArn: arn:aws:iam::000000000000:role/lambda-invoke-target
+    lambda:
+      accountId: "000000000000"
+      functionName: hello-function
+      endpointURL: "http://172.18.0.2:31566"

--- a/test/e2e/features/lambda/testdata/sts-service.yaml
+++ b/test/e2e/features/lambda/testdata/sts-service.yaml
@@ -1,0 +1,18 @@
+---
+# Exposes the localstack gateway on port 443 so Envoy's assume-role credential
+# provider can reach it: Envoy hardcodes the STS endpoint to
+# https://sts.<region>.amazonaws.com:443, so the test remaps that hostname to
+# this service's cluster IP (via pod hostAliases) and localstack terminates the
+# TLS connection itself on its multiplexed HTTP/HTTPS gateway port.
+apiVersion: v1
+kind: Service
+metadata:
+  name: localstack-sts
+  namespace: localstack
+spec:
+  selector:
+    app.kubernetes.io/name: localstack
+  ports:
+    - name: https
+      port: 443
+      targetPort: 4566

--- a/test/e2e/features/lambda/types.go
+++ b/test/e2e/features/lambda/types.go
@@ -13,17 +13,24 @@ import (
 )
 
 const (
-	gatewayName     = "lambda-gateway"
-	lambdaNamespace = "lambda-test"
+	gatewayName           = "lambda-gateway"
+	assumeRoleGatewayName = "lambda-assume-role-gateway"
+	lambdaNamespace       = "lambda-test"
+
+	// stsServiceIPPlaceholder is replaced with the localstack-sts service's
+	// cluster IP when the assume-role manifest is applied.
+	stsServiceIPPlaceholder = "STS_SERVICE_CLUSTER_IP"
 )
 
 var (
-	setupManifest           = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
-	awsCliPodManifest       = filepath.Join(fsutils.MustGetThisDir(), "testdata", "aws-cli.yaml")
-	lambdaBackendManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "lambda-backend.yaml")
-	lambdaAsyncManifest     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "lambda-async.yaml")
-	lambdaQualifierManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "lambda-qualifier.yaml")
-	lambdaFunctionPath      = filepath.Join(fsutils.MustGetThisDir(), "functions", "hello-function.js")
+	setupManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	awsCliPodManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "aws-cli.yaml")
+	lambdaBackendManifest    = filepath.Join(fsutils.MustGetThisDir(), "testdata", "lambda-backend.yaml")
+	lambdaAsyncManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "lambda-async.yaml")
+	lambdaQualifierManifest  = filepath.Join(fsutils.MustGetThisDir(), "testdata", "lambda-qualifier.yaml")
+	lambdaAssumeRoleManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "lambda-assume-role.yaml")
+	stsServiceManifest       = filepath.Join(fsutils.MustGetThisDir(), "testdata", "sts-service.yaml")
+	lambdaFunctionPath       = filepath.Join(fsutils.MustGetThisDir(), "functions", "hello-function.js")
 
 	gatewayObjectMeta = metav1.ObjectMeta{
 		Name:      gatewayName,
@@ -40,6 +47,25 @@ var (
 	proxyServiceMeta = &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gatewayName,
+			Namespace: lambdaNamespace,
+		},
+	}
+
+	assumeRoleGatewayObjectMeta = metav1.ObjectMeta{
+		Name:      assumeRoleGatewayName,
+		Namespace: lambdaNamespace,
+	}
+
+	assumeRoleProxyDeploymentMeta = &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      assumeRoleGatewayName,
+			Namespace: lambdaNamespace,
+		},
+	}
+
+	assumeRoleProxyServiceMeta = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      assumeRoleGatewayName,
 			Namespace: lambdaNamespace,
 		},
 	}


### PR DESCRIPTION
# Description

Cherry-pick of #14632 onto `v2.4.x` (upstream commit 157129931b2b99974edc99c8ba1826388da6ef2b). Applied cleanly, no conflicts.

A `Backend` with `spec.aws.auth.type: AssumeRole` never called `sts:AssumeRole`: Lambda invocations were signed with the proxy's ambient credentials (IRSA / EKS Pod Identity / env), and the per-Backend `roleArn` was silently ignored.

**Root cause:** the generated `aws_request_signing` filter config set `assumeRoleCredentialProvider` but left `custom_credential_provider_chain` at its default of `false`. In that mode Envoy treats the credential provider message as a set of *modifiers* to the default provider chain, and the default chain only accepts web-identity, credentials-file, and IAM-Roles-Anywhere providers as modifiers — the assume-role provider is discarded without any error (see [credential_provider_chains.cc](https://github.com/envoyproxy/envoy/blob/v1.38.0/source/extensions/common/aws/credential_provider_chains.cc#L74-L109)).

**Fix:** set `custom_credential_provider_chain: true`, so the chain contains only the assume-role provider. The `sts:AssumeRole` request itself is still signed with credentials resolved from the default chain (IRSA / Pod Identity / env), because the provider's nested `credential_provider` is left unset — which is exactly the role-chaining contract the API documents.

**E2E test:** adds `TestLambdaBackendAssumeRole` to the localstack-backed lambda suite (STS is now included in localstack's started services). Envoy hardcodes the STS endpoint to `https://sts.<region>.amazonaws.com:443`, so the test exposes localstack's gateway on port 443 via a Service and remaps the STS hostname to it with pod `hostAliases` on a dedicated gateway (via `deploymentOverlay`); base credentials for the AssumeRole call are provided as env vars on the Envoy container. Because localstack community does not enforce IAM, a 200 alone cannot distinguish role-chained signing from ambient-credential signing, so the test additionally asserts `cluster.sts_token_service_internal-us-east-1.upstream_rq_2xx >= 1` — Envoy only creates that cluster when the assume-role provider is active, so the stat's presence proves the STS call happened.

# Change Type

/kind fix
/kind test

# Changelog

```release-note
Fixed AWS Lambda Backends with `spec.aws.auth.type: AssumeRole` silently ignoring the configured role. The proxy now calls `sts:AssumeRole` using its ambient credentials (IRSA / EKS Pod Identity / environment) and signs Lambda requests with the returned temporary credentials, instead of signing with the ambient credentials directly.
```

# Additional Notes

Verification on this branch: `go build -tags e2e` and `go test ./pkg/kgateway/extensions2/plugins/backend/...` both pass; the golden output files for the two assume-role backend cases carry the new `customCredentialProviderChain: true` line.
