### PR TITLE
fix(deployer): merge gmsaCredentialSpecName from its own field

### DIFF
--- a/pkg/deployer/merge.go
+++ b/pkg/deployer/merge.go
@@ -203,7 +203,7 @@ func deepMergeWindowsSecurityContextOptions(dst, src *corev1.WindowsSecurityCont
 		return src
 	}
 
-	dst.GMSACredentialSpecName = MergePointers(dst.GMSACredentialSpec, src.GMSACredentialSpec)
+	dst.GMSACredentialSpecName = MergePointers(dst.GMSACredentialSpecName, src.GMSACredentialSpecName)
 	dst.GMSACredentialSpec = MergePointers(dst.GMSACredentialSpec, src.GMSACredentialSpec)
 	dst.RunAsUserName = MergePointers(dst.RunAsUserName, src.RunAsUserName)
 	dst.HostProcess = MergePointers(dst.HostProcess, src.HostProcess)

--- a/pkg/deployer/merge_test.go
+++ b/pkg/deployer/merge_test.go
@@ -607,3 +607,71 @@ func TestDeepMergeImage(t *testing.T) {
 		})
 	}
 }
+
+func TestDeepMergeSecurityContextWindowsOptions(t *testing.T) {
+	const gmsaSpec = `{"apiVersion":"windows.k8s.io/v1","kind":"GMSACredentialSpec"}`
+
+	tests := []struct {
+		name string
+		dst  *corev1.WindowsSecurityContextOptions
+		src  *corev1.WindowsSecurityContextOptions
+		want *corev1.WindowsSecurityContextOptions
+	}{
+		{
+			name: "src gmsaCredentialSpecName overrides dst",
+			dst: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpecName: new("default-gmsa"),
+				RunAsUserName:          new("default-user"),
+			},
+			src: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpecName: new("override-gmsa"),
+			},
+			want: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpecName: new("override-gmsa"),
+				RunAsUserName:          new("default-user"),
+			},
+		},
+		{
+			name: "dst gmsaCredentialSpecName is kept when src does not set it",
+			dst: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpecName: new("default-gmsa"),
+			},
+			src: &corev1.WindowsSecurityContextOptions{
+				RunAsUserName: new("override-user"),
+			},
+			want: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpecName: new("default-gmsa"),
+				RunAsUserName:          new("override-user"),
+			},
+		},
+		{
+			name: "gmsaCredentialSpec does not leak into gmsaCredentialSpecName",
+			dst: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpec: new(gmsaSpec),
+			},
+			src: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpecName: new("override-gmsa"),
+			},
+			want: &corev1.WindowsSecurityContextOptions{
+				GMSACredentialSpecName: new("override-gmsa"),
+				GMSACredentialSpec:     new(gmsaSpec),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DeepMergeSecurityContext(
+				&corev1.SecurityContext{WindowsOptions: tt.dst.DeepCopy()},
+				&corev1.SecurityContext{WindowsOptions: tt.src.DeepCopy()},
+			)
+			assert.Equal(t, tt.want, got.WindowsOptions, "container securityContext.windowsOptions")
+
+			gotPod := deepMergePodSecurityContext(
+				&corev1.PodSecurityContext{WindowsOptions: tt.dst.DeepCopy()},
+				&corev1.PodSecurityContext{WindowsOptions: tt.src.DeepCopy()},
+			)
+			assert.Equal(t, tt.want, gotPod.WindowsOptions, "pod securityContext.windowsOptions")
+		})
+	}
+}


### PR DESCRIPTION
# Description

`deepMergeWindowsSecurityContextOptions` in `pkg/deployer/merge.go:206` merged `gmsaCredentialSpecName` out of the wrong pair of fields:

```go
dst.GMSACredentialSpecName = MergePointers(dst.GMSACredentialSpec, src.GMSACredentialSpec)
dst.GMSACredentialSpec = MergePointers(dst.GMSACredentialSpec, src.GMSACredentialSpec)
```

The helper only runs when both sides set `securityContext.windowsOptions`, which is the normal case once a Gateway's GatewayParameters overrides the GatewayClass defaults. When it runs, whatever `gmsaCredentialSpecName` the user configured on either side is discarded. If neither side sets `gmsaCredentialSpec`, the merged name comes out nil and the pod loses the GMSA reference. If either side does set it, the name becomes the credential spec JSON document, and kubelet then tries to resolve a GMSACredentialSpec cluster resource named after a blob of JSON.

Both security context types go through this helper, so `DeepMergeSecurityContext` (container, used for the envoy, sds and istio containers) and `deepMergePodSecurityContext` (pod) are both affected. Both fields are exposed in the GatewayParameters CRD under `spec.kube.podTemplate.securityContext.windowsOptions` and the per-container `securityContext.windowsOptions`.

The fix merges the field from `dst.GMSACredentialSpecName` and `src.GMSACredentialSpecName`. `TestDeepMergeSecurityContextWindowsOptions` covers the three behaviors against both helpers: the override wins, an unset override inherits the default, and `gmsaCredentialSpec` no longer leaks into `gmsaCredentialSpecName`.

# Change Type

/kind fix

# Changelog

```release-note
Fixed GatewayParameters merging so that securityContext.windowsOptions.gmsaCredentialSpecName is preserved instead of being overwritten with the value of gmsaCredentialSpec.
```

# Additional Notes

All three test cases fail on unmodified `main` and pass with the change. On `main` the third one reports `GMSACredentialSpecName: (*string)((len=62) "{\"apiVersion\":\"windows.k8s.io/v1\",\"kind\":\"GMSACredentialSpec\"}")` where `"override-gmsa"` was expected.

Verified with `go test ./pkg/deployer/...` (ok, both packages), `./_output/golangci-lint-custom run --build-tags e2e ./pkg/deployer/...` (0 issues), and `make generated-code` followed by `git diff --exit-code`, which reports no generated diff.
