### PR TITLE
fix: ignore resourceVersion-only changes in KRT equality

### DIFF
--- a/pkg/kgateway/extensions2/plugins/backend/ec2.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2.go
@@ -2,6 +2,9 @@ package backend
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
@@ -142,10 +145,10 @@ type ec2BackendConfig struct {
 }
 
 type ec2CredentialKey struct {
-	region                string
-	roleArn               string
-	secretResourceName    string
-	secretResourceVersion string
+	region             string
+	roleArn            string
+	secretResourceName string
+	secretContentHash  string
 }
 
 type ec2CredentialSource struct {
@@ -197,8 +200,8 @@ type ec2InstanceLister interface {
 }
 
 // ec2ClientIdentity identifies a cached EC2 client independent of the secret's
-// resource version. At most one client is cached per identity, so a newer
-// secret version overwrites (and thus evicts) the prior client without needing
+// contents. At most one client is cached per identity, so rotated credentials
+// overwrite (and thus evict) the prior client without needing
 // to scan the cache for superseded entries.
 type ec2ClientIdentity struct {
 	region             string
@@ -206,37 +209,37 @@ type ec2ClientIdentity struct {
 	secretResourceName string
 }
 
-func (k ec2ClientIdentity) singleflightKey(secretResourceVersion string) string {
+func (k ec2ClientIdentity) singleflightKey(secretContentHash string) string {
 	return strings.Join([]string{
 		k.region,
 		k.roleArn,
 		k.secretResourceName,
-		secretResourceVersion,
+		secretContentHash,
 	}, "\x00")
 }
 
-// ec2CachedClient is a cached client together with the secret resource version
-// it was built from, so a rotated secret can be detected on lookup.
+// ec2CachedClient retains the credential fingerprint used to build the client.
+// API-server revisions alone must not invalidate it.
 type ec2CachedClient struct {
-	secretResourceVersion string
-	client                *awsec2.Client
+	secretContentHash string
+	client            *awsec2.Client
 }
 
 type ec2BackendStateKey struct {
-	region                string // +noKrtEquals compared in endpointSemanticsEqual
-	roleArn               string
-	port                  uint32                  // +noKrtEquals compared in endpointSemanticsEqual
-	addressType           kgateway.AwsAddressType // +noKrtEquals compared in endpointSemanticsEqual
-	filters               []ec2TagFilter          // +noKrtEquals compared in endpointSemanticsEqual
-	secretResourceName    string
-	secretResourceVersion string
+	region             string // +noKrtEquals compared in endpointSemanticsEqual
+	roleArn            string
+	port               uint32                  // +noKrtEquals compared in endpointSemanticsEqual
+	addressType        kgateway.AwsAddressType // +noKrtEquals compared in endpointSemanticsEqual
+	filters            []ec2TagFilter          // +noKrtEquals compared in endpointSemanticsEqual
+	secretResourceName string
+	secretContentHash  string
 }
 
 func (k ec2BackendStateKey) Equals(other ec2BackendStateKey) bool {
 	return k.endpointSemanticsEqual(other) &&
 		k.roleArn == other.roleArn &&
 		k.secretResourceName == other.secretResourceName &&
-		k.secretResourceVersion == other.secretResourceVersion
+		k.secretContentHash == other.secretContentHash
 }
 
 // endpointSemanticsEqual reports whether two configs resolve to the same
@@ -271,24 +274,22 @@ func (l *awsEc2InstanceLister) clientFor(ctx context.Context, source ec2Credenti
 		region:  source.region,
 		roleArn: source.roleArn,
 	}
-	version := ""
+	contentHash := ""
 	if source.secret != nil {
 		identity.secretResourceName = source.secret.ResourceName()
-		if source.secret.Obj != nil {
-			version = source.secret.Obj.GetResourceVersion()
-		}
+		contentHash = ec2SecretContentHash(source.secret)
 	}
 
 	l.mu.Lock()
-	if cached, ok := l.clients[identity]; ok && cached.secretResourceVersion == version {
+	if cached, ok := l.clients[identity]; ok && cached.secretContentHash == contentHash {
 		l.mu.Unlock()
 		return cached.client, nil
 	}
 	l.mu.Unlock()
 
-	value, err, _ := l.clientLoads.Do(identity.singleflightKey(version), func() (any, error) {
+	value, err, _ := l.clientLoads.Do(identity.singleflightKey(contentHash), func() (any, error) {
 		l.mu.Lock()
-		if cached, ok := l.clients[identity]; ok && cached.secretResourceVersion == version {
+		if cached, ok := l.clients[identity]; ok && cached.secretContentHash == contentHash {
 			l.mu.Unlock()
 			return cached.client, nil
 		}
@@ -301,13 +302,13 @@ func (l *awsEc2InstanceLister) clientFor(ctx context.Context, source ec2Credenti
 
 		l.mu.Lock()
 		defer l.mu.Unlock()
-		// Another caller may have populated the entry for this version meanwhile.
-		// Storing per-identity means a different version overwrites (and evicts)
-		// the prior client without scanning the cache.
-		if cached, ok := l.clients[identity]; ok && cached.secretResourceVersion == version {
+		// Another caller may have populated the entry for these credentials meanwhile.
+		// Storing per identity lets rotated credentials replace the prior client
+		// without scanning the cache.
+		if cached, ok := l.clients[identity]; ok && cached.secretContentHash == contentHash {
 			return cached.client, nil
 		}
-		l.clients[identity] = ec2CachedClient{secretResourceVersion: version, client: client}
+		l.clients[identity] = ec2CachedClient{secretContentHash: contentHash, client: client}
 		return client, nil
 	})
 	if err != nil {
@@ -633,9 +634,7 @@ func (c *ec2EndpointsCollection) computeState(ctx context.Context) (map[string]e
 		}
 		if cfg.secret != nil {
 			key.secretResourceName = cfg.secret.ResourceName()
-			if cfg.secret.Obj != nil {
-				key.secretResourceVersion = cfg.secret.Obj.GetResourceVersion()
-			}
+			key.secretContentHash = ec2SecretContentHash(cfg.secret)
 		}
 		byCredential[key] = append(byCredential[key], cfg)
 	}
@@ -1029,6 +1028,33 @@ func normalizeEc2TagFilters(in []kgateway.AwsTagFilter) []ec2TagFilter {
 	return out
 }
 
+// ec2SecretContentHash detects credential rotation and object replacement without
+// treating an RV-only update as a rotation. Length-prefixed fields make the hash
+// unambiguous, and sorting makes it independent of map iteration order. Never
+// put credential bytes directly in cache/singleflight keys or diagnostics.
+func ec2SecretContentHash(secret *ir.Secret) string {
+	if secret == nil {
+		return ""
+	}
+	h := sha256.New()
+	writeField := func(value []byte) {
+		var length [8]byte
+		binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+		h.Write(length[:])
+		h.Write(value)
+	}
+	if secret.Obj != nil {
+		writeField([]byte(secret.Obj.GetUID()))
+	} else {
+		writeField(nil)
+	}
+	for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+		writeField([]byte(key))
+		writeField(secret.Data[key])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 func (c ec2BackendConfig) stateKey() ec2BackendStateKey {
 	key := ec2BackendStateKey{
 		region:      c.region,
@@ -1039,9 +1065,7 @@ func (c ec2BackendConfig) stateKey() ec2BackendStateKey {
 	}
 	if c.secret != nil {
 		key.secretResourceName = c.secret.ResourceName()
-		if c.secret.Obj != nil {
-			key.secretResourceVersion = c.secret.Obj.GetResourceVersion()
-		}
+		key.secretContentHash = ec2SecretContentHash(c.secret)
 	}
 	return key
 }

--- a/pkg/kgateway/extensions2/plugins/backend/ec2_test.go
+++ b/pkg/kgateway/extensions2/plugins/backend/ec2_test.go
@@ -754,7 +754,7 @@ func TestAwsEc2InstanceListerClientForBuildsDifferentKeysConcurrently(t *testing
 	}
 }
 
-func TestAwsEc2InstanceListerClientForPrunesSupersededSecretVersions(t *testing.T) {
+func TestAwsEc2InstanceListerClientForPrunesSupersededCredentials(t *testing.T) {
 	lister := &awsEc2InstanceLister{
 		clients: map[ec2ClientIdentity]ec2CachedClient{},
 		newClient: func(_ context.Context, source ec2CredentialSource) (*awsec2.Client, error) {
@@ -770,6 +770,8 @@ func TestAwsEc2InstanceListerClientForPrunesSupersededSecretVersions(t *testing.
 		region: "us-east-1",
 		secret: newTestAWSSecret("aws-creds", "default", "2"),
 	}
+
+	sourceV2.secret.Data["secretKey"] = []byte("rotated")
 
 	if _, err := lister.clientFor(context.Background(), sourceV1); err != nil {
 		t.Fatalf("clientFor(v1) error = %v", err)
@@ -788,8 +790,75 @@ func TestAwsEc2InstanceListerClientForPrunesSupersededSecretVersions(t *testing.
 	if !ok {
 		t.Fatal("client cache did not retain an entry for the secret identity")
 	}
-	if cached.secretResourceVersion != "2" {
-		t.Fatalf("client cache retained secret version %q, want the latest version %q", cached.secretResourceVersion, "2")
+	if cached.secretContentHash != ec2SecretContentHash(sourceV2.secret) {
+		t.Fatal("client cache did not retain the rotated credentials")
+	}
+}
+
+func TestEc2CredentialChangesIgnoreResourceVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*ir.Secret)
+		equal  bool
+	}{
+		{"revision", func(s *ir.Secret) { s.Obj.SetResourceVersion("2") }, true},
+		{"rotation without revision", func(s *ir.Secret) { s.Data["secretKey"] = []byte("rotated") }, false},
+		{"replacement", func(s *ir.Secret) { s.Obj.SetUID("replacement") }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newTestAWSSecret("creds", "default", "1")
+			b := newTestAWSSecret("creds", "default", "1")
+			tc.mutate(b)
+			if (&EC2Ir{secret: a}).Equals(&EC2Ir{secret: b}) != tc.equal {
+				t.Fatal("unexpected EC2 IR equality")
+			}
+			ca := (ec2BackendConfig{secret: a}).stateKey()
+			cb := (ec2BackendConfig{secret: b}).stateKey()
+			if ca.Equals(cb) != tc.equal {
+				t.Fatal("unexpected discovery key equality")
+			}
+			if (ec2ResolvedBackend{config: ca}).Equals(ec2ResolvedBackend{config: cb}) != tc.equal {
+				t.Fatal("unexpected resolved-state equality")
+			}
+			builds := 0
+			lister := &awsEc2InstanceLister{
+				clients: map[ec2ClientIdentity]ec2CachedClient{},
+				newClient: func(_ context.Context, _ ec2CredentialSource) (*awsec2.Client, error) {
+					builds++
+					return awsec2.NewFromConfig(awssdk.Config{Region: "us-east-1"}), nil
+				},
+			}
+			first, err := lister.clientFor(context.Background(), ec2CredentialSource{secret: a})
+			if err != nil {
+				t.Fatal(err)
+			}
+			second, err := lister.clientFor(context.Background(), ec2CredentialSource{secret: b})
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantBuilds := 2
+			if tc.equal {
+				wantBuilds = 1
+			}
+			if builds != wantBuilds || (first == second) != tc.equal {
+				t.Fatalf("built %d clients, want %d", builds, wantBuilds)
+			}
+		})
+	}
+}
+
+func TestEc2SecretContentHashIsStableAndUnambiguous(t *testing.T) {
+	a := &ir.Secret{Data: map[string][]byte{"a": []byte("b"), "c": []byte("d")}}
+	b := &ir.Secret{Data: map[string][]byte{"c": []byte("d"), "a": []byte("b")}}
+	for range 20 {
+		if ec2SecretContentHash(a) != ec2SecretContentHash(b) {
+			t.Fatal("hash depends on map iteration order")
+		}
+	}
+	// Secret bytes may contain zeroes, so delimiter-only field encoding is unsafe.
+	b.Data = map[string][]byte{"a": []byte("b\x00c\x00d")}
+	if ec2SecretContentHash(a) == ec2SecretContentHash(b) {
+		t.Fatal("ambiguous field encoding")
 	}
 }
 

--- a/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/collections.go
@@ -52,13 +52,10 @@ func (s seSelector) GetLabelSelector() map[string]string {
 }
 
 func (s seSelector) Equals(in seSelector) bool {
-	// compare basics including ResourceVersion _first_, attempting to short-circuit
-	// and avoid calling the more expensive maps.Equal or proto.Equal.
-	// We need the more thorough checks because in some environments (like tests)
-	// the ResourceVersion won't be updated properly.
+	// API-server revisions do not change selector or endpoint semantics.
 	metaEqual := s.ServiceEntry.Name == in.ServiceEntry.Name &&
 		s.ServiceEntry.Namespace == in.ServiceEntry.Namespace &&
-		s.ServiceEntry.ResourceVersion == in.ServiceEntry.ResourceVersion &&
+		s.ServiceEntry.UID == in.ServiceEntry.UID &&
 		maps.Equal(s.ServiceEntry.GetLabels(), in.ServiceEntry.GetLabels()) &&
 		maps.Equal(s.ServiceEntry.GetAnnotations(), in.ServiceEntry.GetAnnotations())
 

--- a/pkg/kgateway/extensions2/plugins/serviceentry/collections_equality_test.go
+++ b/pkg/kgateway/extensions2/plugins/serviceentry/collections_equality_test.go
@@ -1,0 +1,35 @@
+package serviceentry
+
+import (
+	"testing"
+
+	networking "istio.io/api/networking/v1alpha3"
+	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSelectorEqualsIgnoresResourceVersion(t *testing.T) {
+	a := seSelector{&networkingclient.ServiceEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "se", Namespace: "default", UID: "uid", Generation: 1, ResourceVersion: "1"},
+		Spec:       networking.ServiceEntry{Hosts: []string{"example.com"}},
+	}}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*networkingclient.ServiceEntry)
+		want   bool
+	}{
+		{"revision", func(s *networkingclient.ServiceEntry) { s.ResourceVersion = "2" }, true},
+		{"spec", func(s *networkingclient.ServiceEntry) { s.Spec.Hosts = []string{"other.example.com"} }, false},
+		{"labels", func(s *networkingclient.ServiceEntry) { s.Labels = map[string]string{"key": "value"} }, false},
+		{"annotations", func(s *networkingclient.ServiceEntry) { s.Annotations = map[string]string{"key": "value"} }, false},
+		{"replacement", func(s *networkingclient.ServiceEntry) { s.UID = "new" }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := seSelector{a.ServiceEntry.DeepCopy()}
+			tc.mutate(b.ServiceEntry)
+			if a.Equals(b) != tc.want || b.Equals(a) != tc.want {
+				t.Fatalf("equality should be %v in both directions", tc.want)
+			}
+		})
+	}
+}

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -412,7 +413,6 @@ type Secret struct {
 	// original object. Opaque to us other than metadata.
 	Obj metav1.Object
 
-	// +krtEqualsTodo evaluate secret data equality handling
 	Data map[string][]byte
 }
 
@@ -421,7 +421,9 @@ func (c Secret) ResourceName() string {
 }
 
 func (c Secret) Equals(in Secret) bool {
-	return c.ObjectSource.Equals(in.ObjectSource) && versionEquals(c.Obj, in.Obj)
+	// Consumers use the projected Data and source metadata, not the raw Secret.
+	return c.ObjectSource.Equals(in.ObjectSource) && sourceMetadataEquals(c.Obj, in.Obj) &&
+		maps.EqualFunc(c.Data, in.Data, bytes.Equal)
 }
 
 var (

--- a/pkg/pluginsdk/ir/equality_harness_test.go
+++ b/pkg/pluginsdk/ir/equality_harness_test.go
@@ -245,12 +245,11 @@ func TestHarnessGatewayEquals(t *testing.T) {
 			},
 		},
 		{
-			// Obj: mutate ResourceVersion so versionEquals (backend.go:523) detects the change.
-			// versionEquals uses ResourceVersion when Generation == 0.
+			// A real metadata change must invalidate the source, even at generation zero.
 			Field: "Obj",
 			Mutate: func(g *Gateway) {
 				obj := baseGatewayObj()
-				obj.ResourceVersion = "999"
+				obj.Labels = map[string]string{"changed": "true"}
 				g.Obj = obj
 			},
 		},
@@ -320,14 +319,13 @@ func TestHarnessListenerSetEquals(t *testing.T) {
 			},
 		},
 		{
-			// Obj: mutate ResourceVersion so versionEquals detects the change.
-			// versionEquals uses ResourceVersion when Generation == 0.
+			// A real metadata change must invalidate the source.
 			Field: "Obj",
 			Mutate: func(ls *ListenerSet) {
 				ls.Obj = &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						ResourceVersion: "999",
-						UID:             "ls-uid-1",
+						Labels: map[string]string{"changed": "true"},
+						UID:    "ls-uid-1",
 					},
 				}
 			},
@@ -539,16 +537,14 @@ func TestHarnessListenerEquals(t *testing.T) {
 			},
 		},
 		{
-			// Bump the parent's ResourceVersion → versionEquals detects a change
-			// (the base parent has Generation 0, so versionEquals falls back to
-			// ResourceVersion + UID).
+			// Change parent labels; API-server revisions alone must remain equal.
 			Field: "Parent",
 			Mutate: func(l *Listener) {
 				l.Parent = &gwv1.Gateway{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            "my-gateway",
-						Namespace:       "default",
-						ResourceVersion: "2",
+						Name:      "my-gateway",
+						Namespace: "default",
+						Labels:    map[string]string{"changed": "true"},
 					},
 				}
 			},

--- a/pkg/pluginsdk/ir/iface.go
+++ b/pkg/pluginsdk/ir/iface.go
@@ -15,7 +15,10 @@ import (
 	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	apiannotations "github.com/kgateway-dev/kgateway/v2/api/annotations"
@@ -311,20 +314,63 @@ func (c PolicyWrapper) ResourceName() string {
 	return c.ObjectSource.ResourceName()
 }
 
+// versionEquals compares source metadata and configuration, never resourceVersion.
+// CRDs with a generation use it to detect spec changes. Generation-zero objects
+// (including Services and test fixtures) need a content comparison instead: RV
+// also changes on status writes and unrelated API-server bookkeeping.
 func versionEquals(a, b metav1.Object) bool {
-	var versionEquals bool
-	if a.GetGeneration() != 0 && b.GetGeneration() != 0 {
-		versionEquals = a.GetGeneration() == b.GetGeneration()
-		// Generation alone is insufficient because Kubernetes only increments generation on spec changes,
-		// not metadata changes like labels.
-		// ResourceVersion: is too broad as it is bumped on status changes as well.
-		if versionEquals {
-			versionEquals = maps.Equal(a.GetLabels(), b.GetLabels()) && maps.Equal(a.GetAnnotations(), b.GetAnnotations())
-		}
-	} else {
-		versionEquals = a.GetResourceVersion() == b.GetResourceVersion()
+	if a == nil || b == nil {
+		return a == nil && b == nil
 	}
-	return versionEquals && a.GetUID() == b.GetUID()
+	if !sourceMetadataEquals(a, b) {
+		return false
+	}
+	if a.GetGeneration() != 0 {
+		return true
+	}
+	// Services are a frequent generation-zero input. Compare their spec directly
+	// rather than allocating an unstructured representation on every update.
+	if svc, ok := a.(*corev1.Service); ok {
+		other, ok := b.(*corev1.Service)
+		return ok && equality.Semantic.DeepEqual(svc.Spec, other.Spec)
+	}
+	// Metadata-only sources have no configuration beyond the fields above.
+	if _, ok := a.(*metav1.ObjectMeta); ok {
+		_, ok := b.(*metav1.ObjectMeta)
+		return ok
+	}
+	// Converting to plain Kubernetes JSON values also avoids comparing embedded
+	// protobuf internals in extension objects. Ignore status and metadata here:
+	// the translation-relevant metadata was compared above, and RV/managedFields
+	// must not cause an otherwise unchanged IR to notify its dependants.
+	left, err := runtime.DefaultUnstructuredConverter.ToUnstructured(a)
+	if err != nil {
+		return false
+	}
+	right, err := runtime.DefaultUnstructuredConverter.ToUnstructured(b)
+	if err != nil {
+		return false
+	}
+	// ToUnstructured may return the original map for an Unstructured input.
+	// Clone the top level before removing fields; informer objects are immutable.
+	left = maps.Clone(left)
+	right = maps.Clone(right)
+	delete(left, "metadata")
+	delete(left, "status")
+	delete(right, "metadata")
+	delete(right, "status")
+	return equality.Semantic.DeepEqual(left, right)
+}
+
+// sourceMetadataEquals covers identity and metadata consumed by translation.
+// Status, resourceVersion, and managedFields are API-server bookkeeping.
+func sourceMetadataEquals(a, b metav1.Object) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.GetUID() == b.GetUID() && a.GetName() == b.GetName() &&
+		a.GetNamespace() == b.GetNamespace() && a.GetGeneration() == b.GetGeneration() &&
+		maps.Equal(a.GetLabels(), b.GetLabels()) && maps.Equal(a.GetAnnotations(), b.GetAnnotations())
 }
 
 func (c PolicyWrapper) Equals(in PolicyWrapper) bool {

--- a/pkg/pluginsdk/ir/resourceversion_test.go
+++ b/pkg/pluginsdk/ir/resourceversion_test.go
@@ -1,0 +1,138 @@
+package ir
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+type revisionTestPolicy struct{}
+
+func (revisionTestPolicy) CreationTime() time.Time { return time.Time{} }
+func (revisionTestPolicy) Equals(any) bool         { return true }
+
+func TestEqualsIgnoresResourceVersion(t *testing.T) {
+	for _, gen := range []int64{0, 1} {
+		a := metav1.ObjectMeta{Name: "x", Namespace: "ns", UID: "uid", Generation: gen, ResourceVersion: "1"}
+		b := *a.DeepCopy()
+		b.ResourceVersion = "2"
+		b.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "status-writer"}}
+		ga := &gwv1.Gateway{ObjectMeta: a}
+		gb := &gwv1.Gateway{ObjectMeta: b}
+		ba := NewBackendObjectIR(ObjectSource{Name: "x", Kind: "Service"}, 80, "", "svc")
+		ba.Obj = &corev1.Service{ObjectMeta: a}
+		bb := ba
+		bb.Obj = &corev1.Service{ObjectMeta: b}
+		cases := map[string]bool{
+			"versionEquals":   versionEquals(&a, &b),
+			"Secret":          (Secret{Obj: &corev1.Secret{ObjectMeta: a}}).Equals(Secret{Obj: &corev1.Secret{ObjectMeta: b}}),
+			"BackendObjectIR": ba.Equals(bb),
+			"Gateway":         (Gateway{Obj: ga}).Equals(Gateway{Obj: gb}),
+			"Listener":        (Listener{Parent: ga}).Equals(Listener{Parent: gb}),
+			"ListenerSet":     (ListenerSet{Obj: &gwv1.ListenerSet{ObjectMeta: a}}).Equals(ListenerSet{Obj: &gwv1.ListenerSet{ObjectMeta: b}}),
+			"HttpRouteIR":     (HttpRouteIR{SourceObject: &gwv1.HTTPRoute{ObjectMeta: a}}).Equals(HttpRouteIR{SourceObject: &gwv1.HTTPRoute{ObjectMeta: b}}),
+			"TcpRouteIR":      (TcpRouteIR{SourceObject: &gwv1a2.TCPRoute{ObjectMeta: a}}).Equals(TcpRouteIR{SourceObject: &gwv1a2.TCPRoute{ObjectMeta: b}}),
+			"TlsRouteIR":      (TlsRouteIR{SourceObject: &gwv1a2.TLSRoute{ObjectMeta: a}}).Equals(TlsRouteIR{SourceObject: &gwv1a2.TLSRoute{ObjectMeta: b}}),
+			"PolicyWrapper":   (PolicyWrapper{Policy: &a, PolicyIR: revisionTestPolicy{}}).Equals(PolicyWrapper{Policy: &b, PolicyIR: revisionTestPolicy{}}),
+		}
+		for name, got := range cases {
+			t.Run(fmt.Sprintf("%s/gen%d", name, gen), func(t *testing.T) {
+				if !got {
+					t.Fatalf("Equals=%v", got)
+				}
+			})
+		}
+	}
+	sa := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", ResourceVersion: "1"}}
+	sb := sa.DeepCopy()
+	sb.ResourceVersion = "2"
+	sb.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "status-writer"}}
+	ba := NewBackendObjectIR(ObjectSource{Name: "svc", Kind: "Service"}, 80, "", "svc")
+	ba.Obj = sa
+	bb := ba
+	bb.Obj = sb
+	route := &gwv1a2.TCPRoute{ObjectMeta: metav1.ObjectMeta{Generation: 1}}
+	ra := TcpRouteIR{SourceObject: route, Backends: []BackendRefIR{{BackendObject: &ba}}}
+	rb := TcpRouteIR{SourceObject: route, Backends: []BackendRefIR{{BackendObject: &bb}}}
+	if !ra.Equals(rb) {
+		t.Fatal("Service RV-only change propagated into an unchanged route")
+	}
+	dataA := Secret{Obj: &metav1.ObjectMeta{}, Data: map[string][]byte{"key": []byte("a")}}
+	dataB := Secret{Obj: &metav1.ObjectMeta{}, Data: map[string][]byte{"key": []byte("b")}}
+	if dataA.Equals(dataB) {
+		t.Fatal("Secret equality missed data-only change at same RV")
+	}
+}
+
+func TestVersionEqualsGenerationZeroContent(t *testing.T) {
+	base := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc", UID: "uid"}, Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.1"}}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*corev1.Service)
+		want   bool
+	}{
+		{"revision", func(s *corev1.Service) { s.ResourceVersion = "2" }, true},
+		{"status", func(s *corev1.Service) { s.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}} }, true},
+		{"spec", func(s *corev1.Service) { s.Spec.ClusterIP = "10.0.0.2" }, false},
+		{"labels", func(s *corev1.Service) { s.Labels = map[string]string{"selector": "new"} }, false},
+		{"annotations", func(s *corev1.Service) { s.Annotations = map[string]string{"config": "new"} }, false},
+		{"replacement", func(s *corev1.Service) { s.UID = "new" }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := base.DeepCopy()
+			tc.mutate(changed)
+			if versionEquals(base, changed) != tc.want || versionEquals(changed, base) != tc.want {
+				t.Fatalf("source equality should be %v in both directions", tc.want)
+			}
+		})
+	}
+	// CRD fixtures with no generation still need to observe real spec changes.
+	route := &gwv1a2.TCPRoute{}
+	changedRoute := route.DeepCopy()
+	changedRoute.Spec.ParentRefs = []gwv1.ParentReference{{Name: "other-gateway"}}
+	if versionEquals(route, changedRoute) {
+		t.Fatal("missed generation-zero route spec change")
+	}
+	config := &corev1.ConfigMap{Data: map[string]string{"key": "old"}}
+	changedConfig := config.DeepCopy()
+	changedConfig.Data["key"] = "new"
+	if versionEquals(config, changedConfig) {
+		t.Fatal("missed ConfigMap data change")
+	}
+}
+
+func TestVersionEqualsDoesNotMutateUnstructuredSources(t *testing.T) {
+	a := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "example.io/v1", "kind": "Policy",
+		"metadata": map[string]any{"name": "policy", "resourceVersion": "1"},
+		"spec":     map[string]any{"key": "value"},
+		"status":   map[string]any{"ready": false},
+	}}
+	b := a.DeepCopy()
+	b.SetResourceVersion("2")
+	b.Object["status"] = map[string]any{"ready": true}
+	if !versionEquals(a, b) {
+		t.Fatal("RV/status-only update should be equal")
+	}
+	if a.GetResourceVersion() != "1" || b.GetResourceVersion() != "2" || a.Object["status"] == nil || b.Object["status"] == nil {
+		t.Fatal("comparison mutated source objects")
+	}
+	b.Object["spec"] = map[string]any{"key": "new"}
+	if versionEquals(a, b) {
+		t.Fatal("missed unstructured spec change")
+	}
+}
+
+func TestSecretEqualsComparesDataWithNonzeroGeneration(t *testing.T) {
+	a := Secret{Obj: &metav1.ObjectMeta{Generation: 1}, Data: map[string][]byte{"key": []byte("old")}}
+	b := Secret{Obj: &metav1.ObjectMeta{Generation: 1}, Data: map[string][]byte{"key": []byte("new")}}
+	if a.Equals(b) || b.Equals(a) {
+		t.Fatal("missed Secret data change with unchanged metadata")
+	}
+}


### PR DESCRIPTION
# Description

A Kubernetes API-server revision alone must not invalidate translated KRT configuration. Previously, versionEquals used resourceVersion whenever either source generation was zero. An unchanged Service could therefore compare unequal as BackendObjectIR, propagate through BackendRefIR, and invalidate a route whose own source had not changed. Secret revisions similarly notified consumers even when credential or certificate data was identical.

Replace that fallback with source-content equality. Continue using generation for resources that supply it, together with source identity, labels, and annotations. Compare generation-zero Service specs directly on the common backend path. For other generation-zero sources, compare their unstructured configuration after excluding status and metadata bookkeeping. Clone the top-level maps before excluding fields so unstructured informer objects remain immutable. Metadata-only sources have no additional configuration to compare.

Give Secret IR an explicit byte-content comparison in addition to source metadata equality. This both suppresses RV-only invalidations and detects real data changes when resourceVersion and generation are unchanged. It also avoids converting the raw Secret to unstructured data during equality checks.

Remove the unconditional resourceVersion check from ServiceEntry selector equality. Keep its full protobuf spec, label, annotation, and name/namespace comparisons, and compare UID so replacement of an object remains observable.

Use a deterministic SHA-256 fingerprint of Secret UID and data throughout EC2 credential grouping, client-cache invalidation, singleflight keys, and discovery state equality. Sort data keys and length-prefix fields so map ordering and embedded zero bytes cannot change or ambiguously encode the fingerprint. RV-only changes now reuse existing clients and discovery state; real credential rotations and object replacement still invalidate them. Keep the existing per-identity cache replacement and cached-endpoint behavior.

Update the Gateway, ListenerSet, and Listener equality harnesses to mutate real metadata instead of requiring RV-only inequality. Add regression coverage for all nine affected IR equality methods at zero and nonzero generations, Service backend-to-route propagation, real Service/route/ConfigMap content changes, Secret data changes with unchanged metadata, unstructured source immutability, ServiceEntry selector changes, and EC2 credential rotation versus client reuse.

# Change Type

/kind fix

# Changelog

```release-note
Avoid unnecessary KRT recomputation and EC2 credential-cache invalidation on resourceVersion-only updates while preserving detection of configuration and Secret data changes.
```

# Additional Notes

Raw informer events and optimistic-concurrency status writes continue to use the current API-server resourceVersion. This change targets translated IR and EC2 credential semantics; it does not change the final xDS content-hash scheme.

Validation:
- go test -tags e2e ./pkg/pluginsdk/ir ./pkg/kgateway/extensions2/plugins/serviceentry ./pkg/kgateway/extensions2/plugins/backend ./pkg/krtcollections ./pkg/kgateway/proxy_syncer ./pkg/pluginsdk/statussync
- go test -tags e2e ./pkg/kgateway/extensions2/plugins/... ./pkg/pluginsdk/...
- make fmt-changed, plus the repository formatter for new test files
- make analyze
- git diff --check

No API or generated-code changes; live-cluster e2e tests were not run.

