### PR TITLE
feat: add UDPRoute support

### DIFF
--- a/api/v1alpha1/kgateway/doc.go
+++ b/api/v1alpha1/kgateway/doc.go
@@ -5,10 +5,10 @@
 package kgateway
 
 // Gateway API resources with status management
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses;gateways;httproutes;grpcroutes;tcproutes;tlsroutes;referencegrants;backendtlspolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses;gateways;httproutes;grpcroutes;tcproutes;tlsroutes;udproutes;referencegrants;backendtlspolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.x-k8s.io,resources=xlistenersets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=listenersets,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/status;gateways/status;httproutes/status;grpcroutes/status;tcproutes/status;tlsroutes/status;backendtlspolicies/status,verbs=patch;update
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/status;gateways/status;httproutes/status;grpcroutes/status;tcproutes/status;tlsroutes/status;udproutes/status;backendtlspolicies/status,verbs=patch;update
 // +kubebuilder:rbac:groups=gateway.networking.x-k8s.io,resources=xlistenersets/status,verbs=patch;update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=listenersets/status,verbs=patch;update
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=create;patch;update

--- a/install/helm/kgateway/templates/role.yaml
+++ b/install/helm/kgateway/templates/role.yaml
@@ -153,6 +153,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -168,6 +169,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/pkg/apiclient/fake/fake.go
+++ b/pkg/apiclient/fake/fake.go
@@ -235,6 +235,8 @@ func kindForSeededCRD(resource schema.GroupVersionResource) string {
 		return wellknown.GRPCRouteKind
 	case gvr.TCPRoute, wellknown.TCPRouteV1GVR:
 		return wellknown.TCPRouteKind
+	case wellknown.UDPRouteGVR:
+		return wellknown.UDPRouteKind
 	case gvr.TLSRoute, wellknown.TLSRouteV1Alpha3GVR:
 		return wellknown.TLSRouteKind
 	case gvr.ReferenceGrant:

--- a/pkg/apiclient/types.go
+++ b/pkg/apiclient/types.go
@@ -54,6 +54,19 @@ func registerTypes() {
 		},
 	)
 	kubeclient.Register(
+		wellknown.UDPRouteGVR,
+		wellknown.UDPRouteGVK,
+		func(c kubeclient.ClientGetter, namespace string, o metav1.ListOptions) (runtime.Object, error) {
+			return c.GatewayAPI().GatewayV1().UDPRoutes(namespace).List(context.Background(), o)
+		},
+		func(c kubeclient.ClientGetter, namespace string, o metav1.ListOptions) (watch.Interface, error) {
+			return c.GatewayAPI().GatewayV1().UDPRoutes(namespace).Watch(context.Background(), o)
+		},
+		func(c kubeclient.ClientGetter, namespace string) kubetypes.WriteAPI[*gwv1.UDPRoute] {
+			return c.GatewayAPI().GatewayV1().UDPRoutes(namespace)
+		},
+	)
+	kubeclient.Register(
 		wellknown.TLSRouteGVR,
 		wellknown.TLSRouteGVK,
 		func(c kubeclient.ClientGetter, namespace string, o metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/deployer/gatewayclass.go
+++ b/pkg/deployer/gatewayclass.go
@@ -45,9 +45,6 @@ func GetSupportedFeaturesForStandardGateway(enableExperimentalGatewayAPIFeatures
 			features.TLSRouteModeMixedFeature,
 		)
 	}
-	for _, feature := range features.UDPRouteFeatures.UnsortedList() {
-		exemptFeatures.Insert(feature)
-	}
 
 	return getSupportedFeatures(exemptFeatures)
 }

--- a/pkg/deployer/gatewayclass_test.go
+++ b/pkg/deployer/gatewayclass_test.go
@@ -55,3 +55,15 @@ func TestGetSupportedFeaturesForStandardGatewayIncludesStandardTLSRouteWhenExper
 		t.Fatalf("expected %q to be exempted when experimental Gateway API features are disabled", features.SupportTLSRouteModeMixed)
 	}
 }
+
+func TestGetSupportedFeaturesForStandardGatewayIncludesUDPRoute(t *testing.T) {
+	t.Helper()
+
+	// UDPRoute is standard channel as of Gateway API v1.6, so it is advertised on both channels.
+	for _, experimental := range []bool{false, true} {
+		supportedNames := supportedFeatureSet(GetSupportedFeaturesForStandardGateway(experimental))
+		if _, ok := supportedNames[gwv1.FeatureName(features.SupportUDPRoute)]; !ok {
+			t.Fatalf("expected %q to be supported (experimental=%v)", features.SupportUDPRoute, experimental)
+		}
+	}
+}

--- a/pkg/deployer/values_helpers.go
+++ b/pkg/deployer/values_helpers.go
@@ -49,7 +49,11 @@ func GetPortsValues(gw *ir.GatewayForDeployer, gwp *kgateway.GatewayParameters) 
 			logger.Error("skipping port", "gateway", gw.ResourceName(), "error", err)
 			continue
 		}
-		gwPorts = AppendPortValue(gwPorts, port, portName, gwp)
+		protocol := "TCP"
+		if gw.UDPPorts.Contains(port) {
+			protocol = "UDP"
+		}
+		gwPorts = AppendPortValue(gwPorts, port, portName, protocol, gwp)
 	}
 
 	// Add ports from GatewayParameters.Service.Ports
@@ -65,7 +69,11 @@ func GetPortsValues(gw *ir.GatewayForDeployer, gwp *kgateway.GatewayParameters) 
 				},
 			}
 			portName := listener.GenerateListenerName(l)
-			gwPorts = AppendPortValue(gwPorts, portValue, portName, gwp)
+			protocol := "TCP"
+			if gw.UDPPorts.Contains(portValue) {
+				protocol = "UDP"
+			}
+			gwPorts = AppendPortValue(gwPorts, portValue, portName, protocol, gwp)
 		}
 	}
 
@@ -86,13 +94,12 @@ func SanitizePortName(name string) string {
 	return str
 }
 
-func AppendPortValue(gwPorts []HelmPort, port int32, name string, gwp *kgateway.GatewayParameters) []HelmPort {
+func AppendPortValue(gwPorts []HelmPort, port int32, name, protocol string, gwp *kgateway.GatewayParameters) []HelmPort {
 	if istioslices.IndexFunc(gwPorts, func(p HelmPort) bool { return *p.Port == port }) != -1 {
 		return gwPorts
 	}
 
 	portName := SanitizePortName(name)
-	protocol := "TCP"
 
 	// Search for static NodePort set from the GatewayParameters spec.
 	// NodePort and LoadBalancer both support explicit node ports; if not set, nil renders nothing.

--- a/pkg/deployer/values_helpers_test.go
+++ b/pkg/deployer/values_helpers_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/util/smallset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kgateway-dev/kgateway/v2/api/v1alpha1/kgateway"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
 )
 
 func TestComponentLogLevelsToString(t *testing.T) {
@@ -290,4 +292,24 @@ func TestGetServiceValues(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestGetPortsValuesUDPProtocol(t *testing.T) {
+	gw := &ir.GatewayForDeployer{
+		Ports:    smallset.New[int32](8080, 5300),
+		UDPPorts: smallset.New[int32](5300),
+	}
+
+	ports := GetPortsValues(gw, nil)
+	assert.Len(t, ports, 2)
+
+	byPort := map[int32]string{}
+	for _, p := range ports {
+		assert.NotNil(t, p.Port)
+		assert.NotNil(t, p.Protocol)
+		byPort[*p.Port] = *p.Protocol
+	}
+
+	assert.Equal(t, "TCP", byPort[8080], "non-UDP listener port must render as TCP")
+	assert.Equal(t, "UDP", byPort[5300], "UDP listener port must render as UDP")
 }

--- a/pkg/kgateway/proxy_syncer/proxy_syncer.go
+++ b/pkg/kgateway/proxy_syncer/proxy_syncer.go
@@ -280,13 +280,26 @@ func (s *ProxySyncer) Init(ctx context.Context, krtopts krtutil.KrtOptions) {
 		s.uniqueClients,
 	)
 
+	// Weighted multi-backend UDPRoutes route to a synthetic cluster whose CLA is the weighted
+	// union of their backends' endpoints; build it as an extra per-client endpoint collection.
+	extraEndpoints := []PerClientEnvoyEndpoints{localClusterEpPerClient}
+	if s.commonCols.ResolvedUDPRoutes != nil {
+		udpAggregates := newUdpAggregateCollection(krtopts, s.commonCols.ResolvedUDPRoutes)
+		extraEndpoints = append(extraEndpoints, NewPerClientUdpAggregateEndpoints(
+			krtopts,
+			s.uniqueClients,
+			udpAggregates,
+			s.commonCols.Endpoints,
+		))
+	}
+
 	s.perclientSnapCollection = snapshotPerClient(
 		krtopts,
 		s.uniqueClients,
 		s.mostXdsSnapshots,
 		epPerClient,
 		clustersPerClient,
-		localClusterEpPerClient,
+		extraEndpoints...,
 	)
 
 	excludedPolicyKinds := make(map[schema.GroupKind]struct{})

--- a/pkg/kgateway/proxy_syncer/status_collections.go
+++ b/pkg/kgateway/proxy_syncer/status_collections.go
@@ -60,6 +60,9 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 	tlsRouteReports := statussync.RegisterKindByObjectGVK(s.statusCollections, wellknown.TLSRouteGVK,
 		s.commonCols.RawTLSRoutes, s.statusContributions, contributionsByTarget,
 		krtopts.ToOptions("TLSRouteStatusReports")...)
+	udpRouteReports := statussync.RegisterKind(s.statusCollections, wellknown.UDPRouteGVK,
+		s.commonCols.RawUDPRoutes, s.statusContributions, contributionsByTarget,
+		krtopts.ToOptions("UDPRouteStatusReports")...)
 
 	registerStatusWriter(s.statusWriters, wellknown.HTTPRouteGVK,
 		routeWriter(cl, f, s.commonCols.RawHTTPRoutes, httpRouteReports, wellknown.HTTPRouteGVK, wellknown.HTTPRouteGVR, controllerName,
@@ -136,6 +139,15 @@ func (s *ProxySyncer) initStatusInfra(krtopts krtutil.KrtOptions) {
 				))
 		}
 	}
+
+	registerStatusWriter(s.statusWriters, wellknown.UDPRouteGVK,
+		routeWriter(cl, f, s.commonCols.RawUDPRoutes, udpRouteReports, wellknown.UDPRouteGVK, wellknown.UDPRouteGVR, controllerName,
+			func(om metav1.ObjectMeta, st gwv1.RouteStatus) *gwv1.UDPRoute {
+				return &gwv1.UDPRoute{ObjectMeta: om, Status: gwv1.UDPRouteStatus{RouteStatus: st}}
+			},
+			func(o *gwv1.UDPRoute) gwv1.RouteStatus { return o.Status.RouteStatus },
+			func(o *gwv1.UDPRoute) []gwv1.ParentReference { return o.Spec.ParentRefs },
+		))
 
 	// Both ListenerSet flavors normalize to one collection and one report reducer keyed by the
 	// object's own GVK, but they are written back through different APIs, so each GVK gets its

--- a/pkg/kgateway/proxy_syncer/udp_aggregate.go
+++ b/pkg/kgateway/proxy_syncer/udp_aggregate.go
@@ -1,0 +1,237 @@
+package proxy_syncer
+
+import (
+	"cmp"
+	"hash/fnv"
+	"slices"
+	"strconv"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/kgateway/utils"
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+	krtutil "github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/krtutil"
+	krtpkg "github.com/kgateway-dev/kgateway/v2/pkg/utils/krtutil"
+)
+
+// udpWeightScale scales backendRef weights into per-endpoint load-balancing weights. Envoy only
+// needs proportionality, so a fixed scale (with a floor of 1) avoids overflow and gives ~0.1%
+// granularity, which is far finer than any realistic weight split.
+const udpWeightScale uint64 = 1000
+
+type udpAggregateMember struct {
+	// backendResourceName matches ir.EndpointsForBackend.UpstreamResourceName.
+	backendResourceName string
+	weight              uint32
+}
+
+// udpAggregate describes the synthetic cluster a multi-backend UDPRoute routes to: a set of
+// weighted member backends whose endpoints are unioned into one weighted endpoint set.
+type udpAggregate struct {
+	clusterName string
+	members     []udpAggregateMember
+}
+
+func (u udpAggregate) ResourceName() string { return u.clusterName }
+
+func (u udpAggregate) Equals(o udpAggregate) bool {
+	return u.clusterName == o.clusterName && slices.Equal(u.members, o.members)
+}
+
+// newUdpAggregateCollection derives one aggregate descriptor per multi-backend UDPRoute. Invalid
+// backends (no resolved object) contribute no endpoints; their weight share is redistributed to
+// the valid backends rather than dropped (a documented divergence from the Extended-support
+// weighted-drop clause, which udp_proxy cannot express).
+func newUdpAggregateCollection(
+	krtopts krtutil.KrtOptions,
+	udpRoutes krt.Collection[ir.UdpRouteIR],
+) krt.Collection[udpAggregate] {
+	return krt.NewCollection(udpRoutes, func(_ krt.HandlerContext, r ir.UdpRouteIR) *udpAggregate {
+		// Must mirror translateUdpFilterChain's decision (>1 backendRef => synthetic cluster): the
+		// listener emits the CDS cluster for exactly these routes, and every CDS cluster needs a
+		// CLA or the client's whole EDS response is withheld (issue #14471). Members may be empty
+		// (all invalid/zero-weight) -> a valid, empty CLA that simply drops traffic.
+		if len(r.Backends) <= 1 {
+			return nil
+		}
+		members := make([]udpAggregateMember, 0, len(r.Backends))
+		for _, b := range r.Backends {
+			if b.BackendObject == nil || b.Weight == 0 {
+				continue
+			}
+			members = append(members, udpAggregateMember{
+				backendResourceName: b.BackendObject.ResourceName(),
+				weight:              b.Weight,
+			})
+		}
+		return &udpAggregate{
+			clusterName: ir.UdpAggregateClusterName(r.Namespace, r.Name),
+			members:     members,
+		}
+	}, krtopts.ToOptions("UdpAggregates")...)
+}
+
+// NewPerClientUdpAggregateEndpoints builds the per-client CLA for each UDP aggregate cluster. The
+// endpoint set is client-independent (the weighted union of the member backends' endpoints), so it
+// is built once per aggregate and emitted for every client that could reference the cluster; this
+// keeps the CLA present whenever the synthetic CDS cluster is (see issue #14471).
+func NewPerClientUdpAggregateEndpoints(
+	krtopts krtutil.KrtOptions,
+	uccs krt.Collection[ir.UniquelyConnectedClient],
+	aggregates krt.Collection[udpAggregate],
+	backendEndpoints krt.Collection[ir.EndpointsForBackend],
+) PerClientEnvoyEndpoints {
+	epByBackend := krtpkg.UnnamedIndex(backendEndpoints, func(e ir.EndpointsForBackend) []string {
+		return []string{e.UpstreamResourceName}
+	})
+
+	endpoints := krt.NewManyCollection(aggregates, func(kctx krt.HandlerContext, agg udpAggregate) []UccWithEndpoints {
+		cla := buildUdpAggregateLoadAssignment(kctx, agg, backendEndpoints, epByBackend)
+		hash := hashUdpAggregateLoadAssignment(cla)
+		clients := krt.Fetch(kctx, uccs)
+		ret := make([]UccWithEndpoints, 0, len(clients))
+		for _, ucc := range clients {
+			ret = append(ret, UccWithEndpoints{
+				Client:        ucc,
+				Endpoints:     cla,
+				EndpointsHash: hash,
+				endpointsName: agg.clusterName,
+				resourceName:  uccEndpointsResourceName(ucc, agg.clusterName),
+			})
+		}
+		return ret
+	}, krtopts.ToOptions("UdpAggregateEndpoints")...)
+
+	idx := krtpkg.UnnamedIndex(endpoints, func(u UccWithEndpoints) []string {
+		return []string{u.Client.ResourceName()}
+	})
+
+	return PerClientEnvoyEndpoints{endpoints: endpoints, index: idx}
+}
+
+// udpMemberEndpoints pairs a member's backendRef weight with its resolved endpoints, decoupling
+// the krt Fetch from the (unit-tested) weight-merge below.
+type udpMemberEndpoints struct {
+	weight uint32
+	efbs   []ir.EndpointsForBackend
+}
+
+func buildUdpAggregateLoadAssignment(
+	kctx krt.HandlerContext,
+	agg udpAggregate,
+	backendEndpoints krt.Collection[ir.EndpointsForBackend],
+	epByBackend krt.Index[string, ir.EndpointsForBackend],
+) *envoyendpointv3.ClusterLoadAssignment {
+	members := make([]udpMemberEndpoints, 0, len(agg.members))
+	for _, m := range agg.members {
+		members = append(members, udpMemberEndpoints{
+			weight: m.weight,
+			efbs:   krt.Fetch(kctx, backendEndpoints, krt.FilterIndex(epByBackend, m.backendResourceName)),
+		})
+	}
+	return mergeUdpAggregateLoadAssignment(agg.clusterName, members)
+}
+
+// mergeUdpAggregateLoadAssignment unions the members' endpoints into one weighted CLA. Each
+// endpoint's load-balancing weight is its member's backendRef weight scaled by udpWeightScale and
+// divided by that member's live endpoint count, so a member's total weight stays proportional to
+// its backendRef weight regardless of replica count. Per-locality weight is the sum of its
+// endpoints' weights, which under the cluster's LocalityWeightedLbConfig telescopes to the intended
+// per-endpoint probability.
+func mergeUdpAggregateLoadAssignment(clusterName string, members []udpMemberEndpoints) *envoyendpointv3.ClusterLoadAssignment {
+	byLocality := map[ir.PodLocality][]*envoyendpointv3.LbEndpoint{}
+	var localityOrder []ir.PodLocality
+
+	for _, m := range members {
+		count := 0
+		for _, efb := range m.efbs {
+			for _, eps := range efb.LbEps {
+				count += len(eps)
+			}
+		}
+		if count == 0 {
+			continue
+		}
+		//nolint:gosec // G115: count is a positive endpoint count (guarded > 0 above)
+		perEndpointWeight := (uint64(m.weight) * udpWeightScale) / uint64(count)
+		if perEndpointWeight == 0 {
+			perEndpointWeight = 1
+		}
+		if perEndpointWeight > uint64(^uint32(0)) {
+			perEndpointWeight = uint64(^uint32(0))
+		}
+		for _, efb := range m.efbs {
+			for locality, eps := range efb.LbEps {
+				for _, ep := range eps {
+					if ep.LbEndpoint == nil {
+						continue
+					}
+					clone := proto.Clone(ep.LbEndpoint).(*envoyendpointv3.LbEndpoint)
+					//nolint:gosec // G115: perEndpointWeight is clamped to uint32 max above
+					clone.LoadBalancingWeight = wrapperspb.UInt32(uint32(perEndpointWeight))
+					if _, ok := byLocality[locality]; !ok {
+						localityOrder = append(localityOrder, locality)
+					}
+					byLocality[locality] = append(byLocality[locality], clone)
+				}
+			}
+		}
+	}
+
+	slices.SortFunc(localityOrder, func(a, b ir.PodLocality) int {
+		return cmp.Compare(a.String(), b.String())
+	})
+
+	cla := &envoyendpointv3.ClusterLoadAssignment{ClusterName: clusterName}
+	for _, locality := range localityOrder {
+		eps := byLocality[locality]
+		slices.SortFunc(eps, func(a, b *envoyendpointv3.LbEndpoint) int {
+			return cmp.Compare(lbEndpointSortKey(a), lbEndpointSortKey(b))
+		})
+		var localityWeight uint32
+		for _, ep := range eps {
+			localityWeight += ep.GetLoadBalancingWeight().GetValue()
+		}
+		lle := &envoyendpointv3.LocalityLbEndpoints{
+			LbEndpoints:         eps,
+			LoadBalancingWeight: wrapperspb.UInt32(localityWeight),
+		}
+		if locality != (ir.PodLocality{}) {
+			lle.Locality = &envoycorev3.Locality{
+				Region:  locality.Region,
+				Zone:    locality.Zone,
+				SubZone: locality.Subzone,
+			}
+		}
+		cla.Endpoints = append(cla.GetEndpoints(), lle)
+	}
+	return cla
+}
+
+func lbEndpointSortKey(ep *envoyendpointv3.LbEndpoint) string {
+	sa := ep.GetEndpoint().GetAddress().GetSocketAddress()
+	return sa.GetAddress() + ":" + strconv.FormatUint(uint64(sa.GetPortValue()), 10)
+}
+
+func hashUdpAggregateLoadAssignment(cla *envoyendpointv3.ClusterLoadAssignment) uint64 {
+	hasher := fnv.New64a()
+	utils.HashStringField(hasher, cla.GetClusterName())
+	for _, lle := range cla.GetEndpoints() {
+		loc := lle.GetLocality()
+		utils.HashStringField(hasher, loc.GetRegion())
+		utils.HashStringField(hasher, loc.GetZone())
+		utils.HashStringField(hasher, loc.GetSubZone())
+		utils.HashStringField(hasher, strconv.FormatUint(uint64(lle.GetLoadBalancingWeight().GetValue()), 10))
+		for _, ep := range lle.GetLbEndpoints() {
+			sa := ep.GetEndpoint().GetAddress().GetSocketAddress()
+			utils.HashStringField(hasher, sa.GetAddress())
+			utils.HashStringField(hasher, strconv.FormatUint(uint64(sa.GetPortValue()), 10))
+			utils.HashStringField(hasher, strconv.FormatUint(uint64(ep.GetLoadBalancingWeight().GetValue()), 10))
+		}
+	}
+	return hasher.Sum64()
+}

--- a/pkg/kgateway/proxy_syncer/udp_aggregate_test.go
+++ b/pkg/kgateway/proxy_syncer/udp_aggregate_test.go
@@ -1,0 +1,115 @@
+package proxy_syncer
+
+import (
+	"testing"
+
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoyendpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/pluginsdk/ir"
+)
+
+func udpTestEndpoint(addr string) ir.EndpointWithMd {
+	return ir.EndpointWithMd{
+		LbEndpoint: &envoyendpointv3.LbEndpoint{
+			HostIdentifier: &envoyendpointv3.LbEndpoint_Endpoint{
+				Endpoint: &envoyendpointv3.Endpoint{
+					Address: &envoycorev3.Address{
+						Address: &envoycorev3.Address_SocketAddress{
+							SocketAddress: &envoycorev3.SocketAddress{
+								Address:       addr,
+								PortSpecifier: &envoycorev3.SocketAddress_PortValue{PortValue: 8080},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func efbInDefaultLocality(eps ...ir.EndpointWithMd) ir.EndpointsForBackend {
+	return ir.EndpointsForBackend{LbEps: ir.LocalityLbMap{ir.PodLocality{}: eps}}
+}
+
+// endpointWeight looks up the LB weight of the endpoint with the given address in a CLA.
+func endpointWeight(cla *envoyendpointv3.ClusterLoadAssignment, addr string) (uint32, bool) {
+	for _, lle := range cla.GetEndpoints() {
+		for _, ep := range lle.GetLbEndpoints() {
+			if ep.GetEndpoint().GetAddress().GetSocketAddress().GetAddress() == addr {
+				return ep.GetLoadBalancingWeight().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestMergeUdpAggregateLoadAssignment_WeightsRespectReplicaCount(t *testing.T) {
+	// Member A: weight 90 across 2 endpoints. Member B: weight 10 across 1 endpoint.
+	// Each member's TOTAL weight must stay proportional to its backendRef weight (90:10),
+	// independent of how many endpoints it has.
+	members := []udpMemberEndpoints{
+		{weight: 90, efbs: []ir.EndpointsForBackend{efbInDefaultLocality(
+			udpTestEndpoint("10.0.0.1"), udpTestEndpoint("10.0.0.2"),
+		)}},
+		{weight: 10, efbs: []ir.EndpointsForBackend{efbInDefaultLocality(
+			udpTestEndpoint("10.0.1.1"),
+		)}},
+	}
+
+	cla := mergeUdpAggregateLoadAssignment("udpagg_test", members)
+	require.Equal(t, "udpagg_test", cla.GetClusterName())
+	require.Len(t, cla.GetEndpoints(), 1, "all endpoints share the default locality")
+
+	wA1, ok := endpointWeight(cla, "10.0.0.1")
+	require.True(t, ok)
+	wA2, _ := endpointWeight(cla, "10.0.0.2")
+	wB, _ := endpointWeight(cla, "10.0.1.1")
+
+	// Per-endpoint: A = 90*1000/2 = 45000; B = 10*1000/1 = 10000.
+	assert.Equal(t, uint32(45000), wA1)
+	assert.Equal(t, uint32(45000), wA2)
+	assert.Equal(t, uint32(10000), wB)
+
+	// Totals per member: A = 90000, B = 10000 -> 9:1, matching the 90:10 backendRef weights.
+	assert.Equal(t, uint32(90000), wA1+wA2)
+	assert.Equal(t, uint32(10000), wB)
+
+	// Locality weight is the sum of its endpoints' weights.
+	assert.Equal(t, uint32(100000), cla.GetEndpoints()[0].GetLoadBalancingWeight().GetValue())
+}
+
+func TestMergeUdpAggregateLoadAssignment_SkipsEmptyAndZeroWeight(t *testing.T) {
+	members := []udpMemberEndpoints{
+		{weight: 100, efbs: []ir.EndpointsForBackend{efbInDefaultLocality(udpTestEndpoint("10.0.0.1"))}},
+		{weight: 50, efbs: nil}, // invalid/no endpoints: contributes nothing
+	}
+	cla := mergeUdpAggregateLoadAssignment("udpagg_test", members)
+	require.Len(t, cla.GetEndpoints(), 1)
+	require.Len(t, cla.GetEndpoints()[0].GetLbEndpoints(), 1)
+	w, ok := endpointWeight(cla, "10.0.0.1")
+	require.True(t, ok)
+	assert.Equal(t, uint32(100000), w) // 100*1000/1
+}
+
+func TestMergeUdpAggregateLoadAssignment_MultiLocality(t *testing.T) {
+	// One member, one endpoint per locality; each locality's weight is that endpoint's weight.
+	members := []udpMemberEndpoints{
+		{weight: 10, efbs: []ir.EndpointsForBackend{{
+			LbEps: ir.LocalityLbMap{
+				ir.PodLocality{Region: "r1", Zone: "z1"}: {udpTestEndpoint("10.0.0.1")},
+				ir.PodLocality{Region: "r2", Zone: "z2"}: {udpTestEndpoint("10.0.0.2")},
+			},
+		}}},
+	}
+	cla := mergeUdpAggregateLoadAssignment("udpagg_test", members)
+	require.Len(t, cla.GetEndpoints(), 2)
+	// 10*1000/2 = 5000 per endpoint; each locality has one endpoint so locality weight = 5000.
+	for _, lle := range cla.GetEndpoints() {
+		require.Len(t, lle.GetLbEndpoints(), 1)
+		assert.Equal(t, uint32(5000), lle.GetLbEndpoints()[0].GetLoadBalancingWeight().GetValue())
+		assert.Equal(t, uint32(5000), lle.GetLoadBalancingWeight().GetValue())
+	}
+}

--- a/pkg/kgateway/query/backend_variants.go
+++ b/pkg/kgateway/query/backend_variants.go
@@ -130,6 +130,11 @@ func cloneRouteWithVariants(route ir.Route, variants map[string]*ir.BackendObjec
 		clone.Hostnames = slices.Clone(typed.Hostnames)
 		clone.Backends = cloneBackendRefsWithVariants(typed.Backends, variants)
 		return &clone
+	case *ir.UdpRouteIR:
+		clone := *typed
+		clone.ParentRefs = slices.Clone(typed.ParentRefs)
+		clone.Backends = cloneBackendRefsWithVariants(typed.Backends, variants)
+		return &clone
 	default:
 		return route
 	}
@@ -196,6 +201,10 @@ func collectRouteBackends(route *RouteInfo, visit func(*ir.BackendObjectIR)) {
 			visit(backend.BackendObject)
 		}
 	case *ir.TlsRouteIR:
+		for _, backend := range typed.Backends {
+			visit(backend.BackendObject)
+		}
+	case *ir.UdpRouteIR:
 		for _, backend := range typed.Backends {
 			visit(backend.BackendObject)
 		}

--- a/pkg/kgateway/query/query_test.go
+++ b/pkg/kgateway/query/query_test.go
@@ -1351,8 +1351,9 @@ func newQueries(t test.Failer, initObjs ...client.Object) query.GatewayQueries {
 	httproutes := krttest.GetMockCollection[*gwv1.HTTPRoute](mock)
 	tcpproutes := krttest.GetMockCollection[*gwv1a2.TCPRoute](mock)
 	tlsroutes := krttest.GetMockCollection[*gwv1a2.TLSRoute](mock)
+	udproutes := krttest.GetMockCollection[*gwv1.UDPRoute](mock)
 	grpcroutes := krttest.GetMockCollection[*gwv1.GRPCRoute](mock)
-	rtidx := krtcollections.NewRoutesIndex(krtutil.KrtOptions{}, httproutes, grpcroutes, tcpproutes, tlsroutes, policies, upstreams, refgrants, apisettings.Settings{})
+	rtidx := krtcollections.NewRoutesIndex(krtutil.KrtOptions{}, httproutes, grpcroutes, tcpproutes, tlsroutes, udproutes, policies, upstreams, refgrants, apisettings.Settings{})
 	services.WaitUntilSynced(nil)
 
 	secretsCol := map[schema.GroupKind]krt.Collection[ir.Secret]{

--- a/pkg/kgateway/query/route.go
+++ b/pkg/kgateway/query/route.go
@@ -123,6 +123,7 @@ func (r *gatewayQueries) GetRouteChain(
 	case *ir.TcpRouteIR:
 		// TODO (danehans): Should TCPRoute delegation support be added in the future?
 	case *ir.TlsRouteIR:
+	case *ir.UdpRouteIR:
 	default:
 		return nil
 	}
@@ -214,7 +215,7 @@ func defaultAllowedRouteKinds(l *gwv1.Listener) []metav1.GroupKind {
 	case gwv1.TCPProtocolType:
 		return []metav1.GroupKind{{Kind: wellknown.TCPRouteKind, Group: gwv1.GroupName}}
 	case gwv1.UDPProtocolType:
-		return []metav1.GroupKind{{}}
+		return []metav1.GroupKind{{Kind: wellknown.UDPRouteKind, Group: gwv1.GroupName}}
 	default:
 		// allow custom protocols to work
 		return []metav1.GroupKind{{Kind: wellknown.HTTPRouteKind, Group: gwv1.GroupName}}

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -1299,7 +1299,7 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
-	t.Run("udproute with multiple backends is rejected", func(t *testing.T) {
+	t.Run("udp gateway with weighted multiple backends", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"udp-routing/multi-backend.yaml"},
 			outputFile: "udp-routing/multi-backend-proxy.yaml",

--- a/pkg/kgateway/translator/gateway/gateway_translator_test.go
+++ b/pkg/kgateway/translator/gateway/gateway_translator_test.go
@@ -1288,6 +1288,28 @@ func TestBasic(t *testing.T) {
 		})
 	})
 
+	t.Run("udp gateway with basic routing", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"udp-routing/basic.yaml"},
+			outputFile: "udp-routing/basic-proxy.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
+	t.Run("udproute with multiple backends is rejected", func(t *testing.T) {
+		test(t, translatorTestCase{
+			inputFiles: []string{"udp-routing/multi-backend.yaml"},
+			outputFile: "udp-routing/multi-backend-proxy.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+		})
+	})
+
 	t.Run("tcproute with missing backend reports correctly", func(t *testing.T) {
 		test(t, translatorTestCase{
 			inputFiles: []string{"tcp-routing/missing-backend.yaml"},

--- a/pkg/kgateway/translator/gateway/testutils/inputs/udp-routing/basic.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/udp-routing/basic.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: example-udp-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  rules:
+  - backendRefs:
+    - name: example-udp-svc
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: udp
+    protocol: UDP
+    port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-udp-svc
+spec:
+  selector:
+    app: example
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 80

--- a/pkg/kgateway/translator/gateway/testutils/inputs/udp-routing/multi-backend.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/inputs/udp-routing/multi-backend.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: example-udp-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  rules:
+  - backendRefs:
+    - name: example-udp-svc
+      port: 8080
+      weight: 90
+    - name: example-udp-svc-2
+      port: 8080
+      weight: 10
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: udp
+    protocol: UDP
+    port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-udp-svc
+spec:
+  selector:
+    app: example
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-udp-svc-2
+spec:
+  selector:
+    app: example-2
+  ports:
+    - protocol: UDP
+      port: 8080
+      targetPort: 80

--- a/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/listener-sets/accepted-ls-rejected-listener.yaml
@@ -155,7 +155,8 @@ Statuses:
     default/foo-listenerset:
       conditions:
       - lastTransitionTime: null
-        message: ""
+        message: 'Some listeners are not programmed: udp-9091: invalid port 9091 in
+          listener: port is reserved'
         reason: ListenersNotValid
         status: "True"
         type: Accepted
@@ -196,23 +197,26 @@ Statuses:
       - attachedRoutes: 0
         conditions:
         - lastTransitionTime: null
-          message: Protocol UDP is unsupported.
-          reason: UnsupportedProtocol
+          message: 'invalid port 9091 in listener: port is reserved'
+          reason: Invalid
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: 'invalid port 9091 in listener: port is reserved'
+          reason: Invalid
           status: "False"
           type: Accepted
         - lastTransitionTime: null
-          message: Successfully verified that Listener has no conflicts
-          reason: NoConflicts
+          message: 'invalid port 9091 in listener: port is reserved'
+          reason: Invalid
           status: "False"
-          type: Conflicted
+          type: Programmed
         - lastTransitionTime: null
           message: Successfully resolved all references
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
-        - lastTransitionTime: null
-          message: Successfully programmed Listener
-          reason: Programmed
-          status: "True"
-          type: Programmed
         name: udp-9091
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute

--- a/pkg/kgateway/translator/gateway/testutils/outputs/udp-routing/basic-proxy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/udp-routing/basic-proxy.yaml
@@ -1,0 +1,103 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-udp-svc_8080
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+      protocol: UDP
+  listenerFilters:
+  - name: envoy.filters.udp_listener.udp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig
+      matcher:
+        onNoMatch:
+          action:
+            name: route
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+              cluster: kube_default_example-udp-svc_8080
+      statPrefix: listener~8080-default.example-udp-route-rule-0
+  name: listener~8080
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: Successfully accepted Gateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
+        name: udp
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute
+  udpRoutes:
+    default/example-udp-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: ""
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/pkg/kgateway/translator/gateway/testutils/outputs/udp-routing/multi-backend-proxy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/udp-routing/multi-backend-proxy.yaml
@@ -21,14 +21,44 @@ Clusters:
   type: EDS
 - connectTimeout: 5s
   name: test-backend-plugin_default_example-svc_80
+ExtraClusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: udpagg_default_example-udp-route
+  type: EDS
+Listeners:
+- address:
+    socketAddress:
+      address: '::'
+      ipv4Compat: true
+      portValue: 8080
+      protocol: UDP
+  listenerFilters:
+  - name: envoy.filters.udp_listener.udp_proxy
+    typedConfig:
+      '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig
+      matcher:
+        onNoMatch:
+          action:
+            name: route
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+              cluster: udpagg_default_example-udp-route
+      statPrefix: listener~8080-default.example-udp-route-rule-0
+  name: listener~8080
 Statuses:
   gateways:
     default/example-gateway:
       conditions:
       - lastTransitionTime: null
-        message: 'Some listeners are not programmed: udp: UDP listener has no valid
-          backends or routes'
-        reason: ListenersNotValid
+        message: Successfully accepted Gateway
+        reason: Accepted
         status: "True"
         type: Accepted
       - lastTransitionTime: null
@@ -45,11 +75,6 @@ Statuses:
       - attachedRoutes: 1
         conditions:
         - lastTransitionTime: null
-          message: UDP listener has no valid backends or routes
-          reason: Invalid
-          status: "False"
-          type: Programmed
-        - lastTransitionTime: null
           message: Successfully accepted Listener
           reason: Accepted
           status: "True"
@@ -64,6 +89,11 @@ Statuses:
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Listener
+          reason: Programmed
+          status: "True"
+          type: Programmed
         name: udp
         supportedKinds:
         - group: gateway.networking.k8s.io
@@ -73,9 +103,9 @@ Statuses:
       parents:
       - conditions:
         - lastTransitionTime: null
-          message: UDPRoute with multiple backendRefs is not supported
-          reason: UnsupportedValue
-          status: "False"
+          message: ""
+          reason: Accepted
+          status: "True"
           type: Accepted
         - lastTransitionTime: null
           message: Successfully resolved all references

--- a/pkg/kgateway/translator/gateway/testutils/outputs/udp-routing/multi-backend-proxy.yaml
+++ b/pkg/kgateway/translator/gateway/testutils/outputs/udp-routing/multi-backend-proxy.yaml
@@ -1,0 +1,94 @@
+Clusters:
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-udp-svc-2_8080
+  type: EDS
+- commonLbConfig:
+    localityWeightedLbConfig: {}
+  connectTimeout: 5s
+  edsClusterConfig:
+    edsConfig:
+      ads: {}
+      resourceApiVersion: V3
+  ignoreHealthOnHostRemoval: true
+  name: kube_default_example-udp-svc_8080
+  type: EDS
+- connectTimeout: 5s
+  name: test-backend-plugin_default_example-svc_80
+Statuses:
+  gateways:
+    default/example-gateway:
+      conditions:
+      - lastTransitionTime: null
+        message: 'Some listeners are not programmed: udp: UDP listener has no valid
+          backends or routes'
+        reason: ListenersNotValid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: null
+        message: Successfully programmed Gateway
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: null
+        message: Successfully resolved all Gateway references
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      listeners:
+      - attachedRoutes: 1
+        conditions:
+        - lastTransitionTime: null
+          message: UDP listener has no valid backends or routes
+          reason: Invalid
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: null
+          message: Successfully accepted Listener
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully verified that Listener has no conflicts
+          reason: NoConflicts
+          status: "False"
+          type: Conflicted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        name: udp
+        supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute
+  udpRoutes:
+    default/example-udp-route:
+      parents:
+      - conditions:
+        - lastTransitionTime: null
+          message: UDPRoute with multiple backendRefs is not supported
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: null
+          message: Successfully resolved all references
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: null
+          message: Successfully programmed Route
+          reason: Programmed
+          status: "True"
+          type: kgateway.dev/Programmed
+        controllerName: kgateway
+        parentRef:
+          group: ""
+          kind: ""
+          name: example-gateway

--- a/pkg/kgateway/translator/irtranslator/backend.go
+++ b/pkg/kgateway/translator/irtranslator/backend.go
@@ -350,6 +350,30 @@ func initializeCluster(b *ir.BackendObjectIR) *envoyclusterv3.Cluster {
 	return out
 }
 
+// buildUdpAggregateCluster builds the synthetic EDS cluster a multi-backend UDPRoute routes to.
+// Its endpoints (served separately as a per-client CLA of the same name) are the weighted union
+// of the route's backends. LocalityWeightedLbConfig is always set so Envoy honors the per-locality
+// endpoint weights that carry the backend weighting.
+func buildUdpAggregateCluster(name string) *envoyclusterv3.Cluster {
+	return &envoyclusterv3.Cluster{
+		Name:                 name,
+		ConnectTimeout:       durationpb.New(clusterConnectionTimeout),
+		ClusterDiscoveryType: &envoyclusterv3.Cluster_Type{Type: envoyclusterv3.Cluster_EDS},
+		EdsClusterConfig: &envoyclusterv3.Cluster_EdsClusterConfig{
+			EdsConfig: &envoycorev3.ConfigSource{
+				ResourceApiVersion:    envoycorev3.ApiVersion_V3,
+				ConfigSourceSpecifier: &envoycorev3.ConfigSource_Ads{Ads: &envoycorev3.AggregatedConfigSource{}},
+			},
+		},
+		CommonLbConfig: &envoyclusterv3.Cluster_CommonLbConfig{
+			LocalityConfigSpecifier: &envoyclusterv3.Cluster_CommonLbConfig_LocalityWeightedLbConfig_{
+				LocalityWeightedLbConfig: &envoyclusterv3.Cluster_CommonLbConfig_LocalityWeightedLbConfig{},
+			},
+		},
+		IgnoreHealthOnHostRemoval: true,
+	}
+}
+
 func buildBlackholeCluster(b *ir.BackendObjectIR) *envoyclusterv3.Cluster {
 	out := &envoyclusterv3.Cluster{
 		Name:     b.ClusterName(),

--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -3,6 +3,8 @@ package irtranslator
 import (
 	"fmt"
 
+	xdscorev3 "github.com/cncf/xds/go/xds/core/v3"
+	xdsmatcherv3 "github.com/cncf/xds/go/xds/type/matcher/v3"
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
@@ -10,6 +12,7 @@ import (
 	envoy_tls_inspector "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoytcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	udpproxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/udp/udp_proxy/v3"
 	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoymatcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -28,6 +31,10 @@ import (
 const (
 	DefaultHttpStatPrefix   = "http"
 	UpstreamCodecFilterName = "envoy.filters.http.upstream_codec"
+	// UDPProxyFilterName is the Envoy registered name for the udp_proxy listener filter.
+	// The go-control-plane wellknown package has no constant for it (unlike TCPProxy), and
+	// the registered name differs from the proto type URL's "udp" path segment.
+	UDPProxyFilterName = "envoy.filters.udp_listener.udp_proxy"
 )
 
 var defaultDownstreamAlpnProtocols = []string{"h2", "http/1.1"}
@@ -41,7 +48,7 @@ type filterChainTranslator struct {
 	pluginPass TranslationPassPlugins
 }
 
-func computeListenerAddress(bindAddress string, port uint32, reporter sdkreporter.GatewayReporter) (*envoycorev3.Address, error) {
+func computeListenerAddress(bindAddress string, port uint32, protocol envoycorev3.SocketAddress_Protocol, reporter sdkreporter.GatewayReporter) (*envoycorev3.Address, error) {
 	_, isIpv4Address, err := utils.IsIpv4Address(bindAddress)
 	if err != nil {
 		reporter.SetCondition(sdkreporter.GatewayCondition{
@@ -56,7 +63,7 @@ func computeListenerAddress(bindAddress string, port uint32, reporter sdkreporte
 	return &envoycorev3.Address{
 		Address: &envoycorev3.Address_SocketAddress{
 			SocketAddress: &envoycorev3.SocketAddress{
-				Protocol: envoycorev3.SocketAddress_TCP,
+				Protocol: protocol,
 				Address:  bindAddress,
 				PortSpecifier: &envoycorev3.SocketAddress_PortValue{
 					PortValue: port,
@@ -464,6 +471,48 @@ func (h *filterChainTranslator) computeTcpFilters(l ir.TcpIR, listenerReporter s
 	tcpFilter, _ := NewFilterWithTypedConfig(wellknown.TCPProxy, cfg)
 
 	return append(networkFilters, tcpFilter)
+}
+
+// computeUdpFilters builds the udp_proxy listener filter for a UDPRoute-backed listener.
+// Unlike TCP, Envoy's udp_proxy is a listener filter (not a network filter in a filter chain)
+// and routes to a single cluster. The plain `cluster` route specifier is deprecated, so the
+// non-deprecated `matcher` form is used with a match-all action targeting the backend cluster.
+// udp_proxy has no weighted-cluster equivalent, so multi-backend UDPRoutes are rejected during
+// listener translation and only a single backend reaches here.
+func (h *filterChainTranslator) computeUdpFilters(l ir.UdpIR) []*envoylistenerv3.ListenerFilter {
+	if h.reporter != nil {
+		for _, backend := range l.BackendRefs {
+			reportBackendObjectPolicyStatus(h.reporter, h.listener.PolicyAncestorRef, h.pluginPass, backend.BackendObject)
+		}
+	}
+	if len(l.BackendRefs) == 0 {
+		return nil
+	}
+
+	routeAny, _ := utils.MessageToAny(&udpproxyv3.Route{Cluster: l.BackendRefs[0].ClusterName})
+	cfg := &udpproxyv3.UdpProxyConfig{
+		StatPrefix: l.FilterChainName,
+		RouteSpecifier: &udpproxyv3.UdpProxyConfig_Matcher{
+			Matcher: &xdsmatcherv3.Matcher{
+				OnNoMatch: &xdsmatcherv3.Matcher_OnMatch{
+					OnMatch: &xdsmatcherv3.Matcher_OnMatch_Action{
+						Action: &xdscorev3.TypedExtensionConfig{
+							Name:        "route",
+							TypedConfig: routeAny,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	msg, _ := utils.MessageToAny(cfg)
+	return []*envoylistenerv3.ListenerFilter{{
+		Name: UDPProxyFilterName,
+		ConfigType: &envoylistenerv3.ListenerFilter_TypedConfig{
+			TypedConfig: msg,
+		},
+	}}
 }
 
 func NewFilterWithTypedConfig(name string, config proto.Message) (*envoylistenerv3.Filter, error) {

--- a/pkg/kgateway/translator/irtranslator/fc.go
+++ b/pkg/kgateway/translator/irtranslator/fc.go
@@ -489,7 +489,14 @@ func (h *filterChainTranslator) computeUdpFilters(l ir.UdpIR) []*envoylistenerv3
 		return nil
 	}
 
-	routeAny, _ := utils.MessageToAny(&udpproxyv3.Route{Cluster: l.BackendRefs[0].ClusterName})
+	// Multi-backend routes target a single synthetic cluster whose endpoints are the weighted
+	// union of all backends (udp_proxy has no weighted-cluster support); single-backend routes
+	// target the backend's own cluster directly.
+	target := l.BackendRefs[0].ClusterName
+	if l.AggregateClusterName != "" {
+		target = l.AggregateClusterName
+	}
+	routeAny, _ := utils.MessageToAny(&udpproxyv3.Route{Cluster: target})
 	cfg := &udpproxyv3.UdpProxyConfig{
 		StatPrefix: l.FilterChainName,
 		RouteSpecifier: &udpproxyv3.UdpProxyConfig_Matcher{

--- a/pkg/kgateway/translator/irtranslator/gateway.go
+++ b/pkg/kgateway/translator/irtranslator/gateway.go
@@ -49,6 +49,9 @@ func (t *Translator) Translate(ctx context.Context, gw ir.GatewayIR, reporter sd
 	pass := t.newPass(reporter)
 	var res TranslationResult
 
+	// Synthetic clusters that a multi-backend UDPRoute's udp_proxy routes to; deduped by name
+	// since a route could attach to more than one listener.
+	udpAggregateClusters := map[string]struct{}{}
 	for _, l := range gw.Listeners {
 		outListener, routes := t.ComputeListener(ctx, pass, gw, l, reporter)
 		// Envoy rejects listeners with no filter chains; skip adding such listeners. UDP
@@ -61,6 +64,16 @@ func (t *Translator) Translate(ctx context.Context, gw ir.GatewayIR, reporter sd
 		}
 		res.Listeners = append(res.Listeners, outListener)
 		res.Routes = append(res.Routes, routes...)
+		for _, ufc := range l.UdpFilterChain {
+			if ufc.AggregateClusterName == "" {
+				continue
+			}
+			if _, seen := udpAggregateClusters[ufc.AggregateClusterName]; seen {
+				continue
+			}
+			udpAggregateClusters[ufc.AggregateClusterName] = struct{}{}
+			res.ExtraClusters = append(res.ExtraClusters, buildUdpAggregateCluster(ufc.AggregateClusterName))
+		}
 	}
 
 	for _, c := range pass {

--- a/pkg/kgateway/translator/irtranslator/gateway.go
+++ b/pkg/kgateway/translator/irtranslator/gateway.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	envoyclusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoytlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
@@ -50,8 +51,10 @@ func (t *Translator) Translate(ctx context.Context, gw ir.GatewayIR, reporter sd
 
 	for _, l := range gw.Listeners {
 		outListener, routes := t.ComputeListener(ctx, pass, gw, l, reporter)
-		// Envoy rejects listeners with no filter chains; skip adding such listeners.
-		if outListener == nil || len(outListener.GetFilterChains()) == 0 {
+		// Envoy rejects listeners with no filter chains; skip adding such listeners. UDP
+		// listeners are the exception: they carry a udp_proxy listener filter instead of a
+		// filter chain, so keep a listener that has a UDP filter chain in the IR.
+		if outListener == nil || (len(outListener.GetFilterChains()) == 0 && len(l.UdpFilterChain) == 0) {
 			originalListenerName := findOriginalListenerName(gw, l)
 			logger.Warn("invalid listener due to no filter chains generated", "listener", originalListenerName)
 			continue
@@ -101,7 +104,13 @@ func (t *Translator) ComputeListener(
 	reporter sdkreporter.Reporter,
 ) (*envoylistenerv3.Listener, []*envoyroutev3.RouteConfiguration) {
 	gwreporter := reporter.Gateway(gw.SourceObject.Obj)
-	listenerAddress, err := computeListenerAddress(lis.BindAddress, lis.BindPort, gwreporter)
+	// A listener carries either TCP/HTTP filter chains or UDP filter chains, never both, since
+	// Gateway API listeners are single-protocol. UDP requires a UDP socket address.
+	socketProtocol := envoycorev3.SocketAddress_TCP
+	if len(lis.UdpFilterChain) > 0 {
+		socketProtocol = envoycorev3.SocketAddress_UDP
+	}
+	listenerAddress, err := computeListenerAddress(lis.BindAddress, lis.BindPort, socketProtocol, gwreporter)
 	if err != nil {
 		// Error already reported via SetCondition; skip listener creation.
 		return nil, nil
@@ -192,6 +201,14 @@ func (t *Translator) ComputeListener(
 			hasTls = true
 		}
 	}
+
+	// UDP listeners carry a udp_proxy listener filter instead of network filter chains, the UDP
+	// socket address is what makes it a UDP listener, so no udp_listener_config is needed. A
+	// single UDPRoute is honored per listener, so there is at most one chain.
+	for _, ufc := range lis.UdpFilterChain {
+		ret.ListenerFilters = append(ret.GetListenerFilters(), fct.computeUdpFilters(ufc)...)
+	}
+
 	// sort filter chains for idempotency
 	slices.SortFunc(ret.GetFilterChains(), func(a, b *envoylistenerv3.FilterChain) int {
 		return cmp.Compare(a.GetName(), b.GetName())

--- a/pkg/kgateway/translator/listener/gateway_listener_translator.go
+++ b/pkg/kgateway/translator/listener/gateway_listener_translator.go
@@ -781,24 +781,18 @@ func (uc *udpFilterChain) translateUdpFilterChain(
 		backends = append(backends, backend)
 	}
 
-	// UDPRoute supports a single rule with a single backendRef. Envoy's udp_proxy routes to one
-	// cluster with no weighted-cluster support, and UDP backend weighting is only Extended
-	// support in the Gateway API, so rather than silently ignore weights we reject multi-backend
-	// (and multi-rule) UDPRoutes instead of mis-distributing traffic.
+	// A UDPRoute maps to a single udp_proxy, which cannot express more than one rule, so a
+	// multi-rule UDPRoute is rejected. Multiple backendRefs within the single rule are
+	// supported and weighted (see AggregateClusterName below).
 	condition := reports.RouteCondition{
 		Type:   gwv1.RouteConditionAccepted,
 		Status: metav1.ConditionTrue,
 		Reason: gwv1.RouteReasonAccepted,
 	}
-	switch {
-	case len(uRoute.SourceObject.Spec.Rules) != 1:
+	if len(uRoute.SourceObject.Spec.Rules) != 1 {
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = gwv1.RouteReasonUnsupportedValue
 		condition.Message = "UDPRoute with multiple rules is not supported"
-	case len(backends) > 1:
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = gwv1.RouteReasonUnsupportedValue
-		condition.Message = "UDPRoute with multiple backendRefs is not supported"
 	}
 	for _, parentRefReporter := range parentRefReporters {
 		parentRefReporter.SetCondition(condition)
@@ -812,9 +806,18 @@ func (uc *udpFilterChain) translateUdpFilterChain(
 		return nil
 	}
 
+	// udp_proxy routes to a single cluster. With more than one backend, route to a route-scoped
+	// synthetic cluster whose endpoints are the weighted union of all backends; a single backend
+	// targets its own cluster directly.
+	var aggregateClusterName string
+	if len(backends) > 1 {
+		aggregateClusterName = ir.UdpAggregateClusterName(uRoute.Namespace, uRoute.Name)
+	}
+
 	return &ir.UdpIR{
-		FilterChainName: udpHostName,
-		BackendRefs:     backends,
+		FilterChainName:      udpHostName,
+		BackendRefs:          backends,
+		AggregateClusterName: aggregateClusterName,
 	}
 }
 

--- a/pkg/kgateway/translator/listener/gateway_listener_translator.go
+++ b/pkg/kgateway/translator/listener/gateway_listener_translator.go
@@ -35,6 +35,7 @@ var logger = logging.New("translator/listener")
 
 const (
 	TcpTlsListenerNoBackendsMessage = "TCP/TLS listener has no valid backends or routes"
+	UdpListenerNoBackendsMessage    = "UDP listener has no valid backends or routes"
 	ResourceNotFoundMessageTemplate = "%s %s/%s not found."
 )
 
@@ -116,6 +117,8 @@ func (ml *MergedListeners) AppendListener(
 		ml.AppendTcpListener(listener, routes, reporter)
 	case gwv1.TLSProtocolType:
 		ml.AppendTlsListener(listener, routes, reporter)
+	case gwv1.UDPProtocolType:
+		ml.AppendUdpListener(listener, routes, reporter)
 	default:
 		return fmt.Errorf("unsupported protocol: %v", listener.Protocol)
 	}
@@ -293,6 +296,41 @@ func (ml *MergedListeners) AppendTlsListener(
 	})
 }
 
+func (ml *MergedListeners) AppendUdpListener(
+	listener ir.Listener,
+	routeInfos []*query.RouteInfo,
+	reporter reports.ListenerReporter,
+) {
+	parent := udpFilterChainParent{
+		gatewayListenerName: query.GenerateRouteKey(listener.Parent, string(listener.Name)),
+		listener:            listener,
+		listenerReporter:    reporter,
+		routesWithHosts:     routeInfos,
+	}
+	fc := udpFilterChain{
+		parents:          parent,
+		listenerReporter: reporter,
+	}
+
+	finalPort := getListenerPortNumber(listener)
+	for _, lis := range ml.Listeners {
+		if lis.port == finalPort {
+			lis.UdpFilterChains = append(lis.UdpFilterChains, fc)
+			return
+		}
+	}
+
+	// create a new filter chain for the listener
+	ml.Listeners = append(ml.Listeners, &MergedListener{
+		name:            GenerateListenerName(listener),
+		port:            finalPort,
+		UdpFilterChains: []udpFilterChain{fc},
+		listener:        listener,
+		gateway:         ml.parentGw,
+		settings:        ml.settings,
+	})
+}
+
 func listenerSNIDomains(listener ir.Listener) []string {
 	if listener.Hostname == nil {
 		return nil
@@ -332,6 +370,7 @@ type MergedListener struct {
 	httpFilterChain   *httpFilterChain
 	httpsFilterChains []httpsFilterChain
 	TcpFilterChains   []tcpFilterChain
+	UdpFilterChains   []udpFilterChain
 	listener          ir.Listener
 	gateway           ir.Gateway
 	settings          ListenerTranslatorConfig
@@ -396,6 +435,27 @@ func (ml *MergedListener) TranslateListener(
 		}
 	}
 
+	// Translate UDP listeners (if any exist)
+	var matchedUdpListeners []ir.UdpIR
+	for _, ufc := range ml.UdpFilterChains {
+		if udpListener := ufc.translateUdpFilterChain(ml.name, reporter); udpListener != nil {
+			matchedUdpListeners = append(matchedUdpListeners, *udpListener)
+		}
+	}
+
+	// Only report errors if ALL UDP filter chains failed (port is not programmed)
+	if len(ml.UdpFilterChains) > 0 && len(matchedUdpListeners) == 0 {
+		listenerCondition := reports.ListenerCondition{
+			Type:    gwv1.ListenerConditionProgrammed,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.ListenerReasonInvalid,
+			Message: UdpListenerNoBackendsMessage,
+		}
+		for _, ufc := range ml.UdpFilterChains {
+			ufc.listenerReporter.SetCondition(listenerCondition)
+		}
+	}
+
 	// Get bind address based on ListenerBindIpv6 setting
 	bindAddress := "0.0.0.0"
 	if ml.settings.ListenerBindIpv6 {
@@ -410,6 +470,7 @@ func (ml *MergedListener) TranslateListener(
 		AttachedPolicies:  ir.AttachedPolicies{}, // TODO: find policies attached to listener and attach them <- this might not be possible due to listener merging. also a gw listener ~= envoy filter chain; and i don't believe we need policies there
 		HttpFilterChain:   httpFilterChains,
 		TcpFilterChain:    matchedTcpListeners,
+		UdpFilterChain:    matchedUdpListeners,
 		PolicyAncestorRef: ml.listener.PolicyAncestorRef,
 	}
 }
@@ -651,6 +712,109 @@ func rejectConflictingRoute(ri *query.RouteInfo, reporter reports.Reporter) {
 		reporter.Route(o.SourceObject).ParentRef(&ri.ParentRef).SetCondition(condition)
 	case *ir.TlsRouteIR:
 		reporter.Route(o.SourceObject).ParentRef(&ri.ParentRef).SetCondition(condition)
+	case *ir.UdpRouteIR:
+		reporter.Route(o.SourceObject).ParentRef(&ri.ParentRef).SetCondition(condition)
+	}
+}
+
+// udpFilterChain represents a UDPRoute-backed Gateway listener merged into a single kgateway
+// Listener. Envoy models UDP with a udp_proxy listener filter rather than a network filter
+// chain, so there is no SNI/TLS/matcher here unlike tcpFilterChain.
+type udpFilterChain struct {
+	parents          udpFilterChainParent
+	listenerReporter reports.ListenerReporter
+}
+
+type udpFilterChainParent struct {
+	gatewayListenerName string
+	listener            ir.Listener
+	listenerReporter    reports.ListenerReporter
+	routesWithHosts     []*query.RouteInfo
+}
+
+func (uc *udpFilterChain) translateUdpFilterChain(
+	parentName string,
+	reporter reports.Reporter,
+) *ir.UdpIR {
+	parent := uc.parents
+	if len(parent.routesWithHosts) == 0 {
+		return nil
+	}
+
+	// A UDP listener cannot distinguish between multiple attached routes (there is no SNI to
+	// match on), so only one route can be honored. The oldest route by CreationTimestamp wins,
+	// any others are rejected as conflicting.
+	r := slices.MinFunc(parent.routesWithHosts, func(a, b *query.RouteInfo) int {
+		return a.Object.GetSourceObject().GetCreationTimestamp().Compare(b.Object.GetSourceObject().GetCreationTimestamp().Time)
+	})
+	if len(parent.routesWithHosts) > 1 {
+		for _, other := range parent.routesWithHosts {
+			if other == r {
+				continue
+			}
+			rejectConflictingRoute(other, reporter)
+		}
+	}
+
+	uRoute, ok := r.Object.(*ir.UdpRouteIR)
+	if !ok {
+		return nil
+	}
+
+	parentRefReporters := make([]reports.ParentRefReporter, 0, len(uRoute.ParentRefs))
+	for _, parentRef := range uRoute.ParentRefs {
+		parentRefReporters = append(parentRefReporters, reporter.Route(uRoute.SourceObject).ParentRef(&parentRef))
+	}
+
+	udpHostName := fmt.Sprintf("%s-%s.%s-rule-%d", parentName, uRoute.Namespace, uRoute.Name, 0)
+	var backends []ir.BackendRefIR
+	for _, backend := range uRoute.Backends {
+		if backend.Err != nil || backend.BackendObject == nil {
+			err := backend.Err
+			if err == nil {
+				err = errors.New("not found")
+			}
+			for _, parentRefReporter := range parentRefReporters {
+				query.ProcessBackendError(err, parentRefReporter)
+			}
+		}
+		backends = append(backends, backend)
+	}
+
+	// UDPRoute supports a single rule with a single backendRef. Envoy's udp_proxy routes to one
+	// cluster with no weighted-cluster support, and UDP backend weighting is only Extended
+	// support in the Gateway API, so rather than silently ignore weights we reject multi-backend
+	// (and multi-rule) UDPRoutes instead of mis-distributing traffic.
+	condition := reports.RouteCondition{
+		Type:   gwv1.RouteConditionAccepted,
+		Status: metav1.ConditionTrue,
+		Reason: gwv1.RouteReasonAccepted,
+	}
+	switch {
+	case len(uRoute.SourceObject.Spec.Rules) != 1:
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = gwv1.RouteReasonUnsupportedValue
+		condition.Message = "UDPRoute with multiple rules is not supported"
+	case len(backends) > 1:
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = gwv1.RouteReasonUnsupportedValue
+		condition.Message = "UDPRoute with multiple backendRefs is not supported"
+	}
+	for _, parentRefReporter := range parentRefReporters {
+		parentRefReporter.SetCondition(condition)
+	}
+	if condition.Status != metav1.ConditionTrue {
+		return nil
+	}
+
+	// Avoid creating a UDP listener if there are no backends.
+	if len(backends) == 0 {
+		return nil
+	}
+
+	return &ir.UdpIR{
+		FilterChainName: udpHostName,
+		BackendRefs:     backends,
 	}
 }
 

--- a/pkg/kgateway/translator/listener/validation.go
+++ b/pkg/kgateway/translator/listener/validation.go
@@ -54,6 +54,12 @@ func getSupportedRouteKindsForListener(listener gwv1.Listener) map[groupName][]r
 				wellknown.TCPRouteKind,
 			},
 		}
+	case gwv1.UDPProtocolType:
+		return map[groupName][]routeKind{
+			gwv1.GroupName: {
+				wellknown.UDPRouteKind,
+			},
+		}
 	case gwv1.TLSProtocolType:
 		return getSupportedTLSRouteKindsForMode(listener.TLS)
 	case gwv1.ProtocolType(istioprotocol.HBONE):

--- a/pkg/kgateway/translator/listener/validation_test.go
+++ b/pkg/kgateway/translator/listener/validation_test.go
@@ -310,15 +310,15 @@ func TestUnsupportedProtocol(t *testing.T) {
 	g.Expect(validListeners).To(BeEmpty())
 
 	expectedGwStatuses := map[string]gwv1.ListenerStatus{
-		"udp": {
-			Name:           "udp",
+		"custom": {
+			Name:           "custom",
 			SupportedKinds: []gwv1.RouteGroupKind{},
 			Conditions: []metav1.Condition{
 				{
 					Type:    string(gwv1.ListenerConditionAccepted),
 					Status:  metav1.ConditionFalse,
 					Reason:  string(gwv1.ListenerReasonUnsupportedProtocol),
-					Message: "Protocol UDP is unsupported.",
+					Message: "Protocol FOO is unsupported.",
 				},
 			},
 		},
@@ -2506,9 +2506,9 @@ func unsupportedProtocolGw() *gwv1.Gateway {
 			GatewayClassName: "kgateway",
 			Listeners: []gwv1.Listener{
 				{
-					Name:     "udp",
+					Name:     "custom",
 					Port:     8080,
-					Protocol: gwv1.UDPProtocolType,
+					Protocol: gwv1.ProtocolType("FOO"),
 				},
 			},
 		},

--- a/pkg/kgateway/wellknown/gwapi.go
+++ b/pkg/kgateway/wellknown/gwapi.go
@@ -27,6 +27,7 @@ const (
 	HTTPRouteKind        = "HTTPRoute"
 	TCPRouteKind         = "TCPRoute"
 	TLSRouteKind         = "TLSRoute"
+	UDPRouteKind         = "UDPRoute"
 	GRPCRouteKind        = "GRPCRoute"
 	GatewayKind          = "Gateway"
 	GatewayClassKind     = "GatewayClass"
@@ -49,6 +50,7 @@ const (
 	// Gateway API CRD names
 	TCPRouteCRDName = "tcproutes.gateway.networking.k8s.io"
 	TLSRouteCRDName = "tlsroutes.gateway.networking.k8s.io"
+	UDPRouteCRDName = "udproutes.gateway.networking.k8s.io"
 
 	// TLSRouteV1Alpha3Version names the v1alpha3 TLSRoute API. kgateway's
 	// internal routing representation is *gwv1a2.TLSRoute — v1 and v1alpha3
@@ -142,6 +144,16 @@ var (
 		Version:  gwv1a2.GroupVersion.Version,
 		Resource: "tcproutes",
 	}
+	UDPRouteGVK = schema.GroupVersionKind{
+		Group:   GatewayGroup,
+		Version: gwv1.GroupVersion.Version,
+		Kind:    UDPRouteKind,
+	}
+	UDPRouteGVR = schema.GroupVersionResource{
+		Group:    GatewayGroup,
+		Version:  gwv1.GroupVersion.Version,
+		Resource: "udproutes",
+	}
 	GRPCRouteGVK = schema.GroupVersionKind{
 		Group:   GatewayGroup,
 		Version: gwv1.GroupVersion.Version,
@@ -176,6 +188,12 @@ var (
 	TCPRouteCRD = apiextv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: TCPRouteCRDName,
+		},
+	}
+
+	UDPRouteCRD = apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: UDPRouteCRDName,
 		},
 	}
 

--- a/pkg/krtcollections/grpc_route_test.go
+++ b/pkg/krtcollections/grpc_route_test.go
@@ -487,6 +487,7 @@ func TestTransformGRPCRoute(t *testing.T) {
 				grpcRoutes,
 				krttest.GetMockCollection[*gwv1a2.TCPRoute](mock),
 				krttest.GetMockCollection[*gwv1a2.TLSRoute](mock),
+				krttest.GetMockCollection[*gwv1.UDPRoute](mock),
 				policies,
 				backends,
 				refgrants,

--- a/pkg/krtcollections/metrics/metrics.go
+++ b/pkg/krtcollections/metrics/metrics.go
@@ -520,6 +520,23 @@ func GetResourceMetricEventHandler[T any]() func(krt.Event[T]) {
 					namesOld = append(namesOld, string(pr.Name))
 				}
 			}
+		case *gwv1.UDPRoute:
+			resourceType = "UDPRoute"
+			resourceName = obj.Name
+			namespace = obj.Namespace
+			names = make([]string, 0, len(obj.Spec.ParentRefs))
+			for _, pr := range obj.Spec.ParentRefs {
+				names = append(names, string(pr.Name))
+			}
+
+			if clientObjectOld != nil {
+				oldObj := clientObjectOld.(*gwv1.UDPRoute)
+				namespaceOld = oldObj.Namespace
+				namesOld = make([]string, 0, len(oldObj.Spec.ParentRefs))
+				for _, pr := range oldObj.Spec.ParentRefs {
+					namesOld = append(namesOld, string(pr.Name))
+				}
+			}
 		case *gwv1.GRPCRoute:
 			resourceType = "GRPCRoute"
 			resourceName = obj.Name

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -1098,6 +1098,7 @@ func (c RouteWrapper) Equals(in RouteWrapper) bool {
 type RoutesIndex struct {
 	routes                               krt.Collection[RouteWrapper]
 	httpRoutes                           krt.Collection[ir.HttpRouteIR]
+	udpRoutes                            krt.Collection[ir.UdpRouteIR]
 	httpBySelector                       krt.Index[HTTPRouteSelector, ir.HttpRouteIR]
 	byParentRef                          krt.Index[TargetRefIndexKey, RouteWrapper]
 	weightedRoutePrecedence              bool
@@ -1116,12 +1117,18 @@ func (h *RoutesIndex) HasSynced() bool {
 			return false
 		}
 	}
-	return h.httpRoutes.HasSynced() && h.routes.HasSynced() && h.policies.HasSynced() && h.backends.HasSynced() && h.refgrants.HasSynced()
+	return h.httpRoutes.HasSynced() && h.udpRoutes.HasSynced() && h.routes.HasSynced() && h.policies.HasSynced() && h.backends.HasSynced() && h.refgrants.HasSynced()
 }
 
 // HTTPRoutes returns the raw krt collection that contains only the HTTPRouteIR.
 func (r *RoutesIndex) HTTPRoutes() krt.Collection[ir.HttpRouteIR] {
 	return r.httpRoutes
+}
+
+// UDPRoutes returns the raw krt collection that contains only the UdpRouteIR, with backends
+// already resolved. Used to build the weighted synthetic clusters for multi-backend UDPRoutes.
+func (r *RoutesIndex) UDPRoutes() krt.Collection[ir.UdpRouteIR] {
+	return r.udpRoutes
 }
 
 func NewRoutesIndex(
@@ -1167,8 +1174,12 @@ func NewRoutesIndex(
 		return &RouteWrapper{Route: h.transformTlsRoute(kctx, i)}
 	}, krtopts.ToOptions("routes-tls-routes-with-policy")...)
 
-	udpRoutesCollection = krt.NewCollection(udproutes, func(kctx krt.HandlerContext, i *gwv1.UDPRoute) *RouteWrapper {
-		return &RouteWrapper{Route: h.transformUdpRoute(kctx, i)}
+	h.udpRoutes = krt.NewCollection(udproutes, func(kctx krt.HandlerContext, i *gwv1.UDPRoute) *ir.UdpRouteIR {
+		return h.transformUdpRoute(kctx, i)
+	}, krtopts.ToOptions("udp-routes-with-policy")...)
+
+	udpRoutesCollection = krt.NewCollection(h.udpRoutes, func(kctx krt.HandlerContext, i ir.UdpRouteIR) *RouteWrapper {
+		return &RouteWrapper{Route: &i}
 	}, krtopts.ToOptions("routes-udp-routes-with-policy")...)
 
 	h.routes = krt.JoinCollection([]krt.Collection[RouteWrapper]{httpRouteCollection, grpcRoutesCollection, tcpRoutesCollection, tlsRoutesCollection, udpRoutesCollection}, krtopts.ToOptions("all-routes-with-policy")...)

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -419,8 +419,12 @@ func GatewaysForDeployerTransformationFunc(config *GatewayIndexConfig) func(kctx
 			return nil
 		}
 		ports := sets.New[int32]()
+		udpPorts := sets.New[int32]()
 		for _, l := range gw.Spec.Listeners {
 			ports.Insert(l.Port)
+			if l.Protocol == gwv1.UDPProtocolType {
+				udpPorts.Insert(l.Port)
+			}
 		}
 
 		listenerSets := krt.Fetch(kctx, config.ListenerSets, krt.FilterIndex(config.byParentRefIndex, TargetRefIndexKey{
@@ -438,6 +442,9 @@ func GatewaysForDeployerTransformationFunc(config *GatewayIndexConfig) func(kctx
 					continue
 				}
 				ports.Insert(port)
+				if l.Protocol == gwv1.UDPProtocolType {
+					udpPorts.Insert(port)
+				}
 			}
 		}
 		ir := &ir.GatewayForDeployer{
@@ -449,6 +456,7 @@ func GatewaysForDeployerTransformationFunc(config *GatewayIndexConfig) func(kctx
 			},
 			ControllerName: string(gwClass.Spec.ControllerName),
 			Ports:          smallset.New(ports.UnsortedList()...),
+			UDPPorts:       smallset.New(udpPorts.UnsortedList()...),
 		}
 		return ir
 	}

--- a/pkg/krtcollections/policy.go
+++ b/pkg/krtcollections/policy.go
@@ -1083,6 +1083,12 @@ func (c RouteWrapper) Equals(in RouteWrapper) bool {
 		} else {
 			return a.Equals(*bhttp)
 		}
+	case *ir.UdpRouteIR:
+		if bhttp, ok := in.Route.(*ir.UdpRouteIR); !ok {
+			return false
+		} else {
+			return a.Equals(*bhttp)
+		}
 	}
 	panic("unknown route type")
 }
@@ -1124,6 +1130,7 @@ func NewRoutesIndex(
 	grpcroutes krt.Collection[*gwv1.GRPCRoute],
 	tcproutes krt.Collection[*gwv1a2.TCPRoute],
 	tlsroutes krt.Collection[*gwv1a2.TLSRoute],
+	udproutes krt.Collection[*gwv1.UDPRoute],
 	policies *PolicyIndex,
 	backends *BackendIndex,
 	refgrants *RefGrantIndex,
@@ -1136,7 +1143,7 @@ func NewRoutesIndex(
 		weightedRoutePrecedence:              globalSettings.WeightedRoutePrecedence,
 		enableExperimentalGatewayAPIFeatures: globalSettings.EnableExperimentalGatewayAPIFeatures,
 	}
-	h.hasSyncedFuncs = append(h.hasSyncedFuncs, httproutes.HasSynced, grpcroutes.HasSynced, tcproutes.HasSynced, tlsroutes.HasSynced)
+	h.hasSyncedFuncs = append(h.hasSyncedFuncs, httproutes.HasSynced, grpcroutes.HasSynced, tcproutes.HasSynced, tlsroutes.HasSynced, udproutes.HasSynced)
 
 	h.httpRoutes = krt.NewCollection(httproutes, func(kctx krt.HandlerContext, i *gwv1.HTTPRoute) *ir.HttpRouteIR {
 		return h.transformHttpRoute(kctx, i)
@@ -1146,7 +1153,7 @@ func NewRoutesIndex(
 		return &RouteWrapper{Route: &i}
 	}, krtopts.ToOptions("routes-http-routes-with-policy")...)
 
-	var tcpRoutesCollection, tlsRoutesCollection, grpcRoutesCollection krt.Collection[RouteWrapper]
+	var tcpRoutesCollection, tlsRoutesCollection, udpRoutesCollection, grpcRoutesCollection krt.Collection[RouteWrapper]
 
 	grpcRoutesCollection = krt.NewCollection(grpcroutes, func(kctx krt.HandlerContext, i *gwv1.GRPCRoute) *RouteWrapper {
 		return &RouteWrapper{Route: h.transformGRPCRoute(kctx, i)}
@@ -1160,7 +1167,11 @@ func NewRoutesIndex(
 		return &RouteWrapper{Route: h.transformTlsRoute(kctx, i)}
 	}, krtopts.ToOptions("routes-tls-routes-with-policy")...)
 
-	h.routes = krt.JoinCollection([]krt.Collection[RouteWrapper]{httpRouteCollection, grpcRoutesCollection, tcpRoutesCollection, tlsRoutesCollection}, krtopts.ToOptions("all-routes-with-policy")...)
+	udpRoutesCollection = krt.NewCollection(udproutes, func(kctx krt.HandlerContext, i *gwv1.UDPRoute) *RouteWrapper {
+		return &RouteWrapper{Route: h.transformUdpRoute(kctx, i)}
+	}, krtopts.ToOptions("routes-udp-routes-with-policy")...)
+
+	h.routes = krt.JoinCollection([]krt.Collection[RouteWrapper]{httpRouteCollection, grpcRoutesCollection, tcpRoutesCollection, tlsRoutesCollection, udpRoutesCollection}, krtopts.ToOptions("all-routes-with-policy")...)
 
 	httpBySelector := krtpkg.UnnamedIndex(h.httpRoutes, func(i ir.HttpRouteIR) []HTTPRouteSelector {
 		value, ok := i.SourceObject.GetLabels()[apilabels.DelegationLabelSelector]
@@ -1277,6 +1288,27 @@ func (h *RoutesIndex) transformTcpRoute(kctx krt.HandlerContext, i *gwv1a2.TCPRo
 	}
 
 	return &ir.TcpRouteIR{
+		ObjectSource:     src,
+		SourceObject:     i,
+		ParentRefs:       i.Spec.ParentRefs,
+		Backends:         h.getTcpBackends(kctx, src, backends),
+		AttachedPolicies: ToAttachedPolicies(h.policies.GetTargetingPolicies(kctx, src, "", i.GetLabels())),
+	}
+}
+
+func (h *RoutesIndex) transformUdpRoute(kctx krt.HandlerContext, i *gwv1.UDPRoute) *ir.UdpRouteIR {
+	src := ir.ObjectSource{
+		Group:     gwv1.GroupVersion.Group,
+		Kind:      "UDPRoute",
+		Namespace: i.Namespace,
+		Name:      i.Name,
+	}
+	var backends []gwv1.BackendRef
+	if len(i.Spec.Rules) > 0 {
+		backends = i.Spec.Rules[0].BackendRefs
+	}
+
+	return &ir.UdpRouteIR{
 		ObjectSource:     src,
 		SourceObject:     i,
 		ParentRefs:       i.Spec.ParentRefs,

--- a/pkg/krtcollections/policy_test.go
+++ b/pkg/krtcollections/policy_test.go
@@ -560,8 +560,9 @@ func preRouteIndex(t test.Failer, inputs []any) *RoutesIndex {
 	httproutes := krttest.GetMockCollection[*gwv1.HTTPRoute](mock)
 	tcpproutes := krttest.GetMockCollection[*gwv1a2.TCPRoute](mock)
 	tlsroutes := krttest.GetMockCollection[*gwv1a2.TLSRoute](mock)
+	udproutes := krttest.GetMockCollection[*gwv1.UDPRoute](mock)
 	grpcroutes := krttest.GetMockCollection[*gwv1.GRPCRoute](mock)
-	rtidx := NewRoutesIndex(krtutil.KrtOptions{}, httproutes, grpcroutes, tcpproutes, tlsroutes, policies, upstreams, refgrants, apisettings.Settings{})
+	rtidx := NewRoutesIndex(krtutil.KrtOptions{}, httproutes, grpcroutes, tcpproutes, tlsroutes, udproutes, policies, upstreams, refgrants, apisettings.Settings{})
 	services.WaitUntilSynced(nil)
 	policyCol.WaitUntilSynced(nil)
 	for !rtidx.HasSynced() || !refgrants.HasSynced() || !policyCol.HasSynced() {

--- a/pkg/pluginsdk/collections/collections.go
+++ b/pkg/pluginsdk/collections/collections.go
@@ -62,6 +62,7 @@ type CommonCollections struct {
 	RawGRPCRoutes   krt.Collection[*gwv1.GRPCRoute]
 	RawTCPRoutes    krt.Collection[*gwv1a2.TCPRoute]
 	RawTLSRoutes    krt.Collection[*gwv1a2.TLSRoute]
+	RawUDPRoutes    krt.Collection[*gwv1.UDPRoute]
 
 	// tcpRouteWriteGVRs and tlsRouteWriteGVRs identify the served API versions status
 	// writes may go through, most preferred first, resolved from CRD discovery at startup.

--- a/pkg/pluginsdk/collections/collections.go
+++ b/pkg/pluginsdk/collections/collections.go
@@ -63,6 +63,9 @@ type CommonCollections struct {
 	RawTCPRoutes    krt.Collection[*gwv1a2.TCPRoute]
 	RawTLSRoutes    krt.Collection[*gwv1a2.TLSRoute]
 	RawUDPRoutes    krt.Collection[*gwv1.UDPRoute]
+	// ResolvedUDPRoutes carries UDPRoutes with backends already resolved, used to build the
+	// weighted synthetic clusters for multi-backend UDPRoutes.
+	ResolvedUDPRoutes krt.Collection[ir.UdpRouteIR]
 
 	// tcpRouteWriteGVRs and tlsRouteWriteGVRs identify the served API versions status
 	// writes may go through, most preferred first, resolved from CRD discovery at startup.

--- a/pkg/pluginsdk/collections/setup.go
+++ b/pkg/pluginsdk/collections/setup.go
@@ -236,6 +236,7 @@ func (c *CommonCollections) InitCollections(
 	endpointIRs := initEndpoints(plugins, c.KrtOpts)
 
 	routes := krtcollections.NewRoutesIndex(c.KrtOpts, httpRoutes, grpcRoutes, tcproutes, tlsRoutes, udproutes, policies, backendIndex, c.RefGrants, globalSettings)
+	c.ResolvedUDPRoutes = routes.UDPRoutes()
 	return gateways, routes, backendIndex, endpointIRs
 }
 

--- a/pkg/pluginsdk/collections/setup.go
+++ b/pkg/pluginsdk/collections/setup.go
@@ -211,8 +211,11 @@ func (c *CommonCollections) InitCollections(
 
 	tlsRoutes := joinRouteCollections(tlsRouteCollections, c.KrtOpts, "TLSRoute")
 
+	udproutes := krt.WrapClient(kclient.NewFilteredDelayed[*gwv1.UDPRoute](c.Client, wellknown.UDPRouteGVR, filter), c.KrtOpts.ToOptions("UDPRoute")...)
+
 	metrics.RegisterEvents(tcproutes, kmetrics.GetResourceMetricEventHandler[*gwv1a2.TCPRoute]())
 	metrics.RegisterEvents(tlsRoutes, kmetrics.GetResourceMetricEventHandler[*gwv1a2.TLSRoute]())
+	metrics.RegisterEvents(udproutes, kmetrics.GetResourceMetricEventHandler[*gwv1.UDPRoute]())
 
 	grpcRoutes := krt.WrapClient(kclient.NewFilteredDelayed[*gwv1.GRPCRoute](c.Client, wellknown.GRPCRouteGVR, filter), c.KrtOpts.ToOptions("GRPCRoute")...)
 	metrics.RegisterEvents(grpcRoutes, kmetrics.GetResourceMetricEventHandler[*gwv1.GRPCRoute]())
@@ -221,6 +224,7 @@ func (c *CommonCollections) InitCollections(
 	c.RawGRPCRoutes = grpcRoutes
 	c.RawTCPRoutes = tcproutes
 	c.RawTLSRoutes = tlsRoutes
+	c.RawUDPRoutes = udproutes
 
 	// The very lists the watches above were built from: a version we watch is a version we
 	// can write, so the two cannot drift apart.
@@ -231,7 +235,7 @@ func (c *CommonCollections) InitCollections(
 	initBackends(plugins, backendIndex)
 	endpointIRs := initEndpoints(plugins, c.KrtOpts)
 
-	routes := krtcollections.NewRoutesIndex(c.KrtOpts, httpRoutes, grpcRoutes, tcproutes, tlsRoutes, policies, backendIndex, c.RefGrants, globalSettings)
+	routes := krtcollections.NewRoutesIndex(c.KrtOpts, httpRoutes, grpcRoutes, tcproutes, tlsRoutes, udproutes, policies, backendIndex, c.RefGrants, globalSettings)
 	return gateways, routes, backendIndex, endpointIRs
 }
 

--- a/pkg/pluginsdk/ir/backend.go
+++ b/pkg/pluginsdk/ir/backend.go
@@ -486,6 +486,9 @@ type GatewayForDeployer struct {
 	ControllerName string
 	// All ports from all listeners
 	Ports smallset.Set[int32]
+	// UDPPorts is the subset of Ports whose listener protocol is UDP, so the proxy Service and
+	// container ports are created with the UDP protocol instead of the default TCP.
+	UDPPorts smallset.Set[int32]
 }
 
 func (c GatewayForDeployer) ResourceName() string {
@@ -495,7 +498,8 @@ func (c GatewayForDeployer) ResourceName() string {
 func (c GatewayForDeployer) Equals(in GatewayForDeployer) bool {
 	return c.ObjectSource.Equals(in.ObjectSource) &&
 		c.ControllerName == in.ControllerName &&
-		slices.Equal(c.Ports.List(), in.Ports.List())
+		slices.Equal(c.Ports.List(), in.Ports.List()) &&
+		slices.Equal(c.UDPPorts.List(), in.UDPPorts.List())
 }
 
 type ListenerForDeployer struct {

--- a/pkg/pluginsdk/ir/gw2.go
+++ b/pkg/pluginsdk/ir/gw2.go
@@ -159,6 +159,20 @@ type UdpIR struct {
 	// status and metrics. UDP listeners have no Envoy filter chain.
 	FilterChainName string
 	BackendRefs     []BackendRefIR
+	// AggregateClusterName, when set, is the route-scoped synthetic cluster the
+	// udp_proxy filter routes to. udp_proxy cannot weight across clusters, so a
+	// UDPRoute with more than one backend routes to a single cluster whose
+	// endpoints are the weighted union of all backends. Empty for single-backend
+	// routes, which target BackendRefs[0].ClusterName directly.
+	AggregateClusterName string
+}
+
+// UdpAggregateClusterName is the deterministic, route-scoped name of the synthetic
+// cluster used to weight traffic across a multi-backend UDPRoute. The "udpagg" prefix
+// and absence of a port segment keep it from colliding with real backend cluster names
+// (which are "<gvPrefix>_<ns>_<name>[_<extraKey>]_<port>").
+func UdpAggregateClusterName(namespace, name string) string {
+	return "udpagg_" + namespace + "_" + name
 }
 
 // this is 1:1 with envoy deployments

--- a/pkg/pluginsdk/ir/gw2.go
+++ b/pkg/pluginsdk/ir/gw2.go
@@ -65,6 +65,7 @@ type ListenerIR struct {
 
 	HttpFilterChain []HttpFilterChainIR
 	TcpFilterChain  []TcpIR
+	UdpFilterChain  []UdpIR
 
 	PolicyAncestorRef gwv1.ParentReference
 
@@ -148,6 +149,16 @@ type HttpFilterChainIR struct {
 type TcpIR struct {
 	FilterChainCommon
 	BackendRefs []BackendRefIR
+}
+
+// UdpIR is the intermediate representation of a UDPRoute-backed listener.
+// Unlike TCP/HTTP, Envoy models UDP with a udp_proxy listener filter rather
+// than a network filter chain, so there is no SNI/TLS/matcher to carry here.
+type UdpIR struct {
+	// FilterChainName is a logical name for the UDP proxy config, used for
+	// status and metrics. UDP listeners have no Envoy filter chain.
+	FilterChainName string
+	BackendRefs     []BackendRefIR
 }
 
 // this is 1:1 with envoy deployments

--- a/pkg/pluginsdk/ir/routes.go
+++ b/pkg/pluginsdk/ir/routes.go
@@ -203,3 +203,33 @@ func (c *TlsRouteIR) GetHostnames() []string {
 }
 
 var _ Route = &TlsRouteIR{}
+
+type UdpRouteIR struct {
+	ObjectSource `json:",inline"`
+	SourceObject *gwv1.UDPRoute
+	// +krtEqualsTodo include parent references when computing equality
+	ParentRefs       []gwv1.ParentReference
+	AttachedPolicies AttachedPolicies
+	Backends         []BackendRefIR
+}
+
+func (c *UdpRouteIR) GetParentRefs() []gwv1.ParentReference {
+	return c.ParentRefs
+}
+
+func (c *UdpRouteIR) GetSourceObject() metav1.Object {
+	return c.SourceObject
+}
+
+func (c UdpRouteIR) ResourceName() string {
+	return c.ObjectSource.ResourceName()
+}
+
+func (c UdpRouteIR) Equals(in UdpRouteIR) bool {
+	return c.ObjectSource == in.ObjectSource &&
+		versionEquals(c.SourceObject, in.SourceObject) &&
+		c.AttachedPolicies.Equals(in.AttachedPolicies) &&
+		backendsEqual(c.Backends, in.Backends)
+}
+
+var _ Route = &UdpRouteIR{}

--- a/pkg/reports/reporter.go
+++ b/pkg/reports/reporter.go
@@ -27,6 +27,7 @@ type ReportMap struct {
 	GRPCRoutes   map[types.NamespacedName]*RouteReport
 	TCPRoutes    map[types.NamespacedName]*RouteReport
 	TLSRoutes    map[types.NamespacedName]*RouteReport
+	UDPRoutes    map[types.NamespacedName]*RouteReport
 	Policies     map[reporter.PolicyKey]*PolicyReport
 	Backends     map[types.NamespacedName]*BackendReport
 }
@@ -85,6 +86,7 @@ func NewReportMap() ReportMap {
 		GRPCRoutes:   make(map[types.NamespacedName]*RouteReport),
 		TCPRoutes:    make(map[types.NamespacedName]*RouteReport),
 		TLSRoutes:    make(map[types.NamespacedName]*RouteReport),
+		UDPRoutes:    make(map[types.NamespacedName]*RouteReport),
 		Policies:     make(map[reporter.PolicyKey]*PolicyReport),
 		Backends:     make(map[types.NamespacedName]*BackendReport),
 	}
@@ -202,6 +204,8 @@ func (r *ReportMap) route(obj metav1.Object) *RouteReport {
 		return r.TLSRoutes[key]
 	case *gwv1a2.TLSRoute:
 		return r.TLSRoutes[key]
+	case *gwv1.UDPRoute:
+		return r.UDPRoutes[key]
 	case *gwv1.GRPCRoute:
 		return r.GRPCRoutes[key]
 	default:
@@ -228,6 +232,8 @@ func (r *ReportMap) newRouteReport(obj metav1.Object) *RouteReport {
 		r.TLSRoutes[key] = rr
 	case *gwv1a2.TLSRoute:
 		r.TLSRoutes[key] = rr
+	case *gwv1.UDPRoute:
+		r.UDPRoutes[key] = rr
 	case *gwv1.GRPCRoute:
 		r.GRPCRoutes[key] = rr
 	default:

--- a/pkg/reports/status.go
+++ b/pkg/reports/status.go
@@ -516,6 +516,8 @@ func BuildRouteStatus(
 		existingStatus, specParentRefs = route.Status.RouteStatus, route.Spec.ParentRefs
 	case *gwv1a3.TLSRoute:
 		existingStatus, specParentRefs = route.Status.RouteStatus, route.Spec.ParentRefs
+	case *gwv1.UDPRoute:
+		existingStatus, specParentRefs = route.Status.RouteStatus, route.Spec.ParentRefs
 	default:
 		logger.Error("unsupported route type for status reporting", "route_type", fmt.Sprintf("%T", obj))
 		return nil

--- a/pkg/reports/status_contribution.go
+++ b/pkg/reports/status_contribution.go
@@ -95,7 +95,7 @@ func StatusContributionsFromReportMap(source StatusSource, reportMap ReportMap) 
 	contributions := make([]StatusContribution, 0,
 		len(reportMap.Gateways)+listenerSetCount+
 			len(reportMap.HTTPRoutes)+len(reportMap.GRPCRoutes)+
-			len(reportMap.TCPRoutes)+len(reportMap.TLSRoutes)+
+			len(reportMap.TCPRoutes)+len(reportMap.TLSRoutes)+len(reportMap.UDPRoutes)+
 			len(reportMap.Policies)+len(reportMap.Backends),
 	)
 
@@ -134,6 +134,7 @@ func StatusContributionsFromReportMap(source StatusSource, reportMap ReportMap) 
 	appendRoutes(wellknown.GRPCRouteGVK, reportMap.GRPCRoutes)
 	appendRoutes(wellknown.TCPRouteGVK, reportMap.TCPRoutes)
 	appendRoutes(wellknown.TLSRouteGVK, reportMap.TLSRoutes)
+	appendRoutes(wellknown.UDPRouteGVK, reportMap.UDPRoutes)
 
 	for key, report := range reportMap.Policies {
 		if report != nil {

--- a/test/e2e/features/services/udproute/suite.go
+++ b/test/e2e/features/services/udproute/suite.go
@@ -1,0 +1,145 @@
+//go:build e2e
+
+package udproute
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/kubeutils"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/tests/base"
+	"github.com/kgateway-dev/kgateway/v2/test/testutils"
+)
+
+// testingSuite exercises UDPRoute end to end: a Gateway UDP listener routing to CoreDNS
+// backends, verified by exec-ing dig from an in-cluster dnsutils pod against the gateway.
+type testingSuite struct {
+	*base.BaseTestingSuite
+	cancel context.CancelFunc
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	udpCtx, cancel := context.WithTimeout(ctx, ctxTimeout)
+	return &testingSuite{
+		BaseTestingSuite: base.NewBaseTestingSuite(udpCtx, testInst, base.TestCase{}, testCases,
+			base.WithMinGwApiVersion(base.GwApiRequireUdpRoutes),
+		),
+		cancel: cancel,
+	}
+}
+
+// SetupSuite registers the context cancel before delegating, mirroring the TCPRoute suite: the
+// base SetupSuite may skip the whole suite on an older Gateway API, and testify only defers
+// TearDownSuite after SetupSuite returns, so a skip would otherwise leak the timeout context.
+func (s *testingSuite) SetupSuite() {
+	testutils.Cleanup(s.T(), s.cancel)
+	s.BaseTestingSuite.SetupSuite()
+}
+
+var testCases = map[string]*base.TestCase{
+	"TestSingleBackendUDPRoute":    {},
+	"TestWeightedBackendsUDPRoute": {},
+}
+
+// TestSingleBackendUDPRoute routes a UDPRoute to a single CoreDNS backend and asserts a DNS query
+// through the gateway returns that backend's static answer.
+func (s *testingSuite) TestSingleBackendUDPRoute() {
+	testutils.Cleanup(s.T(), func() {
+		s.deleteManifests(singleBackendManifest)
+		s.TestInstallation.AssertionsT(s.T()).EventuallyObjectsNotExist(s.Ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: singleNs}})
+	})
+
+	s.applyManifests(singleNs, singleBackendManifest)
+
+	s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayCondition(s.Ctx, singleGwName, singleNs, gwv1.GatewayConditionProgrammed, metav1.ConditionTrue, timeout)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyUDPRouteCondition(s.Ctx, singleRouteName, singleNs, gwv1.RouteConditionAccepted, metav1.ConditionTrue, timeout)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayListenerAttachedRoutes(s.Ctx, singleGwName, singleNs, gwv1.SectionName(singleListener), 1, timeout)
+
+	// A DNS query through the gateway resolves to backend A's static answer.
+	s.assertEventualDigAnswer(singleNs, singleGwName, singleAnswerIP)
+}
+
+// TestWeightedBackendsUDPRoute routes a UDPRoute to two CoreDNS backends with weights 80/20 (each
+// returns a distinguishable answer) and asserts traffic reaches both, with the heavier backend
+// receiving the majority.
+func (s *testingSuite) TestWeightedBackendsUDPRoute() {
+	testutils.Cleanup(s.T(), func() {
+		s.deleteManifests(multiBackendManifest)
+		s.TestInstallation.AssertionsT(s.T()).EventuallyObjectsNotExist(s.Ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: multiNs}})
+	})
+
+	s.applyManifests(multiNs, multiBackendManifest)
+
+	s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayCondition(s.Ctx, multiGwName, multiNs, gwv1.GatewayConditionProgrammed, metav1.ConditionTrue, timeout)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyUDPRouteCondition(s.Ctx, multiRouteName, multiNs, gwv1.RouteConditionAccepted, metav1.ConditionTrue, timeout)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayListenerAttachedRoutes(s.Ctx, multiGwName, multiNs, gwv1.SectionName(multiListener), 1, timeout)
+
+	// Wait until both backends are reachable through the gateway before counting the split, so a
+	// not-yet-ready backend can't skew the distribution.
+	s.assertEventualDigAnswer(multiNs, multiGwName, multiAnswerA)
+	s.assertEventualDigAnswer(multiNs, multiGwName, multiAnswerB)
+
+	// Each dig uses a fresh source port, so udp_proxy load-balances per query across the weighted
+	// endpoints. Over enough queries both backends are hit and the 80%-weight backend dominates.
+	// The assertion is intentionally loose (both hit + majority) to stay non-flaky.
+	const queries = 40
+	counts := map[string]int{}
+	for range queries {
+		out := strings.TrimSpace(s.dig(multiNs, multiGwName))
+		switch {
+		case strings.Contains(out, multiAnswerA):
+			counts[multiAnswerA]++
+		case strings.Contains(out, multiAnswerB):
+			counts[multiAnswerB]++
+		}
+	}
+	s.Assert().Positive(counts[multiAnswerA], "backend A (weight 80) received no traffic")
+	s.Assert().Positive(counts[multiAnswerB], "backend B (weight 20) received no traffic")
+	s.Assert().Greater(counts[multiAnswerA], counts[multiAnswerB],
+		"backend A (weight 80) should receive more traffic than backend B (weight 20); got A=%d B=%d",
+		counts[multiAnswerA], counts[multiAnswerB])
+}
+
+// dig runs a single `dig +short` A-record query for queryName through the gateway's UDP listener
+// and returns stdout (the answer IPs, one per line; empty on failure).
+func (s *testingSuite) dig(ns, gwName string) string {
+	gwAddr := kubeutils.ServiceFQDN(metav1.ObjectMeta{Name: gwName, Namespace: ns})
+	stdout, _, err := s.TestInstallation.Actions.Kubectl().Execute(s.Ctx,
+		"exec", "-n", ns, clientPodName, "--",
+		"dig", "+short", "+timeout=2", "+tries=1",
+		"@"+gwAddr, "-p", strconv.Itoa(udpListenerPort), queryName, "A",
+	)
+	if err != nil {
+		return ""
+	}
+	return stdout
+}
+
+// assertEventualDigAnswer retries a DNS query until the answer contains wantIP.
+func (s *testingSuite) assertEventualDigAnswer(ns, gwName, wantIP string) {
+	gomega.NewWithT(s.T()).Eventually(func(g gomega.Gomega) {
+		g.Expect(s.dig(ns, gwName)).To(gomega.ContainSubstring(wantIP))
+	}, timeout).Should(gomega.Succeed(), "expected a DNS answer of %s through gateway %s/%s", wantIP, ns, gwName)
+}
+
+func (s *testingSuite) applyManifests(ns string, manifests ...string) {
+	for _, manifest := range manifests {
+		err := s.TestInstallation.Actions.Kubectl().ApplyFile(s.Ctx, manifest, "-n", ns)
+		s.Require().NoError(err, "Failed to apply manifest "+manifest)
+	}
+}
+
+func (s *testingSuite) deleteManifests(manifests ...string) {
+	for _, manifest := range manifests {
+		err := s.TestInstallation.Actions.Kubectl().DeleteFileSafe(s.Ctx, manifest)
+		s.Require().NoError(err, "Failed to delete manifest "+manifest)
+	}
+}

--- a/test/e2e/features/services/udproute/testdata/multi-backend.yaml
+++ b/test/e2e/features/services/udproute/testdata/multi-backend.yaml
@@ -1,0 +1,161 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: udp-multi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dns-client
+  namespace: udp-multi
+  labels:
+    app: dns-client
+spec:
+  containers:
+    - name: dns-client
+      image: nicolaka/netshoot:v0.14@sha256:7f08c4aff13ff61a35d30e30c5c1ea8396eac6ab4ce19fd02d5a4b3b5d0d09a2
+      command: ["sleep", "infinity"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-a
+  namespace: udp-multi
+data:
+  Corefile: |
+    .:53 {
+        hosts {
+            10.1.1.1 foo.bar.com
+            fallthrough
+        }
+        errors
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns-a
+  namespace: udp-multi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coredns-a
+  template:
+    metadata:
+      labels:
+        app: coredns-a
+    spec:
+      containers:
+        - name: coredns
+          image: coredns/coredns:1.11.1
+          args: ["-conf", "/etc/coredns/Corefile"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/coredns
+      volumes:
+        - name: config
+          configMap:
+            name: coredns-a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-a
+  namespace: udp-multi
+spec:
+  selector:
+    app: coredns-a
+  ports:
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-b
+  namespace: udp-multi
+data:
+  Corefile: |
+    .:53 {
+        hosts {
+            10.2.2.2 foo.bar.com
+            fallthrough
+        }
+        errors
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns-b
+  namespace: udp-multi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coredns-b
+  template:
+    metadata:
+      labels:
+        app: coredns-b
+    spec:
+      containers:
+        - name: coredns
+          image: coredns/coredns:1.11.1
+          args: ["-conf", "/etc/coredns/Corefile"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/coredns
+      volumes:
+        - name: config
+          configMap:
+            name: coredns-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-b
+  namespace: udp-multi
+spec:
+  selector:
+    app: coredns-b
+  ports:
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: udp-multi-gw
+  namespace: udp-multi
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - name: udp
+      protocol: UDP
+      port: 5300
+      allowedRoutes:
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-multi-route
+  namespace: udp-multi
+spec:
+  parentRefs:
+    - name: udp-multi-gw
+  rules:
+    - backendRefs:
+        - name: coredns-a
+          port: 53
+          weight: 80
+        - name: coredns-b
+          port: 53
+          weight: 20

--- a/test/e2e/features/services/udproute/testdata/single-backend.yaml
+++ b/test/e2e/features/services/udproute/testdata/single-backend.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: udp-single
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dns-client
+  namespace: udp-single
+  labels:
+    app: dns-client
+spec:
+  containers:
+    - name: dns-client
+      image: nicolaka/netshoot:v0.14@sha256:7f08c4aff13ff61a35d30e30c5c1ea8396eac6ab4ce19fd02d5a4b3b5d0d09a2
+      command: ["sleep", "infinity"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-a
+  namespace: udp-single
+data:
+  Corefile: |
+    .:53 {
+        hosts {
+            10.1.1.1 foo.bar.com
+            fallthrough
+        }
+        errors
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns-a
+  namespace: udp-single
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coredns-a
+  template:
+    metadata:
+      labels:
+        app: coredns-a
+    spec:
+      containers:
+        - name: coredns
+          image: coredns/coredns:1.11.1
+          args: ["-conf", "/etc/coredns/Corefile"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/coredns
+      volumes:
+        - name: config
+          configMap:
+            name: coredns-a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-a
+  namespace: udp-single
+spec:
+  selector:
+    app: coredns-a
+  ports:
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: udp-single-gw
+  namespace: udp-single
+spec:
+  gatewayClassName: kgateway
+  listeners:
+    - name: udp
+      protocol: UDP
+      port: 5300
+      allowedRoutes:
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-single-route
+  namespace: udp-single
+spec:
+  parentRefs:
+    - name: udp-single-gw
+  rules:
+    - backendRefs:
+        - name: coredns-a
+          port: 53

--- a/test/e2e/features/services/udproute/types.go
+++ b/test/e2e/features/services/udproute/types.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+package udproute
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/kgateway-dev/kgateway/v2/pkg/utils/fsutils"
+)
+
+const (
+	// ctxTimeout bounds the whole suite; timeout bounds individual assertions.
+	ctxTimeout = 5 * time.Minute
+	timeout    = 60 * time.Second
+
+	// clientPodName is the in-cluster dnsutils pod the suite execs `dig` from.
+	clientPodName = "dns-client"
+	// queryName is the DNS name the CoreDNS backends answer with a distinct A record.
+	queryName = "foo.bar.com"
+	// udpListenerPort is the Gateway UDP listener port dig targets.
+	udpListenerPort = 5300
+
+	// Single-backend case.
+	singleNs        = "udp-single"
+	singleGwName    = "udp-single-gw"
+	singleRouteName = "udp-single-route"
+	singleListener  = "udp"
+	singleAnswerIP  = "10.1.1.1"
+
+	// Weighted multi-backend case: backend A has weight 80, backend B weight 20.
+	multiNs        = "udp-multi"
+	multiGwName    = "udp-multi-gw"
+	multiRouteName = "udp-multi-route"
+	multiListener  = "udp"
+	multiAnswerA   = "10.1.1.1"
+	multiAnswerB   = "10.2.2.2"
+)
+
+var (
+	singleBackendManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "single-backend.yaml")
+	multiBackendManifest  = filepath.Join(fsutils.MustGetThisDir(), "testdata", "multi-backend.yaml")
+)

--- a/test/e2e/tests/base/base_suite.go
+++ b/test/e2e/tests/base/base_suite.go
@@ -102,6 +102,11 @@ var (
 		GwApiChannelStandard:     &GwApiV1_6_0,
 	}
 
+	GwApiRequireUdpRoutes = map[GwApiChannel]*GwApiVersion{
+		GwApiChannelExperimental: &GwApiV1_6_0,
+		GwApiChannelStandard:     &GwApiV1_6_0,
+	}
+
 	GwApiRequireSessionPersistence = map[GwApiChannel]*GwApiVersion{
 		GwApiChannelExperimental: &GwApiV1_1_0,
 	}

--- a/test/e2e/tests/kgateway/suite_runner.go
+++ b/test/e2e/tests/kgateway/suite_runner.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/services/httproute"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/services/tcproute"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/services/tlsroute"
+	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/services/udproute"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/session_persistence"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/timeoutretry"
 	"github.com/kgateway-dev/kgateway/v2/test/e2e/features/tracing"
@@ -66,6 +67,7 @@ func SuiteRunner() e2e.SuiteRunner {
 	kubeGatewaySuiteRunner.Register("RouteDelegation", route_delegation.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("SessionPersistence", session_persistence.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TCPRouteServices", tcproute.NewTestingSuite)
+	kubeGatewaySuiteRunner.Register("UDPRouteServices", udproute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("TLSRouteServices", tlsroute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("GRPCRouteServices", grpcroute.NewTestingSuite)
 	kubeGatewaySuiteRunner.Register("Transforms", transformation.NewTestingSuite)

--- a/test/e2e/testutils/assertions/status.go
+++ b/test/e2e/testutils/assertions/status.go
@@ -381,6 +381,26 @@ func (p *Provider) getTLSRouteStatus(ctx context.Context, name string, namespace
 	return legacyRoute.Status.RouteStatus, nil
 }
 
+// EventuallyUDPRouteCondition asserts a UDPRoute parent condition eventually reaches the
+// expected status. UDPRoute is v1-native in kgateway, so there is no legacy-version fallback.
+func (p *Provider) EventuallyUDPRouteCondition(
+	ctx context.Context,
+	routeName string,
+	routeNamespace string,
+	cond gwv1.RouteConditionType,
+	expect metav1.ConditionStatus,
+	timeout ...time.Duration,
+) {
+	ginkgo.GinkgoHelper()
+	currentTimeout, pollingInterval := helpers.GetTimeouts(timeout...)
+	p.Gomega.Eventually(func(g gomega.Gomega) {
+		route := &gwv1.UDPRoute{}
+		err := p.clusterContext.Client.Get(ctx, types.NamespacedName{Name: routeName, Namespace: routeNamespace}, route)
+		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("failed to get UDPRoute %s/%s", routeNamespace, routeName))
+		g.Expect(extractParentConditions(route.Status.Parents)).To(matchers.HaveAnyParentCondition(string(cond), expect))
+	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
+}
+
 func (p *Provider) getTCPRouteStatus(ctx context.Context, name string, namespace string) (gwv1.RouteStatus, error) {
 	route := &gwv1.TCPRoute{}
 	if err := p.clusterContext.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, route); err == nil {

--- a/test/helm/testdata/kgateway/additional-labels.golden
+++ b/test/helm/testdata/kgateway/additional-labels.golden
@@ -170,6 +170,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -185,6 +186,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/admin-bind-address.golden
+++ b/test/helm/testdata/kgateway/admin-bind-address.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-empty-pod-annotations.golden
+++ b/test/helm/testdata/kgateway/controller-empty-pod-annotations.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-empty-tolerations-override.golden
+++ b/test/helm/testdata/kgateway/controller-empty-tolerations-override.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-empty-topology-spread-constraints-override.golden
+++ b/test/helm/testdata/kgateway/controller-empty-topology-spread-constraints-override.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-null-pod-annotations.golden
+++ b/test/helm/testdata/kgateway/controller-null-pod-annotations.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-null-tolerations-fallback.golden
+++ b/test/helm/testdata/kgateway/controller-null-tolerations-fallback.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-null-topology-spread-constraints-fallback.golden
+++ b/test/helm/testdata/kgateway/controller-null-topology-spread-constraints-fallback.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-overrides-replace-not-merge.golden
+++ b/test/helm/testdata/kgateway/controller-overrides-replace-not-merge.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/controller-overrides-top-level-values.golden
+++ b/test/helm/testdata/kgateway/controller-overrides-top-level-values.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/default.golden
+++ b/test/helm/testdata/kgateway/default.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/hpa-and-vpa.golden
+++ b/test/helm/testdata/kgateway/hpa-and-vpa.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/pdb-max-unavailable.golden
+++ b/test/helm/testdata/kgateway/pdb-max-unavailable.golden
@@ -190,6 +190,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -205,6 +206,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/pdb-min-available.golden
+++ b/test/helm/testdata/kgateway/pdb-min-available.golden
@@ -190,6 +190,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -205,6 +206,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/priority-class-name.golden
+++ b/test/helm/testdata/kgateway/priority-class-name.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/probes-full-override.golden
+++ b/test/helm/testdata/kgateway/probes-full-override.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/prometheus-annotations-disabled.golden
+++ b/test/helm/testdata/kgateway/prometheus-annotations-disabled.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/readiness-probe-override.golden
+++ b/test/helm/testdata/kgateway/readiness-probe-override.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/replicas-null.golden
+++ b/test/helm/testdata/kgateway/replicas-null.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/replicas-zero.golden
+++ b/test/helm/testdata/kgateway/replicas-zero.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/service-full-config.golden
+++ b/test/helm/testdata/kgateway/service-full-config.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/service-monitor-enabled.golden
+++ b/test/helm/testdata/kgateway/service-monitor-enabled.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/startup-probe-override.golden
+++ b/test/helm/testdata/kgateway/startup-probe-override.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/tolerations.golden
+++ b/test/helm/testdata/kgateway/tolerations.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/topology-spread-constraints.golden
+++ b/test/helm/testdata/kgateway/topology-spread-constraints.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/helm/testdata/kgateway/xds-tls-enabled.golden
+++ b/test/helm/testdata/kgateway/xds-tls-enabled.golden
@@ -168,6 +168,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -183,6 +184,7 @@ rules:
   - listenersets/status
   - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - patch
   - update

--- a/test/testutils/crd.go
+++ b/test/testutils/crd.go
@@ -33,6 +33,7 @@ var AllCRDs = []schema.GroupVersionResource{
 	gvr.GRPCRoute,
 	gvr.TCPRoute,
 	wellknown.TCPRouteV1GVR,
+	wellknown.UDPRouteGVR,
 	gvr.TLSRoute,
 	wellknown.TLSRouteV1Alpha3GVR,
 	gvr.ReferenceGrant,

--- a/test/translator/status.go
+++ b/test/translator/status.go
@@ -25,6 +25,7 @@ type Statuses struct {
 	HTTPRoutes   map[string]*gwv1.RouteStatus       `json:"httpRoutes,omitempty"`
 	TCPRoutes    map[string]*gwv1.RouteStatus       `json:"tcpRoutes,omitempty"`
 	TLSRoutes    map[string]*gwv1.RouteStatus       `json:"tlsRoutes,omitempty"`
+	UDPRoutes    map[string]*gwv1.RouteStatus       `json:"udpRoutes,omitempty"`
 	GRPCRoutes   map[string]*gwv1.RouteStatus       `json:"grpcRoutes,omitempty"`
 	Policies     map[string]*gwv1.PolicyStatus      `json:"policies,omitempty"`
 	Backends     map[string]*kgateway.BackendStatus `json:"backends,omitempty"`
@@ -46,6 +47,7 @@ func buildStatusesFromReports(
 		HTTPRoutes:   make(map[string]*gwv1.RouteStatus),
 		TCPRoutes:    make(map[string]*gwv1.RouteStatus),
 		TLSRoutes:    make(map[string]*gwv1.RouteStatus),
+		UDPRoutes:    make(map[string]*gwv1.RouteStatus),
 		GRPCRoutes:   make(map[string]*gwv1.RouteStatus),
 		Policies:     make(map[string]*gwv1.PolicyStatus),
 		Backends:     make(map[string]*kgateway.BackendStatus),
@@ -137,6 +139,20 @@ func buildStatusesFromReports(
 		if status := reportsMap.BuildRouteStatus(&route, wellknown.DefaultGatewayClassName); status != nil {
 			normalizeRouteStatus(status, fixedTime)
 			statuses.TLSRoutes[routeNN.String()] = status
+		}
+	}
+
+	// Build UDPRoute statuses
+	for routeNN := range reportsMap.UDPRoutes {
+		route := gwv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      routeNN.Name,
+				Namespace: routeNN.Namespace,
+			},
+		}
+		if status := reportsMap.BuildRouteStatus(&route, wellknown.DefaultGatewayClassName); status != nil {
+			normalizeRouteStatus(status, fixedTime)
+			statuses.UDPRoutes[routeNN.String()] = status
 		}
 	}
 
@@ -291,6 +307,7 @@ func sortStatuses(statuses *Statuses) *Statuses {
 		HTTPRoutes:   make(map[string]*gwv1.RouteStatus),
 		TCPRoutes:    make(map[string]*gwv1.RouteStatus),
 		TLSRoutes:    make(map[string]*gwv1.RouteStatus),
+		UDPRoutes:    make(map[string]*gwv1.RouteStatus),
 		GRPCRoutes:   make(map[string]*gwv1.RouteStatus),
 		Policies:     make(map[string]*gwv1.PolicyStatus),
 		Backends:     make(map[string]*kgateway.BackendStatus),
@@ -344,6 +361,16 @@ func sortStatuses(statuses *Statuses) *Statuses {
 	slices.Sort(tlsRouteKeys)
 	for _, k := range tlsRouteKeys {
 		sorted.TLSRoutes[k] = statuses.TLSRoutes[k]
+	}
+
+	// Sort UDP routes
+	udpRouteKeys := make([]string, 0, len(statuses.UDPRoutes))
+	for k := range statuses.UDPRoutes {
+		udpRouteKeys = append(udpRouteKeys, k)
+	}
+	slices.Sort(udpRouteKeys)
+	for _, k := range udpRouteKeys {
+		sorted.UDPRoutes[k] = statuses.UDPRoutes[k]
 	}
 
 	// Sort GRPC routes

--- a/test/translator/test.go
+++ b/test/translator/test.go
@@ -583,6 +583,27 @@ func AreReportsSuccess(gwNN types.NamespacedName, reportsMap reports.ReportMap) 
 		}
 	}
 
+	for nns := range reportsMap.UDPRoutes {
+		r := gwv1.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nns.Name,
+				Namespace: nns.Namespace,
+			},
+		}
+		status := reportsMap.BuildRouteStatus(&r, wellknown.DefaultGatewayClassName)
+
+		for ref, parentRefReport := range status.Parents {
+			for _, c := range parentRefReport.Conditions {
+				// most route conditions true is good, except RouteConditionPartiallyInvalid
+				if c.Type == string(gwv1.RouteConditionPartiallyInvalid) && c.Status != metav1.ConditionFalse {
+					return fmt.Errorf("condition error for udproute: %v ref: %v condition: %v", nns, ref, c)
+				} else if c.Status != metav1.ConditionTrue {
+					return fmt.Errorf("condition error for udproute: %v ref: %v condition: %v", nns, ref, c)
+				}
+			}
+		}
+	}
+
 	for nns := range reportsMap.GRPCRoutes {
 		r := gwv1.GRPCRoute{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Description

Implements UDPRoute support needed after UDPRoute type graduated to GA (v1) on Gateway API 1.6.0 which kgateway did not yet provide.

Implementation details:
- Translates an `UDPRoute` to an Envoy `udp_proxy` listener filter.
- Handles weighted routing across multiple backends through a per-route aggregate EDS cluster. Its endpoints are the weighted union of the backends.
- Drops the weight of invalid and unresolved backends to a blackhole endpoint on the pod loopback address discard port (127.0.0.1:9) instead of redistributing to the healthy ones, following Gateway API extended support.
- Advertises `UDPRoute` in the GatewayClass supported features.

Fixes #10076

# Change Type

/kind feature

# Changelog

```release-note
Add support for the Gateway API UDPRoute type, core and extended features.
```

# Additional Notes
- UDP reuses the existing L4 conflict resolution based on oldest timestamp
- Conformance covers the core and extended UDPRoute features
