### PR TITLE
jwt: add AllowMissingOrFailed validation mode

### DIFF
--- a/api/v1alpha1/kgateway/gateway_extensions_types.go
+++ b/api/v1alpha1/kgateway/gateway_extensions_types.go
@@ -78,9 +78,10 @@ type JWT struct {
 	// ValidationMode configures how JWT validation behaves.
 	// If unset or empty, Strict mode is used (JWT is required).
 	// If set to AllowMissing, unauthenticated requests without a JWT are allowed through.
-	// If using this mode, make sure to consider the security implications and
+	// If set to AllowMissingOrFailed, no request is ever rejected by the JWT filter.
+	// If using either of those modes, make sure to consider the security implications and
 	// consider using an `RBAC` policy to enforce authorization.
-	// +kubebuilder:validation:Enum=Strict;AllowMissing
+	// +kubebuilder:validation:Enum=Strict;AllowMissing;AllowMissingOrFailed
 	// +optional
 	ValidationMode *ValidationMode `json:"validationMode,omitempty"`
 
@@ -103,6 +104,16 @@ const (
 	// If a token exists, validate it.
 	// Warning: this allows requests without a JWT token.
 	ValidationModeAllowMissing ValidationMode = "AllowMissing"
+	// Validate tokens but never reject a request. Requests with a missing, expired,
+	// malformed, or otherwise invalid token are all allowed through.
+	// Every JWT is still verified, so a valid token still populates `claimsToHeaders`
+	// and the JWT dynamic metadata, and a verification failure is recorded in the
+	// dynamic metadata for observability. This is a non-enforcing mode,
+	// intended for evaluating a JWT policy against live traffic before enforcing it.
+	// Warning: this mode provides no authentication. A downstream `RBAC` policy that
+	// matches on JWT claims sees the same empty metadata for an invalid token as it does
+	// for a request with no token at all.
+	ValidationModeAllowMissingOrFailed ValidationMode = "AllowMissingOrFailed"
 )
 
 // GatewayExtensionType indicates the type of the GatewayExtension.

--- a/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
+++ b/install/helm/kgateway-crds/templates/gateway.kgateway.dev_gatewayextensions.yaml
@@ -1279,11 +1279,13 @@ spec:
                       ValidationMode configures how JWT validation behaves.
                       If unset or empty, Strict mode is used (JWT is required).
                       If set to AllowMissing, unauthenticated requests without a JWT are allowed through.
-                      If using this mode, make sure to consider the security implications and
+                      If set to AllowMissingOrFailed, no request is ever rejected by the JWT filter.
+                      If using either of those modes, make sure to consider the security implications and
                       consider using an `RBAC` policy to enforce authorization.
                     enum:
                     - Strict
                     - AllowMissing
+                    - AllowMissingOrFailed
                     type: string
                 type: object
               oauth2:

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt.go
@@ -34,7 +34,16 @@ import (
 )
 
 const (
-	PayloadInMetadata                       = "payload"
+	// PayloadInMetadata is the dynamic metadata key, under the
+	// `envoy.filters.http.jwt_authn` namespace, that the JWT filter writes a verified
+	// token's payload to.
+	PayloadInMetadata = "payload"
+	// FailedStatusInMetadata is the dynamic metadata key, under the same namespace, that
+	// the filter writes the verification failure `{code, message}` to. It is set on every
+	// provider so that rejections (and, in AllowMissingOrFailed mode, would-be rejections) are visible
+	// in access logs.
+	FailedStatusInMetadata = "failed_status"
+
 	jwtFilterNamePrefix                     = "jwt"
 	jwtConfigMapKey                         = "jwks"
 	jwtGlobalDisableFilterName              = "global_disable/jwt"
@@ -211,11 +220,12 @@ func translateProvider(
 		shouldForward = true
 	}
 	jwtProvider := &jwtauthnv3.JwtProvider{
-		Issuer:            provider.Issuer,
-		Audiences:         provider.Audiences,
-		PayloadInMetadata: PayloadInMetadata,
-		ClaimToHeaders:    claimToHeaders,
-		Forward:           shouldForward,
+		Issuer:                 provider.Issuer,
+		Audiences:              provider.Audiences,
+		PayloadInMetadata:      PayloadInMetadata,
+		FailedStatusInMetadata: FailedStatusInMetadata,
+		ClaimToHeaders:         claimToHeaders,
+		Forward:                shouldForward,
 		// TODO(npolshak): Do we want to set NormalizePayload  to support https://datatracker.ietf.org/doc/html/rfc8693#name-scope-scopes-claim
 	}
 	if len(claimToHeaders) > 0 {
@@ -507,24 +517,35 @@ func buildJwtRequirementFromProviders(
 		}
 	}
 
+	var nonStrictReq *jwtauthnv3.JwtRequirement
 	if validationMode != nil {
 		switch *validationMode {
 		case kgateway.ValidationModeAllowMissing:
-			allowMissingReq := &jwtauthnv3.JwtRequirement{
+			// satisfied when no JWT is present, but a present-and-invalid JWT still fails
+			nonStrictReq = &jwtauthnv3.JwtRequirement{
 				RequiresType: &jwtauthnv3.JwtRequirement_AllowMissing{
 					AllowMissing: &empty.Empty{},
 				},
 			}
-			jwtReqs = &jwtauthnv3.JwtRequirement{
-				RequiresType: &jwtauthnv3.JwtRequirement_RequiresAny{
-					RequiresAny: &jwtauthnv3.JwtRequirementOrList{
-						Requirements: []*jwtauthnv3.JwtRequirement{
-							jwtReqs,
-							allowMissingReq,
-						},
-					},
+		case kgateway.ValidationModeAllowMissingOrFailed:
+			// always satisfied, whether the JWT is missing or fails verification
+			nonStrictReq = &jwtauthnv3.JwtRequirement{
+				RequiresType: &jwtauthnv3.JwtRequirement_AllowMissingOrFailed{
+					AllowMissingOrFailed: &empty.Empty{},
 				},
 			}
+		}
+	}
+	if nonStrictReq != nil {
+		jwtReqs = &jwtauthnv3.JwtRequirement{
+			RequiresType: &jwtauthnv3.JwtRequirement_RequiresAny{
+				RequiresAny: &jwtauthnv3.JwtRequirementOrList{
+					Requirements: []*jwtauthnv3.JwtRequirement{
+						jwtReqs,
+						nonStrictReq,
+					},
+				},
+			},
 		}
 	}
 	return jwtReqs

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/jwt_test.go
@@ -79,15 +79,34 @@ func TestTranslateKey(t *testing.T) {
 	}
 }
 
+// nonStrictArm reports which non-strict JwtRequirement arm, if any, is OR-ed onto a
+// requirement: "allowMissing", "allowMissingOrFailed", or "" when the requirement is strict.
+func nonStrictArm(req *jwtauthnv3.JwtRequirement) string {
+	if req.GetAllowMissing() != nil {
+		return "allowMissing"
+	}
+	if req.GetAllowMissingOrFailed() != nil {
+		return "allowMissingOrFailed"
+	}
+	for _, r := range req.GetRequiresAny().GetRequirements() {
+		if arm := nonStrictArm(r); arm != "" {
+			return arm
+		}
+	}
+	return ""
+}
+
 func TestBuildJwtRequirementFromProviders(t *testing.T) {
 	tests := []struct {
-		name            string
-		routeName       string
-		providers       map[string]*jwtauthnv3.JwtProvider
-		validationMode  *kgateway.ValidationMode
-		expectedType    string
-		expectedCount   int
-		hasAllowMissing bool
+		name           string
+		routeName      string
+		providers      map[string]*jwtauthnv3.JwtProvider
+		validationMode *kgateway.ValidationMode
+		expectedType   string
+		expectedCount  int
+		// expectedNonStrict is the JwtRequirement arm OR-ed onto the provider requirements
+		// for non-strict modes: "" (strict), "allowMissing", or "allowMissingOrFailed".
+		expectedNonStrict string
 	}{
 		{
 			name:      "single provider strict mode",
@@ -95,10 +114,10 @@ func TestBuildJwtRequirementFromProviders(t *testing.T) {
 			providers: map[string]*jwtauthnv3.JwtProvider{
 				"provider1": {Issuer: "test-issuer"},
 			},
-			validationMode:  nil,
-			expectedType:    "provider_name",
-			expectedCount:   1,
-			hasAllowMissing: false,
+			validationMode:    nil,
+			expectedType:      "provider_name",
+			expectedCount:     1,
+			expectedNonStrict: "",
 		},
 		{
 			name:      "multiple providers strict mode",
@@ -107,10 +126,10 @@ func TestBuildJwtRequirementFromProviders(t *testing.T) {
 				"provider1": {Issuer: "test-issuer-1"},
 				"provider2": {Issuer: "test-issuer-2"},
 			},
-			validationMode:  nil,
-			expectedType:    "requires_any",
-			expectedCount:   2,
-			hasAllowMissing: false,
+			validationMode:    nil,
+			expectedType:      "requires_any",
+			expectedCount:     2,
+			expectedNonStrict: "",
 		},
 		{
 			name:      "single provider allow missing mode",
@@ -118,10 +137,10 @@ func TestBuildJwtRequirementFromProviders(t *testing.T) {
 			providers: map[string]*jwtauthnv3.JwtProvider{
 				"provider1": {Issuer: "test-issuer"},
 			},
-			validationMode:  new(kgateway.ValidationModeAllowMissing),
-			expectedType:    "requires_any",
-			expectedCount:   2, // provider requirement + allow missing
-			hasAllowMissing: true,
+			validationMode:    new(kgateway.ValidationModeAllowMissing),
+			expectedType:      "requires_any",
+			expectedCount:     2, // provider requirement + allow missing
+			expectedNonStrict: "allowMissing",
 		},
 		{
 			name:      "multiple providers allow missing mode",
@@ -130,30 +149,44 @@ func TestBuildJwtRequirementFromProviders(t *testing.T) {
 				"provider1": {Issuer: "test-issuer-1"},
 				"provider2": {Issuer: "test-issuer-2"},
 			},
-			validationMode:  new(kgateway.ValidationModeAllowMissing),
-			expectedType:    "requires_any",
-			expectedCount:   2, // requires_any with providers + allow missing
-			hasAllowMissing: true,
+			validationMode:    new(kgateway.ValidationModeAllowMissing),
+			expectedType:      "requires_any",
+			expectedCount:     2, // requires_any with providers + allow missing
+			expectedNonStrict: "allowMissing",
+		},
+		{
+			name:      "single provider allow missing or failed mode",
+			routeName: "test-route",
+			providers: map[string]*jwtauthnv3.JwtProvider{
+				"provider1": {Issuer: "test-issuer"},
+			},
+			validationMode:    new(kgateway.ValidationModeAllowMissingOrFailed),
+			expectedType:      "requires_any",
+			expectedCount:     2, // provider requirement + allow missing or failed
+			expectedNonStrict: "allowMissingOrFailed",
+		},
+		{
+			name:      "multiple providers allow missing or failed mode",
+			routeName: "test-route",
+			providers: map[string]*jwtauthnv3.JwtProvider{
+				"provider1": {Issuer: "test-issuer-1"},
+				"provider2": {Issuer: "test-issuer-2"},
+			},
+			validationMode:    new(kgateway.ValidationModeAllowMissingOrFailed),
+			expectedType:      "requires_any",
+			expectedCount:     2, // requires_any with providers + allow missing or failed
+			expectedNonStrict: "allowMissingOrFailed",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := buildJwtRequirementFromProviders(tt.providers, tt.validationMode)
-			if tt.hasAllowMissing {
-				// When allow missing is enabled, the top level should be RequiresAny
+			if tt.expectedNonStrict != "" {
+				// In a non-strict mode the top level should be RequiresAny
 				assert.NotNil(t, req.GetRequiresAny())
 				assert.Equal(t, tt.expectedCount, len(req.GetRequiresAny().Requirements))
-
-				// Check that one of the requirements is AllowMissing
-				hasAllowMissing := false
-				for _, r := range req.GetRequiresAny().Requirements {
-					if r.GetAllowMissing() != nil {
-						hasAllowMissing = true
-						break
-					}
-				}
-				assert.True(t, hasAllowMissing, "expected AllowMissing requirement")
+				assert.Equal(t, tt.expectedNonStrict, nonStrictArm(req), "unexpected non-strict requirement")
 			} else if tt.expectedType == "provider_name" {
 				assert.NotNil(t, req.GetProviderName())
 				assert.Equal(t, "provider1", req.GetProviderName())
@@ -546,9 +579,11 @@ func TestConvertJwtValidationConfig(t *testing.T) {
 
 func TestResolveJwtProvidersWithValidationMode(t *testing.T) {
 	tests := []struct {
-		name                    string
-		jwt                     *kgateway.JWT
-		expectedHasAllowMissing bool
+		name string
+		jwt  *kgateway.JWT
+		// expectedNonStrict is the JwtRequirement arm OR-ed onto the provider requirements:
+		// "" (strict), "allowMissing", or "allowMissingOrFailed".
+		expectedNonStrict string
 	}{
 		{
 			name: "strict mode (nil validation mode)",
@@ -568,7 +603,7 @@ func TestResolveJwtProvidersWithValidationMode(t *testing.T) {
 					},
 				},
 			},
-			expectedHasAllowMissing: false,
+			expectedNonStrict: "",
 		},
 		{
 			name: "allow missing mode",
@@ -588,7 +623,7 @@ func TestResolveJwtProvidersWithValidationMode(t *testing.T) {
 					},
 				},
 			},
-			expectedHasAllowMissing: true,
+			expectedNonStrict: "allowMissing",
 		},
 		{
 			name: "allow missing mode with multiple providers",
@@ -619,7 +654,27 @@ func TestResolveJwtProvidersWithValidationMode(t *testing.T) {
 					},
 				},
 			},
-			expectedHasAllowMissing: true,
+			expectedNonStrict: "allowMissing",
+		},
+		{
+			name: "allow missing or failed mode",
+			jwt: &kgateway.JWT{
+				ValidationMode: new(kgateway.ValidationModeAllowMissingOrFailed),
+				Providers: []kgateway.NamedJWTProvider{
+					{
+						Name: "test-provider",
+						JWTProvider: kgateway.JWTProvider{
+							Issuer: "test-issuer",
+							JWKS: kgateway.JWKS{
+								LocalJWKS: &kgateway.LocalJWKS{
+									Inline: new(`{"keys":[{"kty":"RSA","kid":"test-key","use":"sig","alg":"RS256","n":"test-n","e":"AQAB"}]}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNonStrict: "allowMissingOrFailed",
 		},
 	}
 
@@ -634,26 +689,11 @@ func TestResolveJwtProvidersWithValidationMode(t *testing.T) {
 			req, ok := config.RequirementMap[requirementsName]
 			require.True(t, ok, "requirements not found in map")
 
-			if tt.expectedHasAllowMissing {
-				// Should have RequiresAny at top level with AllowMissing
+			if tt.expectedNonStrict != "" {
+				// Non-strict modes OR an extra arm onto the provider requirements
 				assert.NotNil(t, req.GetRequiresAny())
-				hasAllowMissing := false
-				for _, r := range req.GetRequiresAny().Requirements {
-					if r.GetAllowMissing() != nil {
-						hasAllowMissing = true
-						break
-					}
-				}
-				assert.True(t, hasAllowMissing, "expected AllowMissing requirement")
-			} else {
-				// Strict mode: should have provider name directly (single provider) or RequiresAny (multiple providers)
-				// but no AllowMissing
-				if req.GetRequiresAny() != nil {
-					for _, r := range req.GetRequiresAny().Requirements {
-						assert.Nil(t, r.GetAllowMissing(), "should not have AllowMissing in strict mode")
-					}
-				}
 			}
+			assert.Equal(t, tt.expectedNonStrict, nonStrictArm(req), "unexpected non-strict requirement")
 		})
 	}
 }

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -3547,6 +3547,17 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("JWT Policy with validation mode AllowMissingOrFailed", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"jwt/gateway-validation-mode-allow-missing-or-failed.yaml"},
+			outputFile: "jwt/gateway-validation-mode-allow-missing-or-failed.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("OAuth2 policy", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"traffic-policy/oauth2.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/jwt/gateway-validation-mode-allow-missing-or-failed.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/jwt/gateway-validation-mode-allow-missing-or-failed.yaml
@@ -1,0 +1,87 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+    - name: example-gateway
+  hostnames:
+    - "example.com"
+  rules:
+    - backendRefs:
+        - name: example-svc
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /foo
+    - backendRefs:
+        - name: example-svc
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /bar
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: test
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: gateway-test
+spec:
+  targetRefs:
+    - kind: Gateway
+      group: gateway.networking.k8s.io
+      name: example-gateway
+  jwtAuth:
+    extensionRef:
+      name: jwt-ext-allow-missing-or-failed
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: jwt-ext-allow-missing-or-failed
+spec:
+  jwt:
+    validationMode: AllowMissingOrFailed
+    providers:
+    - name: gateway-example
+      claimsToHeaders:
+        - name: gateway
+          header: x-gateway
+      issuer: https://gateway.example.com
+      jwks:
+        local:
+          inline: |
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAruK9KacQjDePRyfG7oPI
+            aqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa/ijLV9huoNvpdflld4B+SaT7
+            m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3
+            ur5BaBCc+BZZRRaXDTLy6KyD1Pyd6XRsxyZXt/SYOIww0NSt5u0CTyZUGJhQungJ
+            pI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0+owLsA25WJOPZXizxpTB4tPvJu
+            YGATajDpzrHf+WXgOgvwyxaHJSN/fE+eFuRT3ooDaAuytsfYotsn4z/ajdEPSwXY
+            CwIDAQAB
+            -----END PUBLIC KEY-----
+

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/clock-skew.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/clock-skew.yaml
@@ -58,6 +58,7 @@ Listeners:
                                   headerName: x-gateway
                                 clearRouteCache: true
                                 clockSkewSeconds: 3600
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/cross-namespace.yaml
@@ -77,6 +77,7 @@ Listeners:
                                 - claimName: org
                                   headerName: x-org
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://allowed.example.com
                                 payloadInMetadata: payload
                                 remoteJwks:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-and-route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-and-route.yaml
@@ -59,6 +59,7 @@ Listeners:
                                 - claimName: bar
                                   headerName: x-bar
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev2.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'
@@ -68,6 +69,7 @@ Listeners:
                                 - claimName: foo
                                   headerName: x-foo
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev3.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'
@@ -120,6 +122,7 @@ Listeners:
                                 - claimName: gateway
                                   headerName: x-gateway
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-configmap.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-configmap.yaml
@@ -59,6 +59,7 @@ Listeners:
                                 - claimName: email
                                   headerName: x-email
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev1.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-disable.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-disable.yaml
@@ -57,6 +57,7 @@ Listeners:
                                 - claimName: gateway
                                   headerName: x-gateway
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-listener.yaml
@@ -57,6 +57,7 @@ Listeners:
                                 - claimName: gateway
                                   headerName: x-gateway
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode-allow-missing-or-failed.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode-allow-missing-or-failed.yaml
@@ -7,7 +7,7 @@ Clusters:
       ads: {}
       resourceApiVersion: V3
   ignoreHealthOnHostRemoval: true
-  name: kube_default_backend-svc_80
+  name: kube_default_example-svc_80
   type: EDS
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
@@ -32,7 +32,7 @@ Listeners:
               value:
                 disable: true
         - disabled: true
-          name: jwt/other-ns/jwt-ext
+          name: jwt/default/jwt-ext-allow-missing-or-failed
           typedConfig:
             '@type': type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
             extensionConfig:
@@ -52,7 +52,7 @@ Listeners:
                           typedConfig:
                             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                             providers:
-                              jwt-ext_other-ns_gateway-example:
+                              jwt-ext-allow-missing-or-failed_default_gateway-example:
                                 claimToHeaders:
                                 - claimName: gateway
                                   headerName: x-gateway
@@ -63,8 +63,11 @@ Listeners:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'
                                 payloadInMetadata: payload
                             requirementMap:
-                              jwt-ext_other-ns_requirements:
-                                providerName: jwt-ext_other-ns_gateway-example
+                              jwt-ext-allow-missing-or-failed_default_requirements:
+                                requiresAny:
+                                  requirements:
+                                  - providerName: jwt-ext-allow-missing-or-failed_default_gateway-example
+                                  - allowMissingOrFailed: {}
                   predicate:
                     singlePredicate:
                       customMatch:
@@ -104,39 +107,50 @@ Listeners:
         statPrefix: http
         useRemoteAddress: true
     name: listener~80
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        jwt:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-test
   name: listener~80
 Routes:
 - ignorePortInHostMatching: true
+  metadata:
+    filterMetadata:
+      merge.TrafficPolicy.gateway.kgateway.dev:
+        jwt:
+        - gateway.kgateway.dev/TrafficPolicy/default/gateway-test
   name: listener~80
+  typedPerFilterConfig:
+    jwt/default/jwt-ext-allow-missing-or-failed:
+      '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+      requirementName: jwt-ext-allow-missing-or-failed_default_requirements
+    jwt_enabled:
+      '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_modules.v3.DynamicModuleFilterPerRoute
+      dynamicModuleConfig:
+        name: rust_module
+      filterConfig:
+        '@type': type.googleapis.com/google.protobuf.StringValue
+        value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
+      filterName: rustformation
+      perRouteConfigName: rustformation
   virtualHosts:
   - domains:
-    - jwt-auth.example.com
-    name: listener~80~jwt-auth_example_com
+    - example.com
+    name: listener~80~example_com
     routes:
     - match:
-        prefix: /
-      metadata:
-        filterMetadata:
-          merge.TrafficPolicy.gateway.kgateway.dev:
-            jwt:
-            - gateway.kgateway.dev/TrafficPolicy/default/cross-namespace-ref-policy
-      name: listener~80~jwt-auth_example_com-route-0-httproute-cross-namespace-default-0-0-matcher-0
+        pathSeparatedPrefix: /foo
+      name: listener~80~example_com-route-0-httproute-example-route-default-0-0-matcher-0
       route:
-        cluster: kube_default_backend-svc_80
+        cluster: kube_default_example-svc_80
         clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
-      typedPerFilterConfig:
-        jwt/other-ns/jwt-ext:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-          requirementName: jwt-ext_other-ns_requirements
-        jwt_enabled:
-          '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_modules.v3.DynamicModuleFilterPerRoute
-          dynamicModuleConfig:
-            name: rust_module
-          filterConfig:
-            '@type': type.googleapis.com/google.protobuf.StringValue
-            value: '{"request":{"body":{"parseAs":"None"},"dynamicMetadata":[{"namespace":"dev.kgateway.auth_policy","key":"auth_succeeded","value":{"stringValue":"true"}}]},"response":{"body":{"parseAs":"None"}}}'
-          filterName: rustformation
-          perRouteConfigName: rustformation
+    - match:
+        pathSeparatedPrefix: /bar
+      name: listener~80~example_com-route-1-httproute-example-route-default-1-0-matcher-0
+      route:
+        cluster: kube_default_example-svc_80
+        clusterNotFoundResponseCode: INTERNAL_SERVER_ERROR
 Statuses:
   gateways:
     default/example-gateway:
@@ -186,7 +200,7 @@ Statuses:
         - group: gateway.networking.k8s.io
           kind: GRPCRoute
   httpRoutes:
-    default/cross-namespace:
+    default/example-route:
       parents:
       - conditions:
         - lastTransitionTime: null
@@ -210,7 +224,7 @@ Statuses:
           kind: ""
           name: example-gateway
   policies:
-    TrafficPolicy/default/cross-namespace-ref-policy:
+    TrafficPolicy/default/gateway-test:
       ancestors:
       - ancestorRef:
           group: gateway.networking.k8s.io

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway-validation-mode.yaml
@@ -57,6 +57,7 @@ Listeners:
                                 - claimName: gateway
                                   headerName: x-gateway
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/gateway.yaml
@@ -57,6 +57,7 @@ Listeners:
                                 - claimName: gateway
                                   headerName: x-gateway
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute-remote-jwks.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute-remote-jwks.yaml
@@ -69,6 +69,7 @@ Listeners:
                                 - claimName: bar
                                   headerName: x-bar
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev2.example.com
                                 payloadInMetadata: payload
                                 remoteJwks:
@@ -82,6 +83,7 @@ Listeners:
                                 - claimName: foo
                                   headerName: x-foo
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev3.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/httproute.yaml
@@ -59,6 +59,7 @@ Listeners:
                                 - claimName: email
                                   headerName: x-email
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev1.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/listenerset.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/listenerset.yaml
@@ -82,6 +82,7 @@ Listeners:
                                 - claimName: listenerset
                                   headerName: x-listenerset
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'
@@ -174,6 +175,7 @@ Listeners:
                                 - claimName: listenerset
                                   headerName: x-listenerset
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://gateway.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/rbac.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/rbac.yaml
@@ -59,6 +59,7 @@ Listeners:
                                 - claimName: email
                                   headerName: x-email
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/remote-jwks-async.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/remote-jwks-async.yaml
@@ -63,6 +63,7 @@ Listeners:
                             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                             providers:
                               jwt-ext_default_async-provider:
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev.example.com
                                 payloadInMetadata: payload
                                 remoteJwks:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/remote-jwks-timeout.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/remote-jwks-timeout.yaml
@@ -63,6 +63,7 @@ Listeners:
                             '@type': type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
                             providers:
                               jwt-ext_default_timeout-provider:
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev.example.com
                                 payloadInMetadata: payload
                                 remoteJwks:

--- a/pkg/kgateway/translator/gateway/testutils/outputs/jwt/route.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/jwt/route.yaml
@@ -59,6 +59,7 @@ Listeners:
                                 - claimName: bar
                                   headerName: x-bar
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev2.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'
@@ -68,6 +69,7 @@ Listeners:
                                 - claimName: foo
                                   headerName: x-foo
                                 clearRouteCache: true
+                                failedStatusInMetadata: failed_status
                                 issuer: https://dev3.example.com
                                 localJwks:
                                   inlineString: '{"keys":[{"use":"sig","kty":"RSA","alg":"RS256","n":"ruK9KacQjDePRyfG7oPIaqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa_ijLV9huoNvpdflld4B-SaT7m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3ur5BaBCc-BZZRRaXDTLy6KyD1Pyd6XRsxyZXt_SYOIww0NSt5u0CTyZUGJhQungJpI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0-owLsA25WJOPZXizxpTB4tPvJuYGATajDpzrHf-WXgOgvwyxaHJSN_fE-eFuRT3ooDaAuytsfYotsn4z_ajdEPSwXYCw","e":"AQAB"}]}'

--- a/test/e2e/features/jwt/suite.go
+++ b/test/e2e/features/jwt/suite.go
@@ -22,13 +22,14 @@ import (
 
 var (
 	// manifests
-	setupManifest          = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
-	jwtManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt.yaml")
-	jwtRbacManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-rbac.yaml")
-	jwtHTTPRouteManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-httproute.yaml")
-	jwtDisableManifest     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-disable.yaml")
-	jwtRemoteManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-remote.yaml")
-	jwtRemoteAsyncManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-remote-async.yaml")
+	setupManifest                   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	jwtManifest                     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt.yaml")
+	jwtRbacManifest                 = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-rbac.yaml")
+	jwtHTTPRouteManifest            = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-httproute.yaml")
+	jwtDisableManifest              = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-disable.yaml")
+	jwtRemoteManifest               = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-remote.yaml")
+	jwtRemoteAsyncManifest          = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-remote-async.yaml")
+	jwtAllowMissingOrFailedManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "jwt-allow-missing-or-failed.yaml")
 
 	// Matches
 	expectedJwtMissingFailedResponse = &matchers.HttpResponse{
@@ -48,6 +49,18 @@ var (
 	expectStatus200Success = &matchers.HttpResponse{
 		StatusCode: http.StatusOK,
 		Body:       nil,
+	}
+
+	// httpbin's /get echoes the request headers it received back in the body, so the
+	// claim headers are how we tell a verified token from an unverified one.
+	expectClaimHeadersForwarded = &matchers.HttpResponse{
+		StatusCode: http.StatusOK,
+		Body:       gomega.ContainSubstring("dev1@kgateway.io"),
+	}
+
+	expectNoClaimHeadersForwarded = &matchers.HttpResponse{
+		StatusCode: http.StatusOK,
+		Body:       gomega.Not(gomega.ContainSubstring("X-Email")),
 	}
 
 	expectRbacDeniedWithJwt = &matchers.HttpResponse{
@@ -106,6 +119,9 @@ var (
 		},
 		"TestJwtAuthenticationRemoteAsync": {
 			Manifests: []string{jwtRemoteAsyncManifest},
+		},
+		"TestJwtAllowMissingOrFailed": {
+			Manifests: []string{jwtAllowMissingOrFailedManifest},
 		},
 	}
 )
@@ -265,6 +281,27 @@ func (s *testingSuite) TestJwtDisable() {
 	// The /status/200 route has JWT disabled, should work without JWT
 	s.T().Log("The /status/200 route has JWT disabled, should work without JWT")
 	s.assertResponseWithoutAuth("/status/200", expectStatus200Success)
+}
+
+// TestJwtAllowMissingOrFailed tests that validationMode AllowMissingOrFailed never rejects a
+// request, while still verifying tokens that are present.
+func (s *testingSuite) TestJwtAllowMissingOrFailed() {
+	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPRouteCondition(
+		s.Ctx,
+		"httpbin-route-allow-missing-or-failed",
+		"kgateway-base",
+		gwv1.RouteConditionAccepted,
+		metav1.ConditionTrue,
+	)
+
+	s.T().Log("AllowMissingOrFailed should allow a request with no JWT, and forward no claim headers")
+	s.assertResponseWithoutAuth("/get", expectNoClaimHeadersForwarded)
+
+	s.T().Log("AllowMissingOrFailed should allow a request with an invalid JWT, and forward no claim headers")
+	s.assertResponse("/get", badJwtToken, expectNoClaimHeadersForwarded)
+
+	s.T().Log("AllowMissingOrFailed should still verify a valid JWT and forward its claim headers")
+	s.assertResponse("/get", dev1JwtToken, expectClaimHeadersForwarded)
 }
 
 func (s *testingSuite) assertResponse(path, authHeader string, expected *matchers.HttpResponse) {

--- a/test/e2e/features/jwt/testdata/jwt-allow-missing-or-failed.yaml
+++ b/test/e2e/features/jwt/testdata/jwt-allow-missing-or-failed.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-route-allow-missing-or-failed
+  namespace: kgateway-base
+spec:
+  hostnames:
+    - httpbin
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway
+      namespace: kgateway-base
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: httpbin
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /status/200
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: httpbin
+          port: 8000
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.kgateway.dev
+            kind: TrafficPolicy
+            name: jwt-allow-missing-or-failed-policy
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: jwt-allow-missing-or-failed-policy
+  namespace: kgateway-base
+spec:
+  jwtAuth:
+    extensionRef:
+      name: allow-missing-or-failed-jwt-provider
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayExtension
+metadata:
+  name: allow-missing-or-failed-jwt-provider
+  namespace: kgateway-base
+spec:
+  type: JWT
+  jwt:
+    validationMode: AllowMissingOrFailed
+    providers:
+    - name: my-example
+      claimsToHeaders:
+        - name: org
+          header: x-org
+        - name: email
+          header: x-email
+      issuer: https://dev.example.com
+      jwks:
+        local:
+          inline: |
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAruK9KacQjDePRyfG7oPI
+            aqAIyCeOCBIGB2nBbDLGp1Szdm7rsWcrzGf7Avpa/ijLV9huoNvpdflld4B+SaT7
+            m3EDDMDUyA4LayJC5JBI10Qfu3Qn8BEpcdN2uRiycXOzgsoIXneXp9hENlS5Vsr3
+            ur5BaBCc+BZZRRaXDTLy6KyD1Pyd6XRsxyZXt/SYOIww0NSt5u0CTyZUGJhQungJ
+            pI8Hhrzdf87mLZGZd16dOGObE5LqFwk2prN3D0+owLsA25WJOPZXizxpTB4tPvJu
+            YGATajDpzrHf+WXgOgvwyxaHJSN/fE+eFuRT3ooDaAuytsfYotsn4z/ajdEPSwXY
+            CwIDAQAB
+            -----END PUBLIC KEY-----


### PR DESCRIPTION
# Description

**Motivation:** There is no way to run JWT validation in a non-enforcing mode. Today the only options are `Strict` (reject missing or invalid tokens) and `AllowMissing` (reject invalid tokens, allow missing ones). Turning on a JWT policy in front of existing traffic therefore means deploying `Strict` and discovering which clients are broken in production.

**What changed:** Adds `validationMode: AllowMissingOrFailed` to the JWT `GatewayExtension`, mapping to Envoy's `allow_missing_or_failed` requirement. Requests with a missing, expired, malformed, or otherwise invalid token are all allowed through, while every JWT is still verified — so a valid token continues to populate `claimsToHeaders` and the JWT dynamic metadata.

The non-strict handling in `buildJwtRequirementFromProviders` was refactored into a single catch-all requirement that gets OR-ed onto the provider requirements, so `AllowMissing` (`allow_missing`) and `AllowMissingOrFailed` (`allow_missing_or_failed`) share one code path.

Also sets `failed_status_in_metadata` on every provider. AllowMissingOrFailed mode denies nothing, so `jwt_authn.denied` never moves and there is otherwise no signal for what `Strict` would have rejected. The key is set unconditionally rather than only in AllowMissingOrFailed mode, since it is equally useful for debugging `Strict` rejections and costs nothing when verification succeeds. It is readable from access logs via `%DYNAMIC_METADATA(envoy.filters.http.jwt_authn:failed_status)%`. This is the only reason the 14 existing JWT golden files change — one added line each.

# Change Type

/kind feature

# Changelog

```release-note
Add `validationMode: AllowMissingOrFailed` to the JWT GatewayExtension, which verifies JWTs but never rejects a request. Intended for evaluating a JWT policy against live traffic before enforcing it. JWT providers now also record verification failures in the `envoy.filters.http.jwt_authn:failed_status` dynamic metadata, available to access logs in all validation modes.
```

# Additional Notes

**AllowMissingOrFailed provides no authentication.** Two interactions worth reviewer attention, both called out in the API doc comment:

- A downstream RBAC policy matching on JWT claims sees the same empty metadata for an invalid token as for a request with no token at all — `payload_in_metadata` is only written on successful verification. AllowMissingOrFailed mode on JWT therefore silently changes RBAC behavior, and the two live on the same `TrafficPolicy`.
- `claimsToHeaders` is unreliable for the same reason: invalid-token requests reach the backend with no claim headers, and nothing signals to the upstream that a request was allowed.

A status condition warning when AllowMissingOrFailed is set seems like a reasonable guardrail (it is easy to leave on after a migration), but that is a separate mechanism and is not included here.

**Testing:**
- Unit: both validation-mode tables in `jwt_test.go` generalized from a `hasAllowMissing bool` to a three-valued `expectedCatchAll`, with AllowMissingOrFailed cases added.
- Golden: new `jwt/gateway-validation-mode-allow-missing-or-failed.yaml`; output confirms `providerName` OR `allowMissingOrFailed: {}`.
- E2E: `TestJwtAllowMissingOrFailed` asserts no-JWT → 200, invalid JWT → 200, and valid JWT → 200 *with* claim headers forwarded. The last assertion is what distinguishes AllowMissingOrFailed from the filter simply being bypassed.