### PR TITLE
[2.4] fix: retain ADS endpoint watches across unanswerable snapshots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ godebug x509negativeserial=1
 require (
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2
-	github.com/envoyproxy/go-control-plane v0.14.0
+	github.com/envoyproxy/go-control-plane v0.14.1-0.20260702184136-1cd1226616f5
 	github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260529185539-1175069dbb2c
 	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260529185539-1175069dbb2c
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250507123352-93990c5ec02f

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/emirpasic/gods v1.9.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3y
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
-github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
+github.com/envoyproxy/go-control-plane v0.14.1-0.20260702184136-1cd1226616f5 h1:TdPAax9doXlBbpFHx9OBB9uwe+wOvwpwBn5EJc3ACHw=
+github.com/envoyproxy/go-control-plane v0.14.1-0.20260702184136-1cd1226616f5/go.mod h1:H3lDamtuGa0Y80VmchcmbutXMYNPDr0j+JrLlsgyEyo=
 github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260529185539-1175069dbb2c h1:V2dPDXkYlYWc6pxcXZgWuvIVH5YXzHce5bzD7q4aWSM=
 github.com/envoyproxy/go-control-plane/contrib v1.36.1-0.20260529185539-1175069dbb2c/go.mod h1:v21y1Uq30hmHbNsT2JOGMJG9cF+Ls7zTfIVOBLAU1TE=
 github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260529185539-1175069dbb2c h1:/YT8pzaezoxioJleRAWkxgs6GfDymDK1tIKROvouo+U=

--- a/hack/utils/oss_compliance/osa_provided.md
+++ b/hack/utils/oss_compliance/osa_provided.md
@@ -11,7 +11,7 @@ Name|Version|License
 [service/sts](https://github.com/aws/aws-sdk-go-v2)|v1.42.1|Apache License 2.0
 [aws/smithy-go](https://github.com/aws/smithy-go)|v1.25.1|Apache License 2.0
 [xds/go](https://github.com/cncf/xds)|v0.0.0-20260202195803-dba9d589def2|Apache License 2.0
-[envoyproxy/go-control-plane](https://github.com/envoyproxy/go-control-plane)|v0.14.0|Apache License 2.0
+[envoyproxy/go-control-plane](https://github.com/envoyproxy/go-control-plane)|v0.14.1-0.20260702184136-1cd1226616f5|Apache License 2.0
 [go-control-plane/contrib](https://github.com/envoyproxy/go-control-plane)|v1.36.1-0.20260529185539-1175069dbb2c|Apache License 2.0
 [go-control-plane/envoy](https://github.com/envoyproxy/go-control-plane)|v1.37.1-0.20260529185539-1175069dbb2c|Apache License 2.0
 [go-control-plane/ratelimit](https://github.com/envoyproxy/go-control-plane)|v0.1.1-0.20250507123352-93990c5ec02f|Apache License 2.0

--- a/pkg/kgateway/admin/xds_snapshot_test.go
+++ b/pkg/kgateway/admin/xds_snapshot_test.go
@@ -26,10 +26,12 @@ func TestRedactSecrets(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "secret data isredacted",
+			name: "secret data is redacted",
 			in: &cache.Snapshot{
+				// Index by the named response-type constants: their numeric
+				// values shift whenever go-control-plane adds a type.
 				Resources: [types.UnknownType]cache.Resources{
-					{
+					types.Cluster: {
 						Version: "cluster1",
 						Items: map[string]types.ResourceWithTTL{
 							"cluster1": {
@@ -39,7 +41,7 @@ func TestRedactSecrets(t *testing.T) {
 							},
 						},
 					},
-					{
+					types.Endpoint: {
 						Version: "endpoint1",
 						Items: map[string]types.ResourceWithTTL{
 							"endpoint1": {
@@ -49,19 +51,19 @@ func TestRedactSecrets(t *testing.T) {
 							},
 						},
 					},
-					{
+					types.Listener: {
 						Version: "listener",
 					},
-					{
+					types.Route: {
 						Version: "route",
 					},
-					{
+					types.ScopedRoute: {
 						Version: "scopedroute",
 					},
-					{
+					types.VirtualHost: {
 						Version: "virtualhost",
 					},
-					{
+					types.Secret: {
 						Version: "secret1",
 						Items: map[string]types.ResourceWithTTL{
 							"secret-foo": {
@@ -98,7 +100,7 @@ func TestRedactSecrets(t *testing.T) {
 			},
 			want: &cache.Snapshot{
 				Resources: [types.UnknownType]cache.Resources{
-					{
+					types.Cluster: {
 						Version: "cluster1",
 						Items: map[string]types.ResourceWithTTL{
 							"cluster1": {
@@ -108,7 +110,7 @@ func TestRedactSecrets(t *testing.T) {
 							},
 						},
 					},
-					{
+					types.Endpoint: {
 						Version: "endpoint1",
 						Items: map[string]types.ResourceWithTTL{
 							"endpoint1": {
@@ -118,19 +120,19 @@ func TestRedactSecrets(t *testing.T) {
 							},
 						},
 					},
-					{
+					types.Listener: {
 						Version: "listener",
 					},
-					{
+					types.Route: {
 						Version: "route",
 					},
-					{
+					types.ScopedRoute: {
 						Version: "scopedroute",
 					},
-					{
+					types.VirtualHost: {
 						Version: "virtualhost",
 					},
-					{
+					types.Secret: {
 						Version: "secret1",
 						Items: map[string]types.ResourceWithTTL{
 							"secret-foo": {

--- a/pkg/kgateway/setup/ads_watch_retention_test.go
+++ b/pkg/kgateway/setup/ads_watch_retention_test.go
@@ -1,0 +1,163 @@
+package setup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	cachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoyresource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests characterize the go-control-plane snapshot cache's handling of a
+// named ADS watch it cannot answer, which is the mechanism behind proxies
+// stranded on stale endpoints. In ADS mode the cache answers a named request
+// (EDS, RDS, SDS) only when the snapshot holds no resource of that type outside
+// the request's names, and what it does with the unanswerable watch decides
+// whether the proxy can ever be updated again without reconnecting.
+//
+// They are deliberately written against the dependency rather than our code:
+// they say what this pinned go-control-plane does, so a bump that changes it
+// fails here instead of in production.
+
+const retentionNode = "watch-retention-test-node"
+
+type retentionHash struct{}
+
+func (retentionHash) ID(*envoycorev3.Node) string { return retentionNode }
+
+func edsOnlySnapshot(t *testing.T, version string, clusters ...string) *envoycache.Snapshot {
+	t.Helper()
+
+	resources := make([]cachetypes.Resource, 0, len(clusters))
+	for _, name := range clusters {
+		resources = append(resources, &envoyendpointv3.ClusterLoadAssignment{ClusterName: name})
+	}
+	snapshot, err := envoycache.NewSnapshot(version, map[envoyresource.Type][]cachetypes.Resource{
+		envoyresource.EndpointType: resources,
+	})
+	require.NoError(t, err)
+	return snapshot
+}
+
+func namedEDSRequest(version string, names ...string) *envoycache.Request {
+	return &discoveryv3.DiscoveryRequest{
+		TypeUrl:       envoyresource.EndpointType,
+		ResourceNames: names,
+		VersionInfo:   version,
+	}
+}
+
+// newSotwSubscription returns the subscription by pointer, because
+// stream.Subscription is a struct whose mutators take a pointer receiver: the
+// sotw server keeps one per stream and type and hands the cache a copy on each
+// request.
+func newSotwSubscription(names ...string) *stream.Subscription {
+	sub := stream.NewSotwSubscription(names, false)
+	return &sub
+}
+
+func ackSubscription(t *testing.T, resp envoycache.Response, sub *stream.Subscription, req *envoycache.Request) {
+	t.Helper()
+
+	sub.SetReturnedResources(resp.GetReturnedResources())
+	req.VersionInfo = resp.GetResponseVersion()
+}
+
+func awaitResponse(t *testing.T, ch chan envoycache.Response, what string) envoycache.Response {
+	t.Helper()
+
+	select {
+	case resp := <-ch:
+		return resp
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected a response: %s", what)
+		return nil
+	}
+}
+
+func requireNoResponse(t *testing.T, ch chan envoycache.Response, what string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+		t.Fatalf("expected no response: %s", what)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// A parked named watch that a new snapshot cannot answer must survive that
+// snapshot, so a later snapshot the watch CAN accept is delivered.
+//
+// This is the behavior kgateway depends on to keep a proxy's endpoints fresh
+// while some other cluster of the same proxy is in an unusable state (a
+// rejected cluster, or one the proxy has not applied yet): the endpoint update
+// is withheld while the snapshot is misaligned, then delivered once it is not.
+// Older go-control-plane discarded the watch instead, leaving the proxy with no
+// watch for anything to answer — endpoints frozen until it reconnected, even
+// after the control plane had corrected the snapshot.
+func TestADSCacheRetainsNamedWatchItCannotAnswer(t *testing.T) {
+	ctx := context.Background()
+	cache := envoycache.NewSnapshotCache(true, retentionHash{}, nil)
+	require.NoError(t, cache.SetSnapshot(ctx, retentionNode, edsOnlySnapshot(t, "1", "backend")))
+
+	req := namedEDSRequest("", "backend")
+	sub := newSotwSubscription("backend")
+	initial := make(chan envoycache.Response, 1)
+	_, err := cache.CreateWatch(req, *sub, initial)
+	require.NoError(t, err)
+	ackSubscription(t, awaitResponse(t, initial, "initial endpoints"), sub, req)
+
+	// The proxy re-requests at the version it accepted: the watch parks.
+	parked := make(chan envoycache.Response, 1)
+	cancel, err := cache.CreateWatch(req, *sub, parked)
+	require.NoError(t, err)
+	defer cancel()
+	require.Equal(t, 1, cache.GetStatusInfo(retentionNode).GetNumWatches())
+
+	// A snapshot that also carries endpoints for a cluster this proxy has not
+	// requested cannot be sent to this watch.
+	require.NoError(t, cache.SetSnapshot(ctx, retentionNode, edsOnlySnapshot(t, "2", "backend", "backend-v2")))
+	requireNoResponse(t, parked, "snapshot names a resource the watch did not request")
+	require.Equal(t, 1, cache.GetStatusInfo(retentionNode).GetNumWatches(),
+		"the unanswerable watch must be retained, or the proxy can never be updated without reconnecting")
+
+	// Once the snapshot is answerable again, the retained watch receives it.
+	require.NoError(t, cache.SetSnapshot(ctx, retentionNode, edsOnlySnapshot(t, "3", "backend")))
+	resp := awaitResponse(t, parked, "corrected snapshot delivered to the retained watch")
+	version := resp.GetResponseVersion()
+	require.Equal(t, "3", version)
+}
+
+// A NEW named request the current snapshot cannot answer is still dropped
+// without registering a watch, so a later answerable snapshot has nothing to
+// deliver to. Upstream marks this path with a TODO ("likely unneeded now, to be
+// cleaned"); until it is removed, a proxy that (re)requests endpoints while the
+// snapshot is misaligned — the window around a rejected or not-yet-applied
+// cluster update — can be left waiting on a request that is never answered.
+//
+// This test documents the residual gap. If it starts failing, upstream has
+// closed it and any local mitigation can be dropped.
+func TestADSCacheDropsNewNamedRequestItCannotAnswer(t *testing.T) {
+	ctx := context.Background()
+	cache := envoycache.NewSnapshotCache(true, retentionHash{}, nil)
+	require.NoError(t, cache.SetSnapshot(ctx, retentionNode, edsOnlySnapshot(t, "2", "backend", "backend-v2")))
+
+	dropped := make(chan envoycache.Response, 1)
+	cancel, err := cache.CreateWatch(namedEDSRequest("1", "backend"), *newSotwSubscription("backend"), dropped)
+	require.NoError(t, err)
+	defer cancel()
+
+	requireNoResponse(t, dropped, "snapshot names a resource the request did not ask for")
+	require.Equal(t, 0, cache.GetStatusInfo(retentionNode).GetNumWatches(),
+		"the request is dropped without a watch (residual gap; see the test doc)")
+
+	require.NoError(t, cache.SetSnapshot(ctx, retentionNode, edsOnlySnapshot(t, "3", "backend")))
+	requireNoResponse(t, dropped, "nothing to answer: the request left no watch behind")
+}

--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -74,7 +74,7 @@ func tlsInspectorFilter() *envoylistenerv3.ListenerFilter {
 	configEnvoy := &envoy_tls_inspector.TlsInspector{}
 	msg, _ := utils.MessageToAny(configEnvoy)
 	return &envoylistenerv3.ListenerFilter{
-		Name: wellknown.TlsInspector,
+		Name: wellknown.TLSInspector,
 		ConfigType: &envoylistenerv3.ListenerFilter_TypedConfig{
 			TypedConfig: msg,
 		},


### PR DESCRIPTION
# Description

Backport https://github.com/kgateway-dev/kgateway/pull/14654 to v2.4.x.

Update go-control-plane from v0.14.0 to
v0.14.1-0.20260702184136-1cd1226616f5 to retain pending named ADS watches when a published snapshot cannot answer them. Previously, the cache discarded such a watch even though it sent no response. If Envoy did not issue another EDS request, later snapshots could not deliver endpoint updates, leaving healthy backends on stale endpoints until a new request or reconnect. The retained watch can now receive the next snapshot its subscription allows.

This includes upstream envoyproxy/go-control-plane#1356. It complements the existing filtering of endpoints for errored clusters: avoiding that known subscription mismatch does not fix the cache's watch lifecycle itself.

The dependency update also includes envoyproxy/go-control-plane#1498, which filters superseded responses against the current subscription when ordered ADS is enabled. Ordered ADS is disabled by default on v2.4.x; that fix benefits installations that explicitly enable it.

Carry over the two cache characterization tests, update the TLSInspector constant, use named resource-type indexes in the secret-redaction test, and refresh the dependency attribution. The envoy, contrib, and ratelimit module pins are unchanged.

# Change Type

/kind fix
/kind bump

# Changelog

```release-note
Fix an ADS snapshot-cache bug that discarded pending endpoint watches when a snapshot could not answer them, potentially leaving proxies on stale endpoints even after the snapshot was corrected. Also fix superseded responses being sent after subscription changes when ordered ADS is explicitly enabled (disabled by default on v2.4.x).
```

# Additional Notes

This fixes watch retention during snapshot publication. A new named request that the current snapshot cannot answer can still be dropped without a watch; the second characterization test documents this remaining upstream limitation.

The pseudo-version pins the same dependency commit as the original PR.
