### PR TITLE
[2.4] feat: make normalize_path and merge_slashes configurable (#14619)

### DIFF
--- a/api/v1alpha1/kgateway/listener_policy_types.go
+++ b/api/v1alpha1/kgateway/listener_policy_types.go
@@ -216,6 +216,22 @@ type HTTPSettings struct {
 	// +optional
 	GenerateRequestId *bool `json:"generateRequestId,omitempty"`
 
+	// NormalizePath determines whether the connection manager normalizes the path per RFC 3986 before
+	// routing, e.g. collapsing `.` and `..` segments and decoding percent-encoded characters. This
+	// defaults to true. Disable this if a backend (e.g. an S3-compatible object store) needs to see
+	// the original, unnormalized request path.
+	// See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path
+	// +optional
+	NormalizePath *bool `json:"normalizePath,omitempty"`
+
+	// MergeSlashes determines whether the connection manager merges adjacent slashes in the request
+	// path before routing. This defaults to true. Disable this if a backend (e.g. an S3-compatible
+	// object store) relies on repeated slashes in the path having meaning, such as object keys that
+	// contain "//".
+	// See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-merge-slashes
+	// +optional
+	MergeSlashes *bool `json:"mergeSlashes,omitempty"`
+
 	// XffNumTrustedHops is the number of additional ingress proxy hops from the right side of the X-Forwarded-For HTTP header to trust when determining the origin client's IP address.
 	// This is mutually exclusive with XffTrustedCIDRs.
 	// See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-xff-num-trusted-hops

--- a/api/v1alpha1/kgateway/zz_generated.deepcopy.go
+++ b/api/v1alpha1/kgateway/zz_generated.deepcopy.go
@@ -2596,6 +2596,16 @@ func (in *HTTPSettings) DeepCopyInto(out *HTTPSettings) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NormalizePath != nil {
+		in, out := &in.NormalizePath, &out.NormalizePath
+		*out = new(bool)
+		**out = **in
+	}
+	if in.MergeSlashes != nil {
+		in, out := &in.MergeSlashes, &out.MergeSlashes
+		*out = new(bool)
+		**out = **in
+	}
 	if in.XffNumTrustedHops != nil {
 		in, out := &in.XffNumTrustedHops, &out.XffNumTrustedHops
 		*out = new(int32)

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml
@@ -2636,6 +2636,22 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              mergeSlashes:
+                description: |-
+                  MergeSlashes determines whether the connection manager merges adjacent slashes in the request
+                  path before routing. This defaults to true. Disable this if a backend (e.g. an S3-compatible
+                  object store) relies on repeated slashes in the path having meaning, such as object keys that
+                  contain "//".
+                  See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-merge-slashes
+                type: boolean
+              normalizePath:
+                description: |-
+                  NormalizePath determines whether the connection manager normalizes the path per RFC 3986 before
+                  routing, e.g. collapsing `.` and `..` segments and decoding percent-encoded characters. This
+                  defaults to true. Disable this if a backend (e.g. an S3-compatible object store) needs to see
+                  the original, unnormalized request path.
+                  See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path
+                type: boolean
               preserveExternalRequestId:
                 description: |-
                   PreserveExternalRequestId determines whether the connection manager will keep the x-request-id header if passed for

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_listenerpolicies.yaml
@@ -2753,6 +2753,22 @@ spec:
                         format: int32
                         minimum: 0
                         type: integer
+                      mergeSlashes:
+                        description: |-
+                          MergeSlashes determines whether the connection manager merges adjacent slashes in the request
+                          path before routing. This defaults to true. Disable this if a backend (e.g. an S3-compatible
+                          object store) relies on repeated slashes in the path having meaning, such as object keys that
+                          contain "//".
+                          See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-merge-slashes
+                        type: boolean
+                      normalizePath:
+                        description: |-
+                          NormalizePath determines whether the connection manager normalizes the path per RFC 3986 before
+                          routing, e.g. collapsing `.` and `..` segments and decoding percent-encoded characters. This
+                          defaults to true. Disable this if a backend (e.g. an S3-compatible object store) needs to see
+                          the original, unnormalized request path.
+                          See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path
+                        type: boolean
                       preserveExternalRequestId:
                         description: |-
                           PreserveExternalRequestId determines whether the connection manager will keep the x-request-id header if passed for
@@ -6013,6 +6029,22 @@ spec:
                               format: int32
                               minimum: 0
                               type: integer
+                            mergeSlashes:
+                              description: |-
+                                MergeSlashes determines whether the connection manager merges adjacent slashes in the request
+                                path before routing. This defaults to true. Disable this if a backend (e.g. an S3-compatible
+                                object store) relies on repeated slashes in the path having meaning, such as object keys that
+                                contain "//".
+                                See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-merge-slashes
+                              type: boolean
+                            normalizePath:
+                              description: |-
+                                NormalizePath determines whether the connection manager normalizes the path per RFC 3986 before
+                                routing, e.g. collapsing `.` and `..` segments and decoding percent-encoded characters. This
+                                defaults to true. Disable this if a backend (e.g. an S3-compatible object store) needs to see
+                                the original, unnormalized request path.
+                                See here for more information: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path
+                              type: boolean
                             preserveExternalRequestId:
                               description: |-
                                 PreserveExternalRequestId determines whether the connection manager will keep the x-request-id header if passed for

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/equality_harness_test.go
@@ -46,6 +46,8 @@ func baseHarnessHttpListenerPolicyIr() *HttpListenerPolicyIr {
 		preserveHttp1HeaderCase:   new(true),
 		preserveExternalRequestId: new(true),
 		generateRequestId:         new(true),
+		normalizePath:             new(true),
+		mergeSlashes:              new(true),
 		accessLogConfig:           []proto.Message{wrapperspb.String("access-log")},
 		accessLogPolicies: []kgateway.AccessLog{
 			{FileSink: &kgateway.FileSink{Path: "/dev/stdout"}},
@@ -136,6 +138,14 @@ func TestHarnessHttpListenerPolicyIrEquals(t *testing.T) {
 		{
 			Field:  "generateRequestId",
 			Mutate: func(d **HttpListenerPolicyIr) { (*d).generateRequestId = new(false) },
+		},
+		{
+			Field:  "normalizePath",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).normalizePath = new(false) },
+		},
+		{
+			Field:  "mergeSlashes",
+			Mutate: func(d **HttpListenerPolicyIr) { (*d).mergeSlashes = new(false) },
 		},
 		{
 			Field: "accessLogConfig",

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/http.go
@@ -50,6 +50,8 @@ type HttpListenerPolicyIr struct {
 	preserveHttp1HeaderCase    *bool
 	preserveExternalRequestId  *bool
 	generateRequestId          *bool
+	normalizePath              *bool
+	mergeSlashes               *bool
 	// For a better UX, we set the default serviceName for access logs to the envoy cluster name (`<gateway-name>.<gateway-namespace>`).
 	// Since the gateway name can only be determined during translation, the access log configs and policies
 	// are stored so that during translation, the default serviceName is set if not already provided
@@ -123,6 +125,14 @@ func (d *HttpListenerPolicyIr) Equals(in any) bool {
 	}
 
 	if !cmputils.PointerValsEqual(d.generateRequestId, d2.generateRequestId) {
+		return false
+	}
+
+	if !cmputils.PointerValsEqual(d.normalizePath, d2.normalizePath) {
+		return false
+	}
+
+	if !cmputils.PointerValsEqual(d.mergeSlashes, d2.mergeSlashes) {
 		return false
 	}
 
@@ -393,6 +403,8 @@ func NewHttpListenerPolicy(krtctx krt.HandlerContext, commoncol *collections.Com
 		useRemoteAddress:              h.UseRemoteAddress,
 		preserveExternalRequestId:     h.PreserveExternalRequestId,
 		generateRequestId:             h.GenerateRequestId,
+		normalizePath:                 h.NormalizePath,
+		mergeSlashes:                  h.MergeSlashes,
 		xffNumTrustedHops:             xffNumTrustedHops,
 		xffConfig:                     xffConfig,
 		skipXffAppend:                 h.SkipXffAppend,

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/listener_plugin.go
@@ -445,6 +445,12 @@ func (p *listenerPolicyPluginGwPass) ApplyHCM(
 	if policy.generateRequestId != nil {
 		out.GenerateRequestId = wrapperspb.Bool(*policy.generateRequestId)
 	}
+	if policy.normalizePath != nil {
+		out.NormalizePath = wrapperspb.Bool(*policy.normalizePath)
+	}
+	if policy.mergeSlashes != nil {
+		out.MergeSlashes = *policy.mergeSlashes
+	}
 
 	// translate xffNumTrustedHops
 	if policy.xffNumTrustedHops != nil {

--- a/pkg/kgateway/extensions2/plugins/listenerpolicy/merge_http.go
+++ b/pkg/kgateway/extensions2/plugins/listenerpolicy/merge_http.go
@@ -28,6 +28,8 @@ func MergeHttpPolicies(
 		mergeUseRemoteAddress,
 		mergePreserveExternalRequestId,
 		mergeGenerateRequestId,
+		mergeNormalizePath,
+		mergeMergeSlashes,
 		mergeXffNumTrustedHops,
 		mergeXffConfig,
 		mergeSkipXffAppend,
@@ -172,6 +174,38 @@ func mergeGenerateRequestId(
 
 	p1.generateRequestId = p2.generateRequestId
 	mergeOrigins.SetOne(origin+"generateRequestId", p2Ref, p2MergeOrigins)
+}
+
+func mergeNormalizePath(
+	origin string,
+	p1, p2 *HttpListenerPolicyIr,
+	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
+	opts policy.MergeOptions,
+	mergeOrigins ir.MergeOrigins,
+) {
+	if !policy.IsMergeable(p1.normalizePath, p2.normalizePath, opts) {
+		return
+	}
+
+	p1.normalizePath = p2.normalizePath
+	mergeOrigins.SetOne(origin+"normalizePath", p2Ref, p2MergeOrigins)
+}
+
+func mergeMergeSlashes(
+	origin string,
+	p1, p2 *HttpListenerPolicyIr,
+	p2Ref *ir.AttachedPolicyRef,
+	p2MergeOrigins ir.MergeOrigins,
+	opts policy.MergeOptions,
+	mergeOrigins ir.MergeOrigins,
+) {
+	if !policy.IsMergeable(p1.mergeSlashes, p2.mergeSlashes, opts) {
+		return
+	}
+
+	p1.mergeSlashes = p2.mergeSlashes
+	mergeOrigins.SetOne(origin+"mergeSlashes", p2Ref, p2MergeOrigins)
 }
 
 func mergePreserveHttp1HeaderCase(

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -2280,6 +2280,28 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("ListenerPolicy with normalizePath false", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-policy-http/normalize-path-false.yaml"},
+			outputFile: "listener-policy-http/normalize-path-false.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("ListenerPolicy with mergeSlashes false", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"listener-policy-http/merge-slashes-false.yaml"},
+			outputFile: "listener-policy-http/merge-slashes-false.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("ListenerPolicy with defaultHostForHttp10", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"listener-policy-http/default-host-for-http10.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/merge-slashes-false.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/merge-slashes-false.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 80
+      targetPort: test
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: ListenerPolicy
+metadata:
+  name: merge-slashes-false
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  default:
+    httpSettings:
+      mergeSlashes: false

--- a/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/normalize-path-false.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/listener-policy-http/normalize-path-false.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: HTTP
+      port: 80
+      targetPort: test
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: ListenerPolicy
+metadata:
+  name: normalize-path-false
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: example-gateway
+  default:
+    httpSettings:
+      normalizePath: false

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/merge-slashes-false.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/merge-slashes-false.yaml
@@ -1,0 +1,154 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        normalizePath: true
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.mergeSlashes:
+        - gateway.kgateway.dev/ListenerPolicy/default/merge-slashes-false
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.mergeSlashes:
+        - gateway.kgateway.dev/ListenerPolicy/default/merge-slashes-false
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    ListenerPolicy/default/merge-slashes-false:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/normalize-path-false.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-policy-http/normalize-path-false.yaml
@@ -1,0 +1,155 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-svc_80
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 80
+  filterChains:
+  - filters:
+    - name: envoy.filters.network.http_connection_manager
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        httpFilters:
+        - name: envoy.filters.http.router
+          typedConfig:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+        mergeSlashes: true
+        normalizePath: false
+        rds:
+          configSource:
+            ads: {}
+            resourceApiVersion: V3
+          routeConfigName: listener~80
+        statPrefix: http
+        useRemoteAddress: true
+    name: listener~80
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.normalizePath:
+        - gateway.kgateway.dev/ListenerPolicy/default/normalize-path-false
+  name: listener~80
+Routes:
+- ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.ListenerPolicy.gateway.kgateway.dev:
+        default.httpSettings.normalizePath:
+        - gateway.kgateway.dev/ListenerPolicy/default/normalize-path-false
+  name: listener~80
+  virtualHosts:
+  - domains:
+    - example.com
+    name: listener~80~example_com
+    routes:
+    - match:
+        prefix: /
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: http
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+  httpRoutes:
+    default/example-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Route
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway
+  policies:
+    ListenerPolicy/default/normalize-path-false:
+      ancestors:
+      - ancestorRef:
+          group: gateway.networking.k8s.io
+          kind: Gateway
+          name: example-gateway
+          namespace: default
+        conditions:
+        - lastTransitionTime: null
+          message: Policy accepted
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Attached to all targets
+          reason: Attached
+          status: "True"
+          type: Attached
+        controllerName: kgateway.dev/kgateway


### PR DESCRIPTION
# Description

Backport of #14619 to the `v2.4.x` release branch (targets the next patch, v2.4.5).

**Motivation:** kgateway hardcodes both `normalize_path` and `merge_slashes` to `true` on every Envoy HTTP Connection Manager, with no way to turn either off. This breaks routing for backends that give repeated slashes meaning in the URL path — most commonly S3-compatible object stores, where object keys legitimately contain `//`. Path normalization/slash-merging silently rewrites those paths before they reach the backend.

**What changed** (same as #14619):
- Added `NormalizePath` and `MergeSlashes` (`*bool`) to `HTTPSettings` in `api/v1alpha1/kgateway/listener_policy_types.go`.
- Threaded the fields through `HttpListenerPolicyIr` (`pkg/kgateway/extensions2/plugins/listenerpolicy/http.go`), including `Equals()`.
- `ApplyHCM()` overrides the HCM's `NormalizePath`/`MergeSlashes` only when the policy field is explicitly set; otherwise the existing hardcoded default of `true` is unchanged.
- Added merge functions for both fields in `merge_http.go`.
- Regenerated `zz_generated.deepcopy.go` and the CRDs.
- Added golden translator tests and equality-harness coverage.

**Cherry-pick notes:**
- Cherry-picked from `b269044acab9bbc4e2008fa93a31846068b978f9` with `-x`.
- Conflicts in 6 files, all because the new fields sit adjacent to `Proxy100Continue` on `main`, which does not exist on `v2.4.x`. Resolved by taking only the `normalizePath`/`mergeSlashes` additions; no `Proxy100Continue` code was pulled in.
- One file beyond the original commit: `install/helm/kgateway-crds/templates/gateway.kgateway.dev_httplistenerpolicies.yaml`. `v2.4.x` still ships the deprecated `HTTPListenerPolicy` CRD, which shares `HTTPSettings`, so `make generate-all` adds the two properties there as well.

**Related issues:** Fixes #14618 on the 2.4 branch

# Change Type

/kind feature

# Changelog

```release-note
Added `normalizePath` and `mergeSlashes` fields to `ListenerPolicy`'s `httpSettings` to control whether the HTTP Connection Manager normalizes request paths and merges adjacent slashes. Both default to `true`, matching prior (hardcoded) behavior.
```

# Additional Notes

- Defaults are unchanged (`true`/`true`) — existing deployments see no behavior change unless a `ListenerPolicy` explicitly sets one of these fields to `false`.
- This is a feature backport into a patch line, so it needs maintainer sign-off before merge.
- Verified on this branch: `go build -tags e2e` on the affected packages, `go test ./pkg/kgateway/extensions2/plugins/listenerpolicy/...` (101 passed), the two new golden cases pass, and `make generate-all` leaves a clean tree. `TestBasic/AWS_Lambda_backend_with_AssumeRole_auth_in_strict_mode` fails, but it fails identically on the unmodified `v2.4.x` base — pre-existing and unrelated.
