### PR TITLE
bump envoy to v1.39.1 to fix Lambda AssumeRole hang

### DIFF
--- a/.github/workflows/.env/nightly-tests/max_versions.env
+++ b/.github/workflows/.env/nightly-tests/max_versions.env
@@ -1,6 +1,6 @@
 node_version='v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5'
 kubectl_version='v1.36.1'
 kind_version='v0.32.0'
-istio_version='1.30.1'
+istio_version='1.31.0'
 cluster_type='kind'
 envtest_k8s_version='1.36'

--- a/.github/workflows/.env/pr-tests/versions.env
+++ b/.github/workflows/.env/pr-tests/versions.env
@@ -2,5 +2,5 @@ node_version='v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d10
 kubectl_version='v1.36.1'
 # Waypoint coverage requires at least 1.25.1; this default tracks the
 # latest supported Istio patch used by autoMtls.
-istio_version='1.30.1'
+istio_version='1.31.0'
 cluster_type='kind'

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ else
 	OSV_SCANNER_PLATFORM := --platform=linux/amd64
 endif
 
-export ENVOY_IMAGE ?= envoyproxy/envoy:v1.38.3
+export ENVOY_IMAGE ?= envoyproxy/envoy:v1.39.1
 
 # ENVOY_IMAGE is used by some of the *-docker targets which are used by CI e2e tests, so figure out the correct image
 # to use base on GOARCH. This doesn't affect goreleaser

--- a/internal/envoy_modules/Cargo.lock
+++ b/internal/envoy_modules/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "envoy-proxy-dynamic-modules-rust-sdk"
 version = "0.1.0"
-source = "git+https://github.com/envoyproxy/envoy?tag=v1.38.3#0ebfcfe5b0484b89ca85b761da9e05ce75dbda8d"
+source = "git+https://github.com/envoyproxy/envoy?tag=v1.39.1#b579d07d3ad7ee11d32b105e91a5a39ad24718d7"
 dependencies = [
  "bindgen",
  "mockall",

--- a/internal/envoy_modules/Cargo.toml
+++ b/internal/envoy_modules/Cargo.toml
@@ -13,4 +13,4 @@ default-members = ["module-init"]
 [workspace.dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
 # Update this single entry when upgrading Envoy.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.38.3" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", tag = "v1.39.1" }

--- a/pkg/deployer/gateway_parameters.go
+++ b/pkg/deployer/gateway_parameters.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DefaultIstioProxyImageTag is the default Istio proxyv2 image tag used for auto mTLS cert-agent sidecars.
-const DefaultIstioProxyImageTag = "1.30.1"
+const DefaultIstioProxyImageTag = "1.31.0"
 
 // Inputs is the set of options used to configure gateway/inference pool deployment.
 type Inputs struct {

--- a/pkg/kgateway/extensions2/plugins/backend/aws.go
+++ b/pkg/kgateway/extensions2/plugins/backend/aws.go
@@ -188,10 +188,17 @@ func configureAWSAuth(auth *kgateway.AwsAuth, secret *ir.Secret, region string) 
 		}
 
 	case kgateway.AwsAuthTypeAssumeRole:
-		// handle STS role chaining. The base credentials that sign the AssumeRole request are
-		// left unset so Envoy resolves them from the default provider chain (e.g. the gateway
-		// ServiceAccount's IRSA or EKS Pod Identity credentials). The temporary credentials
-		// returned by STS are then used to sign requests to the backend.
+		// handle STS role chaining. The assume-role provider's nested credential_provider is
+		// left unset: Envoy then builds an inner *default* provider chain (environment,
+		// credentials file, container, instance profile, web identity) to sign the AssumeRole
+		// request, so the gateway's ambient identity (e.g. the ServiceAccount's IRSA or EKS Pod
+		// Identity credentials) is used. The temporary credentials returned by STS are then used
+		// to sign requests to the backend.
+		//
+		// Envoy < v1.39.0 never subscribes that inner chain to its async providers
+		// (envoyproxy/envoy#45643), so when the base credentials come from an async source such
+		// as IRSA the AssumeRole call is never issued and every request hangs. The Envoy image
+		// pinned in the Makefile must therefore be >= v1.39.0 for this auth type to work.
 		if auth.AssumeRole == nil {
 			return nil, fmt.Errorf("assumeRole is required for %q auth", kgateway.AwsAuthTypeAssumeRole)
 		}

--- a/pkg/kgateway/extensions2/plugins/backend/aws_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/aws_test.go
@@ -85,7 +85,8 @@ func TestConfigureAWSAuthAssumeRole(t *testing.T) {
 	assumeRole := signing.GetCredentialProvider().GetAssumeRoleCredentialProvider()
 	require.NotNil(t, assumeRole, "assume role auth should set the assume role credential provider")
 	assert.Equal(t, "arn:aws:iam::311275790335:role/project-invoke-role", assumeRole.GetRoleArn())
-	// base credentials must be left unset so Envoy falls back to the default provider chain (IRSA).
+	// The nested credential provider must be left unset so Envoy signs the AssumeRole call with an
+	// inner default provider chain (IRSA, Pod Identity, instance profile, env vars, ...).
 	assert.Nil(t, assumeRole.GetCredentialProvider(), "base credential provider should be unset to use the gateway's ambient credentials")
 	// Envoy's default chain discards an assume-role provider passed as a modifier, so a custom
 	// chain is required for the provider to take effect at all.

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar-out.yaml
@@ -505,7 +505,7 @@ spec:
               fieldPath: metadata.namespace
         - name: DISABLE_ENVOY
           value: "true"
-        image: docker.io/istio/proxyv2:1.30.1
+        image: docker.io/istio/proxyv2:1.31.0
         name: istio-proxy
         resources: {}
         volumeMounts:

--- a/test/deployer/testdata/envoy-sds-and-custom-sidecar.yaml
+++ b/test/deployer/testdata/envoy-sds-and-custom-sidecar.yaml
@@ -36,7 +36,7 @@ spec:
         image:
           registry: docker.io/istio
           repository: proxyv2
-          tag: 1.30.1
+          tag: 1.31.0
         istioDiscoveryAddress: istiod.istio-system.svc:15012
         istioMetaMeshId: cluster.local
         istioMetaClusterId: Kubernetes

--- a/test/deployer/testdata/istio-enabled-out.yaml
+++ b/test/deployer/testdata/istio-enabled-out.yaml
@@ -493,7 +493,7 @@ spec:
               fieldPath: metadata.namespace
         - name: DISABLE_ENVOY
           value: "true"
-        image: docker.io/istio/proxyv2:1.30.1
+        image: docker.io/istio/proxyv2:1.31.0
         name: istio-proxy
         resources: {}
         volumeMounts:

--- a/test/deployer/testdata/istio-enabled-waypoint-out.yaml
+++ b/test/deployer/testdata/istio-enabled-waypoint-out.yaml
@@ -502,7 +502,7 @@ spec:
               fieldPath: metadata.namespace
         - name: DISABLE_ENVOY
           value: "true"
-        image: docker.io/istio/proxyv2:1.30.1
+        image: docker.io/istio/proxyv2:1.31.0
         name: istio-proxy
         resources: {}
         volumeMounts:

--- a/test/e2e/features/lambda/suite.go
+++ b/test/e2e/features/lambda/suite.go
@@ -272,9 +272,14 @@ func (s *testingSuite) TestLambdaBackendQualifier() {
 }
 
 // TestLambdaBackendAssumeRole verifies STS role chaining: the proxy must use its
-// base credentials (env vars on the dedicated gateway's Envoy container) to call
-// sts:AssumeRole on the Backend's roleArn, then sign the Lambda invocation with
-// the temporary credentials STS returns.
+// base credentials to call sts:AssumeRole on the Backend's roleArn, then sign the
+// Lambda invocation with the temporary credentials STS returns.
+//
+// The base credentials come from a web identity token (as IRSA provides on EKS),
+// which Envoy resolves asynchronously via sts:AssumeRoleWithWebIdentity. That is
+// the path that hung on Envoy < v1.39.0 (envoyproxy/envoy#45643): the inner
+// chain signing the AssumeRole call never learned its credentials had arrived.
+// Static env-var credentials are synchronous and would mask a regression there.
 func (s *testingSuite) TestLambdaBackendAssumeRole() {
 	// BeforeTest waits on the shared gateway; this test brings its own.
 	s.ti.AssertionsT(s.T()).EventuallyObjectsExist(s.ctx, assumeRoleProxyServiceMeta, assumeRoleProxyDeploymentMeta)
@@ -300,9 +305,10 @@ func (s *testingSuite) TestLambdaBackendAssumeRole() {
 
 	// A 200 alone doesn't prove role chaining: localstack doesn't enforce IAM, so
 	// a proxy that (incorrectly) signs with its base credentials also gets a 200.
-	// Envoy only creates and uses the internal STS cluster when the assume-role
-	// credential provider is actually active, so require a successful AssumeRole
-	// call to have gone through it.
+	// Envoy only creates and uses the internal STS cluster when the web identity
+	// and assume-role credential providers are active, and both talk to it: one
+	// AssumeRoleWithWebIdentity call for the base credentials, then one AssumeRole
+	// call signed with them. Require both to have succeeded.
 	s.ti.AssertionsT(s.T()).AssertEnvoyAdminApi(s.ctx, assumeRoleProxyDeploymentMeta.ObjectMeta,
 		func(ctx context.Context, adminClient *admincli.Client) {
 			stats, err := adminClient.GetStats(ctx, map[string]string{
@@ -314,7 +320,7 @@ func (s *testingSuite) TestLambdaBackendAssumeRole() {
 				"its absence means Envoy never called sts:AssumeRole and signed with its base credentials instead. stats: %q", stats)
 			count, err := strconv.Atoi(matches[1])
 			s.Assert().NoError(err, "can parse STS 2xx stat value")
-			s.Assert().GreaterOrEqual(count, 1, "expected at least one successful sts:AssumeRole call")
+			s.Assert().GreaterOrEqual(count, 2, "expected a successful sts:AssumeRoleWithWebIdentity call followed by a successful sts:AssumeRole call")
 		},
 	)
 }

--- a/test/e2e/features/lambda/suite.go
+++ b/test/e2e/features/lambda/suite.go
@@ -31,8 +31,24 @@ import (
 )
 
 // stsSuccessStatRegex matches the 2xx request counter of the internal cluster
-// Envoy creates for its assume-role credential provider's STS calls.
+// Envoy creates for its STS-backed credential providers. Every STS action of a
+// region shares this one cluster, so the counter proves the proxy talked to STS
+// but not which API it called.
 var stsSuccessStatRegex = regexp.MustCompile(`cluster\.sts_token_service_internal-us-east-1\.upstream_rq_2xx: (\d+)`)
+
+const (
+	stsAssumeRoleAction     = "sts.AssumeRole"
+	stsWebIdentityAction    = "sts.AssumeRoleWithWebIdentity"
+	stsRequestCountTimeout  = 30 * time.Second
+	stsRequestCountInterval = 2 * time.Second
+)
+
+// stsCallCounts holds how many times localstack served each STS action; see
+// localstack.RequestCount.
+type stsCallCounts struct {
+	assumeRole  int
+	webIdentity int
+}
 
 // testingSuite is a suite of Lambda backend routing tests
 type testingSuite struct {
@@ -42,6 +58,10 @@ type testingSuite struct {
 	manifests    map[string][]string
 	endpointURL  string
 	stsServiceIP string
+	// stsCallsBefore is the localstack STS request tally taken before the
+	// current test's manifests were applied, so assertions can count only the
+	// calls made by the current test.
+	stsCallsBefore stsCallCounts
 }
 
 var _ e2e.NewSuiteFunc = NewTestingSuite
@@ -99,6 +119,11 @@ func (s *testingSuite) BeforeTest(suiteName, testName string) {
 	if !ok {
 		s.FailNow("no manifests found for %s, manifest map contents: %v", testName, s.manifests)
 	}
+
+	// Snapshot STS activity before the proxy for this test exists: Envoy's
+	// credential providers call STS as soon as the proxy starts, not on the
+	// first request.
+	s.stsCallsBefore = s.countSTSCalls()
 
 	for _, manifest := range manifests {
 		// Read the manifest content
@@ -305,10 +330,7 @@ func (s *testingSuite) TestLambdaBackendAssumeRole() {
 
 	// A 200 alone doesn't prove role chaining: localstack doesn't enforce IAM, so
 	// a proxy that (incorrectly) signs with its base credentials also gets a 200.
-	// Envoy only creates and uses the internal STS cluster when the web identity
-	// and assume-role credential providers are active, and both talk to it: one
-	// AssumeRoleWithWebIdentity call for the base credentials, then one AssumeRole
-	// call signed with them. Require both to have succeeded.
+	// The proxy must have gone to STS through its own internal cluster...
 	s.ti.AssertionsT(s.T()).AssertEnvoyAdminApi(s.ctx, assumeRoleProxyDeploymentMeta.ObjectMeta,
 		func(ctx context.Context, adminClient *admincli.Client) {
 			stats, err := adminClient.GetStats(ctx, map[string]string{
@@ -317,12 +339,37 @@ func (s *testingSuite) TestLambdaBackendAssumeRole() {
 			s.Assert().NoError(err, "can fetch envoy stats")
 			matches := stsSuccessStatRegex.FindStringSubmatch(stats)
 			s.Require().Len(matches, 2, "expected an upstream_rq_2xx stat for the STS cluster; "+
-				"its absence means Envoy never called sts:AssumeRole and signed with its base credentials instead. stats: %q", stats)
+				"its absence means no credential provider of the proxy ever called STS. stats: %q", stats)
 			count, err := strconv.Atoi(matches[1])
 			s.Assert().NoError(err, "can parse STS 2xx stat value")
-			s.Assert().GreaterOrEqual(count, 2, "expected a successful sts:AssumeRoleWithWebIdentity call followed by a successful sts:AssumeRole call")
+			s.Assert().GreaterOrEqual(count, 1, "expected at least one successful STS call from the proxy")
 		},
 	)
+
+	// ...but that cluster carries every STS action, so it cannot tell an
+	// AssumeRoleWithWebIdentity exchange (which the aws_lambda filter's own
+	// default chain also performs) from the AssumeRole call this test is about.
+	// Localstack logs one line per API action, so require, since this test's
+	// proxy was created, both a web identity exchange (the async base-credential
+	// path that hung on Envoy < v1.39.0) and an AssumeRole call (the role
+	// chaining itself).
+	var after stsCallCounts
+	s.Require().Eventually(func() bool {
+		after = s.countSTSCalls()
+		return after.webIdentity > s.stsCallsBefore.webIdentity && after.assumeRole > s.stsCallsBefore.assumeRole
+	}, stsRequestCountTimeout, stsRequestCountInterval,
+		"expected localstack to have served both sts:AssumeRoleWithWebIdentity and sts:AssumeRole since the proxy started; "+
+			"before: %+v, after: %+v. A missing AssumeRole means Envoy signed the Lambda invocation with the gateway's base credentials",
+		s.stsCallsBefore, after)
+}
+
+// countSTSCalls tallies the successful STS actions localstack has served so far.
+func (s *testingSuite) countSTSCalls() stsCallCounts {
+	assumeRole, err := localstack.RequestCount(s.ctx, s.ti.Actions.Kubectl(), stsAssumeRoleAction, http.StatusOK)
+	s.Require().NoError(err, "can count %s requests in localstack logs", stsAssumeRoleAction)
+	webIdentity, err := localstack.RequestCount(s.ctx, s.ti.Actions.Kubectl(), stsWebIdentityAction, http.StatusOK)
+	s.Require().NoError(err, "can count %s requests in localstack logs", stsWebIdentityAction)
+	return stsCallCounts{assumeRole: assumeRole, webIdentity: webIdentity}
 }
 
 func (s *testingSuite) extractLocalstackEndpoint() {

--- a/test/e2e/features/lambda/testdata/lambda-assume-role.yaml
+++ b/test/e2e/features/lambda/testdata/lambda-assume-role.yaml
@@ -1,11 +1,27 @@
 ---
-# A dedicated gateway for the AssumeRole test so the base AWS credentials
-# (env vars) and the STS host alias don't leak into the other lambda tests.
+# A dedicated gateway for the AssumeRole test so the base AWS credentials and
+# the STS host alias don't leak into the other lambda tests.
 #
 # Role chaining requires the proxy to reach https://sts.us-east-1.amazonaws.com:443,
 # which Envoy hardcodes; the hostAliases entry points that hostname at the
 # localstack-sts service (port 443 -> localstack's gateway port). The suite
 # replaces STS_SERVICE_CLUSTER_IP with the service's cluster IP before applying.
+#
+# The base credentials that sign the sts:AssumeRole call deliberately come from
+# a web identity token (what IRSA injects on EKS) rather than static env vars:
+# the web identity provider is asynchronous, so this exercises the path where
+# Envoy < v1.39.0 never issued the AssumeRole call and hung every request
+# (envoyproxy/envoy#45643, kgateway-dev/kgateway#14661). Static env-var
+# credentials are resolved synchronously and mask that bug. Localstack accepts
+# any token.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lambda-assume-role-web-identity
+  namespace: lambda-test
+data:
+  token: "not-a-real-oidc-token"
+---
 apiVersion: gateway.kgateway.dev/v1alpha1
 kind: GatewayParameters
 metadata:
@@ -16,13 +32,13 @@ spec:
     envoyContainer:
       bootstrap:
         logLevel: debug
-      # The base credentials Envoy's default provider chain resolves to sign the
-      # sts:AssumeRole call itself. Localstack accepts any credentials.
+      # Envoy's default provider chain picks these up the same way it does the
+      # IRSA-injected variables on EKS.
       env:
-        - name: AWS_ACCESS_KEY_ID
-          value: base-identity
-        - name: AWS_SECRET_ACCESS_KEY
-          value: base-secret
+        - name: AWS_ROLE_ARN
+          value: arn:aws:iam::000000000000:role/base-identity
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
     deploymentOverlay:
       spec:
         template:
@@ -31,6 +47,16 @@ spec:
               - ip: "STS_SERVICE_CLUSTER_IP"
                 hostnames:
                   - sts.us-east-1.amazonaws.com
+            volumes:
+              - name: web-identity-token
+                configMap:
+                  name: lambda-assume-role-web-identity
+            containers:
+              - name: kgateway-proxy
+                volumeMounts:
+                  - name: web-identity-token
+                    mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+                    readOnly: true
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/test/e2e/testutils/localstack/localstack.go
+++ b/test/e2e/testutils/localstack/localstack.go
@@ -9,10 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils/kubectl"
 )
 
 const (
@@ -20,6 +23,10 @@ const (
 	serviceNamespace = "localstack"
 	// serviceName is the name of the localstack service.
 	serviceName = "localstack"
+	// podLabel selects the localstack pod.
+	podLabel = "app.kubernetes.io/name=localstack"
+	// containerName is the localstack container within that pod.
+	containerName = "localstack"
 )
 
 // EndpointURL resolves the localstack NodePort endpoint from the cluster as
@@ -68,4 +75,33 @@ func EndpointURL(ctx context.Context, c client.Client) (endpoint string, found b
 		return "", false, fmt.Errorf("failed to parse localstack URL: %w", err)
 	}
 	return parsed.String(), true, nil
+}
+
+// RequestCount returns how many times localstack has served the given AWS API
+// action (e.g. "sts.AssumeRole") with the given HTTP status, according to its
+// request log, which records one line per call:
+//
+//	... localstack.request.aws : AWS sts.AssumeRole => 200
+//
+// This is the only per-action signal available: Envoy funnels every STS call of
+// a region through one internal cluster, so its cluster and credential-provider
+// stats cannot distinguish sts:AssumeRole from sts:AssumeRoleWithWebIdentity.
+func RequestCount(ctx context.Context, cli *kubectl.Cli, action string, status int) (int, error) {
+	pods, err := cli.GetPodsInNsWithLabel(ctx, serviceNamespace, podLabel)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list localstack pods: %w", err)
+	}
+	if len(pods) == 0 {
+		return 0, errors.New("no localstack pod found")
+	}
+	pattern := regexp.MustCompile(fmt.Sprintf(`AWS %s => %d\b`, regexp.QuoteMeta(action), status))
+	count := 0
+	for _, pod := range pods {
+		logs, err := cli.GetContainerLogs(ctx, serviceNamespace, pod, kubectl.WithContainer(containerName))
+		if err != nil {
+			return 0, fmt.Errorf("failed to read logs of localstack pod %s: %w", pod, err)
+		}
+		count += len(pattern.FindAllStringIndex(logs, -1))
+	}
+	return count, nil
 }

--- a/test/e2e/testutils/runtime/istio_version.go
+++ b/test/e2e/testutils/runtime/istio_version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	IstioVersionEnv     = "ISTIO_VERSION"
-	DefaultIstioVersion = "1.30.1"
+	DefaultIstioVersion = "1.31.0"
 )
 
 // ShouldSkipIstioVersion reports whether the current Istio version (from ISTIO_VERSION env)

--- a/tilt-settings.yaml
+++ b/tilt-settings.yaml
@@ -38,7 +38,7 @@ providers:
     # NOTE: Do NOT include ENTRYPOINT here - the Tiltfile will append the correct
     # entrypoint (standard or debug) based on whether debug_port is set.
     dockerfile_contents: |
-      FROM envoyproxy/envoy:v1.38.3 as envoy-bin
+      FROM envoyproxy/envoy:v1.39.1 as envoy-bin
 
       FROM golang:latest as tilt
       WORKDIR /app


### PR DESCRIPTION
# Description

**Motivation:** Since #14632 set `custom_credential_provider_chain: true`, a Lambda `Backend` with `auth.type: AssumeRole` hangs every request when the gateway's base identity is asynchronous (IRSA web identity, EKS Pod Identity, IMDS). The `Backend` still reports `Accepted=True`, so the failure is silent. See #14661.

**Root cause (Envoy, not kgateway):** with the custom chain, Envoy still builds an inner *default* credential chain to sign the `sts:AssumeRole` call, so ambient credentials are found. But in Envoy < v1.39.0 `createAssumeRoleCredentialsProvider` never calls `setupSubscriptions()` on that inner chain. The outer assume-role provider registers a "call me when credentials arrive" callback that is never fired, so the AssumeRole request is never issued and the request-signing filter waits forever. Synchronous base credentials (static env vars, credentials file) skip that callback path, which is why the existing localstack e2e stayed green. Fixed upstream in envoyproxy/envoy#45644 (envoyproxy/envoy#45643); shipped in v1.39.0, not present in v1.38.4 and no `release/v1.38` backport exists. Declaring the nested `credential_provider` explicitly does not help: it goes through the same unsubscribed path.

**What changed:**
- Bump `ENVOY_IMAGE`to v1.39.1
- Bump the default Istio proxy to 1.31.0 
- Harden `TestLambdaBackendAssumeRole`: base credentials now come from a web identity token file (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`, as IRSA injects on EKS) mounted via `deploymentOverlay`. Because Envoy funnels every STS action of a region through one internal cluster (and the `aws_lambda` filter's own default chain also performs a web identity exchange), Envoy stats cannot prove which API was called; the test therefore counts localstack's per-action request log lines, relative to a snapshot taken before the proxy exists, and requires both an `sts.AssumeRoleWithWebIdentity` (the async path that hung) and an `sts.AssumeRole` (the role chaining itself).

**Verification:**
- kind + localstack STS, identical manifests: Envoy 1.39.1 → 2×AssumeRoleWithWebIdentity + 1×AssumeRole, `signing_added: 1`; Envoy 1.38.3 control → web identity only, assume-role refresh never completes, `signing_added: 0`, request hangs.
- kind → **real AWS** (STS + Lambda in us-east-2), async base credentials: Envoy 1.38.3 → 504 after the route timeout, no `AssumeRole` ever issued; Envoy 1.39.1 → `AssumeRole` 200, request signed as the assumed role and delivered to Lambda in 0.67s.

Fixes #14661

# Change Type

/kind fix
/kind bump

# Changelog

```release-note
Bump Envoy to v1.39.1. Fixes Lambda `Backend`s with `auth.type: AssumeRole` hanging every request when the gateway's base AWS identity is asynchronous (IRSA, EKS Pod Identity).
```

# Additional Notes

- `v2.4.x` pins Envoy 1.38.x, which has no backport of the Envoy fix; the backport of #14632 (#14649) leaves that branch hanging on AssumeRole with IRSA and needs a separate decision.