### PR TITLE
[2.4] fix: stop spurious EDS pushes from nondeterministic backend-label has…

### DIFF
--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension.go
@@ -35,7 +35,11 @@ import (
 )
 
 type TrafficPolicyGatewayExtensionIR struct {
-	// +krtEqualsTodo decide whether extension name should affect equality
+	// Name is this extension's KRT key, but it must still be compared: policy IRs embed a
+	// *TrafficPolicyGatewayExtensionIR and delegate to this Equals (see extauth/extproc/jwt/
+	// oauth2/global_rate_limit), and the name reaches the dataplane through providerName() as
+	// the ext_proc/ext_authz filter name and per-route typed-config key. Two identically
+	// configured extensions with different names produce different Envoy config.
 	Name             string
 	ExtAuth          *envoy_ext_authz_v3.ExtAuthz
 	ExtProc          *envoymatchingv3.ExtensionWithMatcher
@@ -53,6 +57,9 @@ func (e TrafficPolicyGatewayExtensionIR) ResourceName() string {
 }
 
 func (e TrafficPolicyGatewayExtensionIR) Equals(other TrafficPolicyGatewayExtensionIR) bool {
+	if e.Name != other.Name {
+		return false
+	}
 	if !proto.Equal(e.ExtAuth, other.ExtAuth) {
 		return false
 	}

--- a/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension_name_equality_test.go
+++ b/pkg/kgateway/extensions2/plugins/trafficpolicy/gateway_extension_name_equality_test.go
@@ -1,0 +1,43 @@
+package trafficpolicy
+
+import (
+	"testing"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+)
+
+func gatewayExtensionIRForNameTest(name string) TrafficPolicyGatewayExtensionIR {
+	return TrafficPolicyGatewayExtensionIR{
+		Name: name,
+		ExtAuth: &envoy_ext_authz_v3.ExtAuthz{
+			Services: &envoy_ext_authz_v3.ExtAuthz_GrpcService{
+				GrpcService: &envoycorev3.GrpcService{
+					TargetSpecifier: &envoycorev3.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &envoycorev3.GrpcService_EnvoyGrpc{ClusterName: "ext-authz-cluster"},
+					},
+				},
+			},
+		},
+		PrecedenceWeight: 5,
+	}
+}
+
+// TestGatewayExtensionIREqualsDetectsNameOnlyChange is a regression test: Equals
+// used to skip Name, so two extensions with identical provider config but
+// different names compared equal. The name is not cosmetic - policy IRs embed a
+// *TrafficPolicyGatewayExtensionIR and delegate to this Equals, and providerName()
+// turns the name into the ext_proc/ext_authz filter name and the per-route
+// typed-config key, so identical-but-renamed extensions yield different Envoy
+// config.
+func TestGatewayExtensionIREqualsDetectsNameOnlyChange(t *testing.T) {
+	a := gatewayExtensionIRForNameTest("default/my-extension")
+	b := gatewayExtensionIRForNameTest("default/renamed-extension")
+
+	if a.Equals(b) {
+		t.Error("Equals returned true for extensions that differ only by name; the name reaches Envoy as the filter name")
+	}
+	if !a.Equals(gatewayExtensionIRForNameTest("default/my-extension")) {
+		t.Error("Equals returned false for two identical extensions")
+	}
+}

--- a/pkg/pluginsdk/ir/model.go
+++ b/pkg/pluginsdk/ir/model.go
@@ -199,10 +199,12 @@ func NewEndpointsForBackend(us BackendObjectIR) *EndpointsForBackend {
 	h.Write([]byte(objSrc.Name))
 	h.Write([]byte{0})
 	h.Write([]byte(objSrc.Namespace))
-	for k, v := range labels {
-		h.Write([]byte{0})
-		h.Write([]byte(k + "=" + v))
-	}
+	// Fold the labels in through HashLabels, which XORs a per-label hash and is therefore
+	// order-independent. Writing the label pairs straight into this hasher makes the result
+	// depend on Go's randomized map iteration order, so two identical backends hash
+	// differently and every recomputation of this collection looks like a change.
+	h.Write([]byte{0})
+	utils.HashUint64(h, utils.HashLabels(labels))
 	h.Write([]byte{0})
 	h.Write([]byte{byte(us.TrafficDistribution)})
 	upstreamHash := h.Sum64()

--- a/pkg/pluginsdk/ir/model_endpoints_hash_test.go
+++ b/pkg/pluginsdk/ir/model_endpoints_hash_test.go
@@ -1,0 +1,68 @@
+package ir
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/wellknown"
+)
+
+func backendWithLabelsForHashTest(labels map[string]string) BackendObjectIR {
+	backend := NewBackendObjectIR(ObjectSource{
+		Kind:      "Service",
+		Namespace: "default",
+		Name:      "my-service",
+	}, 8080, "", "")
+	backend.Obj = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-service",
+			Namespace:       "default",
+			UID:             "svc-uid-1",
+			ResourceVersion: "1",
+			Labels:          labels,
+		},
+	}
+	backend.CanonicalHostname = "my-service.default.svc.cluster.local"
+	backend.TrafficDistribution = wellknown.TrafficDistributionAny
+	return backend
+}
+
+// TestEndpointsForBackendEqualityHashIsDeterministic is a regression test: the
+// backend labels used to be written into a single running FNV hasher in Go map
+// iteration order, so two identical backends hashed differently. Because that
+// hash flows into LbEpsEqualityHash (and from there into the per-client EDS
+// hash), every recomputation of the endpoints collection looked like a change to
+// KRT and pushed EDS again.
+func TestEndpointsForBackendEqualityHashIsDeterministic(t *testing.T) {
+	labels := map[string]string{
+		"a": "1", "b": "2", "c": "3", "d": "4", "e": "5",
+		"f": "6", "g": "7", "h": "8", "i": "9", "j": "10",
+	}
+
+	first := NewEndpointsForBackend(backendWithLabelsForHashTest(labels))
+	for range 100 {
+		next := NewEndpointsForBackend(backendWithLabelsForHashTest(labels))
+		if !first.Equals(*next) {
+			t.Fatalf("two identical EndpointsForBackend compared unequal: hash %d vs %d",
+				first.LbEpsEqualityHash, next.LbEpsEqualityHash)
+		}
+	}
+}
+
+// TestEndpointsForBackendEqualityHashCoversLabels pins the other half of the
+// contract: BackendLabels stays out of Equals only because it is folded into the
+// hash, so a label change must still be observed.
+func TestEndpointsForBackendEqualityHashCoversLabels(t *testing.T) {
+	base := NewEndpointsForBackend(backendWithLabelsForHashTest(map[string]string{
+		"app": "my-app", "version": "v1",
+	}))
+	relabelled := NewEndpointsForBackend(backendWithLabelsForHashTest(map[string]string{
+		"app": "my-app", "version": "v2",
+	}))
+
+	if base.Equals(*relabelled) {
+		t.Error("Equals returned true after a backend label changed; the label hash must move")
+	}
+}


### PR DESCRIPTION
…hing

# Description

Backports #14516 

# Change Type

/kind fix

# Changelog

```release-note
Fixed a bug where backends with more than one label produced a different endpoint hash on every recomputation, causing kgateway to publish a new EDS version and push endpoint updates to every connected proxy even when the endpoints had not changed.
```
