### PR TITLE
Test flakes and fixes

### DIFF
--- a/hack/setup-localstack.sh
+++ b/hack/setup-localstack.sh
@@ -13,6 +13,8 @@ function install_localstack() {
   $HELM repo update
 
   $HELM upgrade -i --create-namespace localstack localstack-repo/localstack --version 0.6.26 --namespace localstack -f ${ROOT_DIR}/localstack-values.yaml
+  # `kubectl wait` fails immediately when no pod matches yet, so let the rollout create it first
+  kubectl rollout status deployment/localstack --namespace localstack --timeout=120s
   kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=localstack -n localstack --timeout=120s
 }
 

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -440,31 +440,54 @@ func (c *Cli) GetContainerLogs(ctx context.Context, namespace string, name strin
 	return stdout + stderr, err
 }
 
-// GetPodsInNsWithLabel returns the pods in the specified namespace with the specified label
+// GetPodsInNsWithLabel returns the pods in the specified namespace with the specified label,
+// excluding pods that are terminating to avoid counting lingering pods from the last test
+// that are in the process of being deleted.
 func (c *Cli) GetPodsInNsWithLabel(ctx context.Context, namespace string, label string) ([]string, error) {
+	return c.getPodsInNsWithLabel(ctx, namespace, label, true)
+}
+
+// GetAllPodsInNsWithLabel is GetPodsInNsWithLabel including terminating pods.
+func (c *Cli) GetAllPodsInNsWithLabel(ctx context.Context, namespace string, label string) ([]string, error) {
+	return c.getPodsInNsWithLabel(ctx, namespace, label, false)
+}
+
+func (c *Cli) getPodsInNsWithLabel(ctx context.Context, namespace string, label string, excludeTerminating bool) ([]string, error) {
 	podStdOut := bytes.NewBuffer(nil)
 	podStdErr := bytes.NewBuffer(nil)
 
-	// Fetch the names of the pods with the given label
+	// deletionTimestamp renders as the empty string unless the pod is terminating
 	getPodNamesCmd := c.Command(ctx, "get", "pod", "-n", namespace,
-		"--selector", label, "--output", "jsonpath='{.items[*].metadata.name}'")
+		"--selector", label, "--output",
+		`jsonpath={range .items[*]}{.metadata.name}{"\t"}{.metadata.deletionTimestamp}{"\n"}{end}`)
 	err := getPodNamesCmd.WithStdout(podStdOut).WithStderr(podStdErr).Run().Cause()
 	if err != nil {
 		fmt.Printf("error running get pod names command: %v\n", err)
 	}
 
-	// Clean up and check the output
-	podNamesString := strings.Trim(podStdOut.String(), "'")
-	if podNamesString == "" {
-		if !c.quiet {
-			fmt.Printf("no %s pods found in namespace %s\n", label, namespace)
-		}
-		return []string{}, nil
+	podNames := selectPodNames(podStdOut.String(), excludeTerminating)
+	if len(podNames) == 0 && !c.quiet {
+		fmt.Printf("no %s pods found in namespace %s\n", label, namespace)
 	}
 
-	// Split the string on whitespace to get the pod names
-	podNames := strings.Fields(podNamesString)
 	return podNames, nil
+}
+
+// selectPodNames reads the "<name>\t<deletionTimestamp>" lines emitted by getPodsInNsWithLabel
+// and returns the names of the pods that should be reported.
+func selectPodNames(jsonpathOutput string, excludeTerminating bool) []string {
+	podNames := []string{}
+	for line := range strings.SplitSeq(jsonpathOutput, "\n") {
+		name, deletionTimestamp, _ := strings.Cut(strings.TrimSpace(line), "\t")
+		if name == "" {
+			continue
+		}
+		if excludeTerminating && deletionTimestamp != "" {
+			continue
+		}
+		podNames = append(podNames, name)
+	}
+	return podNames
 }
 
 func (c *Cli) GetLeaseHolder(ctx context.Context, namespace string, leaderElectionID string) (string, error) {

--- a/pkg/utils/kubeutils/kubectl/cli_test.go
+++ b/pkg/utils/kubeutils/kubectl/cli_test.go
@@ -1,0 +1,58 @@
+package kubectl
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSelectPodNames(t *testing.T) {
+	// a rollout reports both the outgoing (terminating) and incoming pod
+	const rollout = "gw-6b54c85cbf-x6v7s\t2026-09-11T05:23:30Z\ngw-74f7b79947-tfz48\t\n"
+
+	tests := []struct {
+		name               string
+		jsonpathOutput     string
+		excludeTerminating bool
+		expected           []string
+	}{
+		{
+			name:               "drops terminating pod during a rollout",
+			jsonpathOutput:     rollout,
+			excludeTerminating: true,
+			expected:           []string{"gw-74f7b79947-tfz48"},
+		},
+		{
+			name:               "keeps terminating pod when not excluding",
+			jsonpathOutput:     rollout,
+			excludeTerminating: false,
+			expected:           []string{"gw-6b54c85cbf-x6v7s", "gw-74f7b79947-tfz48"},
+		},
+		{
+			name:               "no pods matched the selector",
+			jsonpathOutput:     "",
+			excludeTerminating: true,
+			expected:           []string{},
+		},
+		{
+			name:               "every pod is terminating",
+			jsonpathOutput:     "gw-a\t2026-09-11T05:23:30Z\ngw-b\t2026-09-11T05:23:31Z\n",
+			excludeTerminating: true,
+			expected:           []string{},
+		},
+		{
+			name:               "several running pods are all returned",
+			jsonpathOutput:     "gw-a\t\ngw-b\t\ngw-c\t\n",
+			excludeTerminating: true,
+			expected:           []string{"gw-a", "gw-b", "gw-c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectPodNames(tt.jsonpathOutput, tt.excludeTerminating)
+			if !slices.Equal(got, tt.expected) {
+				t.Errorf("selectPodNames() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/test/e2e/features/dfp/suite.go
+++ b/test/e2e/features/dfp/suite.go
@@ -36,8 +36,15 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	setup := base.TestCase{
 		Manifests: []string{gatewayWithRouteManifest},
 	}
+	testCases := map[string]*base.TestCase{
+		"TestDynamicForwardProxyConnectTermination": {
+			Manifests: []string{connectTerminationManifest},
+			// the manifest attaches its TrafficPolicy by sectionName, which needs a named route rule
+			MinGwApiVersion: base.GwApiRequireRouteNames,
+		},
+	}
 	return &testingSuite{
-		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, nil),
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
 	}
 }
 

--- a/test/e2e/features/dfp/testdata/common.yaml
+++ b/test/e2e/features/dfp/testdata/common.yaml
@@ -17,31 +17,7 @@ spec:
     - name: gateway
       namespace: kgateway-base
   rules:
-    - name: connect
-      matches:
-        - method: CONNECT
-      backendRefs:
+    - backendRefs:
         - name: dfp-backend
           group: gateway.kgateway.dev
           kind: Backend
-    - name: http
-      backendRefs:
-        - name: dfp-backend
-          group: gateway.kgateway.dev
-          kind: Backend
----
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: TrafficPolicy
-metadata:
-  name: dfp-connect-termination
-  namespace: kgateway-base
-spec:
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: route-dfp
-      sectionName: connect
-  httpUpgrade:
-    - type: CONNECT
-      connect:
-        terminate: true

--- a/test/e2e/features/dfp/testdata/connect-termination.yaml
+++ b/test/e2e/features/dfp/testdata/connect-termination.yaml
@@ -1,0 +1,35 @@
+# CONNECT requests hit Envoy's dedicated connect matcher, so they need their own route rather
+# than the catch-all rule in common.yaml.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: kgateway-base
+  name: route-dfp-connect
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: kgateway-base
+  rules:
+    - name: connect
+      matches:
+        - method: CONNECT
+      backendRefs:
+        - name: dfp-backend
+          group: gateway.kgateway.dev
+          kind: Backend
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: dfp-connect-termination
+  namespace: kgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: route-dfp-connect
+      sectionName: connect
+  httpUpgrade:
+    - type: CONNECT
+      connect:
+        terminate: true

--- a/test/e2e/features/dfp/types.go
+++ b/test/e2e/features/dfp/types.go
@@ -8,5 +8,11 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
 )
 
-// gatewayWithRouteManifest contains the DFP Backend and the HTTPRoute that targets it
-var gatewayWithRouteManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "common.yaml")
+var (
+	// gatewayWithRouteManifest contains the DFP Backend and the HTTPRoute that targets it
+	gatewayWithRouteManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "common.yaml")
+
+	// connectTerminationManifest contains the CONNECT route and the TrafficPolicy that
+	// terminates CONNECT on it
+	connectTerminationManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "connect-termination.yaml")
+)

--- a/test/e2e/features/listener_policy/suite.go
+++ b/test/e2e/features/listener_policy/suite.go
@@ -183,6 +183,13 @@ func (s *testingSuite) TestPreserveHttp1HeaderCase() {
 }
 
 func (s *testingSuite) TestAccessLogEmittedToStdout() {
+	// The access log policy rolls the gateway Deployment. Let it finish before sending any
+	// requests, so the pod that serves them is the one whose logs are read below.
+	s.TestInstallation.AssertionsT(s.T()).EventuallyDeploymentsRolledOut(
+		s.Ctx, proxyDeployment.ObjectMeta.GetNamespace(),
+		wellknown.GatewayNameLabel+"="+proxyObjectMeta.GetName(),
+	)
+
 	// First: trigger a 404 that SHOULD be logged (filter is GE 400)
 	s.TestInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
 		s.Ctx,
@@ -196,16 +203,19 @@ func (s *testingSuite) TestAccessLogEmittedToStdout() {
 	)
 
 	// Fetch gateway pod logs and verify the 404 access log JSON fields are present
+	ns := proxyDeployment.ObjectMeta.GetNamespace()
 	pods, err := s.TestInstallation.Actions.Kubectl().GetPodsInNsWithLabel(
-		s.Ctx, proxyDeployment.ObjectMeta.GetNamespace(),
+		s.Ctx, ns,
 		testdefaults.WellKnownAppLabel+"="+proxyDeployment.ObjectMeta.GetName(),
 	)
 	s.Require().NoError(err)
 	s.Require().Len(pods, 1)
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		logs, err := s.TestInstallation.Actions.Kubectl().GetContainerLogs(s.Ctx, proxyDeployment.ObjectMeta.GetNamespace(), pods[0])
-		s.Require().NoError(err)
+		logs, err := s.TestInstallation.Actions.Kubectl().GetContainerLogs(s.Ctx, ns, pods[0])
+		if !assert.NoError(c, err) {
+			return
+		}
 		// Check a few key fields configured in http-listener-policy-access-log.yaml jsonFormat
 		assert.Contains(c, logs, "\"method\":\"GET\"")
 		assert.Contains(c, logs, "\"protocol\":\"HTTP/1.1\"")
@@ -228,7 +238,7 @@ func (s *testingSuite) TestAccessLogEmittedToStdout() {
 	// Confirm 200 logs do not appear over a stability window as it isn't being immediately emitted
 	g := gomega.NewWithT(s.T())
 	g.Consistently(func() string {
-		out, err := s.TestInstallation.Actions.Kubectl().GetContainerLogs(s.Ctx, proxyDeployment.ObjectMeta.GetNamespace(), pods[0])
+		out, err := s.TestInstallation.Actions.Kubectl().GetContainerLogs(s.Ctx, ns, pods[0])
 		s.Require().NoError(err)
 		return out
 	}, 10*time.Second, 200*time.Millisecond).ShouldNot(gomega.ContainSubstring("\"response_code\":200"))

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -323,7 +323,7 @@ func ControllerDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, outLog i
 	outDir string, namespaces []string,
 ) {
 	for _, ns := range namespaces {
-		controllerPodNames, err := kubectlCli.GetPodsInNsWithLabel(ctx, ns, "kgateway=kgateway")
+		controllerPodNames, err := kubectlCli.GetAllPodsInNsWithLabel(ctx, ns, "kgateway=kgateway")
 		if err != nil {
 			fmt.Printf("error fetching controller pod names: %v\n", err)
 			continue
@@ -387,7 +387,7 @@ func EnvoyDumpOnFail(ctx context.Context, kubectlCli *kubectl.Cli, _ io.Writer, 
 	for _, ns := range namespaces {
 		proxies := []string{}
 
-		kubeGatewayProxies, err := kubectlCli.GetPodsInNsWithLabel(ctx, ns, "kgateway=kube-gateway")
+		kubeGatewayProxies, err := kubectlCli.GetAllPodsInNsWithLabel(ctx, ns, "kgateway=kube-gateway")
 		if err != nil {
 			fmt.Printf("error fetching kube-gateway proxies: %v\n", err)
 		} else {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Changes to mitigate test failures and flakes

* DFP CONNECT test - (failure) new test needs use http route names and can only run on GW API versions that support those.
* Localstack setup (flake) - wait for the rollout before waiting for pods
* GetPodsInNsWithLabel (flake) - now ignores terminating pods to prevent pollution from previous tests


Passing nightly run - https://github.com/sheidkamp/kgateway/actions/runs/34622225013

All changes except the DFP CONNECT test (which exists only in main) should be backported manually/agentically to all supported branches.


# Change Type



```
/kind test
```


# Changelog

<!--
Provide the exact line to appear in the release notes for this PR.

A PR gets one release note, filed under the highest-precedence /kind above.
If this change needs no release note, write "NONE" in the block below.
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
