### PR TITLE
test: cover HTTP request buffering boundaries end to end

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -88,7 +88,7 @@ jobs:
           # May 29, 2026: ~10 minutes
           - cluster-name: 'cluster-three'
             go-test-args: '-timeout=25m'
-            go-test-run-regex: '^TestKgateway$$/^DynamicForwardProxy$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^EC2$$|^TestKgateway$$/^AccessLog$$|^TestKgateway$$/^LocalRateLimit$$|^TestKgateway$$/^Cors$$|^TestKgateway$$/^BackendConfigPolicy$$|^TestKgateway$$/^ListenerPolicy$$|^TestKgateway$$/^Tracing$$|^TestKgateway$$/^DirectResponse$$|^TestKgateway$$/^AdminServer$$|^TestKgateway$$/^FaultInjection$$'
+            go-test-run-regex: '^TestKgateway$$/^DynamicForwardProxy$$|^TestKgateway$$/^Lambda$$|^TestKgateway$$/^EC2$$|^TestKgateway$$/^AccessLog$$|^TestKgateway$$/^LocalRateLimit$$|^TestKgateway$$/^Cors$$|^TestKgateway$$/^Buffer$$|^TestKgateway$$/^BackendConfigPolicy$$|^TestKgateway$$/^ListenerPolicy$$|^TestKgateway$$/^Tracing$$|^TestKgateway$$/^DirectResponse$$|^TestKgateway$$/^AdminServer$$|^TestKgateway$$/^FaultInjection$$'
             localstack: 'true'
           # May 29, 2026: ~8 minutes
           - cluster-name: 'cluster-four'

--- a/test/e2e/features/buffer/suite.go
+++ b/test/e2e/features/buffer/suite.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package buffer
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/requestutils/curl"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/common"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+	testmatchers "github.com/kgateway-dev/kgateway/v2/test/gomega/matchers"
+)
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+type testingSuite struct {
+	*base.BaseTestingSuite
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, base.TestCase{}, testCases),
+	}
+}
+
+// Keep this in sync with maxRequestSize in testdata/trafficpolicy.yaml.
+const bufferLimit = 1024
+
+func (s *testingSuite) TestBufferLimit() {
+	for _, tc := range []struct {
+		name           string
+		hostname       string
+		bodySize       int
+		expectedStatus int
+	}{
+		{
+			name:           "empty body",
+			hostname:       "buffer.example.com",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "below limit",
+			hostname:       "buffer.example.com",
+			bodySize:       bufferLimit - 1,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "at limit",
+			hostname:       "buffer.example.com",
+			bodySize:       bufferLimit,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "above limit",
+			hostname:       "buffer.example.com",
+			bodySize:       bufferLimit + 1,
+			expectedStatus: http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:           "untargeted route accepts oversized body",
+			hostname:       "no-buffer.example.com",
+			bodySize:       bufferLimit * 2,
+			expectedStatus: http.StatusOK,
+		},
+	} {
+		s.Run(tc.name, func() {
+			common.BaseGateway.Send(
+				s.T(),
+				&testmatchers.HttpResponse{StatusCode: tc.expectedStatus},
+				curl.WithMethod(http.MethodPost),
+				curl.WithPath("/"),
+				curl.WithHostHeader(tc.hostname),
+				curl.WithPort(80),
+				curl.WithBody(strings.Repeat("a", tc.bodySize)),
+			)
+		})
+	}
+}

--- a/test/e2e/features/buffer/testdata/trafficpolicy.yaml
+++ b/test/e2e/features/buffer/testdata/trafficpolicy.yaml
@@ -1,0 +1,42 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: buffered-route
+  namespace: kgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - buffer.example.com
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: unbuffered-route
+  namespace: kgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - no-buffer.example.com
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: buffer-policy
+  namespace: kgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: buffered-route
+  buffer:
+    maxRequestSize: 1024

--- a/test/e2e/features/buffer/types.go
+++ b/test/e2e/features/buffer/types.go
@@ -1,0 +1,16 @@
+//go:build e2e
+
+package buffer
+
+import (
+	"path/filepath"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+)
+
+var testCases = map[string]*base.TestCase{
+	"TestBufferLimit": {
+		Manifests: []string{filepath.Join(fsutils.MustGetThisDir(), "testdata", "trafficpolicy.yaml")},
+	},
+}

--- a/test/e2e/tests/kgateway/suite_runner.go
+++ b/test/e2e/tests/kgateway/suite_runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/backendtls"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/basicauth"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/basicrouting"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/buffer"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/compression"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/cors"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/csrf"
@@ -89,6 +90,7 @@ func SuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("PolicySelector", policyselector.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TrafficPolicyStatus", trafficpolicystatus.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("Cors", cors.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("Buffer", buffer.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("Compression", compression.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("FaultInjection", faultinjection.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("BackendConfigPolicy", backendconfigpolicy.NewTestingSuite)


### PR DESCRIPTION
# Description

Add end-to-end coverage for the TrafficPolicy request buffer limit and register the Buffer suite in the existing CI shard. The suite uses the shared test Gateway and two routes, applying a 1024-byte buffer policy to one route.

The tests cover empty requests, payloads below and exactly at the limit, a payload one byte over the limit, and a larger payload on the untargeted route. This adapts the earlier test contribution in #13333 to the current suite structure and preserves Aritra Dey's co-author attribution.

Fixes #11946

# Change Type

/kind test

# Changelog

```release-note
NONE
```

# Additional Notes

Validated against contribution commit fd48f732ff18342edf5f17e735b775573ad9815e:

- [Buffer E2E](https://github.com/FenjuFu/kgateway/actions/runs/34435331046): three independent KinD clusters passed all five scenarios, with GO_TEST_RETRIES=0. Payloads of 0, 1023 and 1024 bytes returned 200; 1025 bytes returned 413; the untargeted route accepted 2048 bytes. All 15 scenario executions passed.
- [Full lint](https://github.com/FenjuFu/kgateway/actions/runs/34435428854): Go make analyze, GitHub Actions, Rust and Helm checks passed.
- [make verify](https://github.com/FenjuFu/kgateway/actions/runs/34436473354): passed without generated-code drift. This ran on a validation-only child commit adding workflow_dispatch to verify.yaml; that extra workflow change is absent from this contribution branch.
- The contribution commit is GitHub-verified, contains the matching Signed-off-by trailer, and retains the original co-author attribution. Upstream DCO validation will run after the PR is opened.

Non-trivial AI assistance was used to adapt the tests, inspect the current harness, and run validation.